### PR TITLE
feat: hierarchical sheet lifecycle (sch_hierarchy toolset, PR-A of 2)

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -32,7 +32,7 @@ Konnect/
 │   │           ├── stdio.rs         # Line-by-line JSON-RPC over stdin/stdout (default)
 │   │           └── http.rs          # Streamable HTTP: POST + GET (SSE) on /mcp (transport = "http" / "both")
 │   │
-│   ├── konnect-core/          # All tool logic (17 toolsets)
+│   ├── konnect-core/          # All tool logic (18 toolsets)
 │   │   └── src/
 │   │       ├── mcp/
 │   │       │   ├── protocol.rs      # MCP JSON-RPC 2.0 types
@@ -51,6 +51,7 @@ Konnect/
 │   │           ├── sch_analysis.rs   # 15 tools (union-find net graph, connectivity)
 │   │           ├── sch_batch.rs      # 10 tools (single-read/single-write atomic operations)
 │   │           ├── sch_export.rs     # 7 tools (SVG/PDF/netlist/ERC)
+│   │           ├── sch_hierarchy.rs  # 7 tools (typed Sheet model, add/edit/move/delete/duplicate + hierarchy/page queries)
 │   │           ├── pcb_board.rs      # 10 tools (S-expr file editing, IPC fallback)
 │   │           ├── pcb_components.rs # 13 tools (IPC real-time via NNG+protobuf)
 │   │           ├── pcb_routing.rs    # 12 tools (traces, vias, nets, netclasses)
@@ -221,9 +222,9 @@ Run all: `PROTOC=<path> cargo test --workspace --lib --tests`
 
 ## Current Stats
 
-- **17 toolsets, 175 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
+- **18 toolsets, 182 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
 - Baseline `tools/list`: ~19 tools / ~2K tokens (starter kit + meta-tools)
