### PR TITLE
feat(pcb_board): add import_svg_logo tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +36,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +63,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -132,6 +156,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +217,30 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "diff"
@@ -258,6 +312,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +351,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +377,29 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a6f9af55fb97ad673fb7a69533eb2f967648a06fa21f8c9bb2cd6d33975716"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -699,6 +801,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +900,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "usvg",
  "uuid",
 ]
 
@@ -835,6 +944,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +971,12 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -921,6 +1047,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,6 +1066,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1003,6 +1148,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1099,6 +1253,12 @@ dependencies = [
  "fixedbitset",
  "indexmap",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
@@ -1330,6 +1490,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
 name = "rusqlite"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,6 +1560,24 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85d1ccd519e61834798eb52c4e886e8c2d7d698dd3d6ce0b1b47eb8557f1181"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "ryu"
@@ -1546,10 +1730,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -1574,10 +1788,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -1674,6 +1907,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,6 +1926,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1924,10 +2183,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64af057ad7466495ca113126be61838d8af947f41d93a949980b2389a118082f"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "260bc6647b3893a9a90668360803a15f96b85a5257b1c3a0c3daf6ae2496de42"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-xid"
@@ -1951,6 +2255,33 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+]
+
+[[package]]
+name = "usvg"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447e703d7223b067607655e625e0dbca80822880248937da65966194c4864e6"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -2418,6 +2749,12 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,9 @@ base64 = "0.22"
 # Platform directories (home dir, config dir)
 dirs = "5"
 
+# SVG parsing (import_svg_logo)
+usvg = "0.44"
+
 # Internal crates
 konnect-sexp = { path = "crates/konnect-sexp" }
 konnect-ipc = { path = "crates/konnect-ipc" }

--- a/DEV.md
+++ b/DEV.md
@@ -45,6 +45,7 @@ Konnect/
 │   │       └── tools/
 │   │           ├── mod.rs            # ToolDef, ToolContext, tool! macro, helpers, kicad_config_dir(), resolve_lib_symbol()
 │   │           ├── cli.rs            # kicad-cli v10 subprocess wrapper (verified against actual binary)
+│   │           ├── svg_import.rs     # SVG parsing + Bezier flattening for import_svg_logo (usvg-backed)
 │   │           ├── project.rs        # 6 tools (incl. open_schematic_viewer)
 │   │           ├── sch_components.rs # 17 tools (component placement with lib_symbols embedding)
 │   │           ├── sch_wiring.rs     # 19 tools (incl. connect_pins, power symbol embedding)
@@ -52,10 +53,10 @@ Konnect/
 │   │           ├── sch_batch.rs      # 10 tools (single-read/single-write atomic operations)
 │   │           ├── sch_export.rs     # 7 tools (SVG/PDF/netlist/ERC)
 │   │           ├── sch_hierarchy.rs  # 7 tools (typed Sheet model, add/edit/move/delete/duplicate + hierarchy/page queries)
-│   │           ├── pcb_board.rs      # 10 tools (S-expr file editing, IPC fallback)
+│   │           ├── pcb_board.rs      # 11 tools (S-expr file editing, IPC fallback, SVG logo import)
 │   │           ├── pcb_components.rs # 13 tools (IPC real-time via NNG+protobuf)
 │   │           ├── pcb_routing.rs    # 12 tools (traces, vias, nets, netclasses)
-│   │           ├── pcb_export.rs     # 9 tools (Gerber, PDF, 3D, DRC)
+│   │           ├── pcb_export.rs     # 13 tools (Gerber, PDF, 3D, DRC, DXF/GenCAD/IPC-2581/ODB++)
 │   │           ├── library.rs        # 14 tools (symbol/footprint library management)
 │   │           ├── integration.rs    # 11 tools (JLCPCB SQLite, Freerouting, datasheets)
 │   │           ├── verification.rs   # 8 tools (DRC, design rules, KiCAD UI)
@@ -222,9 +223,9 @@ Run all: `PROTOC=<path> cargo test --workspace --lib --tests`
 
 ## Current Stats
 
-- **18 toolsets, 182 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
+- **18 toolsets, 183 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
 - Baseline `tools/list`: ~19 tools / ~2K tokens (starter kit + meta-tools)
-- Full-catalog `tools/list` (all loaded): ~188 tools / ~24K tokens
+- Full-catalog `tools/list` (all loaded): ~189 tools / ~24K tokens
 - **0 IPC stubs** (all protobuf methods implemented)
 - **0 unimplemented tools**
 - **3 CLI commands removed in KiCAD v10** (specctra DSN/SES, pcb sync — return clear errors)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,8 +14,6 @@ Opening an issue is the best way to influence priority.
 
 ## Tools
 
-- **`import_svg_logo`** — import an SVG file as silkscreen / copper artwork
-  (path parsing + polygon tessellation, placed via the IPC API).
 - **Hierarchical sheets** — create and manage multi-sheet schematics
   (hierarchical sheets, sheet pins, cross-sheet nets).
 - **Symbol & footprint creation** — author new library parts from scratch, not
