### PR TITLE
feat(pcb_export): add DXF, GenCAD, IPC-2581, and ODB++ export tools

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -221,9 +221,9 @@ Run all: `PROTOC=<path> cargo test --workspace --lib --tests`
 
 ## Current Stats
 
-- **17 toolsets, 171 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
+- **17 toolsets, 175 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
 - Baseline `tools/list`: ~19 tools / ~2K tokens (starter kit + meta-tools)
-- Full-catalog `tools/list` (all loaded): ~177 tools / ~23K tokens
+- Full-catalog `tools/list` (all loaded): ~181 tools / ~23K tokens
 - **0 IPC stubs** (all protobuf methods implemented)
 - **0 unimplemented tools**
 - **3 CLI commands removed in KiCAD v10** (specctra DSN/SES, pcb sync — return clear errors)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,6 @@ Opening an issue is the best way to influence priority.
 - **Symbol & footprint creation** — author new library parts from scratch, not
   just search and place existing ones.
 - **Eagle project import** — migrate legacy Eagle designs.
-- **Additional export formats** — IPC-2581, ODB++, GenCAD, DXF.
 - **Multi-sheet schematic viewer** — `kicad-cli sch export svg` emits one SVG
   per sheet; the live viewer currently shows only the root sheet. Add a sheet
   selector for hierarchical designs.
@@ -37,3 +36,7 @@ Opening an issue is the best way to influence priority.
 - ~~HTTP transport~~ — Streamable HTTP (MCP spec 2025-06-18) available via
   `transport = "http"` (or `"both"`): POST + GET (SSE) on a single `/mcp`
   endpoint, Origin validation, and a `/health` probe.
