### PR TITLE
Make PCM packaging cross-platform: stamp IPC entrypoint per OS

### DIFF
--- a/packaging/build-pcm.ps1
+++ b/packaging/build-pcm.ps1
@@ -48,6 +48,15 @@ if ($ViewerPath -and (Test-Path $ViewerPath)) {
     Write-Host "Included schematic viewer: $ViewerPath"
 }
 
+# Stamp the IPC entrypoint to this platform's binary name. plugin.json ships the
+# Windows default; the packaging step is authoritative so a package points at the
+# binary it actually bundles (build-pcm.sh stamps bin/konnect for macOS/Linux).
+$pluginManifest = Get-Content "$staging/plugins/plugin.json" -Raw | ConvertFrom-Json
+foreach ($action in $pluginManifest.actions) {
+    if ($action.entrypoint -like "bin/*") { $action.entrypoint = "bin/konnect.exe" }
+}
+$pluginManifest | ConvertTo-Json -Depth 10 | Set-Content "$staging/plugins/plugin.json"
+
 # Icons: PCM dialog icon at resources/, toolbar icon inside plugins/
 Copy-Item "$repoRoot/packaging/resources/icon.png" "$staging/resources/icon.png"
 Copy-Item "$repoRoot/packaging/resources/icon.png" "$staging/plugins/resources/icon.png"

--- a/packaging/build-pcm.sh
+++ b/packaging/build-pcm.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Assemble the KiCAD PCM plugin package for Konnect (macOS/Linux port of build-pcm.ps1).
+#
+# Produces a zip laid out the way KiCAD's Plugin and Content Manager expects for
+# "Install from File" and for kicad-addons repository submission:
+#
+#   metadata.json                 PCM package manifest (version stamped in)
+#   plugins/                      installed into KiCAD's scripting/plugins dir
+#     __init__.py                 ActionPlugin launcher (settings dialog, server control)
+#     plugin.json                 KiCAD 10 IPC plugin manifest (entrypoint stamped)
+#     settings_dialog.py          wxPython settings UI
+#     resources/icon.png          toolbar icon (referenced by __init__.py)
+#     bin/konnect                 the MCP server binary
+#     bin/schematic-viewer        (optional) live schematic viewer
+#   resources/
+#     icon.png                    icon shown in the PCM dialog
+#
+# The IPC entrypoint in plugin.json is stamped to this platform's binary name
+# (bin/konnect) so the KiCAD 10 IPC action resolves on macOS/Linux, mirroring
+# build-pcm.ps1 which stamps bin/konnect.exe for Windows.
+#
+# Usage:
+#   packaging/build-pcm.sh [--version X.Y.Z] [--binary PATH] [--viewer PATH] [--out DIR]
+#
+# Defaults: version from Cargo.toml, binary target/release/konnect, output dist/.
+# Prints the zip path, size, and SHA256 (needed for the kicad-addons metadata).
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+bin_name="konnect"
+
+version=""
+binary="$repo_root/target/release/$bin_name"
+viewer=""
+out_dir="$repo_root/dist"
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: packaging/build-pcm.sh [--version X.Y.Z] [--binary PATH] [--viewer PATH] [--out DIR]
+
+Assembles the KiCAD PCM plugin zip (macOS/Linux port of build-pcm.ps1).
+Defaults: version from Cargo.toml, binary target/release/konnect, output dist/.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --version) version="${2:?--version needs a value}"; shift 2;;
+        --binary)  binary="${2:?--binary needs a value}";   shift 2;;
+        --viewer)  viewer="${2:?--viewer needs a value}";   shift 2;;
+        --out)     out_dir="${2:?--out needs a value}";     shift 2;;
+        -h|--help) usage; exit 0;;
+        *) echo "Unknown argument: $1" >&2; usage; exit 2;;
+    esac
+done
+
+# Default version = workspace version from Cargo.toml
+if [ -z "$version" ]; then
+    version="$(sed -n 's/^version = "\(.*\)"/\1/p' "$repo_root/Cargo.toml" | head -1)"
+fi
+[ -n "$version" ] || { echo "Could not determine version; pass --version" >&2; exit 1; }
+if [ ! -f "$binary" ]; then
+    echo "Binary not found: $binary" >&2
+    echo "Build it first: cargo build --release -p konnect" >&2
+    exit 1
+fi
+
+staging="$(mktemp -d)/konnect-pcm-$version"
+mkdir -p "$staging/plugins/bin" "$staging/plugins/resources" "$staging/resources"
+
+# Plugin files
+cp "$repo_root/plugin/__init__.py"        "$staging/plugins/"
+cp "$repo_root/plugin/plugin.json"        "$staging/plugins/"
+cp "$repo_root/plugin/settings_dialog.py" "$staging/plugins/"
+cp "$binary"                              "$staging/plugins/bin/$bin_name"
+chmod +x "$staging/plugins/bin/$bin_name"
+if [ -n "$viewer" ] && [ -f "$viewer" ]; then
+    cp "$viewer" "$staging/plugins/bin/schematic-viewer"
+    chmod +x "$staging/plugins/bin/schematic-viewer"
+    echo "Included schematic viewer: $viewer"
+fi
+
+# Icons: PCM dialog icon at resources/, toolbar icon inside plugins/
+cp "$repo_root/packaging/resources/icon.png" "$staging/resources/icon.png"
+cp "$repo_root/packaging/resources/icon.png" "$staging/plugins/resources/icon.png"
+
+# Stamp the IPC entrypoint to this platform's binary name. plugin.json ships a
+# Windows default (bin/konnect.exe); the packaging step is authoritative so a
+# package built on any OS points at the binary it actually bundles.
+python3 - "$staging/plugins/plugin.json" "bin/$bin_name" <<'PY'
+import json, sys
+path, entry = sys.argv[1], sys.argv[2]
+m = json.load(open(path))
+for a in m.get("actions", []):
+    if a.get("entrypoint", "").startswith("bin/"):
+        a["entrypoint"] = entry
+json.dump(m, open(path, "w"), indent=2)
+open(path, "a").write("\n")
+PY
+
+# metadata.json: stamp version + install_size; download_* get schema-valid
+# placeholders (PCM ignores them for install-from-file; the printed values below
+# go into the kicad-addons repository submission). install_size is the staged
+# file total BEFORE metadata.json is written, matching build-pcm.ps1.
+install_size="$(python3 -c 'import os,sys; print(sum(os.path.getsize(os.path.join(d,f)) for d,_,fs in os.walk(sys.argv[1]) for f in fs))' "$staging")"
+python3 - "$repo_root/packaging/metadata.json" "$staging/metadata.json" "$version" "$install_size" <<'PY'
+import json, sys
+src, dst, version, install_size = sys.argv[1:5]
+m = json.load(open(src))
+v = m["versions"][0]
+v["version"] = version
+v["install_size"] = int(install_size)
+v["download_sha256"] = "0" * 64
+v["download_url"] = "https://example.invalid/placeholder.zip"
+v["download_size"] = 1
+json.dump(m, open(dst, "w"), indent=2)
+open(dst, "a").write("\n")
+PY
+
+# Zip it (staged contents at the archive root, matching Compress-Archive)
+mkdir -p "$out_dir"
+zip_path="$out_dir/konnect-pcm-v$version.zip"
+rm -f "$zip_path"
+( cd "$staging" && zip -rqX "$zip_path" metadata.json plugins resources )
+
+if command -v shasum >/dev/null 2>&1; then
+    sha="$(shasum -a 256 "$zip_path" | awk '{print $1}')"
+else
+    sha="$(sha256sum "$zip_path" | awk '{print $1}')"
+fi
+size="$(python3 -c 'import os,sys; print(os.path.getsize(sys.argv[1]))' "$zip_path")"
+
+echo ""
+echo "PCM package: $zip_path"
+echo "  download_size:   $size"
+echo "  install_size:    $install_size"
+echo "  download_sha256: $sha"
+echo "  download_url:    https://github.com/mixelpixx/Konnect/releases/download/v$version/konnect-pcm-v$version.zip"