@@ -45,3 +43,8 @@ Opening an issue is the best way to influence priority.
 - ~~Component search caching~~ — `search_jlcpcb_parts`, `get_jlcpcb_part`, and
   `suggest_jlcpcb_alternatives` now cache results for 5 minutes via a shared
   `QueryCache` on `ToolContext`; responses carry a `"cached"` field.
+- ~~`import_svg_logo`~~ — import an SVG file as filled silkscreen/copper
+  artwork via the new `import_svg_logo` tool in the `pcb_board` toolset.
+  Curved paths (quadratic/cubic Bezier) are flattened into polygon outlines
+  since KiCAD's board format doesn't support curves in filled shapes. Tries
+  the IPC API first, falls back to a direct file edit if KiCAD isn't running.

--- a/crates/konnect-core/Cargo.toml
+++ b/crates/konnect-core/Cargo.toml
@@ -22,6 +22,7 @@ uuid.workspace = true
 base64.workspace = true
 reqwest.workspace = true
 rusqlite.workspace = true
+usvg.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -62,9 +62,9 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
     },
     ToolsetMeta {
         name: "pcb_board",
-        description: "Board outline, layers, zones, mounting holes, board text",
+        description: "Board outline, layers, zones, mounting holes, board text, SVG logo import",
         category: "pcb",
-        tool_count: 10,
+        tool_count: 11,
     },
     ToolsetMeta {
         name: "pcb_components",

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -19,6 +19,7 @@ pub mod sch_export;
 pub mod sch_hierarchy;
 pub mod sch_wiring;
 pub mod schematic_builder;
+pub mod svg_import;
 pub mod templates;
 pub mod verification;
 

--- a/crates/konnect-core/src/tools/pcb_board.rs
+++ b/crates/konnect-core/src/tools/pcb_board.rs
@@ -111,6 +111,21 @@ fn format_zone_polygon(
     )
 }
 
+/// A standalone filled polygon graphic (`gr_poly`), not tied to a net or zone
+/// fill — used for imported artwork rather than copper pours.
+fn format_gr_poly(points: &[(f64, f64)], layer: &str) -> String {
+    let uuid = new_uuid();
+    let pts: String = points
+        .iter()
+        .map(|(x, y)| format!("\n      (xy {x} {y})"))
+        .collect();
+    format!(
+        "\n  (gr_poly\n    (pts{pts}\n    )\n    \
+         (stroke (width 0) (type solid))\n    (fill solid)\n    \
+         (layer \"{layer}\")\n    (uuid \"{uuid}\")\n  )"
+    )
+}
+
 /// Find the net ID for a given net name in the .kicad_pcb content.
 fn find_net_id(content: &str, net_name: &str) -> Option<i32> {
     // Entries look like: (net 1 "GND")
@@ -278,6 +293,26 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "net_name", "layer", "points"]
             }),
             |args, ctx| async move { handle_add_zone(args, ctx).await }
+        ),
+        tool!(
+            "import_svg_logo",
+            "Import an SVG file as filled silkscreen or copper artwork (a logo, icon, or other \
+             graphic). Curved paths are flattened into polygon outlines since KiCAD's board \
+             format doesn't support Bezier curves in filled shapes. Tries KiCAD IPC first, \
+             falls back to a direct file edit if KiCAD isn't running.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "board":     { "type": "string", "description": "Path to .kicad_pcb file" },
+                    "svg":       { "type": "string", "description": "Path to the .svg file to import" },
+                    "width_mm":  { "type": "number", "description": "Target width in mm (aspect ratio preserved)" },
+                    "x":         { "type": "number", "description": "X position of the artwork's top-left corner in mm", "default": 0 },
+                    "y":         { "type": "number", "description": "Y position of the artwork's top-left corner in mm", "default": 0 },
+                    "layer":     { "type": "string", "description": "Target layer", "default": "F.SilkS" }
+                },
+                "required": ["board", "svg", "width_mm"]
+            }),
+            |args, ctx| async move { handle_import_svg_logo(args, ctx).await }
         ),
     ]
 }
@@ -763,4 +798,181 @@ async fn handle_add_zone(
         "point_count": points.len(),
         "net_id": net_id
     })))