+- ~~Additional export formats~~ — IPC-2581, ODB++, GenCAD, and DXF are now
+  available via `export_ipc2581`, `export_odb`, `export_gencad`, and
+  `export_dxf` in the `pcb_export` toolset (all backed by native `kicad-cli`
+  subcommands, verified against KiCAD 10.0).

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -74,9 +74,9 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
     },
     ToolsetMeta {
         name: "pcb_export",
-        description: "Gerber, PDF, SVG, 3D model, BOM, pick-and-place, DRC",
+        description: "Gerber, PDF, SVG, 3D model, BOM, pick-and-place, DRC, DXF/GenCAD/IPC-2581/ODB++",
         category: "pcb",
-        tool_count: 9,
+        tool_count: 13,
     },
     ToolsetMeta {
         name: "library",

--- a/crates/konnect-core/src/tools/cli.rs
+++ b/crates/konnect-core/src/tools/cli.rs
@@ -3,9 +3,10 @@
 //! All exports, ERC, DRC, and annotation operations shell out to kicad-cli.
 //! This module provides a typed interface to those commands.
 //!
-//! VERIFIED against: kicad-cli from KiCAD 10.0 (C:\KiCad\10.0\bin\kicad-cli.exe)
+//! VERIFIED against: kicad-cli from KiCAD 10.0 (C:\Program Files\KiCad\10.0\bin\kicad-cli.exe)
 //! Commands validated: sch erc, sch export (bom/netlist/pdf/svg), pcb drc,
-//!   pcb export (gerbers/drill/pdf/svg/step/vrml/pos/ipcd356), pcb render
+//!   pcb export (gerbers/drill/pdf/svg/step/vrml/pos/ipcd356/dxf/gencad/ipc2581/odb),
+//!   pcb render
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -439,6 +440,90 @@ pub async fn export_ipcd356(cli: &str, pcb: &Path, output: &Path) -> Result<()> 
         "ipcd356",
         "--output",
         output.to_str().unwrap(),
+        pcb.to_str().unwrap(),
+    ];
+    run_cli(cli, &args, LONG_TIMEOUT).await?;
+    Ok(())
+}
+
+/// KiCAD 10: `pcb export dxf --output <dir> [--layers <csv>] --mode-multi <input>`
+///
+/// Unlike `pdf`/`svg`, DXF's `--layers` takes a single comma-separated value
+/// rather than a repeatable flag, and one file per requested layer is written
+/// into `output_dir` (verified against KiCAD 10.0).
+pub async fn export_dxf(cli: &str, pcb: &Path, output_dir: &Path, layers: &[&str]) -> Result<()> {
+    let output_str = output_dir.to_str().unwrap();
+    let pcb_str = pcb.to_str().unwrap();
+    let layers_csv = layers.join(",");
+
+    let mut args: Vec<&str> = vec!["pcb", "export", "dxf", "--output", output_str];
+    if !layers_csv.is_empty() {
+        args.push("--layers");
+        args.push(&layers_csv);
+    }
+    args.push("--mode-multi");
+    args.push(pcb_str);
+
+    run_cli(cli, &args, LONG_TIMEOUT).await?;
+    Ok(())
+}
+
+/// KiCAD 10: `pcb export gencad --output <path> <input>`
+pub async fn export_gencad(cli: &str, pcb: &Path, output: &Path) -> Result<()> {
+    let args = [
+        "pcb",
+        "export",
+        "gencad",
+        "--output",
+        output.to_str().unwrap(),
+        pcb.to_str().unwrap(),
+    ];
+    run_cli(cli, &args, LONG_TIMEOUT).await?;
+    Ok(())
+}
+
+/// KiCAD 10: `pcb export ipc2581 --output <path> --units <mm|in> [--compress] <input>`
+pub async fn export_ipc2581(
+    cli: &str,
+    pcb: &Path,
+    output: &Path,
+    units: &str,
+    compress: bool,
+) -> Result<()> {
+    let output_str = output.to_str().unwrap();
+    let pcb_str = pcb.to_str().unwrap();
+
+    let mut args: Vec<&str> = vec![
+        "pcb", "export", "ipc2581", "--output", output_str, "--units", units,
+    ];
+    if compress {
+        args.push("--compress");
+    }
+    args.push(pcb_str);
+
+    run_cli(cli, &args, LONG_TIMEOUT).await?;
+    Ok(())
+}
+
+/// KiCAD 10: `pcb export odb --output <path> --units <mm|in> --compression <mode> <input>`
+/// Compression modes (verified against KiCAD 10.0): `zip`, `none`, `tgz`.
+pub async fn export_odb(
+    cli: &str,
+    pcb: &Path,
+    output: &Path,
+    units: &str,
+    compression: &str,
+) -> Result<()> {
+    let args = [
+        "pcb",
+        "export",
+        "odb",
+        "--output",
+        output.to_str().unwrap(),
+        "--units",
+        units,
+        "--compression",
+        compression,
         pcb.to_str().unwrap(),
     ];
     run_cli(cli, &args, LONG_TIMEOUT).await?;

--- a/crates/konnect-core/src/tools/pcb_export.rs
+++ b/crates/konnect-core/src/tools/pcb_export.rs
@@ -1,4 +1,5 @@
-//! `pcb_export` toolset — Gerber, PDF, SVG, 3D, BOM, netlist, position file, DRC, zone refill.
+//! `pcb_export` toolset — Gerber, PDF, SVG, 3D, BOM, netlist, position file, DRC,
+//! zone refill, and DXF/GenCAD/IPC-2581/ODB++ interchange formats.
 //!
 //! All operations delegate to `kicad-cli` via the `cli` module, except `refill_zones`
 //! which uses the KiCAD IPC API.
@@ -189,6 +190,72 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "output"]
             }),
             |args, ctx| async move { handle_export_position_file(args, ctx).await }