### PR DESCRIPTION
## Problem

`plugin/plugin.json` hardcodes the KiCAD 10 IPC action entrypoint as `bin/konnect.exe`. The `pcm-package` release job runs on Windows, so official packages happen to match — but a PCM package assembled on **macOS or Linux** bundles `bin/konnect` (no `.exe`). The IPC action then points at a file that doesn't exist and fails to launch.

The wxPython ActionPlugin path (`plugin/__init__.py`) already resolves the binary name per-OS (`konnect.exe` on Windows, `konnect` elsewhere), so it works cross-platform. The IPC exec path was the only place with a hardcoded, Windows-only assumption.

## Fix

- Add **`packaging/build-pcm.sh`** — a macOS/Linux port of `build-pcm.ps1`. Same package layout, same `metadata.json` stamping (version, `install_size`, schema-valid `download_*` placeholders), parameterized (`--version` / `--binary` / `--viewer` / `--out`) with sensible defaults (version from `Cargo.toml`, binary `target/release/konnect`, output `dist/`).
- Both packaging scripts now **stamp `plugin.json`'s `entrypoint`** to match the binary they actually bundle: `bin/konnect` on macOS/Linux, `bin/konnect.exe` on Windows. Packaging is authoritative, so a PCM zip is internally consistent regardless of build host.

**No change to the Windows package output** — `build-pcm.ps1` still emits `bin/konnect.exe` and stamps the same entrypoint value it always used.

## Testing

Built on macOS (arm64) from `cargo build --release -p konnect`:

```
$ ./packaging/build-pcm.sh
PCM package: dist/konnect-pcm-v0.1.1.zip
$ unzip -p dist/konnect-pcm-v0.1.1.zip plugins/plugin.json | grep entrypoint
      "entrypoint": "bin/konnect",
$ unzip -l dist/konnect-pcm-v0.1.1.zip | grep bin/konnect
 12524032  ...  plugins/bin/konnect
```

Package layout matches the Windows CI output (`metadata.json` + `plugins/` + `resources/`); the IPC action and the ActionPlugin now both resolve `bin/konnect` on macOS/Linux. `bash -n` clean.

## Possible follow-up (not in this PR)

The `pcm-package` job in `.github/workflows/release.yml` only runs on `windows-latest`, so releases still ship a Windows-only PCM zip. A natural next step is to matrix that job across OSes and publish per-OS PCM packages (e.g. `konnect-pcm-v<ver>-macos.zip`) built with `build-pcm.sh`. Left out here to keep the change focused, since it also changes release-artifact naming / `download_url` conventions worth deciding separately.