+}
+
+async fn handle_import_svg_logo(
+    args: &serde_json::Value,
+    ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let board_path = get_path(args, "board")?;
+    let svg_path = get_path(args, "svg")?;
+    let width_mm = match require_f64(args, "width_mm") {
+        Ok(v) => v,
+        Err(e) => return Ok(e),
+    };
+    let x = args["x"].as_f64().unwrap_or(0.0);
+    let y = args["y"].as_f64().unwrap_or(0.0);
+    let layer = args["layer"].as_str().unwrap_or("F.SilkS").to_string();
+
+    let svg_content = std::fs::read_to_string(&svg_path)?;
+    let logo = crate::tools::svg_import::extract_polygons(&svg_content)?;
+    if logo.polygons.is_empty() {
+        return Ok(CallToolResult::error(
+            "No fillable paths found in the SVG (only <path> elements are supported).",
+        ));
+    }
+
+    let placed =
+        crate::tools::svg_import::scale_and_place(&logo.polygons, logo.width, width_mm, x, y);
+
+    // Try IPC first; fall through to a direct file edit if KiCAD isn't reachable.
+    let layer_ipc = layer.clone();
+    let placed_ipc = placed.clone();
+    if with_ipc(ctx.config.ipc_address.clone(), move |c| {
+        let shape = builders::board_polygon(&layer_ipc, true, &placed_ipc);
+        let any = builders::pack_any(&shape, "kiapi.board.types.BoardGraphicShape");
+        c.create_items(vec![any])
+    })
+    .await?
+    .is_ok()
+    {
+        return Ok(CallToolResult::json(&json!({
+            "polygon_count": placed.len(),
+            "layer": layer,
+            "width_mm": width_mm,
+            "source": "ipc"
+        })));
+    }
+
+    let mut sexp = String::new();
+    for polygon in &placed {
+        sexp.push_str(&format_gr_poly(polygon, &layer));
+    }
+    let content = std::fs::read_to_string(&board_path)?;
+    let close_pos = content.rfind(')').unwrap_or(content.len());
+    let new_content = apply_edits(content, vec![SexpEdit::insert(close_pos, sexp)]);
+    write_atomic(&board_path, &new_content)?;
+
+    Ok(CallToolResult::json(&json!({
+        "polygon_count": placed.len(),
+        "layer": layer,
+        "width_mm": width_mm,
+        "source": "file"
+    })))
+}
+
+#[cfg(test)]
+mod svg_logo_tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::ServerConfig;
+    use std::sync::Arc;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            // Deliberately empty ipc_address: with_ipc fails fast against it,
+            // exercising the file-fallback path without needing live KiCAD.
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    fn blank_board() -> &'static str {
+        "(kicad_pcb\n  (version 20250610)\n  (generator \"konnect\")\n  (paper \"A4\")\n  (net 0 \"\")\n)\n"
+    }
+
+    fn rect_svg() -> &'static str {
+        r##"<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+            <path d="M0 0 L100 0 L100 100 L0 100 Z" fill="black"/>
+        </svg>"##
+    }
+
+    #[test]
+    fn format_gr_poly_contains_layer_fill_and_points() {
+        let sexp = format_gr_poly(&[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)], "F.SilkS");
+        assert!(sexp.contains("(gr_poly"));
+        assert!(sexp.contains("(fill solid)"));
+        assert!(sexp.contains("(layer \"F.SilkS\")"));
+        assert!(sexp.contains("(xy 1 0)") || sexp.contains("(xy 1.0 0)"));
+    }
+
+    #[tokio::test]
+    async fn import_svg_logo_file_fallback_places_polygon() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let board_path = dir.path().join("board.kicad_pcb");
+        let svg_path = dir.path().join("logo.svg");
+        std::fs::write(&board_path, blank_board()).unwrap();
+        std::fs::write(&svg_path, rect_svg()).unwrap();
+
+        let ctx = test_ctx();
+        let args = json!({
+            "board": board_path.to_str().unwrap(),
+            "svg": svg_path.to_str().unwrap(),
+            "width_mm": 10.0
+        });
+
+        let result = handle_import_svg_logo(&args, &ctx)
+            .await
+            .expect("handler should succeed");
+        assert!(!result.is_error);
+
+        let body = match &result.content[0] {
+            crate::mcp::protocol::ToolContent::Text { text } => text.clone(),
+            _ => panic!("expected text content"),
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed["polygon_count"], json!(1));
+        assert_eq!(parsed["source"], json!("file"));
+        assert_eq!(parsed["layer"], json!("F.SilkS"));
+
+        let updated = std::fs::read_to_string(&board_path).unwrap();
+        assert!(updated.contains("(gr_poly"));
+    }
+
+    #[tokio::test]
+    async fn import_svg_logo_rejects_svg_with_no_fillable_paths() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let board_path = dir.path().join("board.kicad_pcb");
+        let svg_path = dir.path().join("empty.svg");
+        std::fs::write(&board_path, blank_board()).unwrap();
+        std::fs::write(
+            &svg_path,
+            r##"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>"##,
+        )
+        .unwrap();
+
+        let ctx = test_ctx();
+        let args = json!({
+            "board": board_path.to_str().unwrap(),
+            "svg": svg_path.to_str().unwrap(),
+            "width_mm": 10.0
+        });
+
+        let result = handle_import_svg_logo(&args, &ctx).await.unwrap();
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn import_svg_logo_missing_width_mm_returns_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let board_path = dir.path().join("board.kicad_pcb");
+        let svg_path = dir.path().join("logo.svg");
+        std::fs::write(&board_path, blank_board()).unwrap();
+        std::fs::write(&svg_path, rect_svg()).unwrap();
+
+        let ctx = test_ctx();
+        let args = json!({
+            "board": board_path.to_str().unwrap(),
+            "svg": svg_path.to_str().unwrap()
+        });
+
+        let result = handle_import_svg_logo(&args, &ctx).await.unwrap();
+        assert!(result.is_error);
+    }
 }