+        ),
+        tool!(
+            "export_dxf",
+            "Export the PCB to DXF using kicad-cli, one file per requested layer. \
+             Useful for mechanical CAD interchange (enclosures, panelization, laser cutting).",
+            json!({
+                "type": "object",
+                "properties": {
+                    "board": { "type": "string", "description": "Path to .kicad_pcb file" },
+                    "output_dir": { "type": "string", "description": "Directory to write DXF files into (one per layer)" },
+                    "layers": {
+                        "type": "array",
+                        "description": "Layer names to export, e.g. ['Edge.Cuts', 'F.Cu']",
+                        "items": { "type": "string" }
+                    }
+                },
+                "required": ["board", "output_dir", "layers"]
+            }),
+            |args, ctx| async move { handle_export_dxf(args, ctx).await }
+        ),
+        tool!(
+            "export_gencad",
+            "Export the PCB in GenCAD format using kicad-cli. GenCAD is accepted by some \
+             CAM and test-fixture tooling as an alternative to a raw Gerber bundle.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "board": { "type": "string", "description": "Path to .kicad_pcb file" },
+                    "output": { "type": "string", "description": "Output .cad file path" }
+                },
+                "required": ["board", "output"]
+            }),
+            |args, ctx| async move { handle_export_gencad(args, ctx).await }
+        ),
+        tool!(
+            "export_ipc2581",
+            "Export the PCB in IPC-2581 format using kicad-cli. IPC-2581 is a unified \
+             fabrication/assembly/test data format accepted by many contract manufacturers \
+             as an alternative to a Gerber + drill + BOM + pick-and-place bundle.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "board": { "type": "string", "description": "Path to .kicad_pcb file" },
+                    "output": { "type": "string", "description": "Output file path (.xml)" },
+                    "units": { "type": "string", "description": "Output units: 'mm' (default) or 'in'", "default": "mm" },
+                    "compress": { "type": "boolean", "description": "Compress the output into a zip archive", "default": false }
+                },
+                "required": ["board", "output"]
+            }),
+            |args, ctx| async move { handle_export_ipc2581(args, ctx).await }
+        ),
+        tool!(
+            "export_odb",
+            "Export the PCB in ODB++ format using kicad-cli. ODB++ is a unified fabrication \
+             data format accepted by many fab houses as an alternative to a Gerber + drill bundle.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "board": { "type": "string", "description": "Path to .kicad_pcb file" },
+                    "output": { "type": "string", "description": "Output file path" },
+                    "units": { "type": "string", "description": "Output units: 'mm' (default) or 'in'", "default": "mm" },
+                    "compression": { "type": "string", "description": "Compression mode: 'zip' (default), 'none', or 'tgz'", "default": "zip" }
+                },
+                "required": ["board", "output"]
+            }),
+            |args, ctx| async move { handle_export_odb(args, ctx).await }
         ),
         tool!(
             "refill_zones",
@@ -421,6 +488,110 @@ async fn handle_export_position_file(
     ))
 }
 