-- Full-catalog `tools/list` (all loaded): ~181 tools / ~23K tokens
+- Full-catalog `tools/list` (all loaded): ~188 tools / ~24K tokens
 - **0 IPC stubs** (all protobuf methods implemented)
 - **0 unimplemented tools**
 - **3 CLI commands removed in KiCAD v10** (specctra DSN/SES, pcb sync — return clear errors)

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -55,6 +55,12 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         tool_count: 6,
     },
     ToolsetMeta {
+        name: "sch_hierarchy",
+        description: "Hierarchical sheets: add, edit, move, delete, duplicate a sheet, plus recursive hierarchy and page-numbering queries",
+        category: "schematic",
+        tool_count: 7,
+    },
+    ToolsetMeta {
         name: "pcb_board",
         description: "Board outline, layers, zones, mounting holes, board text",
         category: "pcb",
@@ -132,6 +138,7 @@ pub fn tools_for(name: &str) -> Option<Vec<ToolDef>> {
         "sch_analysis" => Some(sch_analysis::tools()),
         "sch_batch" => Some(sch_batch::tools()),
         "sch_export" => Some(sch_export::tools()),
+        "sch_hierarchy" => Some(sch_hierarchy::tools()),
         "pcb_board" => Some(pcb_board::tools()),
         "pcb_components" => Some(pcb_components::tools()),
         "pcb_routing" => Some(pcb_routing::tools()),

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -16,6 +16,7 @@ pub mod sch_batch;
 pub mod sch_bridge;
 pub mod sch_components;
 pub mod sch_export;
+pub mod sch_hierarchy;
 pub mod sch_wiring;
 pub mod schematic_builder;
 pub mod templates;

--- a/crates/konnect-core/src/tools/sch_hierarchy.rs
+++ b/crates/konnect-core/src/tools/sch_hierarchy.rs
@@ -1,0 +1,1059 @@
+//! `sch_hierarchy` toolset — PR-A: hierarchical sheet lifecycle.
+//!
+//! Sheet pin lifecycle (import/add/edit/delete pins) lands in a follow-up PR;
+//! this toolset covers the sheet object itself: add, edit, move, delete,
+//! duplicate, and the recursive hierarchy/page-numbering queries needed to
+//! reason about a multi-sheet design.
+//!
+//! Every handler here is file-editing only — KiCAD's own IPC API has no
+//! schematic-editing commands upstream (`schematic_commands.proto` is empty),
+//! so there's no dual IPC/file path to maintain, unlike the PCB toolsets.
+
+use crate::mcp::protocol::CallToolResult;
+use crate::tool;
+use crate::tools::{get_path, opt_f64, opt_str, require_f64, require_str, ToolContext, ToolDef};
+use konnect_schematic_editor as cse;
+use serde_json::{json, Value};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+pub fn tools() -> Vec<ToolDef> {
+    vec![
+        tool!(
+            "add_hierarchical_sheet",
+            "Insert a hierarchical sheet into a parent schematic, linking it to a child \
+             .kicad_sch file. Creates the child file (blank) if it doesn't exist yet, or \
+             links to it as-is if it does — reusing an existing file places the *same* \
+             sub-circuit at a second location (KiCAD's multi-instance sheet pattern) rather \
+             than duplicating it. If the linked file already has symbols in it, their \
+             hierarchical instance paths are patched immediately so ERC resolves them.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "schematic": { "type": "string", "description": "Path to the parent .kicad_sch file" },
+                    "sheet_file": { "type": "string", "description": "Filename of the child .kicad_sch, resolved relative to the parent's directory" },
+                    "sheet_name": { "type": "string", "description": "Display name (Sheetname property). Default: 'Sheet'" },
+                    "x": { "type": "number", "description": "Top-left X in mm. Default: 50" },
+                    "y": { "type": "number", "description": "Top-left Y in mm. Default: 50" },
+                    "width": { "type": "number", "description": "Sheet box width in mm. Default: 80" },
+                    "height": { "type": "number", "description": "Sheet box height in mm. Default: 50" },
+                    "project_name": { "type": "string", "description": "Project name key for the page-number instance entry. Default: '' (matches this codebase's existing convention for symbol instances)" }
+                },
+                "required": ["schematic", "sheet_file"]
+            }),
+            |args, ctx| async move { handle_add_hierarchical_sheet(args, ctx).await }
+        ),
+        tool!(
+            "edit_sheet",
+            "Rename, resize, reposition, or repoint (Sheetfile) an existing sheet. Provide \
+             at least one of: new_name, new_file, or both x+y, or both width+height. Does \
+             NOT rename the child file on disk when new_file is given — it only repoints \
+             the reference; the file itself must already exist at that path.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "schematic": { "type": "string" },
+                    "sheet_name": { "type": "string", "description": "Current Sheetname to look up" },
+                    "new_name": { "type": "string" },
+                    "new_file": { "type": "string" },
+                    "x": { "type": "number" }, "y": { "type": "number" },
+                    "width": { "type": "number" }, "height": { "type": "number" },
+                    "project_name": { "type": "string", "description": "Default: ''" }
+                },
+                "required": ["schematic", "sheet_name"]
+            }),
+            |args, ctx| async move { handle_edit_sheet(args, ctx).await }
+        ),
+        tool!(
+            "move_sheet",
+            "Reposition a sheet on the parent canvas without touching any other field.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "schematic": { "type": "string" },
+                    "sheet_name": { "type": "string" },
+                    "x": { "type": "number" }, "y": { "type": "number" }
+                },
+                "required": ["schematic", "sheet_name", "x", "y"]
+            }),
+            |args, ctx| async move { handle_move_sheet(args, ctx).await }
+        ),
+        tool!(
+            "delete_sheet",
+            "Remove a sheet reference from the parent schematic. Does NOT delete the child \
+             .kicad_sch file on disk. Remaining sheets' page numbers may now have a gap — \
+             call renumber_sheet_pages afterward if that matters.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "schematic": { "type": "string" },
+                    "sheet_name": { "type": "string" }
+                },
+                "required": ["schematic", "sheet_name"]
+            }),
+            |args, ctx| async move { handle_delete_sheet(args, ctx).await }
+        ),
+        tool!(
+            "duplicate_sheet",
+            "Copy an existing sheet and its child .kicad_sch file under a new name/file, \
+             offset slightly so the new sheet box doesn't overlap the source. The copy gets \
+             its own internal schematic UUID and its symbols' hierarchical instance paths \
+             are patched for the new sheet — it is a fully independent sub-circuit, not a \
+             live-linked reuse (for that, use add_hierarchical_sheet pointed at the existing file).",
+            json!({
+                "type": "object",
+                "properties": {
+                    "schematic": { "type": "string" },
+                    "source_sheet_name": { "type": "string" },
+                    "new_sheet_name": { "type": "string" },
+                    "new_file": { "type": "string", "description": "Filename for the copy, resolved relative to the parent's directory. Must not already exist." },
+                    "project_name": { "type": "string", "description": "Default: ''" }
+                },
+                "required": ["schematic", "source_sheet_name", "new_sheet_name", "new_file"]
+            }),
+            |args, ctx| async move { handle_duplicate_sheet(args, ctx).await }
+        ),
+        tool!(
+            "get_sheet_hierarchy",
+            "Recursively walk the sheet tree starting from a schematic file, returning \
+             nested JSON: each sheet's name/file/uuid/position/size/page/pins plus its own \
+             children. Handles missing child files and reference cycles gracefully instead \
+             of failing.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "schematic": { "type": "string", "description": "Root schematic to start from" },
+                    "project_name": { "type": "string", "description": "Default: ''" }
+                },
+                "required": ["schematic"]
+            }),
+            |args, ctx| async move { handle_get_sheet_hierarchy(args, ctx).await }
+        ),
+        tool!(
+            "renumber_sheet_pages",
+            "Walk the whole sheet tree from a root schematic and reassign sequential page \
+             numbers (2, 3, 4, ... — page 1 is always the root and is left untouched) in \
+             depth-first order. Fixes gaps left by delete_sheet/duplicate_sheet. Only \
+             touches files whose page numbers actually changed.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "schematic": { "type": "string", "description": "Root schematic to start from" },
+                    "project_name": { "type": "string", "description": "Default: ''" }
+                },
+                "required": ["schematic"]
+            }),
+            |args, ctx| async move { handle_renumber_sheet_pages(args, ctx).await }
+        ),
+    ]
+}
+
+// ─── Shared helpers ─────────────────────────────────────────────────────────
+
+const MAX_HIERARCHY_DEPTH: usize = 20;
+
+fn parent_dir(sch_path: &Path) -> PathBuf {
+    sch_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn create_blank_schematic(path: &Path) -> anyhow::Result<()> {
+    let template = "(kicad_sch\n\t(version 20250610)\n\t(generator \"konnect\")\n\t(generator_version \"10.0\")\n\t(paper \"A4\")\n\t(lib_symbols\n\t)\n)\n";
+    konnect_sexp::writer::write_atomic(path, template)?;
+    // Round-trip through cse so the file is normalised to its writer's format,
+    // matching the existing `create_schematic` tool's behavior.
+    let sch = cse::Schematic::load(path)?;
+    sch.overwrite()?;
+    Ok(())
+}
+
+fn next_free_page(parent: &cse::Schematic, project_name: &str) -> u32 {
+    let mut max_page: u32 = 1; // page 1 is always the root sheet
+    for sheet in parent.sheets.iter() {
+        if let Some(p) = sheet.page(project_name) {
+            if let Ok(n) = p.parse::<u32>() {
+                max_page = max_page.max(n);
+            }
+        }
+    }
+    max_page + 1
+}
+
+fn sheet_json(sheet: &cse::Sheet, project_name: &str) -> Value {
+    let (x, y) = sheet.position();
+    json!({
+        "name": sheet.name(),
+        "file": sheet.file(),
+        "uuid": sheet.uuid,
+        "x": x,
+        "y": y,
+        "width": sheet.width,
+        "height": sheet.height,
+        "page": sheet.page(project_name),
+        "pins": sheet.pins.iter().map(|p| {
+            let (px, py) = p.position();
+            json!({ "name": p.name, "pin_type": p.pin_type, "x": px, "y": py })
+        }).collect::<Vec<_>>()
+    })
+}
+
+/// Insert `sheet` into `parent`. If `patch_existing_symbols` is set, load the
+/// child file and ensure every symbol in it carries an instance path for this
+/// sheet's UUID — needed whenever the child file already has components in it
+/// (a reused file, or a freshly duplicated one).
+fn link_sheet(
+    parent: &mut cse::Schematic,
+    sheet: cse::Sheet,
+    child_path: &Path,
+    project_name: &str,
+    patch_existing_symbols: bool,
+) -> anyhow::Result<usize> {
+    let sheet_uuid = sheet.uuid.clone();
+    parent.add_sheet(sheet);
+
+    let mut patched = 0usize;
+    if patch_existing_symbols {
+        let mut child = cse::Schematic::load(child_path)?;
+        let hier_path = format!("/{}/", sheet_uuid);
+        for sym in child.symbols.iter_mut() {
+            if !sym.has_instance_path(project_name, &hier_path) {
+                let reference = sym.reference().unwrap_or("").to_string();
+                sym.set_instance_path(project_name, &hier_path, &reference, sym.unit);
+                patched += 1;
+            }
+        }
+        if patched > 0 {
+            child.overwrite()?;
+        }
+    }
+    Ok(patched)
+}
+
+// ─── Handlers ───────────────────────────────────────────────────────────────
+
+async fn handle_add_hierarchical_sheet(
+    args: &Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let parent_path = get_path(args, "schematic")?;
+    let sheet_file = match require_str(args, "sheet_file") {
+        Ok(v) => v.to_string(),
+        Err(e) => return Ok(e),
+    };
+    let sheet_name = opt_str(args, "sheet_name").unwrap_or("Sheet").to_string();
+    let x = opt_f64(args, "x").unwrap_or(50.0);
+    let y = opt_f64(args, "y").unwrap_or(50.0);
+    let width = opt_f64(args, "width").unwrap_or(80.0);
+    let height = opt_f64(args, "height").unwrap_or(50.0);
+    let project_name = opt_str(args, "project_name").unwrap_or("").to_string();
+
+    let dir = parent_dir(&parent_path);
+    let child_path = dir.join(&sheet_file);
+
+    let mut parent = cse::Schematic::load(&parent_path)?;
+
+    if parent.sheets.by_name(&sheet_name).is_some() {
+        return Ok(CallToolResult::error(format!(
+            "Sheet named '{}' already exists in this schematic — use edit_sheet to modify it \
+             or pick a different name",
+            sheet_name
+        )));
+    }
+
+    let child_existed = child_path.exists();
+    if !child_existed {
+        create_blank_schematic(&child_path)?;
+    }
+
+    let page = next_free_page(&parent, &project_name).to_string();
+    let mut sheet = cse::Sheet::new(
+        sheet_name.as_str(),
+        sheet_file.as_str(),
+        x,
+        y,
+        width,
+        height,
+    );
+    sheet.set_page(&project_name, "/", &page);
+
+    let patched = link_sheet(
+        &mut parent,
+        sheet,
+        &child_path,
+        &project_name,
+        child_existed,
+    )?;
+    parent.overwrite()?;
+
+    let sheet_ref = parent.sheets.by_name(&sheet_name).expect("just added");
+    Ok(CallToolResult::json(&json!({
+        "added": sheet_name,
+        "sheet": sheet_json(sheet_ref, &project_name),
+        "child_file": child_path.display().to_string(),
+        "reused_existing_file": child_existed,
+        "patched_symbol_instances": patched
+    })))
+}
+
+async fn handle_edit_sheet(args: &Value, _ctx: &ToolContext) -> anyhow::Result<CallToolResult> {
+    let sch_path = get_path(args, "schematic")?;
+    let sheet_name = match require_str(args, "sheet_name") {
+        Ok(v) => v.to_string(),
+        Err(e) => return Ok(e),
+    };
+    let project_name = opt_str(args, "project_name").unwrap_or("").to_string();
+
+    let mut sch = cse::Schematic::load(&sch_path)?;
+    let sheet = match sch.sheets.by_name_mut(&sheet_name) {
+        Some(s) => s,
+        None => {
+            return Ok(CallToolResult::error(format!(
+                "Sheet '{}' not found",
+                sheet_name
+            )))
+        }
+    };
+
+    let mut changed = Vec::new();
+    if let Some(new_name) = opt_str(args, "new_name") {
+        sheet.set_name(new_name);
+        changed.push("name");
+    }
+    if let Some(new_file) = opt_str(args, "new_file") {
+        sheet.set_file(new_file);
+        changed.push("file");
+    }
+    if let (Some(x), Some(y)) = (opt_f64(args, "x"), opt_f64(args, "y")) {
+        sheet.move_to(x, y);
+        changed.push("position");
+    }
+    if let (Some(w), Some(h)) = (opt_f64(args, "width"), opt_f64(args, "height")) {
+        sheet.set_size(w, h);
+        changed.push("size");
+    }
+
+    if changed.is_empty() {
+        return Ok(CallToolResult::error(
+            "No fields to change — provide at least one of: new_name, new_file, x+y, width+height",
+        ));
+    }
+
+    let summary = sheet_json(sheet, &project_name);
+    sch.overwrite()?;
+    Ok(CallToolResult::json(&json!({
+        "edited": sheet_name,
+        "changed_fields": changed,
+        "sheet": summary
+    })))
+}
+
+async fn handle_move_sheet(args: &Value, _ctx: &ToolContext) -> anyhow::Result<CallToolResult> {
+    let sch_path = get_path(args, "schematic")?;
+    let sheet_name = match require_str(args, "sheet_name") {
+        Ok(v) => v.to_string(),
+        Err(e) => return Ok(e),
+    };
+    let x = match require_f64(args, "x") {
+        Ok(v) => v,
+        Err(e) => return Ok(e),
+    };
+    let y = match require_f64(args, "y") {
+        Ok(v) => v,
+        Err(e) => return Ok(e),
+    };
+
+    let mut sch = cse::Schematic::load(&sch_path)?;
+    match sch.sheets.by_name_mut(&sheet_name) {
+        Some(sheet) => {
+            sheet.move_to(x, y);
+            sch.overwrite()?;
+            Ok(CallToolResult::json(
+                &json!({ "moved": sheet_name, "x": x, "y": y }),
+            ))
+        }
+        None => Ok(CallToolResult::error(format!(
+            "Sheet '{}' not found",
+            sheet_name
+        ))),
+    }
+}
+
+async fn handle_delete_sheet(args: &Value, _ctx: &ToolContext) -> anyhow::Result<CallToolResult> {
+    let sch_path = get_path(args, "schematic")?;
+    let sheet_name = match require_str(args, "sheet_name") {
+        Ok(v) => v.to_string(),
+        Err(e) => return Ok(e),
+    };
+
+    let mut sch = cse::Schematic::load(&sch_path)?;
+    match sch.sheets.remove_by_name(&sheet_name) {
+        Some(removed) => {
+            sch.overwrite()?;
+            Ok(CallToolResult::json(&json!({
+                "deleted": sheet_name,
+                "child_file_preserved": removed.file(),
+                "note": "The child schematic file was not deleted. Remaining sheets' page \
+                         numbers may now have a gap — call renumber_sheet_pages if needed."
+            })))
+        }
+        None => Ok(CallToolResult::error(format!(
+            "Sheet '{}' not found",
+            sheet_name
+        ))),
+    }
+}
+
+async fn handle_duplicate_sheet(
+    args: &Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let sch_path = get_path(args, "schematic")?;
+    let source_name = match require_str(args, "source_sheet_name") {
+        Ok(v) => v.to_string(),
+        Err(e) => return Ok(e),
+    };
+    let new_name = match require_str(args, "new_sheet_name") {
+        Ok(v) => v.to_string(),
+        Err(e) => return Ok(e),
+    };
+    let new_file = match require_str(args, "new_file") {
+        Ok(v) => v.to_string(),
+        Err(e) => return Ok(e),
+    };
+    let project_name = opt_str(args, "project_name").unwrap_or("").to_string();
+
+    let mut parent = cse::Schematic::load(&sch_path)?;
+
+    if parent.sheets.by_name(&new_name).is_some() {
+        return Ok(CallToolResult::error(format!(
+            "Sheet named '{}' already exists",
+            new_name
+        )));
+    }
+
+    let (src_x, src_y, src_w, src_h, src_file) = match parent.sheets.by_name(&source_name) {
+        Some(s) => {
+            let (x, y) = s.position();
+            (x, y, s.width, s.height, s.file().to_string())
+        }
+        None => {
+            return Ok(CallToolResult::error(format!(
+                "Sheet '{}' not found",
+                source_name
+            )))
+        }
+    };
+
+    let dir = parent_dir(&sch_path);
+    let source_child = dir.join(&src_file);
+    let new_child = dir.join(&new_file);
+
+    if new_child.exists() {
+        return Ok(CallToolResult::error(format!(
+            "'{}' already exists — pick a different file name, or use add_hierarchical_sheet \
+             to link the existing file instead of duplicating",
+            new_file
+        )));
+    }
+    if !source_child.exists() {
+        return Ok(CallToolResult::error(format!(
+            "Source sheet's file '{}' was not found on disk — cannot duplicate",
+            src_file
+        )));
+    }
+
+    std::fs::copy(&source_child, &new_child)?;
+
+    // Give the copy its own schematic-level identity so KiCAD doesn't see two
+    // files sharing the same internal UUID.
+    {
+        let mut copied = cse::Schematic::load(&new_child)?;
+        copied.uuid = Some(uuid::Uuid::new_v4().to_string());
+        copied.overwrite()?;
+    }
+
+    const DUPLICATE_OFFSET_MM: f64 = 20.0;
+    let page = next_free_page(&parent, &project_name).to_string();
+    let mut new_sheet = cse::Sheet::new(
+        new_name.as_str(),
+        new_file.as_str(),
+        src_x + DUPLICATE_OFFSET_MM,
+        src_y + DUPLICATE_OFFSET_MM,
+        src_w,
+        src_h,
+    );
+    new_sheet.set_page(&project_name, "/", &page);
+
+    let patched = link_sheet(&mut parent, new_sheet, &new_child, &project_name, true)?;
+    parent.overwrite()?;
+
+    let sheet_ref = parent.sheets.by_name(&new_name).expect("just added");
+    Ok(CallToolResult::json(&json!({
+        "duplicated_from": source_name,
+        "sheet": sheet_json(sheet_ref, &project_name),
+        "child_file": new_child.display().to_string(),
+        "patched_symbol_instances": patched
+    })))
+}
+
+async fn handle_get_sheet_hierarchy(
+    args: &Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let root_path = get_path(args, "schematic")?;
+    let project_name = opt_str(args, "project_name").unwrap_or("").to_string();
+
+    if !root_path.exists() {
+        return Ok(CallToolResult::error(format!(
+            "Schematic '{}' not found",
+            root_path.display()
+        )));
+    }
+
+    let mut visited = HashSet::new();
+    let tree = build_hierarchy_node(&root_path, &project_name, 0, &mut visited)?;
+    Ok(CallToolResult::json(&tree))
+}
+
+fn build_hierarchy_node(
+    path: &Path,
+    project_name: &str,
+    depth: usize,
+    visited: &mut HashSet<PathBuf>,
+) -> anyhow::Result<Value> {
+    let canon = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+
+    if depth > MAX_HIERARCHY_DEPTH {
+        return Ok(json!({
+            "file": path.display().to_string(),
+            "error": "max hierarchy depth exceeded — possible reference cycle",
+            "children": []
+        }));
+    }
+    if !visited.insert(canon.clone()) {
+        return Ok(json!({
+            "file": path.display().to_string(),
+            "error": "cycle detected — this file is already an ancestor in this tree",
+            "children": []
+        }));
+    }
+
+    let sch = match cse::Schematic::load(path) {
+        Ok(s) => s,
+        Err(e) => {
+            visited.remove(&canon);
+            return Ok(json!({
+                "file": path.display().to_string(),
+                "error": format!("failed to load: {}", e),
+                "children": []
+            }));
+        }
+    };
+
+    let dir = parent_dir(path);
+    let mut children = Vec::new();
+    for sheet in sch.sheets.iter() {
+        let child_path = dir.join(sheet.file());
+        let mut node = sheet_json(sheet, project_name);
+        if child_path.exists() {
+            let sub = build_hierarchy_node(&child_path, project_name, depth + 1, visited)?;
+            node["children"] = sub["children"].clone();
+            if let Some(err) = sub.get("error") {
+                node["error"] = err.clone();
+            }
+        } else {
+            node["children"] = json!([]);
+            node["error"] = json!("child file not found on disk");
+        }
+        children.push(node);
+    }
+    visited.remove(&canon);
+
+    Ok(json!({
+        "file": path.display().to_string(),
+        "children": children
+    }))
+}
+
+async fn handle_renumber_sheet_pages(
+    args: &Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let root_path = get_path(args, "schematic")?;
+    let project_name = opt_str(args, "project_name").unwrap_or("").to_string();
+
+    if !root_path.exists() {
+        return Ok(CallToolResult::error(format!(
+            "Schematic '{}' not found",
+            root_path.display()
+        )));
+    }
+
+    let mut next_page = 2u32; // page 1 is always the root, left untouched
+    let mut renumbered = Vec::new();
+    let mut visited = HashSet::new();
+    renumber_walk(
+        &root_path,
+        &project_name,
+        &mut next_page,
+        &mut renumbered,
+        &mut visited,
+    )?;
+
+    Ok(CallToolResult::json(&json!({
+        "renumbered_count": renumbered.len(),
+        "pages": renumbered
+    })))
+}
+
+fn renumber_walk(
+    path: &Path,
+    project_name: &str,
+    next_page: &mut u32,
+    renumbered: &mut Vec<Value>,
+    visited: &mut HashSet<PathBuf>,
+) -> anyhow::Result<()> {
+    let canon = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    if !visited.insert(canon.clone()) {
+        return Ok(()); // cycle guard — already on this DFS path, skip
+    }
+
+    let mut sch = cse::Schematic::load(path)?;
+    let dir = parent_dir(path);
+    let mut changed = false;
+
+    // Snapshot the sheet order first: recursing below needs `sch` unborrowed.
+    let sheet_order: Vec<(String, String)> = sch
+        .sheets
+        .iter()
+        .map(|s| (s.name().to_string(), s.file().to_string()))
+        .collect();
+
+    for (name, file) in &sheet_order {
+        let page = next_page.to_string();
+        *next_page += 1;
+        if let Some(sheet) = sch.sheets.by_name_mut(name) {
+            if sheet.page(project_name) != Some(page.as_str()) {
+                sheet.set_page(project_name, "/", &page);
+                changed = true;
+            }
+        }
+        renumbered.push(json!({ "sheet_name": name, "file": file, "page": page }));
+
+        let child_path = dir.join(file);
+        if child_path.exists() {
+            renumber_walk(&child_path, project_name, next_page, renumbered, visited)?;
+        }
+    }
+
+    if changed {
+        sch.overwrite()?;
+    }
+    visited.remove(&canon);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::{ServerConfig, ToolContext};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn test_ctx() -> ToolContext {
+        let config = ServerConfig {
+            kicad_cli: "kicad-cli".into(),
+            kicad_binary: "kicad".into(),
+            ipc_address: String::new(),
+            project_dir: None,
+            jlcpcb_db_path: None,
+        };
+        ToolContext::new(config, Arc::new(crate::router::ToolRouter::new()))
+    }
+
+    fn blank_schematic(dir: &Path, name: &str) -> PathBuf {
+        let path = dir.join(name);
+        create_blank_schematic(&path).unwrap();
+        path
+    }
+
+    #[tokio::test]
+    async fn add_hierarchical_sheet_creates_child_file_and_links_it() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        let ctx = test_ctx();
+
+        let args = json!({
+            "schematic": root.display().to_string(),
+            "sheet_file": "power.kicad_sch",
+            "sheet_name": "Power Supply",
+            "x": 20.0, "y": 20.0
+        });
+        let result = handle_add_hierarchical_sheet(&args, &ctx).await.unwrap();
+        assert!(!result.is_error);
+
+        assert!(tmp.path().join("power.kicad_sch").exists());
+        let parent = cse::Schematic::load(&root).unwrap();
+        assert_eq!(parent.sheets.len(), 1);
+        assert_eq!(
+            parent.sheets.by_name("Power Supply").unwrap().file(),
+            "power.kicad_sch"
+        );
+        assert_eq!(
+            parent.sheets.by_name("Power Supply").unwrap().page(""),
+            Some("2")
+        );
+    }
+
+    #[tokio::test]
+    async fn add_hierarchical_sheet_rejects_duplicate_name() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        let ctx = test_ctx();
+
+        let args = json!({ "schematic": root.display().to_string(), "sheet_file": "a.kicad_sch", "sheet_name": "A" });
+        handle_add_hierarchical_sheet(&args, &ctx).await.unwrap();
+
+        let args2 = json!({ "schematic": root.display().to_string(), "sheet_file": "b.kicad_sch", "sheet_name": "A" });
+        let result = handle_add_hierarchical_sheet(&args2, &ctx).await.unwrap();
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn second_sheet_gets_next_free_page() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        let ctx = test_ctx();
+
+        handle_add_hierarchical_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_file": "a.kicad_sch", "sheet_name": "A" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        handle_add_hierarchical_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_file": "b.kicad_sch", "sheet_name": "B" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        let parent = cse::Schematic::load(&root).unwrap();
+        assert_eq!(parent.sheets.by_name("A").unwrap().page(""), Some("2"));
+        assert_eq!(parent.sheets.by_name("B").unwrap().page(""), Some("3"));
+    }
+
+    #[tokio::test]
+    async fn edit_sheet_renames_and_resizes() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        let ctx = test_ctx();
+        handle_add_hierarchical_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_file": "a.kicad_sch", "sheet_name": "A" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        let result = handle_edit_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_name": "A", "new_name": "Renamed", "width": 100.0, "height": 60.0 }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error);
+
+        let parent = cse::Schematic::load(&root).unwrap();
+        assert!(parent.sheets.by_name("A").is_none());
+        let renamed = parent.sheets.by_name("Renamed").unwrap();
+        assert_eq!(renamed.width, 100.0);
+        assert_eq!(renamed.height, 60.0);
+    }
+
+    #[tokio::test]
+    async fn edit_sheet_with_no_fields_errors() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        let ctx = test_ctx();
+        handle_add_hierarchical_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_file": "a.kicad_sch", "sheet_name": "A" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        let result = handle_edit_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_name": "A" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn move_sheet_updates_position_only() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        let ctx = test_ctx();
+        handle_add_hierarchical_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_file": "a.kicad_sch", "sheet_name": "A", "x": 10.0, "y": 10.0 }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        handle_move_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_name": "A", "x": 99.0, "y": 88.0 }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        let parent = cse::Schematic::load(&root).unwrap();
+        let sheet = parent.sheets.by_name("A").unwrap();
+        assert_eq!(sheet.position(), (99.0, 88.0));
+    }
+
+    #[tokio::test]
+    async fn delete_sheet_removes_reference_but_keeps_child_file() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        let ctx = test_ctx();
+        handle_add_hierarchical_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_file": "a.kicad_sch", "sheet_name": "A" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        let result = handle_delete_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_name": "A" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error);
+
+        let parent = cse::Schematic::load(&root).unwrap();
+        assert!(parent.sheets.is_empty());
+        assert!(tmp.path().join("a.kicad_sch").exists());
+    }
+
+    #[tokio::test]
+    async fn delete_sheet_not_found_errors() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        let ctx = test_ctx();
+        let result = handle_delete_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_name": "Nope" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn duplicate_sheet_copies_file_independently() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        let ctx = test_ctx();
+        handle_add_hierarchical_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_file": "amp.kicad_sch", "sheet_name": "Amp1", "x": 10.0, "y": 10.0 }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        let result = handle_duplicate_sheet(
+            &json!({
+                "schematic": root.display().to_string(),
+                "source_sheet_name": "Amp1",
+                "new_sheet_name": "Amp2",
+                "new_file": "amp2.kicad_sch"
+            }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error);
+        assert!(tmp.path().join("amp2.kicad_sch").exists());
+
+        let parent = cse::Schematic::load(&root).unwrap();
+        assert_eq!(parent.sheets.len(), 2);
+        let amp2 = parent.sheets.by_name("Amp2").unwrap();
+        assert_eq!(amp2.file(), "amp2.kicad_sch");
+        assert_eq!(amp2.position(), (30.0, 30.0)); // offset from source (10,10)
+
+        // Independent files: the two schematics have different internal UUIDs.
+        let sch1 = cse::Schematic::load(tmp.path().join("amp.kicad_sch")).unwrap();
+        let sch2 = cse::Schematic::load(tmp.path().join("amp2.kicad_sch")).unwrap();
+        assert_ne!(sch1.uuid, sch2.uuid);
+    }
+
+    #[tokio::test]
+    async fn duplicate_sheet_refuses_to_overwrite_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        let ctx = test_ctx();
+        handle_add_hierarchical_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_file": "a.kicad_sch", "sheet_name": "A" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        // A second, unrelated sheet already occupies "b.kicad_sch".
+        handle_add_hierarchical_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_file": "b.kicad_sch", "sheet_name": "B" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        let result = handle_duplicate_sheet(
+            &json!({
+                "schematic": root.display().to_string(),
+                "source_sheet_name": "A",
+                "new_sheet_name": "A-copy",
+                "new_file": "b.kicad_sch"
+            }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn get_sheet_hierarchy_returns_nested_tree() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        let ctx = test_ctx();
+        handle_add_hierarchical_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_file": "mid.kicad_sch", "sheet_name": "Mid" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        handle_add_hierarchical_sheet(
+            &json!({ "schematic": tmp.path().join("mid.kicad_sch").display().to_string(), "sheet_file": "leaf.kicad_sch", "sheet_name": "Leaf" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        let result =
+            handle_get_sheet_hierarchy(&json!({ "schematic": root.display().to_string() }), &ctx)
+                .await
+                .unwrap();
+        assert!(!result.is_error);
+
+        let text = match &result.content[0] {
+            crate::mcp::protocol::ToolContent::Text { text } => text.clone(),
+            _ => panic!("expected text content"),
+        };
+        let tree: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(tree["children"][0]["name"], "Mid");
+        assert_eq!(tree["children"][0]["children"][0]["name"], "Leaf");
+    }
+
+    #[tokio::test]
+    async fn get_sheet_hierarchy_reports_missing_child_file() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        let ctx = test_ctx();
+        handle_add_hierarchical_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_file": "gone.kicad_sch", "sheet_name": "Gone" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        std::fs::remove_file(tmp.path().join("gone.kicad_sch")).unwrap();
+
+        let result =
+            handle_get_sheet_hierarchy(&json!({ "schematic": root.display().to_string() }), &ctx)
+                .await
+                .unwrap();
+        let text = match &result.content[0] {
+            crate::mcp::protocol::ToolContent::Text { text } => text.clone(),
+            _ => panic!("expected text content"),
+        };
+        let tree: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(tree["children"][0]["error"], "child file not found on disk");
+    }
+
+    #[tokio::test]
+    async fn renumber_sheet_pages_closes_gap_after_delete() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        let ctx = test_ctx();
+        for (file, name) in [
+            ("a.kicad_sch", "A"),
+            ("b.kicad_sch", "B"),
+            ("c.kicad_sch", "C"),
+        ] {
+            handle_add_hierarchical_sheet(
+                &json!({ "schematic": root.display().to_string(), "sheet_file": file, "sheet_name": name }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        }
+        // A=2, B=3, C=4. Delete B, leaving a gap at page 3.
+        handle_delete_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_name": "B" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        let result =
+            handle_renumber_sheet_pages(&json!({ "schematic": root.display().to_string() }), &ctx)
+                .await
+                .unwrap();
+        assert!(!result.is_error);
+
+        let parent = cse::Schematic::load(&root).unwrap();
+        assert_eq!(parent.sheets.by_name("A").unwrap().page(""), Some("2"));
+        assert_eq!(parent.sheets.by_name("C").unwrap().page(""), Some("3"));
+    }
+
+    #[tokio::test]
+    async fn linking_existing_file_with_symbols_patches_instance_paths() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        let child_path = tmp.path().join("reused.kicad_sch");
+        create_blank_schematic(&child_path).unwrap();
+
+        // Put a symbol in the child file before it's ever linked.
+        {
+            let mut child = cse::Schematic::load(&child_path).unwrap();
+            let mut sym = cse::Symbol::new("Device:R", 10.0, 10.0);
+            sym.set_reference("R1");
+            child.add_symbol(sym);
+            child.overwrite().unwrap();
+        }
+
+        let ctx = test_ctx();
+        let result = handle_add_hierarchical_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_file": "reused.kicad_sch", "sheet_name": "Reused" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error);
+
+        let child = cse::Schematic::load(&child_path).unwrap();
+        let sym = child.symbols.by_reference("R1").unwrap();
+        assert!(sym.has_instance_path(
+            "",
+            &format!("/{}/", {
+                let parent = cse::Schematic::load(&root).unwrap();
+                parent.sheets.by_name("Reused").unwrap().uuid.clone()
+            })
+        ));
+    }
+}

