### PR TITLE
feat(integration): cache repeated JLCPCB parts-database queries

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,6 @@ Opening an issue is the best way to influence priority.
 
 ## Infrastructure
 
-- **Retry/backoff for external services** (JLCPCB catalog, datasheet fetches).
 - **Component search caching** for repeated queries against the local parts DB.
 - **Deeper end-to-end tests** — tool-handler tests against a mocked IPC endpoint.
 
@@ -40,3 +39,7 @@ Opening an issue is the best way to influence priority.
   available via `export_ipc2581`, `export_odb`, `export_gencad`, and
   `export_dxf` in the `pcb_export` toolset (all backed by native `kicad-cli`
   subcommands, verified against KiCAD 10.0).
+- ~~Retry/backoff for external services~~ — the JLCPCB database download and
+  both LCSC datasheet lookups now retry transient failures (network errors,
+  429, 5xx) with exponential backoff via `get_with_backoff` in
+  `crates/konnect-core/src/tools/integration.rs`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,6 @@ Opening an issue is the best way to influence priority.
 
 ## Infrastructure
 
-- **Component search caching** for repeated queries against the local parts DB.
 - **Deeper end-to-end tests** — tool-handler tests against a mocked IPC endpoint.
 
 ## Done
@@ -43,3 +42,6 @@ Opening an issue is the best way to influence priority.
   both LCSC datasheet lookups now retry transient failures (network errors,
   429, 5xx) with exponential backoff via `get_with_backoff` in
   `crates/konnect-core/src/tools/integration.rs`.
+- ~~Component search caching~~ — `search_jlcpcb_parts`, `get_jlcpcb_part`, and
+  `suggest_jlcpcb_alternatives` now cache results for 5 minutes via a shared
+  `QueryCache` on `ToolContext`; responses carry a `"cached"` field.

--- a/crates/konnect-core/src/tools/integration.rs
+++ b/crates/konnect-core/src/tools/integration.rs
@@ -3,6 +3,10 @@
 //! JLCPCB tools query a local SQLite cache of the JLCPCB parts database.
 //! Freerouting wraps the Freerouting JAR via subprocess.
 //! Datasheet enrichment uses the LCSC HTTP API.
+//!
+//! The three network calls (JLCPCB database download, LCSC datasheet lookups)
+//! go through `get_with_backoff`, which retries transient failures (network
+//! errors, 429, 5xx) with exponential backoff before giving up.
 
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
@@ -161,6 +165,70 @@ fn resolve_db_path(args: &serde_json::Value, ctx: &ToolContext) -> PathBuf {
     default_jlcpcb_db_path()
 }
 
