### PR TITLE
Add IPC path for PCB graphic primitives with file fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,6 +783,7 @@ dependencies = [
  "konnect-ipc",
  "konnect-schematic-editor",
  "konnect-sexp",
+ "prost-types",
  "reqwest",
  "rusqlite",
  "serde",

--- a/crates/konnect-core/Cargo.toml
+++ b/crates/konnect-core/Cargo.toml
@@ -10,6 +10,7 @@ konnect-sexp.workspace = true
 konnect-ipc.workspace = true
 konnect-schematic-editor.workspace = true
 
+prost-types.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/konnect-core/src/tools/pcb_board.rs
+++ b/crates/konnect-core/src/tools/pcb_board.rs
@@ -7,11 +7,31 @@
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
 use crate::tools::{get_path, require_f64, require_str, ToolContext, ToolDef};
+use konnect_ipc::builders;
 use konnect_sexp::{
     parser::parse_sexp,
     writer::{apply_edits, new_uuid, write_atomic, SexpEdit},
 };
 use serde_json::json;
+
+// Build the 4 Edge.Cuts segments forming a rectangle, packed as Any for create_items.
+fn rect_outline_items(x1: f64, y1: f64, x2: f64, y2: f64, w: f64) -> Vec<prost_types::Any> {
+    let sides = [
+        (x1, y1, x2, y1),
+        (x2, y1, x2, y2),
+        (x2, y2, x1, y2),
+        (x1, y2, x1, y1),
+    ];
+    sides
+        .iter()
+        .map(|&(a, b, c, d)| {
+            builders::pack_any(
+                &builders::board_segment("Edge.Cuts", w, a, b, c, d),
+                "kiapi.board.types.BoardGraphicShape",
+            )
+        })
+        .collect()
+}
 
 // ─── IPC helper ───────────────────────────────────────────────────────────────
 
@@ -266,7 +286,7 @@ pub fn tools() -> Vec<ToolDef> {
 
 async fn handle_set_board_size(
     args: &serde_json::Value,
-    _ctx: &ToolContext,
+    ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
     let board_path = get_path(args, "board")?;
     let width = match require_f64(args, "width") {
@@ -284,6 +304,23 @@ async fn handle_set_board_size(
     let y2 = oy + height;
     let w = 0.05_f64;
 
+    // Try IPC first (live board in KiCAD, undo-aware); fall through to file edit.
+    // ponytail: 4 segments over a single BoardRectangle keeps one builder path;
+    // switch to board_rectangle if a native rect proves less flaky.
+    let items = rect_outline_items(ox, oy, x2, y2, w);
+    if with_ipc(ctx.config.ipc_address.clone(), move |c| {
+        c.create_items(items)
+    })
+    .await?
+    .is_ok()
+    {
+        return Ok(CallToolResult::json(&json!({
+            "width": width, "height": height,
+            "x1": ox, "y1": oy, "x2": x2, "y2": y2,
+            "source": "ipc"
+        })));
+    }
+
     // Append 4 Edge.Cuts lines (top, right, bottom, left)
     let lines = format!(
         "{}{}{}{}",
@@ -300,7 +337,8 @@ async fn handle_set_board_size(
 
     Ok(CallToolResult::json(&json!({
         "width": width, "height": height,
-        "x1": ox, "y1": oy, "x2": x2, "y2": y2
+        "x1": ox, "y1": oy, "x2": x2, "y2": y2,
+        "source": "file"
     })))
 }
 
@@ -550,7 +588,7 @@ async fn handle_set_active_layer(
 
 async fn handle_add_board_outline(
     args: &serde_json::Value,
-    _ctx: &ToolContext,
+    ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
     let board_path = get_path(args, "board")?;
     let x1 = match require_f64(args, "x1") {
@@ -571,6 +609,21 @@ async fn handle_add_board_outline(
     };
     let w = 0.05_f64;
 
+    // Try IPC first; fall through to file edit if KiCAD is not reachable.
+    let items = rect_outline_items(x1, y1, x2, y2, w);
+    if with_ipc(ctx.config.ipc_address.clone(), move |c| {
+        c.create_items(items)
+    })
+    .await?
+    .is_ok()
+    {
+        return Ok(CallToolResult::json(&json!({
+            "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "width": (x2-x1).abs(), "height": (y2-y1).abs(),
+            "source": "ipc"
+        })));
+    }
+
     let lines = format!(
         "{}{}{}{}",
         format_gr_line(x1, y1, x2, y1, "Edge.Cuts", w),
@@ -586,7 +639,8 @@ async fn handle_add_board_outline(
 
     Ok(CallToolResult::json(&json!({
         "x1": x1, "y1": y1, "x2": x2, "y2": y2,
-        "width": (x2-x1).abs(), "height": (y2-y1).abs()
+        "width": (x2-x1).abs(), "height": (y2-y1).abs(),
+        "source": "file"
     })))
 }
 
@@ -619,7 +673,7 @@ async fn handle_add_mounting_hole(
 
 async fn handle_add_board_text(
     args: &serde_json::Value,
-    _ctx: &ToolContext,
+    ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
     let board_path = get_path(args, "board")?;
     let text = match require_str(args, "text") {
@@ -634,18 +688,36 @@ async fn handle_add_board_text(
         Ok(v) => v,
         Err(e) => return Ok(e),
     };
-    let layer = args["layer"].as_str().unwrap_or("F.SilkS");
+    let layer = args["layer"].as_str().unwrap_or("F.SilkS").to_string();
     let size = args["size"].as_f64().unwrap_or(1.0);
     let rotation = args["rotation"].as_f64().unwrap_or(0.0);
 
-    let gr_text = format_gr_text(&text, x, y, rotation, layer, size);
+    // Try IPC first; fall through to file edit if KiCAD isn't reachable.
+    let text_ipc = text.clone();
+    let layer_ipc = layer.clone();
+    if with_ipc(ctx.config.ipc_address.clone(), move |c| {
+        let bt = builders::board_text(&layer_ipc, &text_ipc, x, y, size, rotation, false);
+        let any = builders::pack_any(&bt, "kiapi.board.types.BoardText");
+        c.create_items(vec![any])
+    })
+    .await?
+    .is_ok()
+    {
+        return Ok(CallToolResult::json(&json!({
+            "text": text, "x": x, "y": y, "layer": layer, "size": size,
+            "source": "ipc"
+        })));
+    }
+
+    let gr_text = format_gr_text(&text, x, y, rotation, &layer, size);
     let content = std::fs::read_to_string(&board_path)?;
     let close_pos = content.rfind(')').unwrap_or(content.len());
     let new_content = apply_edits(content, vec![SexpEdit::insert(close_pos, gr_text)]);
     write_atomic(&board_path, &new_content)?;
 
     Ok(CallToolResult::json(&json!({
-        "text": text, "x": x, "y": y, "layer": layer, "size": size
+        "text": text, "x": x, "y": y, "layer": layer, "size": size,
+        "source": "file"
     })))
 }
 

--- a/crates/konnect-ipc/src/builders.rs
+++ b/crates/konnect-ipc/src/builders.rs
@@ -108,3 +108,266 @@ pub fn pack_any<M: prost::Message>(msg: &M, type_name: &str) -> prost_types::Any
         value: buf,
     }
 }
+
+// --- Graphic primitive builders (BoardGraphicShape + BoardText) --------------
+//
+// All wrap a common `stroke(width_mm)` + `fill(filled)` into `GraphicAttributes`,
+// then pack the geometry into `GraphicShape::geometry` (a oneof). Callers `pack_any`
+// the result and hand it to `create_items` / `update_items`, same shape as
+// `add_track` already uses.
+
+fn stroke(width_mm: f64) -> kiapi::common::types::StrokeAttributes {
+    kiapi::common::types::StrokeAttributes {
+        width: Some(distance(width_mm)),
+        // ponytail: leave style/color at proto default (solid, board default color).
+        // Add args when a caller needs dashed/colored graphics.
+        style: 0,
+        color: None,
+    }
+}
+
+fn attrs(width_mm: f64, filled: bool) -> kiapi::common::types::GraphicAttributes {
+    kiapi::common::types::GraphicAttributes {
+        stroke: Some(stroke(width_mm)),
+        fill: Some(kiapi::common::types::GraphicFillAttributes {
+            fill_type: if filled {
+                kiapi::common::types::GraphicFillType::GftFilled as i32
+            } else {
+                kiapi::common::types::GraphicFillType::GftUnfilled as i32
+            },
+            color: None,
+        }),
+    }
+}
+
+fn board_shape(
+    layer: &str,
+    attrs: kiapi::common::types::GraphicAttributes,
+    geometry: kiapi::common::types::graphic_shape::Geometry,
+) -> kiapi::board::types::BoardGraphicShape {
+    kiapi::board::types::BoardGraphicShape {
+        shape: Some(kiapi::common::types::GraphicShape {
+            attributes: Some(attrs),
+            geometry: Some(geometry),
+        }),
+        layer: layer_from_name(layer) as i32,
+        net: None,
+        id: None, // KiCAD assigns
+        locked: kiapi::common::types::LockedState::LsUnlocked as i32,
+    }
+}
+
+/// Build a BoardGraphicShape for a straight segment.
+#[allow(clippy::too_many_arguments)]
+pub fn board_segment(
+    layer: &str,
+    width_mm: f64,
+    x1: f64,
+    y1: f64,
+    x2: f64,
+    y2: f64,
+) -> kiapi::board::types::BoardGraphicShape {
+    board_shape(
+        layer,
+        attrs(width_mm, false),
+        kiapi::common::types::graphic_shape::Geometry::Segment(
+            kiapi::common::types::GraphicSegmentAttributes {
+                start: Some(vec2(x1, y1)),
+                end: Some(vec2(x2, y2)),
+            },
+        ),
+    )
+}
+
+/// Build a BoardGraphicShape rectangle. Corners are (x1,y1) and (x2,y2) in mm.
+#[allow(clippy::too_many_arguments)]
+pub fn board_rectangle(
+    layer: &str,
+    width_mm: f64,
+    x1: f64,
+    y1: f64,
+    x2: f64,
+    y2: f64,
+    filled: bool,
+) -> kiapi::board::types::BoardGraphicShape {
+    board_shape(
+        layer,
+        attrs(width_mm, filled),
+        kiapi::common::types::graphic_shape::Geometry::Rectangle(
+            kiapi::common::types::GraphicRectangleAttributes {
+                top_left: Some(vec2(x1, y1)),
+                bottom_right: Some(vec2(x2, y2)),
+                corner_radius: None,
+            },
+        ),
+    )
+}
+
+/// Build a BoardGraphicShape circle at (cx,cy) with radius r_mm.
+pub fn board_circle(
+    layer: &str,
+    width_mm: f64,
+    cx: f64,
+    cy: f64,
+    r_mm: f64,
+) -> kiapi::board::types::BoardGraphicShape {
+    board_shape(
+        layer,
+        attrs(width_mm, false),
+        kiapi::common::types::graphic_shape::Geometry::Circle(
+            kiapi::common::types::GraphicCircleAttributes {
+                center: Some(vec2(cx, cy)),
+                // Point on the circumference -- KiCAD stores this rather than a radius scalar.
+                radius_point: Some(vec2(cx + r_mm, cy)),
+            },
+        ),
+    )
+}
+
+/// Build a BoardGraphicShape arc from start / mid / end points.
+#[allow(clippy::too_many_arguments)]
+pub fn board_arc(
+    layer: &str,
+    width_mm: f64,
+    sx: f64,
+    sy: f64,
+    mx: f64,
+    my: f64,
+    ex: f64,
+    ey: f64,
+) -> kiapi::board::types::BoardGraphicShape {
+    board_shape(
+        layer,
+        attrs(width_mm, false),
+        kiapi::common::types::graphic_shape::Geometry::Arc(
+            kiapi::common::types::GraphicArcAttributes {
+                start: Some(vec2(sx, sy)),
+                mid: Some(vec2(mx, my)),
+                end: Some(vec2(ex, ey)),
+            },
+        ),
+    )
+}
+
+/// Build a BoardText. `size_mm` sets both width and height of the glyphs.
+#[allow(clippy::too_many_arguments)]
+pub fn board_text(
+    layer: &str,
+    text: &str,
+    x: f64,
+    y: f64,
+    size_mm: f64,
+    rotation_deg: f64,
+    mirror: bool,
+) -> kiapi::board::types::BoardText {
+    kiapi::board::types::BoardText {
+        id: None,
+        text: Some(kiapi::common::types::Text {
+            position: Some(vec2(x, y)),
+            attributes: Some(kiapi::common::types::TextAttributes {
+                // ponytail: font/alignment/bold/italic left at proto default.
+                // Add args (or a builder struct) when a caller needs them.
+                font_name: String::new(),
+                horizontal_alignment: kiapi::common::types::HorizontalAlignment::HaCenter as i32,
+                vertical_alignment: kiapi::common::types::VerticalAlignment::VaCenter as i32,
+                angle: Some(kiapi::common::types::Angle {
+                    value_degrees: rotation_deg,
+                }),
+                line_spacing: 1.0,
+                stroke_width: Some(distance(size_mm * 0.15)),
+                italic: false,
+                bold: false,
+                underlined: false,
+                visible: true,
+                mirrored: mirror,
+                multiline: false,
+                keep_upright: false,
+                size: Some(vec2(size_mm, size_mm)),
+            }),
+            text: text.to_string(),
+            hyperlink: String::new(),
+        }),
+        layer: layer_from_name(layer) as i32,
+        knockout: false,
+        locked: kiapi::common::types::LockedState::LsUnlocked as i32,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kiapi::common::types::graphic_shape::Geometry;
+
+    #[test]
+    fn segment_populates_start_end_and_layer() {
+        let s = board_segment("Edge.Cuts", 0.05, 1.0, 2.0, 3.0, 4.0);
+        assert_eq!(s.layer, kiapi::board::types::BoardLayer::BlEdgeCuts as i32);
+        let shape = s.shape.expect("shape");
+        match shape.geometry.expect("geometry") {
+            Geometry::Segment(g) => {
+                assert_eq!(g.start.unwrap().x_nm, 1_000_000);
+                assert_eq!(g.start.unwrap().y_nm, 2_000_000);
+                assert_eq!(g.end.unwrap().x_nm, 3_000_000);
+                assert_eq!(g.end.unwrap().y_nm, 4_000_000);
+            }
+            _ => panic!("expected Segment geometry"),
+        }
+        let a = shape.attributes.expect("attrs");
+        assert_eq!(a.stroke.unwrap().width.unwrap().value_nm, 50_000);
+        assert_eq!(
+            a.fill.unwrap().fill_type,
+            kiapi::common::types::GraphicFillType::GftUnfilled as i32
+        );
+    }
+
+    #[test]
+    fn rectangle_variant_and_filled_flag() {
+        let s = board_rectangle("F.SilkS", 0.1, 0.0, 0.0, 10.0, 5.0, true);
+        assert_eq!(s.layer, kiapi::board::types::BoardLayer::BlFSilkS as i32);
+        let shape = s.shape.expect("shape");
+        assert!(matches!(shape.geometry, Some(Geometry::Rectangle(_))));
+        assert_eq!(
+            shape.attributes.unwrap().fill.unwrap().fill_type,
+            kiapi::common::types::GraphicFillType::GftFilled as i32
+        );
+    }
+
+    #[test]
+    fn circle_radius_point_is_center_plus_radius() {
+        let s = board_circle("F.SilkS", 0.1, 5.0, 5.0, 2.5);
+        match s.shape.unwrap().geometry.unwrap() {
+            Geometry::Circle(c) => {
+                assert_eq!(c.center.unwrap().x_nm, 5_000_000);
+                assert_eq!(c.radius_point.unwrap().x_nm, 7_500_000);
+                assert_eq!(c.radius_point.unwrap().y_nm, 5_000_000);
+            }
+            _ => panic!("expected Circle geometry"),
+        }
+    }
+
+    #[test]
+    fn arc_start_mid_end_populated() {
+        let s = board_arc("F.SilkS", 0.1, 0.0, 0.0, 1.0, 1.0, 2.0, 0.0);
+        match s.shape.unwrap().geometry.unwrap() {
+            Geometry::Arc(a) => {
+                assert_eq!(a.start.unwrap().x_nm, 0);
+                assert_eq!(a.mid.unwrap().x_nm, 1_000_000);
+                assert_eq!(a.end.unwrap().x_nm, 2_000_000);
+            }
+            _ => panic!("expected Arc geometry"),
+        }
+    }
+
+    #[test]
+    fn text_carries_position_size_layer_and_rotation() {
+        let t = board_text("F.SilkS", "hi", 12.0, 34.0, 1.5, 90.0, false);
+        assert_eq!(t.layer, kiapi::board::types::BoardLayer::BlFSilkS as i32);
+        let text = t.text.expect("text");
+        assert_eq!(text.text, "hi");
+        assert_eq!(text.position.unwrap().x_nm, 12_000_000);
+        let attrs = text.attributes.expect("attrs");
+        assert_eq!(attrs.size.unwrap().x_nm, 1_500_000);
+        assert_eq!(attrs.angle.unwrap().value_degrees, 90.0);
+        assert!(!attrs.mirrored);
+    }
+}

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -304,6 +304,18 @@ impl KiCadIpcClient {
         Ok(())
     }
 
+    /// Update existing items by KIID. Generic wrapper mirroring create_items/delete_items;
+    /// each `Any` must be a fully-formed board item with an existing `id` populated.
+    pub fn update_items(&self, items: Vec<prost_types::Any>) -> Result<()> {
+        let header = self.make_header()?;
+        let cmd = kiapi::common::commands::UpdateItems {
+            header: Some(header),
+            items,
+        };
+        self.send_command(&cmd, "kiapi.common.commands.UpdateItems")?;
+        Ok(())
+    }
+
     /// Delete items by KIID.
     pub fn delete_items(&self, ids: Vec<String>) -> Result<()> {
         let header = self.make_header()?;
@@ -705,67 +717,6 @@ impl KiCadIpcClient {
         } else {
             Ok(vec![])
         }
-    }
-
-    /// Set board outline (rectangle on Edge.Cuts) via S-expression string.
-    pub fn set_board_outline(
-        &self,
-        _shape: &str,
-        x: f64,
-        y: f64,
-        width: f64,
-        height: f64,
-    ) -> Result<()> {
-        let x2 = x + width;
-        let y2 = y + height;
-        // 4 line segments forming a rectangle on Edge.Cuts
-        let sexp = format!(
-            r#"(gr_line (start {} {}) (end {} {}) (stroke (width 0.05) (type default)) (layer "Edge.Cuts"))
-(gr_line (start {} {}) (end {} {}) (stroke (width 0.05) (type default)) (layer "Edge.Cuts"))
-(gr_line (start {} {}) (end {} {}) (stroke (width 0.05) (type default)) (layer "Edge.Cuts"))
-(gr_line (start {} {}) (end {} {}) (stroke (width 0.05) (type default)) (layer "Edge.Cuts"))"#,
-            x,
-            y,
-            x2,
-            y, // top
-            x2,
-            y,
-            x2,
-            y2, // right
-            x2,
-            y2,
-            x,
-            y2, // bottom
-            x,
-            y2,
-            x,
-            y, // left
-        );
-        let doc = self.get_board_document()?;
-        let cmd = kiapi::common::commands::ParseAndCreateItemsFromString {
-            document: Some(doc),
-            contents: sexp,
-        };
-        self.send_command(&cmd, "kiapi.common.commands.ParseAndCreateItemsFromString")?;
-        Ok(())
-    }
-
-    /// Add text to the board via S-expression string.
-    pub fn add_text(&self, layer: &str, text: &str, x: f64, y: f64) -> Result<()> {
-        let sexp = format!(
-            r#"(gr_text "{}" (at {} {}) (layer "{}") (effects (font (size 1.5 1.5) (thickness 0.15))))"#,
-            text.replace('"', "\\\""),
-            x,
-            y,
-            layer
-        );
-        let doc = self.get_board_document()?;
-        let cmd = kiapi::common::commands::ParseAndCreateItemsFromString {
-            document: Some(doc),
-            contents: sexp,
-        };
-        self.send_command(&cmd, "kiapi.common.commands.ParseAndCreateItemsFromString")?;
-        Ok(())
     }
 
     /// Run an arbitrary tool action in KiCAD (e.g. to trigger a refresh).


### PR DESCRIPTION
## Motivation

Konnect's headline feature over the old KiCAD-MCP-Server is real-time IPC edits instead of file-editing + reload. However, the pcb_board tools (set_board_size, add_board_outline, add_board_text) were file-editing-only, so users had to reload the board in KiCAD to see changes. This PR closes that gap for graphic primitives.

## What changed

- Migrated handle_set_board_size, handle_add_board_outline, and handle_add_board_text to try the IPC path first (via with_ipc(...).is_ok()) and fall back to the file-edit path when IPC is unavailable.
- Response JSON for these three tools gains a source field: "ipc" or "file", so callers can tell which path was taken.
- Added IPC builder helpers in crates/konnect-ipc/src/builders.rs: stroke(), attrs(), board_shape(), plus five public builders: board_segment, board_rectangle, board_circle, board_arc, board_text.
- Added update_items() generic wrapper in crates/konnect-ipc/src/client.rs.
- Removed dead set_board_outline() and add_text() helpers from client.rs -- both used a superseded ParseAndCreateItemsFromString path with zero callers.
- Added rect_outline_items() helper in crates/konnect-core/src/tools/pcb_board.rs.
- Added prost-types workspace dependency to crates/konnect-core/Cargo.toml for prost_types::Any.

## Preserved

The file-editing fallback still runs when the IPC socket is unavailable (offline mode), so nothing regresses for users without a running KiCad IPC session.

## Deliberately deferred

- add_zone -- not migrated, no Zone/BoardZone proto exists in this tree.
- add_mounting_hole -- not migrated, needs FootprintInstance + NPTH pad assembly, which is a different shape of change than a graphic primitive.

## Builders ready but unwired

board_circle and board_arc (along with board_rectangle and net) are exposed in builders.rs but not yet wired into any user-facing tool. Kept ready-to-call rather than deleted since they cover primitives that will likely be needed soon. Happy to delete if you prefer YAGNI -- keep if you prefer having ready primitives on hand.

## Tests

- 5 new builder unit tests (struct-assertion style) in konnect-ipc.
- Full workspace suite: 78/78 passing on Windows (cargo test --workspace --lib --tests).

## CONTRIBUTING checklist

- cargo test --workspace --lib --tests: clean, 78/78 passing.
- cargo clippy --workspace -- -D warnings: clean.
- cargo fmt --all -- --check: clean.
- No new tools added, so tool_count in router/registry.rs and tool-directory.md are unchanged -- the 3 migrated tools keep the same MCP surface, only their response gains a source field.