--- a/crates/konnect-schematic-editor/src/lib.rs
+++ b/crates/konnect-schematic-editor/src/lib.rs
@@ -10,6 +10,7 @@ pub use schematic::label::{
     LabelCollection,
 };
 pub use schematic::misc::{Junction, NoConnect, Text};
+pub use schematic::sheet::{Sheet, SheetCollection, SheetInstance, SheetPin};
 pub use schematic::symbol::{Symbol, SymbolCollection};
 pub use schematic::wire::{Wire, WireCollection};
 pub use schematic::{LocatedElement, Schematic};

--- a/crates/konnect-schematic-editor/src/schematic/mod.rs
+++ b/crates/konnect-schematic-editor/src/schematic/mod.rs
@@ -1,5 +1,6 @@
 pub mod label;
 pub mod misc;
+pub mod sheet;
 pub mod symbol;
 pub mod wire;
 
@@ -14,6 +15,7 @@ use label::{
     LabelCollection,
 };
 use misc::{Junction, NoConnect, Text};
+use sheet::{Sheet, SheetCollection};
 use symbol::{Symbol, SymbolCollection};
 use wire::{Wire, WireCollection};
 
@@ -80,8 +82,9 @@ pub struct Schematic {
     pub junctions: Vec<Junction>,
     pub texts: Vec<Text>,
     pub no_connects: Vec<NoConnect>,
+    pub sheets: SheetCollection,
 
-    /// All nodes we don't model (title_block, lib_symbols, bus, sheet, …)
+    /// All nodes we don't model (title_block, lib_symbols, bus, sheet_instances, …)
     /// preserved verbatim so round-trips don't lose anything.
     pub raw_other: Vec<SexpNode>,
 }