+// ─── Retry/backoff for external HTTP calls ────────────────────────────────────
+//
+// JLCPCB database download and LCSC datasheet lookups are the only genuinely
+// networked calls in this toolset (everything else queries the local SQLite
+// cache). Both are prone to transient failures — timeouts, connection resets,
+// rate limiting — that a simple retry clears up without any user action.
+
+/// Retry policy: 3 attempts total, exponential backoff starting at 300ms
+/// (300ms, then 600ms between attempts).
+const RETRY_MAX_ATTEMPTS: u32 = 3;
+const RETRY_BASE_DELAY: std::time::Duration = std::time::Duration::from_millis(300);
+
+/// Whether an HTTP status is worth retrying. 429 (rate limited) and 5xx
+/// (server-side) are transient; other 4xx (404, 401, ...) are not — retrying
+/// a "not found" or "unauthorized" wastes time and won't change the outcome.
+fn is_transient_status(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
+}
+
+/// Delay before the next attempt, given the attempt number just made (1-based).
+fn backoff_delay(attempt: u32) -> std::time::Duration {
+    RETRY_BASE_DELAY * 2u32.pow(attempt.saturating_sub(1))
+}
+
+/// GET `url` with retry/backoff for transient failures (network-level errors,
+/// 429, and 5xx). Returns the last response/error once attempts are exhausted.
+async fn get_with_backoff(
+    client: &reqwest::Client,
+    url: &str,
+) -> anyhow::Result<reqwest::Response> {
+    let mut attempt = 0u32;
+    loop {
+        attempt += 1;
+        match client.get(url).send().await {
+            Ok(resp) => {
+                let status = resp.status();
+                if !is_transient_status(status) || attempt >= RETRY_MAX_ATTEMPTS {
+                    return Ok(resp);
+                }
+                tracing::warn!(
+                    "[BETA] {} returned {} (attempt {}/{}), retrying",
+                    url,
+                    status,
+                    attempt,
+                    RETRY_MAX_ATTEMPTS
+                );
+            }
+            Err(e) => {
+                if attempt >= RETRY_MAX_ATTEMPTS {
+                    return Err(e.into());
+                }
+                tracing::warn!(
+                    "[BETA] request to {} failed (attempt {}/{}): {}, retrying",
+                    url,
+                    attempt,
+                    RETRY_MAX_ATTEMPTS,
+                    e
+                );
+            }
+        }
+        tokio::time::sleep(backoff_delay(attempt)).await;
+    }
+}
+
 // ─── Handlers ─────────────────────────────────────────────────────────────────
 
 async fn handle_download_jlcpcb(
@@ -195,7 +263,7 @@ async fn handle_download_jlcpcb(
         .timeout(std::time::Duration::from_secs(300))
         .build()?;
 
-    let resp = client.get(url).send().await?;
+    let resp = get_with_backoff(&client, url).await?;
     if !resp.status().is_success() {
         return Ok(CallToolResult::error(format!(
             "Download failed: HTTP {}",
@@ -471,7 +539,7 @@ async fn handle_enrich_datasheets(
             "https://wmsc.lcsc.com/ftps/wm/product/detail?productCode={}",
             lcsc_id
         );
-        if let Ok(resp) = client.get(&url).send().await {
+        if let Ok(resp) = get_with_backoff(&client, &url).await {
             if resp.status().is_success() {
                 if let Ok(json_resp) = resp.json::<serde_json::Value>().await {
                     if let Some(datasheet_url) = json_resp
@@ -553,7 +621,7 @@ async fn handle_get_datasheet_url(
             "https://wmsc.lcsc.com/ftps/wm/product/detail?productCode={}",
             id
         );
-        if let Ok(resp) = client.get(&url).send().await {
+        if let Ok(resp) = get_with_backoff(&client, &url).await {
             if resp.status().is_success() {
                 if let Ok(json_resp) = resp.json::<serde_json::Value>().await {
                     if let Some(ds_url) = json_resp
@@ -658,5 +726,131 @@ async fn handle_check_freerouting(
                 .unwrap(),
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod retry_backoff_tests {
+    use super::*;
+
+    /// End-to-end check against a real (hand-rolled) flaky HTTP server: two
+    /// 503s followed by a 200 should be retried through to success, with
+    /// real backoff delays elapsed in between — not just the status-code
+    /// decision logic in isolation.
+    #[tokio::test]
+    async fn get_with_backoff_recovers_after_transient_failures() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            for resp in [
+                "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n",
+                "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n",
+                "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+            ] {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut buf = [0u8; 1024];
+                let _ = socket.read(&mut buf).await;
+                socket.write_all(resp.as_bytes()).await.unwrap();
+            }
+        });
+
+        let client = reqwest::Client::new();
+        let url = format!("http://{}/x", addr);
+
+        let start = std::time::Instant::now();
+        let resp = get_with_backoff(&client, &url).await.unwrap();
+        let elapsed = start.elapsed();
+
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        // Two retries at 300ms + 600ms = 900ms minimum before the 3rd (successful) attempt.
+        assert!(
+            elapsed >= std::time::Duration::from_millis(900),
+            "expected backoff delays to have elapsed, got {:?}",
+            elapsed
+        );
+    }
+
+    /// A persistent (non-transient) failure should return immediately after
+    /// the first attempt — no wasted retries on a 404.
+    #[tokio::test]
+    async fn get_with_backoff_does_not_retry_client_errors() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 1024];
+            let _ = socket.read(&mut buf).await;
+            socket
+                .write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
+                .await
+                .unwrap();
+            // If get_with_backoff retried, it would try to accept() again here
+            // and this task would hang until the test times out.
+        });
+
+        let client = reqwest::Client::new();
+        let url = format!("http://{}/x", addr);
+
+        let start = std::time::Instant::now();
+        let resp = get_with_backoff(&client, &url).await.unwrap();
+        let elapsed = start.elapsed();
+
+        assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+        assert!(
+            elapsed < std::time::Duration::from_millis(200),
+            "expected no retry delay for a 404, took {:?}",
+            elapsed
+        );
+    }
+
+    #[test]
+    fn transient_on_rate_limit_and_server_errors() {
+        assert!(is_transient_status(reqwest::StatusCode::TOO_MANY_REQUESTS));
+        assert!(is_transient_status(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        ));
+        assert!(is_transient_status(reqwest::StatusCode::BAD_GATEWAY));
+        assert!(is_transient_status(
+            reqwest::StatusCode::SERVICE_UNAVAILABLE
+        ));
+        assert!(is_transient_status(reqwest::StatusCode::GATEWAY_TIMEOUT));
+    }
+
+    #[test]
+    fn not_transient_on_client_errors() {
+        // Retrying a 404/401/403/400 wastes time — the request itself is
+        // wrong, not the server having a bad moment.
+        assert!(!is_transient_status(reqwest::StatusCode::BAD_REQUEST));
+        assert!(!is_transient_status(reqwest::StatusCode::UNAUTHORIZED));
+        assert!(!is_transient_status(reqwest::StatusCode::FORBIDDEN));
+        assert!(!is_transient_status(reqwest::StatusCode::NOT_FOUND));
+    }
+
+    #[test]
+    fn not_transient_on_success() {
+        assert!(!is_transient_status(reqwest::StatusCode::OK));
+        assert!(!is_transient_status(reqwest::StatusCode::NO_CONTENT));
+    }
+
+    #[test]
+    fn backoff_delay_doubles_each_attempt() {
+        assert_eq!(backoff_delay(1), std::time::Duration::from_millis(300));
+        assert_eq!(backoff_delay(2), std::time::Duration::from_millis(600));
+        assert_eq!(backoff_delay(3), std::time::Duration::from_millis(1200));
+    }
+
+    #[test]
+    fn backoff_delay_never_panics_on_zero_attempt() {
+        // attempt is 1-based in normal use, but the saturating_sub guards
+        // against an accidental 0 causing an underflow panic.
+        assert_eq!(backoff_delay(0), std::time::Duration::from_millis(300));
     }
 }

--- a/crates/konnect-core/src/tools/integration.rs
+++ b/crates/konnect-core/src/tools/integration.rs
@@ -7,6 +7,12 @@
 //! The three network calls (JLCPCB database download, LCSC datasheet lookups)
 //! go through `get_with_backoff`, which retries transient failures (network
 //! errors, 429, 5xx) with exponential backoff before giving up.
+//!
+//! The three JLCPCB query tools (`search_jlcpcb_parts`, `get_jlcpcb_part`,
+//! `suggest_jlcpcb_alternatives`) cache results in `ToolContext::jlcpcb_cache`
+//! (5-minute TTL) to avoid re-running an identical SQLite query for repeated
+//! lookups within a session. Responses carry a `"cached"` field so callers
+//! can see whether a given result came from cache.
 
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
@@ -283,6 +289,13 @@ async fn handle_download_jlcpcb(
     ))
 }
 
+/// Build a deterministic cache key from a tool name, the resolved DB path
+/// (so pointing at a different `output_path` never serves stale results),
+/// and the query parameters that affect the result set.
+fn cache_key(tool: &str, db_path: &std::path::Path, parts: &[&str]) -> String {
+    format!("{}|{}|{}", tool, db_path.display(), parts.join("|"))
+}
+
 async fn handle_search_jlcpcb_parts(
     args: &serde_json::Value,
     ctx: &ToolContext,
@@ -299,6 +312,25 @@ async fn handle_search_jlcpcb_parts(
     let in_stock = args["in_stock"].as_bool().unwrap_or(true);
     let limit = args["limit"].as_u64().unwrap_or(20) as usize;
     let category = args["category"].as_str().map(String::from);
+
+    let key = cache_key(
+        "search_jlcpcb_parts",
+        &db_path,
+        &[
+            &query,
+            category.as_deref().unwrap_or(""),
+            &basic_only.to_string(),
+            &in_stock.to_string(),
+            &limit.to_string(),
+        ],
+    );
+    if let Some(cached) = ctx.jlcpcb_cache.get(&key) {
+        let mut body = cached;
+        body["cached"] = json!(true);
+        return Ok(CallToolResult::text(
+            serde_json::to_string_pretty(&body).unwrap(),
+        ));
+    }
 
     let results = tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<serde_json::Value>> {
         let conn = rusqlite::Connection::open(&db_path)?;
@@ -337,13 +369,17 @@ async fn handle_search_jlcpcb_parts(
     })
     .await??;
 
+    let body = json!({
+        "query": args["query"].as_str().unwrap_or(""),
+        "count": results.len(),
+        "results": results
+    });
+    ctx.jlcpcb_cache.put(key, body.clone());
+
+    let mut body = body;
+    body["cached"] = json!(false);
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
-            "query": args["query"].as_str().unwrap_or(""),
-            "count": results.len(),
-            "results": results
-        }))
-        .unwrap(),
+        serde_json::to_string_pretty(&body).unwrap(),
     ))
 }
 
@@ -374,6 +410,14 @@ async fn handle_get_jlcpcb_part(
         .map_err(|e| anyhow::anyhow!("{:?}", e))?
         .to_string();
 
+    let key = cache_key("get_jlcpcb_part", &db_path, &[&lcsc_id]);
+    if let Some(mut cached) = ctx.jlcpcb_cache.get(&key) {
+        cached["cached"] = json!(true);
+        return Ok(CallToolResult::text(
+            serde_json::to_string_pretty(&cached).unwrap(),
+        ));
+    }
+
     let result =
         tokio::task::spawn_blocking(move || -> anyhow::Result<Option<serde_json::Value>> {
             let conn = rusqlite::Connection::open(&db_path)?;
@@ -387,9 +431,14 @@ async fn handle_get_jlcpcb_part(
         .await??;
 
     match result {
-        Some(part) => Ok(CallToolResult::text(
-            serde_json::to_string_pretty(&part).unwrap(),
-        )),
+        Some(part) => {
+            ctx.jlcpcb_cache.put(key, part.clone());
+            let mut part = part;
+            part["cached"] = json!(false);
+            Ok(CallToolResult::text(
+                serde_json::to_string_pretty(&part).unwrap(),
+            ))
+        }
         None => Ok(CallToolResult::error(format!(
             "Part not found in database: {}",
             args["lcsc_id"].as_str().unwrap_or("")
@@ -422,6 +471,24 @@ async fn handle_suggest_alternatives(
         .unwrap_or("")
         .to_string();
 
+    let key = cache_key(
+        "suggest_jlcpcb_alternatives",
+        &db_path,
+        &[
+            &value,
+            &footprint,
+            &max_price.map(|v| v.to_string()).unwrap_or_default(),
+            &limit.to_string(),
+        ],
+    );
+    if let Some(cached) = ctx.jlcpcb_cache.get(&key) {
+        let mut body = cached;
+        body["cached"] = json!(true);
+        return Ok(CallToolResult::text(
+            serde_json::to_string_pretty(&body).unwrap(),
+        ));
+    }
+
     let results = tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<serde_json::Value>> {
         let conn = rusqlite::Connection::open(&db_path)?;
         let like_val = format!("%{}%", value);
@@ -445,13 +512,17 @@ async fn handle_suggest_alternatives(
     })
     .await??;
 
+    let body = json!({
+        "value": args["value"].as_str().unwrap_or(""),
+        "footprint": args["footprint"].as_str().unwrap_or(""),
+        "alternatives": results
+    });
+    ctx.jlcpcb_cache.put(key, body.clone());
+
+    let mut body = body;
+    body["cached"] = json!(false);
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
-            "value": args["value"].as_str().unwrap_or(""),
-            "footprint": args["footprint"].as_str().unwrap_or(""),
-            "alternatives": results
-        }))
-        .unwrap(),
+        serde_json::to_string_pretty(&body).unwrap(),
     ))
 }
 
@@ -852,5 +923,132 @@ mod retry_backoff_tests {
         // attempt is 1-based in normal use, but the saturating_sub guards
         // against an accidental 0 causing an underflow panic.
         assert_eq!(backoff_delay(0), std::time::Duration::from_millis(300));
+    }
+}
+
+#[cfg(test)]
+mod jlcpcb_cache_tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::ServerConfig;
+    use std::sync::Arc;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    /// Builds a temp SQLite file with a `components` table matching the
+    /// schema the handlers query, seeded with one part.
+    fn seed_test_db() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("jlcpcb.db");
+        let conn = rusqlite::Connection::open(&db_path).expect("open db");
+        conn.execute(
+            "CREATE TABLE components (
+                LCSC TEXT, MFR_Part TEXT, Package TEXT, Manufacturer TEXT,
+                Library_Type TEXT, Description TEXT, Price REAL, Stock INTEGER
+            )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO components VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            rusqlite::params![
+                "C14663",
+                "RC0402FR-0710KL",
+                "0402",
+                "YAGEO",
+                "Basic",
+                "10k resistor 0402",
+                0.01,
+                5000
+            ],
+        )
+        .unwrap();
+        (dir, db_path)
+    }
+
+    #[tokio::test]
+    async fn search_jlcpcb_parts_caches_repeated_query() {
+        let (_dir, db_path) = seed_test_db();
+        let ctx = test_ctx();
+        let args = json!({
+            "query": "10k",
+            "output_path": db_path.to_str().unwrap()
+        });
+
+        let first = handle_search_jlcpcb_parts(&args, &ctx).await.unwrap();
+        let second = handle_search_jlcpcb_parts(&args, &ctx).await.unwrap();
+
+        let first_body = response_json(&first);
+        let second_body = response_json(&second);
+        assert_eq!(first_body["cached"], json!(false));
+        assert_eq!(second_body["cached"], json!(true));
+        assert_eq!(first_body["results"], second_body["results"]);
+        assert_eq!(first_body["count"], json!(1));
+    }
+
+    #[tokio::test]
+    async fn search_jlcpcb_parts_different_query_is_a_cache_miss() {
+        let (_dir, db_path) = seed_test_db();
+        let ctx = test_ctx();
+
+        let args_a = json!({ "query": "10k", "output_path": db_path.to_str().unwrap() });
+        let args_b = json!({ "query": "100nF", "output_path": db_path.to_str().unwrap() });
+
+        handle_search_jlcpcb_parts(&args_a, &ctx).await.unwrap();
+        let second = handle_search_jlcpcb_parts(&args_b, &ctx).await.unwrap();
+
+        assert_eq!(response_json(&second)["cached"], json!(false));
+    }
+
+    #[tokio::test]
+    async fn get_jlcpcb_part_caches_repeated_lookup() {
+        let (_dir, db_path) = seed_test_db();
+        let ctx = test_ctx();
+        let args = json!({
+            "lcsc_id": "C14663",
+            "output_path": db_path.to_str().unwrap()
+        });
+
+        let first = handle_get_jlcpcb_part(&args, &ctx).await.unwrap();
+        let second = handle_get_jlcpcb_part(&args, &ctx).await.unwrap();
+
+        assert_eq!(response_json(&first)["cached"], json!(false));
+        assert_eq!(response_json(&second)["cached"], json!(true));
+        assert_eq!(response_json(&first)["lcsc"], json!("C14663"));
+    }
+
+    #[tokio::test]
+    async fn suggest_alternatives_caches_repeated_query() {
+        let (_dir, db_path) = seed_test_db();
+        let ctx = test_ctx();
+        let args = json!({
+            "value": "10k",
+            "footprint": "Resistor_SMD:R_0402",
+            "output_path": db_path.to_str().unwrap()
+        });
+
+        let first = handle_suggest_alternatives(&args, &ctx).await.unwrap();
+        let second = handle_suggest_alternatives(&args, &ctx).await.unwrap();
+
+        assert_eq!(response_json(&first)["cached"], json!(false));
+        assert_eq!(response_json(&second)["cached"], json!(true));
+    }
+
+    fn response_json(result: &CallToolResult) -> serde_json::Value {
+        match &result.content[0] {
+            crate::mcp::protocol::ToolContent::Text { text } => serde_json::from_str(text).unwrap(),
+            _ => panic!("expected text content"),
+        }
     }
 }

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -79,6 +79,8 @@ pub struct ToolContext {
     pub config: ServerConfig,
     pub router: Arc<ToolRouter>,
     pub observer: crate::observability::CallObserver,
+    /// In-memory TTL cache for repeated JLCPCB parts-database queries.
+    pub jlcpcb_cache: QueryCache,
 }
 
 impl ToolContext {
@@ -89,6 +91,7 @@ impl ToolContext {
             config,
             router,
             observer: crate::observability::CallObserver::new(None),
+            jlcpcb_cache: QueryCache::default(),
         }
     }
 
@@ -103,7 +106,54 @@ impl ToolContext {
             config,
             router,
             observer,
+            jlcpcb_cache: QueryCache::default(),
         }
+    }
+}
+
+// ─── QueryCache ───────────────────────────────────────────────────────────────
+
+/// A small in-memory, TTL-based cache for repeated read-only query results
+/// (JSON values keyed by a caller-constructed string). One instance lives on
+/// `ToolContext` for the life of the server, shared across all tool calls.
+pub struct QueryCache {
+    ttl: std::time::Duration,
+    entries: std::sync::Mutex<std::collections::HashMap<String, (Value, std::time::Instant)>>,
+}
+
+impl QueryCache {
+    pub fn new(ttl: std::time::Duration) -> Self {
+        QueryCache {
+            ttl,
+            entries: std::sync::Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+
+    /// Returns a cached value for `key` if present and not yet expired.
+    pub fn get(&self, key: &str) -> Option<Value> {
+        let entries = self.entries.lock().unwrap();
+        entries.get(key).and_then(|(value, inserted_at)| {
+            if inserted_at.elapsed() < self.ttl {
+                Some(value.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Stores `value` under `key`, overwriting any existing (possibly expired) entry.
+    pub fn put(&self, key: String, value: Value) {
+        let mut entries = self.entries.lock().unwrap();
+        entries.insert(key, (value, std::time::Instant::now()));
+    }
+}
+
+impl Default for QueryCache {
+    /// 5-minute TTL — long enough to skip redundant re-queries within a single
+    /// design session, short enough that a `download_jlcpcb_database` refresh
+    /// is reflected without needing an explicit cache-invalidation hook.
+    fn default() -> Self {
+        QueryCache::new(std::time::Duration::from_secs(300))
     }
 }
 
@@ -118,6 +168,42 @@ pub struct ServerConfig {
     pub ipc_address: String,
     pub project_dir: Option<std::path::PathBuf>,
     pub jlcpcb_db_path: Option<std::path::PathBuf>,
+}
+
+#[cfg(test)]
+mod query_cache_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn miss_on_unknown_key() {
+        let cache = QueryCache::new(std::time::Duration::from_secs(60));
+        assert!(cache.get("nope").is_none());
+    }
+
+    #[test]
+    fn put_then_get_roundtrips() {
+        let cache = QueryCache::new(std::time::Duration::from_secs(60));
+        cache.put("key".to_string(), json!({ "count": 3 }));
+        assert_eq!(cache.get("key"), Some(json!({ "count": 3 })));
+    }
+
+    #[test]
+    fn entry_expires_after_ttl() {
+        let cache = QueryCache::new(std::time::Duration::from_millis(10));
+        cache.put("key".to_string(), json!("value"));
+        assert_eq!(cache.get("key"), Some(json!("value")));
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        assert!(cache.get("key").is_none());
+    }
+
+    #[test]
+    fn put_overwrites_existing_entry() {
+        let cache = QueryCache::new(std::time::Duration::from_secs(60));
+        cache.put("key".to_string(), json!("first"));
+        cache.put("key".to_string(), json!("second"));
+        assert_eq!(cache.get("key"), Some(json!("second")));
+    }
 }
 
 // ─── Helper macro for defining tools ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add an in-memory, TTL-based cache for repeated JLCPCB parts-database queries — closing the roadmap's "Component search caching" item.
- Applies to the three JLCPCB query tools: `search_jlcpcb_parts`, `get_jlcpcb_part`, `suggest_jlcpcb_alternatives`.

## Motivation
Each of these tools opens a fresh SQLite connection and re-runs its query on every call, even for an identical repeated request. An LLM working through a design will often re-check the same part or search multiple times in a session; caching avoids the redundant I/O for those repeats.

## Implementation
- Added `QueryCache` in `crates/konnect-core/src/tools/mod.rs` — a small `Mutex<HashMap<String, (Value, Instant)>>` with a 5-minute default TTL. Placed alongside `ToolContext`/`ServerConfig` as a generic, reusable utility rather than something JLCPCB-specific, in case other toolsets want the same pattern later.
- Added one field to `ToolContext`: `jlcpcb_cache: QueryCache`, initialized inside the existing `ToolContext::new`/`new_with_observer` constructors — no signature change, so no existing call sites (including test helpers across the codebase) needed updating.
- Added a `cache_key(tool, db_path, parts)` helper in `integration.rs` that builds a deterministic key from the tool name, the *resolved* database path (so pointing `output_path` at a different DB file never serves stale cross-database results), and the query parameters that affect the result set.
- Wired caching into all three handlers. Responses now include a `"cached": true|false` field so callers can see whether a given result came from cache.

## Test plan
- [x] `cargo test --workspace --lib --tests` — 114/114 passed (106 existing + 8 new)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] 4 unit tests on `QueryCache` directly: put/get roundtrip, miss on unknown key, TTL expiry (constructed with a short TTL and confirmed via `std::thread::sleep`), overwrite-on-put.
- [x] 4 handler-level tests build a real temporary SQLite database matching the actual `components` table schema, seed it with a sample part, and confirm: (a) an identical repeated query returns `cached: false` then `cached: true` with matching results for `search_jlcpcb_parts`, `get_jlcpcb_part`, and `suggest_jlcpcb_alternatives`; (b) a *different* search query is correctly treated as a cache miss.