+async fn handle_export_dxf(
+    args: &serde_json::Value,
+    ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let board = get_path(args, "board")?;
+    let output_dir = get_path(args, "output_dir")?;
+    let layers: Vec<String> = args["layers"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    let layer_refs: Vec<&str> = layers.iter().map(|s| s.as_str()).collect();
+
+    tokio::fs::create_dir_all(&output_dir).await?;
+
+    let cli = &ctx.config.kicad_cli;
+    cli::export_dxf(cli, &board, &output_dir, &layer_refs).await?;
+
+    let mut files = Vec::new();
+    if let Ok(mut rd) = tokio::fs::read_dir(&output_dir).await {
+        while let Ok(Some(entry)) = rd.next_entry().await {
+            files.push(entry.file_name().to_string_lossy().to_string());
+        }
+    }
+    files.sort();
+
+    Ok(CallToolResult::text(
+        serde_json::to_string_pretty(&json!({
+            "success": true,
+            "output_dir": output_dir.to_str().unwrap_or(""),
+            "files": files
+        }))
+        .unwrap(),
+    ))
+}
+
+async fn handle_export_gencad(
+    args: &serde_json::Value,
+    ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let board = get_path(args, "board")?;
+    let output = get_path(args, "output")?;
+
+    let cli = &ctx.config.kicad_cli;
+    cli::export_gencad(cli, &board, &output).await?;
+
+    Ok(CallToolResult::text(
+        serde_json::to_string_pretty(&json!({
+            "success": true,
+            "output": output.to_str().unwrap_or("")
+        }))
+        .unwrap(),
+    ))
+}
+
+async fn handle_export_ipc2581(
+    args: &serde_json::Value,
+    ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let board = get_path(args, "board")?;
+    let output = get_path(args, "output")?;
+    let units = args["units"].as_str().unwrap_or("mm");
+    let compress = args["compress"].as_bool().unwrap_or(false);
+
+    let cli = &ctx.config.kicad_cli;
+    cli::export_ipc2581(cli, &board, &output, units, compress).await?;
+
+    Ok(CallToolResult::text(
+        serde_json::to_string_pretty(&json!({
+            "success": true,
+            "units": units,
+            "compressed": compress,
+            "output": output.to_str().unwrap_or("")
+        }))
+        .unwrap(),
+    ))
+}
+
+async fn handle_export_odb(
+    args: &serde_json::Value,
+    ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let board = get_path(args, "board")?;
+    let output = get_path(args, "output")?;
+    let units = args["units"].as_str().unwrap_or("mm");
+    let compression = args["compression"].as_str().unwrap_or("zip");
+
+    let cli = &ctx.config.kicad_cli;
+    cli::export_odb(cli, &board, &output, units, compression).await?;
+
+    Ok(CallToolResult::text(
+        serde_json::to_string_pretty(&json!({
+            "success": true,
+            "units": units,
+            "compression": compression,
+            "output": output.to_str().unwrap_or("")
+        }))
+        .unwrap(),
+    ))
+}
+
 async fn handle_refill_zones(
     args: &serde_json::Value,
     ctx: &ToolContext,
@@ -501,4 +672,113 @@ async fn handle_get_drc_violations(
     Ok(CallToolResult::text(
         serde_json::to_string_pretty(&summary).unwrap(),
     ))
+}
+
+#[cfg(test)]
+mod new_export_format_tests {
+    //! Tests for `export_dxf`/`export_gencad`/`export_ipc2581`/`export_odb`.
+    //!
+    //! These handlers shell out to `kicad-cli`, which isn't available in CI
+    //! (see ROADMAP.md's "mocked IPC endpoint" item — no kicad-cli mock exists
+    //! yet either), so we can only test what's reachable without it:
+    //! argument validation (missing required args fail before ever touching
+    //! `kicad-cli`) and that a missing/unconfigured `kicad-cli` binary produces
+    //! a clean error instead of a panic.
+
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::ServerConfig;
+    use std::sync::Arc;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    #[tokio::test]
+    async fn export_dxf_missing_board_returns_error() {
+        let ctx = test_ctx();
+        let args = json!({ "output_dir": "out", "layers": ["Edge.Cuts"] });
+        assert!(handle_export_dxf(&args, &ctx).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn export_dxf_fails_gracefully_without_kicad_cli() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ctx = test_ctx();
+        let args = json!({
+            "board": dir.path().join("board.kicad_pcb").to_str().unwrap(),
+            "output_dir": dir.path().join("out").to_str().unwrap(),
+            "layers": ["Edge.Cuts", "F.Cu"]
+        });
+        // kicad_cli is "" in test_ctx, so spawning must fail — but as a
+        // returned error, not a panic.
+        assert!(handle_export_dxf(&args, &ctx).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn export_gencad_missing_output_returns_error() {
+        let ctx = test_ctx();
+        let args = json!({ "board": "board.kicad_pcb" });
+        assert!(handle_export_gencad(&args, &ctx).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn export_gencad_fails_gracefully_without_kicad_cli() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ctx = test_ctx();
+        let args = json!({
+            "board": dir.path().join("board.kicad_pcb").to_str().unwrap(),
+            "output": dir.path().join("board.cad").to_str().unwrap()
+        });
+        assert!(handle_export_gencad(&args, &ctx).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn export_ipc2581_missing_board_returns_error() {
+        let ctx = test_ctx();
+        let args = json!({ "output": "board.xml" });
+        assert!(handle_export_ipc2581(&args, &ctx).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn export_ipc2581_fails_gracefully_without_kicad_cli() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ctx = test_ctx();
+        let args = json!({
+            "board": dir.path().join("board.kicad_pcb").to_str().unwrap(),
+            "output": dir.path().join("board.xml").to_str().unwrap(),
+            "units": "mm",
+            "compress": true
+        });
+        assert!(handle_export_ipc2581(&args, &ctx).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn export_odb_missing_output_returns_error() {
+        let ctx = test_ctx();
+        let args = json!({ "board": "board.kicad_pcb" });
+        assert!(handle_export_odb(&args, &ctx).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn export_odb_fails_gracefully_without_kicad_cli() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ctx = test_ctx();
+        let args = json!({
+            "board": dir.path().join("board.kicad_pcb").to_str().unwrap(),
+            "output": dir.path().join("board_odb.zip").to_str().unwrap(),
+            "units": "mm",
+            "compression": "zip"
+        });
+        assert!(handle_export_odb(&args, &ctx).await.is_err());
+    }
 }

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -10,7 +10,7 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 ## Overview
 
 - **17 toolsets** organized into 10 categories
-- **171 registered tools** + **6 always-visible meta-tools** = **177 total**
+- **175 registered tools** + **6 always-visible meta-tools** = **181 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -217,8 +217,8 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `assign_net_to_class` | Assign a net to an existing netclass in the PCB file (S-expression edit). |
 | `route_differential_pair` | Route a differential pair (two parallel traces with a specified gap). |
 
-### `pcb_export` · 9 tools
-**Purpose:** Gerber, PDF, SVG, 3D model, BOM, pick-and-place, DRC.
+### `pcb_export` · 13 tools
+**Purpose:** Gerber, PDF, SVG, 3D model, BOM, pick-and-place, DRC, DXF/GenCAD/IPC-2581/ODB++.
 **Source:** [`crates/konnect-core/src/tools/pcb_export.rs`](crates/konnect-core/src/tools/pcb_export.rs)
 
 | Tool | Description |
@@ -230,6 +230,10 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `export_bom` | Generate a Bill of Materials (BOM) CSV from the schematic's component data. |
 | `export_netlist` | Export the PCB netlist in KiCAD or IPC-D-356 format. |
 | `export_position_file` | Generate a component placement (pick-and-place) position file for SMT assembly. |
+| `export_dxf` | Export the PCB to DXF, one file per layer, using kicad-cli. For mechanical CAD interchange. |
+| `export_gencad` | Export the PCB in GenCAD format using kicad-cli. |
+| `export_ipc2581` | Export the PCB in IPC-2581 format using kicad-cli — a unified fab/assembly/test data format. |
+| `export_odb` | Export the PCB in ODB++ format using kicad-cli — a unified fabrication data format. |
 | `refill_zones` | Refill all copper pour zones using kicad-cli (`zone-fill`). |
 | `get_drc_violations` | Run the Design Rule Check and return a list of violations. |
 


### PR DESCRIPTION
## Summary
- Add four new export tools to the `pcb_export` toolset: `export_dxf`, `export_gencad`, `export_ipc2581`, `export_odb` — closing the roadmap's "Additional export formats" item.
- All four are thin wrappers around native `kicad-cli` subcommands (`pcb export dxf/gencad/ipc2581/odb`), following the same pattern already used by the existing Gerber/PDF/SVG/3D export tools in this file.
- `pcb_export` grows from 9 to 13 tools; workspace total from 171 to 175. `tool_count` in `registry.rs`, `tool-directory.md`, and `DEV.md`'s stats section are updated to match. `ROADMAP.md`'s "Additional export formats" item is moved to Done.

## Motivation
DXF (mechanical CAD interchange), GenCAD (CAM/test-fixture tooling), IPC-2581, and ODB++ (unified fab-data formats accepted by many contract manufacturers as Gerber-bundle alternatives) were explicitly listed on the roadmap and were already fully supported by `kicad-cli` itself — Konnect just didn't expose them yet.

## Implementation
- `crates/konnect-core/src/tools/cli.rs`: added `export_dxf`, `export_gencad`, `export_ipc2581`, `export_odb`, each shelling out to the corresponding `kicad-cli pcb export <format>` subcommand. Flags/behavior were verified directly against a real `kicad-cli.exe` (KiCAD 10.0) rather than assumed from `--help` text alone — this caught that DXF's `--layers` flag takes a single comma-separated value (unlike PDF/SVG's repeatable `--layers` flag), and confirmed ODB++'s valid `--compression` values (`zip`, `none`, `tgz`).
- `crates/konnect-core/src/tools/pcb_export.rs`: added the four corresponding `tool!()` definitions and handlers, following the existing file's conventions (structured JSON success responses, `get_path` for required path args).

## Test plan
- [x] `cargo test --workspace --lib --tests` — 99/99 passed (91 existing + 8 new)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] The 8 new unit tests cover what's testable without `kicad-cli` present (CI doesn't have it installed, matching this file's existing convention of no `cli.rs` tests): missing-required-argument validation, and graceful error handling (not a panic) when `kicad-cli` is unavailable/misconfigured.
- [x] **Real-world verification**: ran all four new tools end-to-end against an actual multi-component board (not a synthetic fixture) via a real `kicad-cli.exe` (KiCAD 10.0) — all four succeeded and produced valid output files.
- [x] **Manual physical check**: opened the generated `Edge.Cuts` DXF in FreeCAD and confirmed the board outline geometry matches the source board correctly.