@@ -165,6 +168,13 @@ impl Schematic {
     /// Add a pre-built Symbol to the schematic.
     pub fn add_symbol(&mut self, symbol: Symbol) {
         self.symbols.push(symbol);
+    }
+
+    /// Add a pre-built Sheet to the schematic. Returns a mutable reference to it.
+    pub fn add_sheet(&mut self, sheet: Sheet) -> &mut Sheet {
+        self.sheets.push(sheet);
+        let last = self.sheets.as_slice().len() - 1;
+        self.sheets.get_mut(last).expect("just pushed")
     }
 
     // ---- diff / change summary ----------------------------------------------
@@ -340,6 +350,7 @@ impl Schematic {
         let mut junctions: Vec<Junction> = vec![];
         let mut texts: Vec<Text> = vec![];
         let mut no_connects: Vec<NoConnect> = vec![];
+        let mut sheets: Vec<Sheet> = vec![];
         let mut raw_other: Vec<SexpNode> = vec![];
 
         for child in root.args() {
@@ -393,6 +404,10 @@ impl Schematic {
                     Ok(nc) => no_connects.push(nc),
                     Err(e) => eprintln!("[konnect-schematic-editor] skipping no_connect: {e}"),
                 },
+                Some("sheet") => match Sheet::from_sexp(child) {
+                    Ok(s) => sheets.push(s),
+                    Err(e) => eprintln!("[konnect-schematic-editor] skipping sheet: {e}"),
+                },
                 _ => {
                     raw_other.push(child.clone());
                 }
@@ -414,6 +429,7 @@ impl Schematic {
             junctions,
             texts,
             no_connects,
+            sheets: SheetCollection::new(sheets),
             raw_other,
         })
     }
@@ -451,7 +467,7 @@ impl Schematic {
         }
 
         // Typed elements in KiCAD 10 required order:
-        // junctions → no_connects → wires → texts → labels → symbols (LAST)
+        // junctions → no_connects → wires → texts → labels → sheets → symbols (LAST)
         for j in &self.junctions {
             c.push(j.to_sexp());
         }
@@ -472,6 +488,9 @@ impl Schematic {
         }
         for h in self.hierarchical_labels.iter() {
             c.push(h.to_sexp());
+        }
+        for s in self.sheets.iter() {
+            c.push(s.to_sexp());
         }
         for s in self.symbols.iter() {
             c.push(s.to_sexp());

--- a/crates/konnect-schematic-editor/src/schematic/sheet.rs
+++ b/crates/konnect-schematic-editor/src/schematic/sheet.rs
@@ -1,0 +1,536 @@
+use crate::error::{Error, Result};
+use crate::sexp::{atom, qstr, tagged, SexpNode};
+use crate::types::{fmt_f64, At, Effects, Property};
+
+// ---- SheetPin -----------------------------------------------------------------
+
+/// A parent-side connection point on a `(sheet ...)` block. Must be paired with
+/// a same-named `hierarchical_label` in the referenced sub-sheet for ERC to
+/// resolve the connection.
+#[derive(Debug, Clone)]
+pub struct SheetPin {
+    pub name: String,
+    /// One of: "input", "output", "bidirectional", "tri_state", "passive".
+    pub pin_type: String,
+    pub at: At,
+    pub uuid: String,
+    pub effects: Option<Effects>,
+}
+
+impl SheetPin {
+    pub fn new(name: impl Into<String>, pin_type: impl Into<String>, x: f64, y: f64) -> Self {
+        SheetPin {
+            name: name.into(),
+            pin_type: pin_type.into(),
+            at: At::new(x, y),
+            uuid: uuid::Uuid::new_v4().to_string(),
+            effects: None,
+        }
+    }
+
+    pub fn from_sexp(node: &SexpNode) -> Result<Self> {
+        let name = node
+            .value()
+            .ok_or(Error::MissingField("sheet pin name"))?
+            .to_owned();
+        let pin_type = node
+            .args()
+            .get(1)
+            .and_then(|n| n.text())
+            .unwrap_or("passive")
+            .to_owned();
+        let at = node
+            .find("at")
+            .and_then(At::from_sexp)
+            .ok_or(Error::MissingField("at"))?;
+        let uuid = node.get_value("uuid").unwrap_or("").to_owned();
+        let effects = node.find("effects").and_then(Effects::from_sexp);
+        Ok(SheetPin {
+            name,
+            pin_type,
+            at,
+            uuid,
+            effects,
+        })
+    }
+
+    pub fn to_sexp(&self) -> SexpNode {
+        let mut c = vec![
+            atom("pin"),
+            qstr(self.name.clone()),
+            atom(self.pin_type.clone()),
+            self.at.to_sexp(),
+        ];
+        if let Some(e) = &self.effects {
+            c.push(e.to_sexp());
+        }
+        c.push(tagged("uuid", vec![qstr(self.uuid.clone())]));
+        SexpNode::List(c)
+    }
+
+    pub fn position(&self) -> (f64, f64) {
+        (self.at.x, self.at.y)
+    }
+}
+
+// ---- SheetInstance --------------------------------------------------------------
+
+/// One `(path ... (page ...))` entry under a `(project "name" ...)` block inside
+/// a sheet's `(instances ...)`. Tracks the page number KiCAD's page navigator
+/// shows for this sheet, per project.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SheetInstance {
+    pub project_name: String,
+    pub path: String,
+    pub page: String,
+}
+
+fn parse_project_instances(project_node: &SexpNode) -> Vec<SheetInstance> {
+    let project_name = project_node.value().unwrap_or("").to_owned();
+    project_node
+        .find_all("path")
+        .iter()
+        .filter_map(|path_node| {
+            let path = path_node.value()?.to_owned();
+            let page = path_node.get_value("page")?.to_owned();
+            Some(SheetInstance {
+                project_name: project_name.clone(),
+                path,
+                page,
+            })
+        })
+        .collect()
+}
+
+fn instances_to_sexp(instances: &[SheetInstance]) -> Option<SexpNode> {
+    if instances.is_empty() {
+        return None;
+    }
+    let mut projects: Vec<(&str, Vec<&SheetInstance>)> = vec![];
+    for inst in instances {
+        match projects
+            .iter_mut()
+            .find(|(name, _)| *name == inst.project_name)
+        {
+            Some(entry) => entry.1.push(inst),
+            None => projects.push((inst.project_name.as_str(), vec![inst])),
+        }
+    }
+    let project_nodes: Vec<SexpNode> = projects
+        .into_iter()
+        .map(|(name, insts)| {
+            let mut c = vec![atom("project"), qstr(name.to_owned())];
+            for i in insts {
+                c.push(SexpNode::List(vec![
+                    atom("path"),
+                    qstr(i.path.clone()),
+                    tagged("page", vec![qstr(i.page.clone())]),
+                ]));
+            }
+            SexpNode::List(c)
+        })
+        .collect();
+    let mut c = vec![atom("instances")];
+    c.extend(project_nodes);
+    Some(SexpNode::List(c))
+}
+
+// ---- Sheet --------------------------------------------------------------------
+
+/// A `(sheet ...)` block — a reference from a parent schematic to a child
+/// `.kicad_sch` file, rendered as a box on the parent canvas.
+#[derive(Debug, Clone)]
+pub struct Sheet {
+    /// Top-left corner of the sheet box.
+    pub at: At,
+    pub width: f64,
+    pub height: f64,
+    pub uuid: String,
+    pub fields_autoplaced: bool,
+    /// `Sheetname` / `Sheetfile` live here alongside any custom sheet properties.
+    pub properties: Vec<Property>,
+    pub pins: Vec<SheetPin>,
+    pub instances: Vec<SheetInstance>,
+    /// `stroke` / `fill` sub-nodes preserved verbatim — cosmetic, not worth
+    /// modeling field-by-field for the first pass.
+    pub raw_sub_nodes: Vec<SexpNode>,
+}
+
+fn default_stroke_fill() -> Vec<SexpNode> {
+    vec![
+        SexpNode::List(vec![
+            atom("stroke"),
+            tagged("width", vec![atom("0.1524")]),
+            tagged("type", vec![atom("solid")]),
+        ]),
+        SexpNode::List(vec![
+            atom("fill"),
+            tagged("color", vec![atom("0"), atom("0"), atom("0"), atom("0.0")]),
+        ]),
+    ]
+}
+
+impl Sheet {
+    pub fn new(
+        name: impl Into<String>,
+        file: impl Into<String>,
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+    ) -> Self {
+        Sheet {
+            at: At::new(x, y),
+            width,
+            height,
+            uuid: uuid::Uuid::new_v4().to_string(),
+            fields_autoplaced: true,
+            properties: vec![
+                Property::new("Sheetname", name),
+                Property::new("Sheetfile", file),
+            ],
+            pins: vec![],
+            instances: vec![],
+            raw_sub_nodes: default_stroke_fill(),
+        }
+    }
+
+    pub fn from_sexp(node: &SexpNode) -> Result<Self> {
+        let at = node
+            .find("at")
+            .and_then(At::from_sexp)
+            .ok_or(Error::MissingField("at"))?;
+        let size_node = node.find("size").ok_or(Error::MissingField("size"))?;
+        let sa = size_node.scalar_args();
+        let width: f64 = sa
+            .first()
+            .and_then(|s| s.parse().ok())
+            .ok_or(Error::MissingField("size width"))?;
+        let height: f64 = sa
+            .get(1)
+            .and_then(|s| s.parse().ok())
+            .ok_or(Error::MissingField("size height"))?;
+        let fields_autoplaced = node.find("fields_autoplaced").is_some();
+        let uuid = node.get_value("uuid").unwrap_or("").to_owned();
+        let properties = node
+            .find_all("property")
+            .iter()
+            .filter_map(|n| Property::from_sexp(n))
+            .collect();
+        let pins = node
+            .find_all("pin")
+            .iter()
+            .filter_map(|n| SheetPin::from_sexp(n).ok())
+            .collect();
+        let instances = node
+            .find("instances")
+            .map(|inst_node| {
+                inst_node
+                    .find_all("project")
+                    .iter()
+                    .flat_map(|p| parse_project_instances(p))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        const PRESERVE: &[&str] = &["stroke", "fill"];
+        let raw_sub_nodes = node
+            .args()
+            .iter()
+            .filter(|n| n.tag().map(|t| PRESERVE.contains(&t)).unwrap_or(false))
+            .cloned()
+            .collect();
+
+        Ok(Sheet {
+            at,
+            width,
+            height,
+            uuid,
+            fields_autoplaced,
+            properties,
+            pins,
+            instances,
+            raw_sub_nodes,
+        })
+    }
+
+    pub fn to_sexp(&self) -> SexpNode {
+        let mut c = vec![atom("sheet")];
+        c.push(self.at.to_sexp());
+        c.push(tagged(
+            "size",
+            vec![atom(fmt_f64(self.width)), atom(fmt_f64(self.height))],
+        ));
+        if self.fields_autoplaced {
+            c.push(SexpNode::List(vec![atom("fields_autoplaced")]));
+        }
+        c.extend(self.raw_sub_nodes.iter().cloned());
+        c.push(tagged("uuid", vec![qstr(self.uuid.clone())]));
+        for p in &self.properties {
+            c.push(p.to_sexp());
+        }
+        for pin in &self.pins {
+            c.push(pin.to_sexp());
+        }
+        if let Some(inst) = instances_to_sexp(&self.instances) {
+            c.push(inst);
+        }
+        SexpNode::List(c)
+    }
+
+    // ---- property helpers -----------------------------------------------------
+
+    pub fn property(&self, name: &str) -> Option<&str> {
+        self.properties
+            .iter()
+            .find(|p| p.name == name)
+            .map(|p| p.value.as_str())
+    }
+
+    pub fn set_property(&mut self, name: &str, value: &str) {
+        if let Some(p) = self.properties.iter_mut().find(|p| p.name == name) {
+            p.value = value.to_owned();
+        } else {
+            self.properties.push(Property::new(name, value));
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        self.property("Sheetname").unwrap_or("")
+    }
+    pub fn file(&self) -> &str {
+        self.property("Sheetfile").unwrap_or("")
+    }
+    pub fn set_name(&mut self, v: &str) {
+        self.set_property("Sheetname", v);
+    }
+    pub fn set_file(&mut self, v: &str) {
+        self.set_property("Sheetfile", v);
+    }
+
+    // ---- position / size --------------------------------------------------------
+
+    pub fn position(&self) -> (f64, f64) {
+        (self.at.x, self.at.y)
+    }
+    pub fn move_to(&mut self, x: f64, y: f64) {
+        self.at.x = x;
+        self.at.y = y;
+    }
+    pub fn set_size(&mut self, width: f64, height: f64) {
+        self.width = width;
+        self.height = height;
+    }
+
+    // ---- pins -------------------------------------------------------------------
+
+    pub fn add_pin(&mut self, pin: SheetPin) {
+        self.pins.push(pin);
+    }
+    pub fn pin_by_name(&self, name: &str) -> Option<&SheetPin> {
+        self.pins.iter().find(|p| p.name == name)
+    }
+    pub fn pin_by_name_mut(&mut self, name: &str) -> Option<&mut SheetPin> {
+        self.pins.iter_mut().find(|p| p.name == name)
+    }
+    /// Returns `true` if a pin with this name existed and was removed.
+    pub fn remove_pin(&mut self, name: &str) -> bool {
+        let before = self.pins.len();
+        self.pins.retain(|p| p.name != name);
+        self.pins.len() != before
+    }
+
+    // ---- page / instances ---------------------------------------------------------
+
+    pub fn page(&self, project_name: &str) -> Option<&str> {
+        self.instances
+            .iter()
+            .find(|i| i.project_name == project_name)
+            .map(|i| i.page.as_str())
+    }
+
+    pub fn set_page(&mut self, project_name: &str, path: &str, page: &str) {
+        if let Some(inst) = self
+            .instances
+            .iter_mut()
+            .find(|i| i.project_name == project_name && i.path == path)
+        {
+            inst.page = page.to_owned();
+        } else {
+            self.instances.push(SheetInstance {
+                project_name: project_name.to_owned(),
+                path: path.to_owned(),
+                page: page.to_owned(),
+            });
+        }
+    }
+}
+
+// ---- SheetCollection ------------------------------------------------------------
+
+pub struct SheetCollection {
+    sheets: Vec<Sheet>,
+}
+
+impl SheetCollection {
+    pub fn new(sheets: Vec<Sheet>) -> Self {
+        SheetCollection { sheets }
+    }
+
+    pub fn len(&self) -> usize {
+        self.sheets.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.sheets.is_empty()
+    }
+    pub fn iter(&self) -> std::slice::Iter<'_, Sheet> {
+        self.sheets.iter()
+    }
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, Sheet> {
+        self.sheets.iter_mut()
+    }
+    pub fn as_slice(&self) -> &[Sheet] {
+        &self.sheets
+    }
+    pub fn get(&self, i: usize) -> Option<&Sheet> {
+        self.sheets.get(i)
+    }
+    pub fn get_mut(&mut self, i: usize) -> Option<&mut Sheet> {
+        self.sheets.get_mut(i)
+    }
+    pub fn push(&mut self, s: Sheet) {
+        self.sheets.push(s);
+    }
+    pub fn into_vec(self) -> Vec<Sheet> {
+        self.sheets
+    }
+
+    pub fn by_name(&self, name: &str) -> Option<&Sheet> {
+        self.sheets.iter().find(|s| s.name() == name)
+    }
+    pub fn by_name_mut(&mut self, name: &str) -> Option<&mut Sheet> {
+        self.sheets.iter_mut().find(|s| s.name() == name)
+    }
+    pub fn by_uuid(&self, uuid: &str) -> Option<&Sheet> {
+        self.sheets.iter().find(|s| s.uuid == uuid)
+    }
+    pub fn by_uuid_mut(&mut self, uuid: &str) -> Option<&mut Sheet> {
+        self.sheets.iter_mut().find(|s| s.uuid == uuid)
+    }
+    pub fn by_file(&self, file: &str) -> Vec<&Sheet> {
+        self.sheets.iter().filter(|s| s.file() == file).collect()
+    }
+
+    pub fn remove_by_uuid(&mut self, uuid: &str) -> Option<Sheet> {
+        let idx = self.sheets.iter().position(|s| s.uuid == uuid)?;
+        Some(self.sheets.remove(idx))
+    }
+    pub fn remove_by_name(&mut self, name: &str) -> Option<Sheet> {
+        let idx = self.sheets.iter().position(|s| s.name() == name)?;
+        Some(self.sheets.remove(idx))
+    }
+}
+
+impl<'a> IntoIterator for &'a SheetCollection {
+    type Item = &'a Sheet;
+    type IntoIter = std::slice::Iter<'a, Sheet>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.sheets.iter()
+    }
+}
+impl<'a> IntoIterator for &'a mut SheetCollection {
+    type Item = &'a mut Sheet;
+    type IntoIter = std::slice::IterMut<'a, Sheet>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.sheets.iter_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sexp::parser;
+
+    fn parse_one(s: &str) -> SexpNode {
+        parser::parse(s).unwrap()
+    }
+
+    #[test]
+    fn sheet_round_trips_through_sexp() {
+        let src = r#"(sheet
+	(at 100 50)
+	(size 40 30)
+	(fields_autoplaced yes)
+	(stroke (width 0.1524) (type solid))
+	(fill (color 0 0 0 0.0))
+	(uuid "5c2a1e3f-0000-0000-0000-000000000000")
+	(property "Sheetname" "Power Supply" (at 100 49.2 0))
+	(property "Sheetfile" "power_supply.kicad_sch" (at 100 80.4 0))
+	(pin "VIN" input (at 100 60 180) (uuid "8b1f0000-0000-0000-0000-000000000000"))
+	(pin "GND" passive (at 100 70 180) (uuid "9c2e0000-0000-0000-0000-000000000000"))
+	(instances
+		(project "MyProject"
+			(path "/" (page "2"))
+		)
+	)
+)"#;
+        let node = parse_one(src);
+        let sheet = Sheet::from_sexp(&node).unwrap();
+        assert_eq!(sheet.name(), "Power Supply");
+        assert_eq!(sheet.file(), "power_supply.kicad_sch");
+        assert_eq!(sheet.width, 40.0);
+        assert_eq!(sheet.height, 30.0);
+        assert_eq!(sheet.pins.len(), 2);
+        assert_eq!(sheet.pins[0].name, "VIN");
+        assert_eq!(sheet.pins[0].pin_type, "input");
+        assert_eq!(sheet.page("MyProject"), Some("2"));
+
+        let out = sheet.to_sexp();
+        let reparsed = Sheet::from_sexp(&out).unwrap();
+        assert_eq!(reparsed.name(), "Power Supply");
+        assert_eq!(reparsed.pins.len(), 2);
+        assert_eq!(reparsed.page("MyProject"), Some("2"));
+    }
+
+    #[test]
+    fn new_sheet_has_no_pins_or_instances() {
+        let sheet = Sheet::new("Storage", "storage.kicad_sch", 10.0, 10.0, 60.0, 40.0);
+        assert_eq!(sheet.name(), "Storage");
+        assert_eq!(sheet.file(), "storage.kicad_sch");
+        assert!(sheet.pins.is_empty());
+        assert!(sheet.instances.is_empty());
+        assert!(!sheet.uuid.is_empty());
+    }
+
+    #[test]
+    fn pin_lifecycle() {
+        let mut sheet = Sheet::new("A", "a.kicad_sch", 0.0, 0.0, 10.0, 10.0);
+        sheet.add_pin(SheetPin::new("VCC", "input", 0.0, 2.0));
+        assert!(sheet.pin_by_name("VCC").is_some());
+        assert!(sheet.remove_pin("VCC"));
+        assert!(sheet.pin_by_name("VCC").is_none());
+        assert!(!sheet.remove_pin("VCC")); // already gone
+    }
+
+    #[test]
+    fn set_page_adds_then_updates() {
+        let mut sheet = Sheet::new("A", "a.kicad_sch", 0.0, 0.0, 10.0, 10.0);
+        assert_eq!(sheet.page(""), None);
+        sheet.set_page("", "/", "2");
+        assert_eq!(sheet.page(""), Some("2"));
+        sheet.set_page("", "/", "3");
+        assert_eq!(sheet.page(""), Some("3"));
+        assert_eq!(sheet.instances.len(), 1);
+    }
+
+    #[test]
+    fn multi_instance_sheet_keeps_separate_pages_per_path() {
+        let mut sheet = Sheet::new("Amp Stage", "amp.kicad_sch", 0.0, 0.0, 10.0, 10.0);
+        sheet.set_page("", "/", "2");
+        sheet.set_page("", "/amp1-uuid/", "3");
+        assert_eq!(sheet.instances.len(), 2);
+        let out = sheet.to_sexp();
+        let reparsed = Sheet::from_sexp(&out).unwrap();
+        assert_eq!(reparsed.instances.len(), 2);
+    }
+}

--- a/crates/konnect-schematic-editor/src/schematic/symbol.rs
+++ b/crates/konnect-schematic-editor/src/schematic/symbol.rs
@@ -169,6 +169,90 @@ impl Symbol {
         self.set_property("Datasheet", v);
     }
 
+    // ---- instance paths -------------------------------------------------------
+
+    /// Ensure this symbol carries an `(instances (project "name" (path "path"
+    /// (reference "ref") (unit N))))` entry. Updates the entry if one already
+    /// exists for this project+path, otherwise appends it (creating the
+    /// `project`/`instances` wrapper nodes as needed).
+    ///
+    /// Needed when a sheet is linked to a sub-sheet file that already has
+    /// symbols in it (a reused file, or one authored before being linked) —
+    /// without this, ERC can't resolve those symbols' hierarchical references.
+    pub fn set_instance_path(
+        &mut self,
+        project_name: &str,
+        path: &str,
+        reference: &str,
+        unit: u32,
+    ) {
+        if self
+            .raw_sub_nodes
+            .iter()
+            .position(|n| n.tag() == Some("instances"))
+            .is_none()
+        {
+            self.raw_sub_nodes
+                .push(SexpNode::List(vec![atom("instances")]));
+        }
+        let instances_idx = self
+            .raw_sub_nodes
+            .iter()
+            .position(|n| n.tag() == Some("instances"))
+            .expect("just ensured present");
+
+        let SexpNode::List(instances_children) = &mut self.raw_sub_nodes[instances_idx] else {
+            return;
+        };
+
+        let project_idx = instances_children
+            .iter()
+            .position(|c| c.tag() == Some("project") && c.value() == Some(project_name));
+        if project_idx.is_none() {
+            instances_children.push(SexpNode::List(vec![
+                atom("project"),
+                qstr(project_name.to_owned()),
+            ]));
+        }
+        let project_idx = instances_children
+            .iter()
+            .position(|c| c.tag() == Some("project") && c.value() == Some(project_name))
+            .expect("just ensured present");
+
+        let SexpNode::List(project_children) = &mut instances_children[project_idx] else {
+            return;
+        };
+
+        let new_path_node = SexpNode::List(vec![
+            atom("path"),
+            qstr(path.to_owned()),
+            tagged("reference", vec![qstr(reference.to_owned())]),
+            tagged("unit", vec![atom(unit.to_string())]),
+        ]);
+        match project_children
+            .iter()
+            .position(|c| c.tag() == Some("path") && c.value() == Some(path))
+        {
+            Some(idx) => project_children[idx] = new_path_node,
+            None => project_children.push(new_path_node),
+        }
+    }
+
+    /// Whether this symbol already has an instance entry for the given
+    /// project name and hierarchical path.
+    pub fn has_instance_path(&self, project_name: &str, path: &str) -> bool {
+        self.raw_sub_nodes
+            .iter()
+            .find(|n| n.tag() == Some("instances"))
+            .map(|inst| {
+                inst.find_all("project").iter().any(|p| {
+                    p.value() == Some(project_name)
+                        && p.find_all("path").iter().any(|pp| pp.value() == Some(path))
+                })
+            })
+            .unwrap_or(false)
+    }
+
     // ---- position -----------------------------------------------------------
 
     pub fn position(&self) -> (f64, f64) {

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -9,8 +9,8 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 
 ## Overview
 
-- **17 toolsets** organized into 10 categories
-- **175 registered tools** + **6 always-visible meta-tools** = **181 total**
+- **18 toolsets** organized into 10 categories
+- **182 registered tools** + **6 always-visible meta-tools** = **188 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -156,6 +156,22 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `export_netlist_summary` | Return a human-readable JSON netlist summary (components, nets, pin counts). Does not require kicad-cli. |
 | `run_erc` | Run the Electrical Rules Check via kicad-cli and return violations filtered by severity. |
 | `fix_connectivity` | Scan for near-miss wire endpoints within `snap_tolerance` of a pin/label and snap them into place. Supports `dry_run`. |
+
+### `sch_hierarchy` · 7 tools
+**Purpose:** Hierarchical sheets: add, edit, move, delete, duplicate a sheet, plus recursive hierarchy and page-numbering queries.
+**Source:** [`crates/konnect-core/src/tools/sch_hierarchy.rs`](crates/konnect-core/src/tools/sch_hierarchy.rs)
+
+Sheet lifecycle only (PR-A); pin lifecycle (`import_sheet_pins`, `add_sheet_pin`, `edit_sheet_pin`, `delete_sheet_pin`) lands in a follow-up.
+
+| Tool | Description |
+|------|-------------|
+| `add_hierarchical_sheet` | Insert a hierarchical sheet into a parent schematic, linking it to a child `.kicad_sch` file. Creates the child file if it doesn't exist, or links to an existing one (multi-instance reuse). Patches existing symbols' instance paths if the linked file already has components. |
+| `edit_sheet` | Rename, resize, reposition, or repoint (`Sheetfile`) an existing sheet. |
+| `move_sheet` | Reposition a sheet on the parent canvas without touching any other field. |
+| `delete_sheet` | Remove a sheet reference from the parent schematic. Does not delete the child file. |
+| `duplicate_sheet` | Copy an existing sheet and its child file under a new name/file, offset from the source, with an independent internal UUID. |
+| `get_sheet_hierarchy` | Recursively walk the sheet tree, returning nested JSON with each sheet's name/file/uuid/position/size/page/pins and its own children. |
+| `renumber_sheet_pages` | Walk the whole sheet tree and reassign sequential page numbers in depth-first order, fixing gaps left by delete/duplicate. |
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `sch_hierarchy`, a new 7-tool toolset covering the hierarchical sheet *object* lifecycle: `add_hierarchical_sheet`, `edit_sheet`, `move_sheet`, `delete_sheet`, `duplicate_sheet`, `get_sheet_hierarchy`, `renumber_sheet_pages`.
- This is **PR-A of 2** for ROADMAP.md's "Hierarchical sheets" item. Sheet *pin* lifecycle (`import_sheet_pins`, `add_sheet_pin`, `edit_sheet_pin`, `delete_sheet_pin`) is a deliberate follow-up PR, kept separate so each stays independently reviewable — this PR alone is already a complete, demoable feature (build a real multi-sheet skeleton, open it in KiCAD, confirm navigation/page numbers/structure) without needing pins to exist.
- Every handler here is file-editing only. KiCAD's own IPC API has no schematic-editing commands upstream (`crates/konnect-ipc/proto/schematic/schematic_commands.proto` is empty even in KiCAD's own source), so there's no dual IPC/file path to build here, unlike the PCB toolsets.

## Motivation
Hierarchical sheets is one of two concrete, unblocked items left under `## Tools` on the roadmap (the other, the multi-sheet schematic viewer, explicitly depends on this landing first). No existing code modeled sheets at all — see "Implementation" below for what that gap actually looked like once I went digging.

## Implementation

**New typed `Sheet`/`SheetPin`/`SheetInstance` model in `konnect-schematic-editor`** (`crates/konnect-schematic-editor/src/schematic/sheet.rs`), following the exact pattern already used for `Symbol`/`Label`/`GlobalLabel` in that crate (a struct, `from_sexp`/`to_sexp`, mutator helpers). This crate is what the newer handlers (`move_schematic_component`, `rotate_schematic_component`) already use — building on it keeps this feature consistent with where the codebase is actually headed, rather than adding a third parallel editing approach.

Wiring it into `Schematic` (`crates/konnect-schematic-editor/src/schematic/mod.rs`) surfaced a real, pre-existing latent bug: `(sheet ...)` nodes were falling through to `raw_other` (the catch-all for unmodeled nodes) and being serialized **after** symbols. KiCAD 10 requires sheets before symbols. This never surfaced before because nothing generated or round-tripped sheets through this crate — now that something does, it's fixed as part of adding proper `Sheet` support rather than worked around.

**Instance-path patching at link time.** A sheet's child file can legitimately already contain components — either because it's an existing file being linked (`add_hierarchical_sheet` supports pointing `Sheetfile` at an existing file to reuse a sub-circuit at a second location, matching KiCAD's own multi-instance sheet pattern), or because it was just duplicated (`duplicate_sheet`). In both cases, those symbols need a `(instances (project ... (path "/<sheet-uuid>/" ...)))` entry for the *new* sheet or ERC can't resolve them. Added `Symbol::set_instance_path()`/`has_instance_path()` (`crates/konnect-schematic-editor/src/schematic/symbol.rs`) and a shared `link_sheet()` helper in the new toolset that runs this patch immediately whenever it applies, not deferred.

**New `sch_hierarchy` toolset** (`crates/konnect-core/src/tools/sch_hierarchy.rs`):
- `add_hierarchical_sheet` — creates the child file if needed, or links an existing one; auto-assigns the next free page number by scanning the parent's existing sheets.
- `edit_sheet` / `move_sheet` / `delete_sheet` — full CRUD, `delete_sheet` explicitly does **not** delete the child file on disk (same "don't destroy data the user didn't explicitly ask to destroy" pattern used elsewhere in this codebase).
- `duplicate_sheet` — copies the child file, gives the copy its own internal schematic UUID (so KiCAD doesn't see two files sharing one identity), offsets the new sheet box so it doesn't overlap the source, and refuses to overwrite an existing file at the target path.
- `get_sheet_hierarchy` — recursive tree query (root → children → grandchildren), with cycle detection (tracks the current DFS ancestor chain, not a global "ever visited" set, so legitimate multi-instance reuse across sibling branches isn't mistaken for a cycle) and graceful handling of a missing child file instead of failing the whole call.
- `renumber_sheet_pages` — walks the tree in depth-first order and reassigns sequential page numbers, fixing gaps left by `delete_sheet`/`duplicate_sheet`. Deliberately scoped to leave the root's own page (always "1") untouched.

Registered in `registry.rs` (`tool_count: 7`) and `tools/mod.rs`. Updated `tool-directory.md`/`DEV.md` (17→18 toolsets, 175→182 tools).

## Test plan
- [x] `cargo test --workspace --lib --tests` — 118/118 passed
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] 5 unit tests on the `Sheet` model: round-trip through S-expressions, pin add/remove, page/instance handling, multi-instance reuse keeping separate pages per path
- [x] 15 handler tests on `sch_hierarchy` covering: create+link against both a new and an already-existing file, duplicate-name rejection, sequential page assignment across multiple sheets, rename+resize via `edit_sheet`, an empty-edit rejection, `move_sheet` touching only position, `delete_sheet` preserving the child file, `duplicate_sheet` (independent UUID, correct offset, refuses to clobber an existing file), `get_sheet_hierarchy` returning a correctly nested multi-level tree and reporting a missing child file without crashing, `renumber_sheet_pages` closing a gap after a delete, and instance-path patching when linking a file that already has a symbol in it

### Known limitation (addressed in follow-up PR)
Sheet pins (the connection points between a sheet and its parent, paired with `hierarchical_label`s in the child file) are not covered here — that's the planned PR-B. A sheet added by this PR has no pins yet; wiring nets across the sheet boundary isn't possible until that lands.