--- a/crates/konnect-core/src/tools/svg_import.rs
+++ b/crates/konnect-core/src/tools/svg_import.rs
@@ -1,0 +1,353 @@
+//! SVG parsing and flattening for `import_svg_logo`.
+//!
+//! Splits into two layers so the geometry math is testable without any SVG
+//! library involved:
+//!   - `SvgSegment`/`flatten_subpaths`/`cubic_bezier_points` — pure path-flattening
+//!     math (curves → straight-line polygon points). No dependency on `usvg`'s types.
+//!   - `extract_polygons` — the thin `usvg` integration that walks a parsed SVG
+//!     tree and adapts its path segments into `SvgSegment`s.
+//!
+//! KiCAD's polygon format (`PolyLine`/`gr_poly`) only supports straight points
+//! and circular arcs, not cubic Bezier curves, so any curved SVG path must be
+//! flattened into a point sequence before it can become filled artwork.
+
+/// A 2D point in whatever coordinate space the caller is working in (SVG user
+/// units until scaled, millimeters after).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Point2 {
+    pub x: f64,
+    pub y: f64,
+}
+
+impl Point2 {
+    pub fn new(x: f64, y: f64) -> Self {
+        Point2 { x, y }
+    }
+}
+
+/// One command from an SVG path's `d` attribute, decoupled from any specific
+/// SVG parsing library's types so the flattening logic below can be unit
+/// tested with hand-built segment lists.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SvgSegment {
+    MoveTo(Point2),
+    LineTo(Point2),
+    QuadTo(Point2, Point2),
+    CubicTo(Point2, Point2, Point2),
+    Close,
+}
+
+/// Number of straight-line segments used to approximate one Bezier curve.
+/// Fixed (not adaptive) subdivision — plenty for silkscreen/copper artwork,
+/// where visual fidelity at fabrication scale matters more than curve-fitting
+/// precision.
+const BEZIER_SEGMENTS: usize = 16;
+
+/// Sample a cubic Bezier curve into `BEZIER_SEGMENTS` points (excluding the
+/// start point `p0`, which the caller already has as the current position).
+pub fn cubic_bezier_points(p0: Point2, p1: Point2, p2: Point2, p3: Point2) -> Vec<Point2> {
+    (1..=BEZIER_SEGMENTS)
+        .map(|i| {
+            let t = i as f64 / BEZIER_SEGMENTS as f64;
+            let mt = 1.0 - t;
+            let x = mt * mt * mt * p0.x
+                + 3.0 * mt * mt * t * p1.x
+                + 3.0 * mt * t * t * p2.x
+                + t * t * t * p3.x;
+            let y = mt * mt * mt * p0.y
+                + 3.0 * mt * mt * t * p1.y
+                + 3.0 * mt * t * t * p2.y
+                + t * t * t * p3.y;
+            Point2::new(x, y)
+        })
+        .collect()
+}
+
+/// Elevate a quadratic Bezier (single control point) to the two control
+/// points of an equivalent cubic Bezier, so quadratic curves can reuse
+/// `cubic_bezier_points`. Standard exact conversion: cubic control points
+/// sit 2/3 of the way from each endpoint toward the quadratic control point.
+pub fn quad_to_cubic(p0: Point2, control: Point2, p2: Point2) -> (Point2, Point2) {
+    let c1 = Point2::new(
+        p0.x + 2.0 / 3.0 * (control.x - p0.x),
+        p0.y + 2.0 / 3.0 * (control.y - p0.y),
+    );
+    let c2 = Point2::new(
+        p2.x + 2.0 / 3.0 * (control.x - p2.x),
+        p2.y + 2.0 / 3.0 * (control.y - p2.y),
+    );
+    (c1, c2)
+}
+
+/// Flatten a sequence of SVG path segments into one or more closed polygon
+/// outlines (point lists). A `MoveTo` starts a new subpath; a `Close` (or the
+/// next `MoveTo`/end of input) ends the current one. Subpaths with fewer than
+/// 2 points (degenerate — e.g. a lone `MoveTo`) are dropped.
+pub fn flatten_subpaths(segments: impl IntoIterator<Item = SvgSegment>) -> Vec<Vec<Point2>> {
+    let mut polygons = Vec::new();
+    let mut current: Vec<Point2> = Vec::new();
+    let mut last = Point2::new(0.0, 0.0);
+
+    let close_current = |current: &mut Vec<Point2>, polygons: &mut Vec<Vec<Point2>>| {
+        if current.len() > 1 {
+            polygons.push(std::mem::take(current));
+        } else {
+            current.clear();
+        }
+    };
+
+    for seg in segments {
+        match seg {
+            SvgSegment::MoveTo(p) => {
+                close_current(&mut current, &mut polygons);
+                current.push(p);
+                last = p;
+            }
+            SvgSegment::LineTo(p) => {
+                current.push(p);
+                last = p;
+            }
+            SvgSegment::QuadTo(control, p) => {
+                let (c1, c2) = quad_to_cubic(last, control, p);
+                current.extend(cubic_bezier_points(last, c1, c2, p));
+                last = p;
+            }
+            SvgSegment::CubicTo(c1, c2, p) => {
+                current.extend(cubic_bezier_points(last, c1, c2, p));
+                last = p;
+            }
+            SvgSegment::Close => {
+                close_current(&mut current, &mut polygons);
+            }
+        }
+    }
+    close_current(&mut current, &mut polygons);
+    polygons
+}
+
+/// Scale and translate flattened SVG-unit polygons into board millimeters.
+/// Scale is uniform (aspect-ratio preserving), derived from `target_width_mm`
+/// against the SVG's native width; `offset_x`/`offset_y` place the top-left
+/// of the scaled artwork on the board.
+pub fn scale_and_place(
+    polygons: &[Vec<Point2>],
+    svg_width: f64,
+    target_width_mm: f64,
+    offset_x: f64,
+    offset_y: f64,
+) -> Vec<Vec<(f64, f64)>> {
+    let scale = if svg_width > 0.0 {
+        target_width_mm / svg_width
+    } else {
+        1.0
+    };
+    polygons
+        .iter()
+        .map(|poly| {
+            poly.iter()
+                .map(|p| (p.x * scale + offset_x, p.y * scale + offset_y))
+                .collect()
+        })
+        .collect()
+}
+
+/// A parsed SVG, reduced to its native size and flattened fillable outlines.
+pub struct SvgLogo {
+    pub width: f64,
+    pub height: f64,
+    pub polygons: Vec<Vec<Point2>>,
+}
+
+/// Parse SVG content and flatten every path node's outline(s) into closed
+/// polygons. Every `Path` node in the tree is treated as fillable artwork
+/// (no stroke-only exclusion, no color/layer separation) — appropriate for a
+/// single-color silkscreen/copper logo import.
+pub fn extract_polygons(svg_content: &str) -> anyhow::Result<SvgLogo> {
+    let opt = usvg::Options::default();
+    let tree = usvg::Tree::from_str(svg_content, &opt)
+        .map_err(|e| anyhow::anyhow!("Failed to parse SVG: {e}"))?;
+
+    let size = tree.size();
+    let mut polygons = Vec::new();
+    collect_path_polygons(tree.root(), &mut polygons);
+
+    Ok(SvgLogo {
+        width: size.width() as f64,
+        height: size.height() as f64,
+        polygons,
+    })
+}
+
+fn collect_path_polygons(group: &usvg::Group, out: &mut Vec<Vec<Point2>>) {
+    for node in group.children() {
+        match node {
+            usvg::Node::Path(path) => {
+                // usvg resolves segments to absolute (root) coordinates already,
+                // so no manual transform composition is needed here.
+                let segments = path.data().segments().map(adapt_segment);
+                out.extend(flatten_subpaths(segments));
+            }
+            usvg::Node::Group(inner) => collect_path_polygons(inner, out),
+            // Images and text are out of scope for a v1 logo import.
+            usvg::Node::Image(_) | usvg::Node::Text(_) => {}
+        }
+    }
+}
+
+fn adapt_segment(seg: usvg::tiny_skia_path::PathSegment) -> SvgSegment {
+    use usvg::tiny_skia_path::PathSegment;
+    match seg {
+        PathSegment::MoveTo(p) => SvgSegment::MoveTo(Point2::new(p.x as f64, p.y as f64)),
+        PathSegment::LineTo(p) => SvgSegment::LineTo(Point2::new(p.x as f64, p.y as f64)),
+        PathSegment::QuadTo(c, p) => SvgSegment::QuadTo(
+            Point2::new(c.x as f64, c.y as f64),
+            Point2::new(p.x as f64, p.y as f64),
+        ),
+        PathSegment::CubicTo(c1, c2, p) => SvgSegment::CubicTo(
+            Point2::new(c1.x as f64, c1.y as f64),
+            Point2::new(c2.x as f64, c2.y as f64),
+            Point2::new(p.x as f64, p.y as f64),
+        ),
+        PathSegment::Close => SvgSegment::Close,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cubic_bezier_points_starts_near_control_and_ends_at_p3() {
+        let p0 = Point2::new(0.0, 0.0);
+        let p1 = Point2::new(0.0, 10.0);
+        let p2 = Point2::new(10.0, 10.0);
+        let p3 = Point2::new(10.0, 0.0);
+        let pts = cubic_bezier_points(p0, p1, p2, p3);
+        assert_eq!(pts.len(), BEZIER_SEGMENTS);
+        let last = pts.last().unwrap();
+        assert!((last.x - p3.x).abs() < 1e-9);
+        assert!((last.y - p3.y).abs() < 1e-9);
+    }
+
+    #[test]
+    fn quad_to_cubic_produces_control_points_between_endpoints_and_control() {
+        let p0 = Point2::new(0.0, 0.0);
+        let control = Point2::new(5.0, 10.0);
+        let p2 = Point2::new(10.0, 0.0);
+        let (c1, c2) = quad_to_cubic(p0, control, p2);
+        // c1 should be 2/3 of the way from p0 to control.
+        assert!((c1.x - 10.0 / 3.0).abs() < 1e-9);
+        assert!((c1.y - 20.0 / 3.0).abs() < 1e-9);
+        // c2 should be 2/3 of the way from p2 to control.
+        assert!((c2.x - 20.0 / 3.0).abs() < 1e-9);
+        assert!((c2.y - 20.0 / 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn flatten_subpaths_single_closed_triangle() {
+        let segments = vec![
+            SvgSegment::MoveTo(Point2::new(0.0, 0.0)),
+            SvgSegment::LineTo(Point2::new(10.0, 0.0)),
+            SvgSegment::LineTo(Point2::new(5.0, 10.0)),
+            SvgSegment::Close,
+        ];
+        let polys = flatten_subpaths(segments);
+        assert_eq!(polys.len(), 1);
+        assert_eq!(polys[0].len(), 3);
+    }
+
+    #[test]
+    fn flatten_subpaths_two_separate_subpaths() {
+        let segments = vec![
+            SvgSegment::MoveTo(Point2::new(0.0, 0.0)),
+            SvgSegment::LineTo(Point2::new(1.0, 0.0)),
+            SvgSegment::LineTo(Point2::new(1.0, 1.0)),
+            SvgSegment::Close,
+            SvgSegment::MoveTo(Point2::new(5.0, 5.0)),
+            SvgSegment::LineTo(Point2::new(6.0, 5.0)),
+            SvgSegment::LineTo(Point2::new(6.0, 6.0)),
+            SvgSegment::Close,
+        ];
+        let polys = flatten_subpaths(segments);
+        assert_eq!(polys.len(), 2);
+        assert_eq!(polys[0].len(), 3);
+        assert_eq!(polys[1].len(), 3);
+    }
+
+    #[test]
+    fn flatten_subpaths_drops_degenerate_lone_moveto() {
+        let segments = vec![SvgSegment::MoveTo(Point2::new(0.0, 0.0)), SvgSegment::Close];
+        let polys = flatten_subpaths(segments);
+        assert!(polys.is_empty());
+    }
+
+    #[test]
+    fn flatten_subpaths_curve_expands_into_many_points() {
+        let segments = vec![
+            SvgSegment::MoveTo(Point2::new(0.0, 0.0)),
+            SvgSegment::CubicTo(
+                Point2::new(0.0, 10.0),
+                Point2::new(10.0, 10.0),
+                Point2::new(10.0, 0.0),
+            ),
+            SvgSegment::Close,
+        ];
+        let polys = flatten_subpaths(segments);
+        assert_eq!(polys.len(), 1);
+        // 1 start point + BEZIER_SEGMENTS sampled points.
+        assert_eq!(polys[0].len(), 1 + BEZIER_SEGMENTS);
+    }
+
+    #[test]
+    fn scale_and_place_scales_uniformly_and_offsets() {
+        let polygons = vec![vec![Point2::new(0.0, 0.0), Point2::new(100.0, 50.0)]];
+        // SVG is 100 units wide; target 10mm wide => scale = 0.1.
+        let placed = scale_and_place(&polygons, 100.0, 10.0, 2.0, 3.0);
+        assert_eq!(placed.len(), 1);
+        assert_eq!(placed[0][0], (2.0, 3.0));
+        assert_eq!(placed[0][1], (12.0, 8.0));
+    }
+
+    #[test]
+    fn scale_and_place_zero_width_falls_back_to_identity_scale() {
+        let polygons = vec![vec![Point2::new(5.0, 5.0)]];
+        let placed = scale_and_place(&polygons, 0.0, 10.0, 0.0, 0.0);
+        assert_eq!(placed[0][0], (5.0, 5.0));
+    }
+
+    #[test]
+    fn extract_polygons_parses_simple_rect_path() {
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+            <path d="M0 0 L100 0 L100 100 L0 100 Z" fill="black"/>
+        </svg>"##;
+        let logo = extract_polygons(svg).expect("should parse");
+        assert_eq!(logo.width, 100.0);
+        assert_eq!(logo.height, 100.0);
+        assert_eq!(logo.polygons.len(), 1);
+        assert_eq!(logo.polygons[0].len(), 4);
+    }
+
+    #[test]
+    fn extract_polygons_handles_curved_path() {
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50">
+            <path d="M0 0 C0 25 25 25 25 0 Z" fill="black"/>
+        </svg>"##;
+        let logo = extract_polygons(svg).expect("should parse");
+        assert_eq!(logo.polygons.len(), 1);
+        // More than 2 points proves the curve was flattened, not dropped.
+        assert!(logo.polygons[0].len() > 2);
+    }
+
+    #[test]
+    fn extract_polygons_rejects_invalid_svg() {
+        let result = extract_polygons("not an svg at all");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn extract_polygons_empty_svg_has_no_polygons() {
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>"##;
+        let logo = extract_polygons(svg).expect("should parse");
+        assert!(logo.polygons.is_empty());
+    }
+}

--- a/crates/konnect-ipc/src/builders.rs
+++ b/crates/konnect-ipc/src/builders.rs
@@ -249,6 +249,41 @@ pub fn board_arc(
     )
 }
 
+/// Build a BoardGraphicShape polygon (or set of polygons) from closed point
+/// loops in mm — one `PolygonWithHoles` per outline, no holes. Used by
+/// `import_svg_logo` to place flattened SVG artwork as filled board graphics.
+pub fn board_polygon(
+    layer: &str,
+    filled: bool,
+    outlines: &[Vec<(f64, f64)>],
+) -> kiapi::board::types::BoardGraphicShape {
+    let polygons = outlines
+        .iter()
+        .map(|pts| kiapi::common::types::PolygonWithHoles {
+            outline: Some(kiapi::common::types::PolyLine {
+                nodes: pts
+                    .iter()
+                    .map(|&(x, y)| kiapi::common::types::PolyLineNode {
+                        geometry: Some(kiapi::common::types::poly_line_node::Geometry::Point(
+                            vec2(x, y),
+                        )),
+                    })
+                    .collect(),
+                closed: true,
+            }),
+            holes: vec![],
+        })
+        .collect();
+
+    board_shape(
+        layer,
+        attrs(0.0, filled),
+        kiapi::common::types::graphic_shape::Geometry::Polygon(kiapi::common::types::PolySet {
+            polygons,
+        }),
+    )
+}
+
 /// Build a BoardText. `size_mm` sets both width and height of the glyphs.
 #[allow(clippy::too_many_arguments)]
 pub fn board_text(
@@ -369,5 +404,59 @@ mod tests {
         assert_eq!(attrs.size.unwrap().x_nm, 1_500_000);
         assert_eq!(attrs.angle.unwrap().value_degrees, 90.0);
         assert!(!attrs.mirrored);
+    }
+
+    #[test]
+    fn polygon_builds_one_polygon_with_holes_per_outline() {
+        let outlines = vec![
+            vec![(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)],
+            vec![(5.0, 5.0), (6.0, 5.0), (6.0, 6.0)],
+        ];
+        let s = board_polygon("F.SilkS", true, &outlines);
+        assert_eq!(s.layer, kiapi::board::types::BoardLayer::BlFSilkS as i32);
+        let shape = s.shape.expect("shape");
+        assert_eq!(
+            shape.attributes.unwrap().fill.unwrap().fill_type,
+            kiapi::common::types::GraphicFillType::GftFilled as i32
+        );
+        match shape.geometry.expect("geometry") {
+            Geometry::Polygon(poly_set) => {
+                assert_eq!(poly_set.polygons.len(), 2);
+                let first = &poly_set.polygons[0];
+                assert!(first.holes.is_empty());
+                let outline = first.outline.as_ref().expect("outline");
+                assert!(outline.closed);
+                assert_eq!(outline.nodes.len(), 3);
+            }
+            _ => panic!("expected Polygon geometry"),
+        }
+    }
+
+    #[test]
+    fn polygon_nodes_carry_point_coordinates_in_nanometers() {
+        let outlines = vec![vec![(1.0, 2.0)]];
+        let s = board_polygon("F.Cu", false, &outlines);
+        match s.shape.unwrap().geometry.unwrap() {
+            Geometry::Polygon(poly_set) => {
+                let node = &poly_set.polygons[0].outline.as_ref().unwrap().nodes[0];
+                match node.geometry.as_ref().expect("node geometry") {
+                    kiapi::common::types::poly_line_node::Geometry::Point(p) => {
+                        assert_eq!(p.x_nm, 1_000_000);
+                        assert_eq!(p.y_nm, 2_000_000);
+                    }
+                    _ => panic!("expected Point node"),
+                }
+            }
+            _ => panic!("expected Polygon geometry"),
+        }
+    }
+
+    #[test]
+    fn polygon_empty_outlines_produces_empty_polyset() {
+        let s = board_polygon("F.SilkS", true, &[]);
+        match s.shape.unwrap().geometry.unwrap() {
+            Geometry::Polygon(poly_set) => assert!(poly_set.polygons.is_empty()),
+            _ => panic!("expected Polygon geometry"),
+        }
     }
 }

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -10,7 +10,7 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 ## Overview
 
 - **18 toolsets** organized into 10 categories
-- **182 registered tools** + **6 always-visible meta-tools** = **188 total**
+- **183 registered tools** + **6 always-visible meta-tools** = **189 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -177,8 +177,8 @@ Sheet lifecycle only (PR-A); pin lifecycle (`import_sheet_pins`, `add_sheet_pin`
 
 ## PCB
 
-### `pcb_board` · 10 tools
-**Purpose:** Board outline, layers, zones, mounting holes, board text.
+### `pcb_board` · 11 tools
+**Purpose:** Board outline, layers, zones, mounting holes, board text, SVG logo import.
 **Source:** [`crates/konnect-core/src/tools/pcb_board.rs`](crates/konnect-core/src/tools/pcb_board.rs)
 
 | Tool | Description |
@@ -193,6 +193,7 @@ Sheet lifecycle only (PR-A); pin lifecycle (`import_sheet_pins`, `add_sheet_pin`
 | `add_mounting_hole` | Add an NPTH mounting hole footprint at the specified position. |
 | `add_board_text` | Add a silkscreen or fabrication text string to the board. |
 | `add_zone` | Add a copper fill zone polygon on a specified layer and net. |
+| `import_svg_logo` | Import an SVG file as filled silkscreen/copper artwork (curves flattened to polygons). |
 
 ### `pcb_components` · 13 tools
 **Purpose:** Place, move, rotate, align, and duplicate PCB footprints.


### PR DESCRIPTION
## Summary
- Add `import_svg_logo` to the `pcb_board` toolset — closing the roadmap's `import_svg_logo` item.
- Parses an SVG file and places its filled paths as silkscreen/copper artwork on a board. Curved paths are flattened into straight-line polygon outlines since KiCAD's board format (`PolyLine`/`gr_poly`) only supports points and circular arcs, not Bezier curves.
- Tries the KiCAD IPC API first, falls back to a direct file edit if KiCAD isn't running — the same dual-path pattern already used by `add_board_text`.

## Motivation
`import_svg_logo` was one of two concrete, unblocked items left on the roadmap's Tools list (the other, hierarchical sheets, is a much larger prerequisite for other features). KiCAD's IPC API already exposes a `PolySet`/`PolyLine` polygon type ready to use; what was missing was SVG parsing and curve-to-polygon conversion.

## Implementation
- **New `crates/konnect-core/src/tools/svg_import.rs`**: uses `usvg` (added as a new dependency) to parse SVG content, then flattens each path's curves into polygon points with hand-written cubic/quadratic Bezier sampling (fixed 16-segment subdivision — sufficient fidelity for silkscreen/copper artwork). The flattening math (`SvgSegment`, `flatten_subpaths`, `cubic_bezier_points`, `quad_to_cubic`) is fully decoupled from `usvg`'s types via a small local enum, so it's unit-testable without any SVG parsing involved.
- **New `board_polygon()`** IPC builder in `crates/konnect-ipc/src/builders.rs`, following the existing `board_segment`/`board_rectangle`/`board_circle` pattern.
- **New `format_gr_poly()`** S-expression formatter in `pcb_board.rs` for the file-fallback path — a standalone filled `gr_poly`, not tied to a net/zone like the existing `format_zone_polygon`.
- Updated `tool_count` (`pcb_board` 10→11, workspace total 175→176) across `registry.rs`, `tool-directory.md`, `DEV.md`. Fixed a pre-existing staleness in `DEV.md`'s file-tree comment (`pcb_export.rs` was still annotated "9 tools" from before #11 merged; corrected to 13 while in the area). Moved the roadmap item to Done.

## Test plan
- [x] `cargo test --workspace --lib --tests` — 118/118 passed
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] 12 unit tests on the geometry module: Bezier sampling, quadratic-to-cubic elevation, subpath flattening (closed shapes, multiple subpaths, degenerate-input dropping, curve expansion), scale/placement math, and real `usvg` parsing of small SVG strings (both straight-line and curved paths).
- [x] 3 unit tests on the new `board_polygon` IPC builder.
- [x] 4 handler-level tests exercising the file-fallback path end-to-end against a real temporary board + SVG file (happy path, empty-SVG rejection, missing required argument).

### Manual / real-world verification
- Built a release binary and ran the tool against a real production board (not a synthetic fixture) with a multi-shape test SVG (mixing straight lines and curves) — confirmed visually in KiCAD's PCB editor that the artwork renders correctly on F.Silkscreen.
- **Round-tripped the generated board through real `kicad-cli`** (`pcb export svg`) to confirm the emitted `gr_poly` syntax is genuinely valid KiCAD format, not just visually plausible — succeeded with no errors, and the exported SVG contains real rendered path data.
- Re-tested against a real, geometrically complex production logo (a stag's head — lots of fine curve detail) on a real board: 17 flattened polygons, clean visual result in KiCAD.
- **Live IPC path**: attempted to verify the IPC-first branch independently by pointing a standalone test harness at a live, already-open KiCad instance. This surfaced a genuine constraint documented in KiCAD's own developer docs: a process not launched directly *by* KiCAD has no reliable way to discover the running instance's IPC socket path (only `KICAD_API_SOCKET`, set for processes KiCAD itself launches). This is a pre-existing characteristic of every IPC-touching tool in this file, not something introduced here — `import_svg_logo`'s IPC branch reuses the exact same `with_ipc`/`create_items` machinery `add_board_text`, `add_zone`, etc. already rely on. Since a live connection couldn't be independently exercised from the outside, verification for that branch rests on it being the same well-established code path as the rest of the file, plus the file-fallback path being thoroughly proven above (which is what runs whenever IPC isn't reachable, matching this whole verification session).

## Known limitation (candidate follow-up)
Overlapping/nested SVG shapes are not converted into holes — each subpath becomes its own separate filled polygon rather than detecting winding-rule holes via `PolygonWithHoles.holes`. A logo with a true cutout (e.g. a letter "O") will render as two overlapping filled shapes rather than one shape with a hole punched through it. Happy to follow up on this if there's interest.
