### PR TITLE
feat(schematic-viewer): hierarchical multi-sheet viewing with live incremental rendering

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -17,6 +17,13 @@ cd crates/schematic-viewer
 cargo build --release
 ```
 
+Schematic-viewer build notes (Windows):
+
+- If `cargo` is not recognized in a fresh shell, add it to the session PATH first:
+  `set PATH=%PATH%;%USERPROFILE%\.cargo\bin`
+- Close any running viewer window before rebuilding — Windows locks a running
+  `.exe`, so the link step fails while the app is open.
+
 ## Architecture
 
 ```
@@ -83,8 +90,9 @@ Konnect/
 │   │
 │   └── schematic-viewer/            # Tauri desktop app (separate from workspace)
 │       ├── tauri.conf.json
-│       ├── src/main.rs               # File watcher + kicad-cli SVG rendering + Tauri commands
-│       └── frontend/index.html       # Pan/zoom SVG viewer with auto-refresh
+│       ├── capabilities/default.json # Tauri 2 ACL grant (core:default) — without it event.listen() is silently denied
+│       ├── src/main.rs               # Multi-sheet watcher + snapshot-isolated incremental kicad-cli SVG rendering + Tauri commands, 20 unit tests
+│       └── frontend/index.html       # Pan/zoom SVG viewer, sheet selector, auto-refresh
 │
 ├── plugin/                           # Python thin launcher (runs inside KiCAD)
 │   ├── __init__.py                   # pcbnew.ActionPlugin — settings dialog (PCB Editor only)
@@ -200,7 +208,14 @@ The router is defined in `crates/konnect-core/src/router/mod.rs`.
 - `protoc` binary (for protobuf code generation in konnect-ipc crate)
   - Set `PROTOC` environment variable or install on PATH
   - Download: https://github.com/protocolbuffers/protobuf/releases
-- For schematic-viewer: Tauri 2 prerequisites (WebView2 on Windows — usually pre-installed)
+- For schematic-viewer (built separately from the workspace — see Quick Start):
+  - Rust toolchain on PATH (Windows: `set PATH=%PATH%;%USERPROFILE%\.cargo\bin` if `cargo`
+    isn't recognized in the shell)
+  - Tauri 2 prerequisites: WebView2 runtime on Windows (usually pre-installed on Win 10/11)
+  - At runtime it discovers `kicad-cli` from the standard KiCAD install paths, then PATH;
+    override with `--kicad-cli <path>`
+  - Rebuilds fail while a viewer window is open (Windows locks the running `.exe`) — close
+    the app before `cargo build`
 
 ## Test Suite
 
@@ -212,6 +227,16 @@ Run all: `PROTOC=<path> cargo test --workspace --lib --tests`
 | `konnect-core` unit tests | Router load/unload, starter-kit, registry invariants, observability, error taxonomy, arg helpers |
 | `konnect-core` integration tests | Fixture files: parse, edit, write, observability, structured errors |
 | `konnect-schematic-editor` tests | Typed schematic model + round-tripping |
+
+`schematic-viewer` is **excluded from the workspace** (`Cargo.toml`'s `[workspace] exclude`) since
+it's a Tauri app built separately — `cargo test --workspace` never touches it, and neither does
+CI (`.github/workflows/ci.yml` runs everything with `--workspace`). Run its tests explicitly:
+`cd crates/schematic-viewer && cargo test`. Its 20 unit tests cover the pure sheet-tree-walking,
+watch-directory, render-snapshot, event-debounce, and incremental-render-selection logic
+(`walk_sheet_tree`, `compute_watch_dirs`, `snapshot_tree`, `drain_until_quiet`,
+`files_needing_render`, `render_all`'s error handling) — the actual `kicad-cli` subprocess call
+and Tauri command/event plumbing stay thin and untested, matching this codebase's existing
+convention for other `kicad-cli`-calling code.
 
 ## Adding a New Tool
 

--- a/README.md
+++ b/README.md
@@ -143,12 +143,20 @@ snippet into a `.mcp.json` in your project root (see [examples/](examples/)).
 A standalone viewer that auto-refreshes as the schematic file changes:
 
 ```bash
-schematic-viewer.exe path\to\your\schematic.kicad_sch
+schematic-viewer.exe path\to\your\root_schematic.kicad_sch
 ```
 
-Pan with click-drag, zoom with the wheel, `0` to fit, `R` to refresh, drag-and-drop
-to open a different file. Also launchable by the AI via the `open_schematic_viewer`
-tool.
+Point it at the root sheet of a hierarchical design and every sub-sheet is rendered
+too, with a depth-indented sheet selector in the toolbar. Edits saved from KiCAD (or
+made by the AI through the schematic tools) re-render only the sheets that changed
+and refresh the view live — rendering runs against temp-folder snapshots, so the
+viewer never blocks KiCAD from saving. Pan with click-drag, zoom with the wheel,
+`0` to fit, `R` to refresh, drag-and-drop to open a different file. Also launchable
+by the AI via the `open_schematic_viewer` tool.
+
+Needs the WebView2 runtime (pre-installed on Windows 10/11) and a KiCAD install for
+`kicad-cli` (auto-discovered, or pass `--kicad-cli <path>`). Built separately from
+the main workspace — see [DEV.md](DEV.md) for build steps.
 
 ## Requirements
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,9 +17,6 @@ Opening an issue is the best way to influence priority.
 - **Symbol & footprint creation** — author new library parts from scratch, not
   just search and place existing ones.
 - **Eagle project import** — migrate legacy Eagle designs.
-- **Multi-sheet schematic viewer** — `kicad-cli sch export svg` emits one SVG
-  per sheet; the live viewer currently shows only the root sheet. Add a sheet
-  selector for hierarchical designs.
 
 ## Infrastructure
 
@@ -51,3 +48,8 @@ Opening an issue is the best way to influence priority.
   Curved paths (quadratic/cubic Bezier) are flattened into polygon outlines
   since KiCAD's board format doesn't support curves in filled shapes. Tries
   the IPC API first, falls back to a direct file edit if KiCAD isn't running.
+- ~~Multi-sheet schematic viewer~~ — point the viewer at the root schematic of a
+  hierarchical design and it walks every reachable sheet, renders each via
+  `kicad-cli`, and offers a depth-indented sheet selector. Edits saved from KiCAD
+  re-render only the changed sheets and refresh live; rendering runs against
+  temp-folder snapshots so the viewer never blocks KiCAD from saving.

--- a/crates/konnect-core/src/tools/project.rs
+++ b/crates/konnect-core/src/tools/project.rs
@@ -113,13 +113,15 @@ pub fn tools() -> Vec<ToolDef> {
             "open_schematic_viewer",
             "Launch the live schematic viewer. The viewer shows the schematic as SVG and \
              auto-refreshes when the file changes. Use this after placing components so the \
-             user can see the schematic in real-time as you edit it.",
+             user can see the schematic in real-time as you edit it. For hierarchical designs, \
+             pass the root schematic — the viewer discovers every sheet reachable from it and \
+             shows a sheet selector.",
             json!({
                 "type": "object",
                 "properties": {
                     "schematic": {
                         "type": "string",
-                        "description": "Path to .kicad_sch file to view"
+                        "description": "Path to the root .kicad_sch file to view"
                     }
                 },
                 "required": ["schematic"]

--- a/crates/schematic-viewer/Cargo.lock
+++ b/crates/schematic-viewer/Cargo.lock
@@ -1721,6 +1721,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "konnect-schematic-editor"
+version = "0.1.3"
+dependencies = [
+ "konnect-sexp",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "konnect-sexp"
+version = "0.1.3"
+dependencies = [
+ "anyhow",
+ "nom",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,6 +1830,12 @@ dependencies = [
  "plain",
  "redox_syscall 0.7.3",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1901,6 +1928,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2017,16 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "notify"
@@ -2823,6 +2866,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2892,11 +2948,13 @@ dependencies = [
 name = "schematic-viewer"
 version = "0.1.3"
 dependencies = [
+ "konnect-schematic-editor",
  "notify",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "tempfile",
  "tokio",
 ]
 
@@ -3629,6 +3687,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/schematic-viewer/Cargo.toml
+++ b/crates/schematic-viewer/Cargo.toml
@@ -16,6 +16,12 @@ notify = "7"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Not a workspace member (Tauri app, built separately), so this is a plain
+# path dependency rather than `.workspace = true`.
+konnect-schematic-editor = { path = "../konnect-schematic-editor" }
+
+[dev-dependencies]
+tempfile = "3"
 
 [package.metadata.bundle]
 identifier = "com.konnect.schematic-viewer"

--- a/crates/schematic-viewer/capabilities/default.json
+++ b/crates/schematic-viewer/capabilities/default.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Default capability for the viewer's single main window. Without this file Tauri 2 denies all core-plugin APIs (deny-by-default ACL): app-defined invoke commands still work, but the frontend's event.listen() calls are silently rejected, so no backend-emitted event (schematic-updated, sheets-updated, viewer-error, change-detected) ever reaches the UI and live updates appear dead.",
+  "windows": ["main"],
+  "permissions": ["core:default"]
+}

--- a/crates/schematic-viewer/frontend/index.html
+++ b/crates/schematic-viewer/frontend/index.html
@@ -68,6 +68,10 @@
   .toolbar .status {
     font-size: 12px;
     color: var(--text-dim);
+    max-width: 32vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .toolbar .zoom-display {
     font-size: 13px;
@@ -80,6 +84,16 @@
     font-weight: 600;
     color: var(--accent);
   }
+  .toolbar select#sheet-selector {
+    background: var(--btn-bg);
+    border: 1px solid var(--btn-border);
+    color: var(--text);
+    padding: 5px 8px;
+    border-radius: 4px;
+    font-size: 13px;
+    max-width: 240px;
+  }
+  .toolbar select#sheet-selector[hidden] { display: none; }
 
   /* SVG Container */
   #viewer {
@@ -110,38 +124,63 @@
   }
   .overlay h2 { color: var(--overlay-h); margin-bottom: 8px; }
   .overlay p { color: var(--overlay-p); font-size: 14px; }
+  .overlay .spinner {
+    width: 40px;
+    height: 40px;
+    border: 4px solid var(--btn-border);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    margin: 0 auto 12px;
+    animation: spin 0.8s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
 
-  /* Update / error flash */
+  /* Update / error flash: centered just below the toolbar, big enough to
+     catch the eye (top-right small text went unnoticed in real testing).
+     pointer-events: none is load-bearing, not cosmetic — opacity: 0 still
+     hit-tests, and this element previously sat invisible over the toolbar's
+     right-side buttons, silently swallowing their clicks. */
   .flash {
     position: fixed;
-    top: 10px;
-    right: 10px;
+    top: 48px;
+    left: 50%;
+    transform: translateX(-50%);
     background: var(--btn-bg);
     color: var(--accent);
-    padding: 6px 14px;
-    border-radius: 4px;
-    font-size: 13px;
+    padding: 10px 22px;
+    border: 1px solid var(--accent);
+    border-radius: 6px;
+    font-size: 15px;
+    font-weight: 600;
+    text-align: center;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.45);
     opacity: 0;
     transition: opacity 0.3s;
-    z-index: 20;
-    max-width: 60vw;
+    z-index: 30;
+    max-width: 80vw;
+    pointer-events: none;
   }
   .flash.visible { opacity: 1; }
-  .flash.error { background: #5c1a2a; color: #ffb3c0; }
+  .flash.error { background: #5c1a2a; color: #ffb3c0; border-color: #ffb3c0; }
 </style>
 </head>
 <body>
 
 <div class="toolbar">
   <span class="filename" id="filename">No file loaded</span>
-  <div class="spacer"></div>
-  <button onclick="zoomIn()">Zoom +</button>
-  <button onclick="zoomOut()">Zoom -</button>
-  <span class="zoom-display" id="zoom-display">100%</span>
-  <button onclick="fitToPage()">Fit</button>
-  <button onclick="toggleTheme()">Theme</button>
-  <button onclick="openInKicad()">Open in KiCAD</button>
+  <select id="sheet-selector" hidden onchange="onSheetSelected()"></select>
+  <!-- Status sits on the left of the flexible spacer: its text changes
+       constantly (Live / Rendering / errors), and when it lived at the far
+       right it kept shifting the buttons sideways under the cursor. -->
   <span class="status" id="status">Waiting...</span>
+  <div class="spacer"></div>
+  <button onclick="zoomIn()" title="Zoom in (+)">Zoom +</button>
+  <button onclick="zoomOut()" title="Zoom out (-)">Zoom -</button>
+  <span class="zoom-display" id="zoom-display">100%</span>
+  <button onclick="fitToPage()" title="Fit to window (0)">Fit</button>
+  <button onclick="manualRefresh()" title="Re-render the current sheet (R)">Refresh</button>
+  <button onclick="toggleTheme()" title="Toggle dark/light theme">Theme</button>
+  <button onclick="openInKicad()" title="Open this project in KiCAD">Open in KiCAD</button>
 </div>
 
 <div id="viewer">
@@ -151,6 +190,10 @@
     <p>Schematic Viewer</p>
     <p style="margin-top:12px">Drag a .kicad_sch file here or use the MCP tool to open</p>
   </div>
+  <div class="overlay" id="loading-overlay" style="display:none;">
+    <div class="spinner"></div>
+    <h2 id="loading-text">Rendering…</h2>
+  </div>
 </div>
 
 <div class="flash" id="flash">Updated</div>
@@ -159,6 +202,12 @@
   const { invoke } = window.__TAURI__.core;
   const { listen } = window.__TAURI__.event;
   const { getCurrentWindow } = window.__TAURI__.window;
+
+  // WebView2's native right-click menu includes its own "Reload", which
+  // reloads the whole embedded page (losing track of the open file — the
+  // startup-file argument is consumed on first read) rather than doing
+  // anything meaningful for a single-purpose viewer like this one.
+  document.addEventListener('contextmenu', (e) => e.preventDefault());
 
   const MIN_SCALE = 0.05, MAX_SCALE = 40;
 
@@ -174,7 +223,23 @@
   const statusEl = document.getElementById('status');
   const flashEl = document.getElementById('flash');
   const emptyState = document.getElementById('empty-state');
+  const sheetSelector = document.getElementById('sheet-selector');
   const filenameEl = document.getElementById('filename');
+  const loadingOverlay = document.getElementById('loading-overlay');
+  const loadingText = document.getElementById('loading-text');
+
+  // Unmistakable, centered loading state — a small "Rendering..." label in
+  // the corner reads as "the app might be hung" on a large, slow-to-render
+  // hierarchical design (real-world case: ~20 sheets took long enough that
+  // it looked frozen). This can't be missed the same way.
+  function showLoading(text) {
+    loadingText.textContent = text || 'Rendering…';
+    loadingOverlay.style.display = '';
+    emptyState.style.display = 'none';
+  }
+  function hideLoading() {
+    loadingOverlay.style.display = 'none';
+  }
 
   function clampScale(s) {
     return Math.min(MAX_SCALE, Math.max(MIN_SCALE, s));
@@ -195,6 +260,7 @@
   function setSvg(svgContent) {
     container.innerHTML = svgContent;
     emptyState.style.display = 'none';
+    hideLoading();
 
     const svgEl = container.querySelector('svg');
     if (svgEl) {
@@ -205,15 +271,41 @@
         const h = parseFloat(svgEl.getAttribute('height'));
         if (w && h) svgEl.setAttribute('viewBox', `0 0 ${w} ${h}`);
       }
+      // kicad-cli's width/height carry real-world units (e.g. "419.9890mm"
+      // for an A3 sheet). The browser renders the SVG's on-screen size from
+      // those — at ~3.78 CSS px/mm, an A3 sheet is natively ~1587x1122px —
+      // but fitToPage()'s scale math assumes 1 viewBox unit = 1 CSS pixel.
+      // Left alone, that mismatch makes "Fit" wildly over-zoom on anything
+      // bigger than a postage stamp. Force width/height to the viewBox's
+      // own numeric units so the two always agree, regardless of sheet size.
+      const vb = svgEl.getAttribute('viewBox');
+      if (vb) {
+        const parts = vb.split(/\s+/).map(Number);
+        if (parts.length === 4 && parts[2] && parts[3]) {
+          svgEl.setAttribute('width', String(parts[2]));
+          svgEl.setAttribute('height', String(parts[3]));
+        }
+      }
     }
     applySvgTheme();
   }
 
-  function flash(msg, isError) {
+  // `sticky` keeps the message up until the next flash replaces it — for
+  // in-progress states (re-rendering) rather than one-shot notifications.
+  // The single shared timer matters: without it, an earlier flash's
+  // hide-timeout fires late and wipes whatever message replaced it.
+  let flashTimer = null;
+  function flash(msg, isError, sticky) {
     flashEl.textContent = msg || 'Updated';
     flashEl.classList.toggle('error', !!isError);
     flashEl.classList.add('visible');
-    setTimeout(() => flashEl.classList.remove('visible'), isError ? 4000 : 1500);
+    if (flashTimer) {
+      clearTimeout(flashTimer);
+      flashTimer = null;
+    }
+    if (!sticky) {
+      flashTimer = setTimeout(() => flashEl.classList.remove('visible'), isError ? 4000 : 2000);
+    }
   }
 
   function fitToPage() {
@@ -299,24 +391,112 @@
   async function manualRefresh() {
     try {
       statusEl.textContent = 'Refreshing...';
+      showLoading('Refreshing...');
       const svg = await invoke('refresh');
       setSvg(svg);
       flash('Refreshed');
       statusEl.textContent = 'Ready';
     } catch (e) {
+      hideLoading();
       statusEl.textContent = 'Error: ' + e;
       flash(String(e), true);
     }
   }
 
-  // Live updates and errors from the Rust backend
-  listen('schematic-updated', (event) => {
+  // ─── Sheet selector ────────────────────────────────────────────────────
+
+  // Depth-indented flat list, in the same depth-first order the backend's
+  // walk (and sch_hierarchy's get_sheet_hierarchy/renumber_sheet_pages)
+  // already use — not a collapsible tree, see the design note for why.
+  function populateSheetSelector(sheets, activeFile) {
+    sheetSelector.innerHTML = '';
+    if (!sheets || sheets.length <= 1) {
+      sheetSelector.hidden = true;
+      return;
+    }
+    for (const s of sheets) {
+      const opt = document.createElement('option');
+      opt.value = s.file;
+      // Plain spaces collapse to a single space inside <option> text (normal HTML whitespace rules apply even here), so indentation below uses non-breaking spaces, not regular ones, to actually show up.
+      const indent = '    '.repeat(s.depth);
+      const marker = s.depth > 0 ? '└─ ' : ''; // box-drawing tree marker
+      opt.textContent = indent + marker + s.name;
+      sheetSelector.appendChild(opt);
+    }
+    sheetSelector.value = activeFile;
+    sheetSelector.hidden = false;
+  }
+
+  async function onSheetSelected() {
+    const file = sheetSelector.value;
+    try {
+      statusEl.textContent = 'Loading sheet...';
+      showLoading('Loading sheet...');
+      const svg = await invoke('select_sheet', { file });
+      setSvg(svg);
+      fitToPage();
+      statusEl.textContent = 'Watching for changes...';
+    } catch (e) {
+      hideLoading();
+      statusEl.textContent = 'Error: ' + e;
+      flash(String(e), true);
+    }
+  }
+
+  // Live updates and errors from the Rust backend.
+  //
+  // listen() returns a promise that REJECTS if the event API isn't permitted
+  // by the app's Tauri capability file — and a top-level unhandled rejection
+  // is completely silent. That exact failure shipped once: with no
+  // capabilities/ dir, every listener below was dead, the backend emitted
+  // into a void, and live updates simply "didn't work" with nothing in any
+  // log. Surface it unmissably instead.
+  function listenOrWarn(name, handler) {
+    listen(name, handler).catch((e) => {
+      statusEl.textContent = 'Event wiring failed';
+      flash('Event wiring failed for "' + name + '": ' + e, true);
+    });
+  }
+
+  listenOrWarn('schematic-updated', (event) => {
     setSvg(event.payload);
     flash('File changed — updated');
     statusEl.textContent = 'Live';
   });
 
-  listen('viewer-error', (event) => {
+  // Fired whenever the watcher re-walks the tree — keeps the selector in
+  // sync without requiring the viewer to be reopened. `active_file` reflects
+  // any backend fallback-to-root (e.g. the selected sheet was deleted).
+  // Emitted at the end of every render cycle (whether or not the active
+  // sheet changed) — so it also retires the sticky "re-rendering" flash.
+  // The retirement is deferred a beat: when the active sheet WAS
+  // re-rendered, schematic-updated lands right behind this event and takes
+  // over the flash — showing "Re-render complete" for a split second first
+  // just reads as flicker. It only appears when it's genuinely the final
+  // word (the edit touched sheets other than the one on screen).
+  listenOrWarn('sheets-updated', (event) => {
+    populateSheetSelector(event.payload.sheets, event.payload.active_file);
+    statusEl.textContent = 'Live';
+    setTimeout(() => {
+      if (flashEl.classList.contains('visible') && flashEl.textContent === RENDERING_MSG) {
+        flash('Re-render complete');
+      }
+    }, 150);
+  });
+
+  // Fired the instant the backend's watcher notices a relevant file change,
+  // before any rendering starts (which can take a while on a big design) -
+  // makes "watcher never fired" visibly different from "render failed".
+  const RENDERING_MSG = 'Change detected - re-rendering...';
+  listenOrWarn('change-detected', () => {
+    statusEl.textContent = RENDERING_MSG;
+    // Sticky: stays up for the whole render (can be several seconds on a
+    // big design) so the user watches a state, not a vanishing blip. The
+    // sheets-updated handler below retires it when the cycle finishes.
+    flash(RENDERING_MSG, false, true);
+  });
+
+  listenOrWarn('viewer-error', (event) => {
     statusEl.textContent = 'Error';
     flash(String(event.payload), true);
   });
@@ -340,15 +520,23 @@
   });
 
   // Called on startup (with the CLI-arg file, if any) and on drag-drop.
+  // Opens the ROOT of a design — the backend walks the full sheet tree from
+  // there and eagerly renders every sheet it finds.
   window.loadSchematic = async function(path) {
     try {
       filenameEl.textContent = path.split(/[\\/]/).pop();
       statusEl.textContent = 'Rendering...';
-      const svg = await invoke('open_schematic', { path });
-      setSvg(svg);
+      showLoading('Rendering... (a large hierarchical design can take a while — every sheet is rendered up front)');
+      const result = await invoke('open_schematic', { path });
+      populateSheetSelector(result.sheets, result.active_file);
+      setSvg(result.svg);
       fitToPage();
+      if (result.render_errors && result.render_errors.length) {
+        flash(`${result.render_errors.length} sheet(s) failed to render`, true);
+      }
       statusEl.textContent = 'Watching for changes...';
     } catch (e) {
+      hideLoading();
       statusEl.textContent = 'Error: ' + e;
       flash(String(e), true);
       console.error(e);

--- a/crates/schematic-viewer/gen/schemas/capabilities.json
+++ b/crates/schematic-viewer/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{}
+{"default":{"identifier":"default","description":"Default capability for the viewer's single main window. Without this file Tauri 2 denies all core-plugin APIs (deny-by-default ACL): app-defined invoke commands still work, but the frontend's event.listen() calls are silently rejected, so no backend-emitted event (schematic-updated, sheets-updated, viewer-error, change-detected) ever reaches the UI and live updates appear dead.","local":true,"windows":["main"],"permissions":["core:default"]}}

--- a/crates/schematic-viewer/src/main.rs
+++ b/crates/schematic-viewer/src/main.rs
@@ -5,27 +5,135 @@
 
 //! Konnect — Live Schematic Viewer
 //!
-//! Watches a .kicad_sch file, renders to SVG via kicad-cli, and displays
-//! in a native window with pan/zoom and auto-refresh.
+//! Watches a .kicad_sch file (and, for hierarchical designs, every sheet
+//! reachable from it), renders each to SVG via kicad-cli, and displays them
+//! in a native window with pan/zoom, a sheet selector, and auto-refresh.
 //!
 //! Usage: schematic-viewer [--kicad-cli <path>] [path/to/file.kicad_sch]
 
 use notify::{EventKind, RecursiveMode, Watcher};
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager};
+
+// ─── Sheet hierarchy ────────────────────────────────────────────────────────
+
+/// One entry in the flat, depth-indented sheet list shown in the frontend's
+/// selector. `file` is the absolute path, used as the cache/lookup key.
+#[derive(Debug, Clone, serde::Serialize)]
+struct SheetEntry {
+    name: String,
+    file: String,
+    depth: usize,
+}
+
+/// Guards against a pathological reference cycle in a hand-edited file —
+/// matches the same depth cap `sch_hierarchy.rs`'s `get_sheet_hierarchy` uses.
+const MAX_SHEET_DEPTH: usize = 20;
+
+/// Walk the sheet tree starting at `root` in depth-first order, using
+/// `konnect-schematic-editor`'s typed `Sheet` model (the same one
+/// `sch_hierarchy`'s MCP tools are built on) rather than re-implementing
+/// `.kicad_sch` parsing here. Missing child files are skipped silently —
+/// this is a display surface, not a validator; `sch_hierarchy`'s own
+/// `validate_sheet_pins`/`get_sheet_hierarchy` tools are where that's
+/// surfaced loudly.
+fn walk_sheet_tree(root: &Path) -> Vec<SheetEntry> {
+    let root_name = root
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    let mut out = Vec::new();
+    let mut visited = HashSet::new();
+    walk_sheet_tree_inner(root, &root_name, 0, &mut visited, &mut out);
+    out
+}
+
+fn walk_sheet_tree_inner(
+    path: &Path,
+    display_name: &str,
+    depth: usize,
+    visited: &mut HashSet<PathBuf>,
+    out: &mut Vec<SheetEntry>,
+) {
+    if depth > MAX_SHEET_DEPTH {
+        return;
+    }
+    let canon = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    if !visited.insert(canon.clone()) {
+        return; // cycle guard — already an ancestor on *this* branch
+    }
+
+    out.push(SheetEntry {
+        name: display_name.to_string(),
+        file: path.to_string_lossy().to_string(),
+        depth,
+    });
+
+    if let Ok(sch) = konnect_schematic_editor::Schematic::load(path) {
+        let dir = path.parent().unwrap_or(Path::new(".")).to_path_buf();
+        for sheet in sch.sheets.iter() {
+            let child_path = dir.join(sheet.file());
+            if child_path.exists() {
+                walk_sheet_tree_inner(&child_path, sheet.name(), depth + 1, visited, out);
+            }
+        }
+    }
+
+    // Backtrack: remove from the ancestor set so a sibling branch reusing the
+    // same file (a legitimate multi-instance sheet, not a cycle) isn't
+    // mistakenly skipped — only an actual ancestor-of-itself loop should stop.
+    visited.remove(&canon);
+}
+
+/// Unique parent directories across every sheet's file — what the watcher
+/// needs to cover so an edit to any sheet (not just the root) is caught.
+fn compute_watch_dirs(entries: &[SheetEntry]) -> HashSet<PathBuf> {
+    entries
+        .iter()
+        .filter_map(|e| Path::new(&e.file).parent().map(|p| p.to_path_buf()))
+        .collect()
+}
+
+/// Whether a changed path is a genuine schematic edit worth re-walking the
+/// tree for. KiCAD periodically writes its own `_autosave-*.kicad_sch` and
+/// `~*.kicad_sch` (lock) files into the same directory as the real sheets —
+/// these fire on a timer independent of any real edit, and reacting to them
+/// wastes a full parallel re-render *and* can eat the debounce window right
+/// before a genuine save, silently dropping the real change.
+fn is_relevant_sch_change(path: &Path) -> bool {
+    let is_sch = path.extension().map(|e| e == "kicad_sch").unwrap_or(false);
+    if !is_sch {
+        return false;
+    }
+    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    !(name.starts_with("_autosave-") || name.starts_with('~'))
+}
 
 // ─── State ──────────────────────────────────────────────────────────────────
 
 struct ViewerState {
-    schematic_path: Mutex<Option<PathBuf>>,
+    root_path: Mutex<Option<PathBuf>>,
+    active_file: Mutex<Option<PathBuf>>,
+    sheets: Mutex<Vec<SheetEntry>>,
+    /// Rendered SVG per sheet, keyed by `SheetEntry::file`. All sheets are
+    /// rendered eagerly on open/refresh so switching sheets is instant.
+    svg_cache: Mutex<HashMap<String, String>>,
+    /// Directories the live watcher currently covers — diffed against a
+    /// fresh `compute_watch_dirs` on every change so sheets added in a new
+    /// folder get picked up without reopening the viewer.
+    watched_dirs: Mutex<HashSet<PathBuf>>,
     kicad_cli: Mutex<String>,
     /// File passed on the command line, handed to the frontend when it asks.
     startup_file: Mutex<Option<String>>,
     /// The active file watcher. Replacing it drops (and stops) the previous
-    /// one, so only the currently-open schematic is ever watched.
+    /// one, so only the currently-open design is ever watched.
     watcher: Mutex<Option<notify::RecommendedWatcher>>,
 }
 
@@ -86,6 +194,14 @@ fn resolve_kicad_binary() -> String {
     "kicad".to_string()
 }
 
+/// KiCAD's own lock-file convention for a file it has open: `~<name>.lck`
+/// in the same directory.
+fn kicad_lock_path(target: &Path) -> PathBuf {
+    let dir = target.parent().unwrap_or(Path::new("."));
+    let name = target.file_name().unwrap_or_default().to_string_lossy();
+    dir.join(format!("~{}.lck", name))
+}
+
 // ─── SVG Rendering ──────────────────────────────────────────────────────────
 
 /// Per-process temp dir so concurrent viewer instances don't clobber each
@@ -94,25 +210,216 @@ fn render_temp_dir() -> PathBuf {
     std::env::temp_dir().join(format!("konnect-viewer-{}", std::process::id()))
 }
 
-fn render_to_svg(cli: &str, schematic: &Path) -> Result<String, String> {
-    let temp_dir = render_temp_dir();
-    std::fs::create_dir_all(&temp_dir).map_err(|e| e.to_string())?;
+/// A fresh, unique working directory for one render batch, so overlapping
+/// batches (a watcher-triggered render racing a manual refresh or a reopen)
+/// never share snapshot or output paths.
+fn render_batch_dir() -> PathBuf {
+    static RENDER_BATCH: AtomicU64 = AtomicU64::new(0);
+    render_temp_dir().join(format!(
+        "batch-{}",
+        RENDER_BATCH.fetch_add(1, Ordering::Relaxed)
+    ))
+}
 
-    let output = Command::new(cli)
-        .args(["sch", "export", "svg", "--output"])
-        .arg(&temp_dir)
-        .arg(schematic)
+/// Copy every unique sheet file (plus the root's `.kicad_pro`, if any) into
+/// `snap_dir`, mirroring each file's path relative to the root's parent so
+/// parent-to-child sheet references still resolve inside the snapshot.
+/// Returns a map from each live file (the `SheetEntry::file` string) to the
+/// path kicad-cli should actually be pointed at.
+///
+/// Why render from copies at all: kicad-cli holds every `.kicad_sch` in the
+/// exported tree open *without write sharing* for the entire export
+/// (verified directly on Windows: concurrent write-opens fail with a
+/// sharing violation, which KiCAD's GUI surfaces as the misleading "You do
+/// not have write permissions to: ..." dialog when a user's save lands
+/// mid-export). Rendering from a temp snapshot means no kicad-cli process
+/// ever holds the user's real files open, so a KiCAD save can never collide
+/// with a render, no matter how many renders run in parallel. It also keeps
+/// kicad-cli's transient `~<project>.lck` file out of the real project
+/// folder.
+fn snapshot_tree(root: &Path, entries: &[SheetEntry], snap_dir: &Path) -> HashMap<String, PathBuf> {
+    let base = root.parent().unwrap_or(Path::new("."));
+    let mut map = HashMap::new();
+    let mut seen = HashSet::new();
+    for e in entries {
+        if !seen.insert(e.file.as_str()) {
+            continue;
+        }
+        let live = Path::new(&e.file);
+        let copied = live
+            .strip_prefix(base)
+            .ok()
+            .map(|rel| snap_dir.join(rel))
+            .and_then(|dest| {
+                std::fs::create_dir_all(dest.parent()?).ok()?;
+                // Explicit read + write rather than fs::copy: std's
+                // File::open shares read/write/delete access, so the copy
+                // itself can never block a concurrent KiCAD save either.
+                let bytes = std::fs::read(live).ok()?;
+                std::fs::write(&dest, bytes).ok()?;
+                Some(dest)
+            });
+        // A sheet outside the root's folder (or a failed copy) falls back to
+        // rendering from the live path: no worse than the pre-snapshot
+        // behavior, and the common everything-under-one-project-dir case is
+        // fully isolated.
+        map.insert(e.file.clone(), copied.unwrap_or_else(|| live.to_path_buf()));
+    }
+    // Text variables and title-block settings live in the project file;
+    // copy it alongside the root sheet so rendered frames stay faithful.
+    let pro = root.with_extension("kicad_pro");
+    if pro.exists() {
+        if let Some(name) = pro.file_name() {
+            let _ = std::fs::create_dir_all(snap_dir);
+            if let Ok(bytes) = std::fs::read(&pro) {
+                let _ = std::fs::write(snap_dir.join(name), bytes);
+            }
+        }
+    }
+    map
+}
+
+/// Render `schematic` to SVG via kicad-cli, writing into `output_dir` (which
+/// is created if needed). Takes an explicit output directory — rather than
+/// always using the shared per-process temp dir — so concurrent calls (see
+/// `render_all`) never race on the same `<stem>.svg` output filename, which
+/// two *different* sheets could coincidentally share.
+fn render_to_svg_in(cli: &str, schematic: &Path, output_dir: &Path) -> Result<String, String> {
+    std::fs::create_dir_all(output_dir).map_err(|e| e.to_string())?;
+
+    let mut cmd = Command::new(cli);
+    cmd.args(["sch", "export", "svg", "--output"])
+        .arg(output_dir)
+        .arg(schematic);
+    // kicad-cli is a console-subsystem binary — without this, Windows
+    // flashes a console window for every invocation. Since every sheet is
+    // rendered eagerly, a multi-sheet design would otherwise flash one
+    // window per sheet on every open/refresh.
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    let output = cmd
         .output()
         .map_err(|e| format!("Failed to run kicad-cli ({}): {}", cli, e))?;
 
+    let stem = schematic.file_stem().unwrap_or_default().to_string_lossy();
+    let svg_path = output_dir.join(format!("{}.svg", stem));
+
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("kicad-cli failed: {}", stderr));
+        // kicad-cli's exit code can lie: with a pre-existing foreign or
+        // unparseable project lock file present it completes the entire
+        // export and still exits -1 (verified against KiCAD 10 on Windows).
+        // Trust the artifact over the exit code; only a missing or empty
+        // SVG is a real failure.
+        let produced = std::fs::metadata(&svg_path)
+            .map(|m| m.len() > 0)
+            .unwrap_or(false);
+        if !produced {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!("kicad-cli failed: {}", stderr));
+        }
     }
 
-    let stem = schematic.file_stem().unwrap_or_default().to_string_lossy();
-    let svg_path = temp_dir.join(format!("{}.svg", stem));
     std::fs::read_to_string(&svg_path).map_err(|e| format!("Failed to read SVG: {}", e))
+}
+
+/// Render every *unique* file among `entries`, in parallel — one kicad-cli
+/// subprocess per file rather than one per tree position, since a
+/// multi-instance sheet can appear at several positions but only needs
+/// rendering once. A failure on one sheet doesn't stop the rest — the
+/// caller gets whatever succeeded plus a list of what didn't.
+///
+/// Deliberately NOT using kicad-cli's own single-call whole-tree export
+/// (`sch export svg` against the root emits one SVG per sheet in one
+/// invocation): it names outputs by hyphen-joining ancestor sheet names,
+/// which is ambiguous to parse back when a sheet name itself contains a
+/// hyphen (real-world example: a sheet literally named "H-Bridge" produces
+/// the same kind of filename shape as a genuine two-level "PMS-Filter"
+/// path). Calling kicad-cli once per exactly-known file path sidesteps that
+/// ambiguity entirely, at the cost of more subprocess spawns — mitigated
+/// by running them concurrently instead of serially.
+fn render_all(
+    cli: &str,
+    root: &Path,
+    entries: &[SheetEntry],
+) -> (HashMap<String, String>, Vec<String>) {
+    render_some(cli, root, entries, None)
+}
+
+/// Like `render_all`, but when `subset` is Some, only the unique files it
+/// names are actually rendered — the watcher uses this to re-render just
+/// what a save touched instead of the whole design (a full ~20-sheet
+/// re-render costs several seconds of save-to-screen lag; one edited sheet
+/// costs one render). The snapshot still covers the *whole* tree
+/// regardless, because kicad-cli loads a sheet's children even when
+/// exporting only that sheet.
+fn render_some(
+    cli: &str,
+    root: &Path,
+    entries: &[SheetEntry],
+    subset: Option<&HashSet<String>>,
+) -> (HashMap<String, String>, Vec<String>) {
+    let mut unique_files: Vec<(&str, &str)> = Vec::new(); // (file, first-seen name)
+    let mut seen = HashSet::new();
+    for e in entries {
+        if seen.insert(e.file.as_str()) {
+            let wanted = match subset {
+                Some(s) => s.contains(e.file.as_str()),
+                None => true,
+            };
+            if wanted {
+                unique_files.push((e.file.as_str(), e.name.as_str()));
+            }
+        }
+    }
+    if unique_files.is_empty() {
+        return (HashMap::new(), Vec::new());
+    }
+
+    // Renders run against a temp snapshot of the sheet files, never the
+    // live ones (see snapshot_tree for why), inside a batch dir that's
+    // cleaned up at the end.
+    let batch_dir = render_batch_dir();
+    let snapshot = snapshot_tree(root, entries, &batch_dir.join("src"));
+
+    let results: Vec<(String, Result<String, String>)> = std::thread::scope(|scope| {
+        let handles: Vec<_> = unique_files
+            .iter()
+            .enumerate()
+            .map(|(i, (file, name))| {
+                let out_dir = batch_dir.join(i.to_string());
+                let src = snapshot
+                    .get(*file)
+                    .cloned()
+                    .unwrap_or_else(|| PathBuf::from(*file));
+                scope.spawn(move || {
+                    let r = render_to_svg_in(cli, &src, &out_dir);
+                    (*file, *name, r)
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|h| h.join().unwrap())
+            .map(|(file, name, r)| (file.to_string(), r.map_err(|e| format!("{}: {}", name, e))))
+            .collect()
+    });
+
+    let mut cache = HashMap::new();
+    let mut errors = Vec::new();
+    for (file, r) in results {
+        match r {
+            Ok(svg) => {
+                cache.insert(file, svg);
+            }
+            Err(e) => errors.push(e),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&batch_dir);
+    (cache, errors)
 }
 
 // ─── Tauri Commands ─────────────────────────────────────────────────────────
@@ -124,130 +431,415 @@ fn get_startup_file(state: tauri::State<'_, ViewerState>) -> Option<String> {
     state.startup_file.lock().unwrap().take()
 }
 
+#[derive(serde::Serialize)]
+struct OpenResult {
+    svg: String,
+    sheets: Vec<SheetEntry>,
+    active_file: String,
+    render_errors: Vec<String>,
+}
+
+/// Payload for the `sheets-updated` event, emitted by the file watcher when
+/// a re-walk finds the tree changed. Carries `active_file` alongside the new
+/// list so the frontend's selector can stay in sync even when the
+/// previously active sheet vanished and the backend fell back to root.
+#[derive(serde::Serialize)]
+struct SheetsUpdated {
+    sheets: Vec<SheetEntry>,
+    active_file: String,
+}
+
 #[tauri::command]
 fn open_schematic(
     app: AppHandle,
     state: tauri::State<'_, ViewerState>,
     path: String,
-) -> Result<String, String> {
-    let sch_path = PathBuf::from(&path);
-    if !sch_path.exists() {
+) -> Result<OpenResult, String> {
+    let root = PathBuf::from(&path);
+    if !root.exists() {
         return Err(format!("File not found: {}", path));
     }
 
-    *state.schematic_path.lock().unwrap() = Some(sch_path.clone());
-
     let cli = state.kicad_cli.lock().unwrap().clone();
-    let svg = render_to_svg(&cli, &sch_path)?;
+    let sheets = walk_sheet_tree(&root);
+    let (cache, errors) = render_all(&cli, &root, &sheets);
+
+    let active_key = root.to_string_lossy().to_string();
+    let svg = cache
+        .get(&active_key)
+        .cloned()
+        .ok_or_else(|| format!("Failed to render root schematic: {}", errors.join("; ")))?;
 
     if let Some(window) = app.get_webview_window("main") {
-        let name = sch_path.file_name().unwrap_or_default().to_string_lossy();
+        let name = root.file_name().unwrap_or_default().to_string_lossy();
         let _ = window.set_title(&format!("{} — Schematic Viewer", name));
     }
 
-    // Replace the watcher. Assigning drops the previous one, which stops
-    // watching the old file — no stale renders overwriting the new view.
-    let watcher = build_watcher(app.clone(), cli, sch_path)?;
+    let watch_dirs = compute_watch_dirs(&sheets);
+    let watcher = build_watcher(app.clone(), cli, root.clone())?;
+
+    *state.root_path.lock().unwrap() = Some(root.clone());
+    *state.active_file.lock().unwrap() = Some(root);
+    *state.sheets.lock().unwrap() = sheets.clone();
+    *state.svg_cache.lock().unwrap() = cache;
+    *state.watched_dirs.lock().unwrap() = watch_dirs;
     *state.watcher.lock().unwrap() = Some(watcher);
 
+    Ok(OpenResult {
+        svg,
+        sheets,
+        active_file: active_key,
+        render_errors: errors,
+    })
+}
+
+/// Switch which sheet is displayed, without re-rendering — all sheets were
+/// already rendered eagerly by `open_schematic`/the watcher, so this is
+/// just a cache lookup.
+#[tauri::command]
+fn select_sheet(state: tauri::State<'_, ViewerState>, file: String) -> Result<String, String> {
+    let known = state.sheets.lock().unwrap().iter().any(|e| e.file == file);
+    if !known {
+        return Err(format!(
+            "'{}' is not a known sheet in the current design",
+            file
+        ));
+    }
+    let svg = state
+        .svg_cache
+        .lock()
+        .unwrap()
+        .get(&file)
+        .cloned()
+        .ok_or_else(|| "This sheet failed to render — see the earlier error".to_string())?;
+    *state.active_file.lock().unwrap() = Some(PathBuf::from(&file));
     Ok(svg)
 }
 
 #[tauri::command]
 fn refresh(state: tauri::State<'_, ViewerState>) -> Result<String, String> {
-    let path = state.schematic_path.lock().unwrap().clone();
+    let active = state
+        .active_file
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or("No schematic loaded")?;
     let cli = state.kicad_cli.lock().unwrap().clone();
-    match path {
-        Some(p) => render_to_svg(&cli, &p),
-        None => Err("No schematic loaded".to_string()),
-    }
+    // Same snapshot isolation as render_all, scoped to the active sheet's
+    // subtree (children must be present for kicad-cli to load the sheet).
+    let entries = walk_sheet_tree(&active);
+    let batch_dir = render_batch_dir();
+    let snapshot = snapshot_tree(&active, &entries, &batch_dir.join("src"));
+    let key = active.to_string_lossy().to_string();
+    let src = snapshot
+        .get(&key)
+        .cloned()
+        .unwrap_or_else(|| active.clone());
+    let result = render_to_svg_in(&cli, &src, &batch_dir.join("out"));
+    let _ = std::fs::remove_dir_all(&batch_dir);
+    let svg = result?;
+    state.svg_cache.lock().unwrap().insert(key, svg.clone());
+    Ok(svg)
 }
 
+/// Opens the currently *active* sheet in KiCAD — not necessarily the root —
+/// so "Open in KiCAD" matches whatever the user is actually looking at.
 #[tauri::command]
 fn open_in_kicad(state: tauri::State<'_, ViewerState>) -> Result<(), String> {
-    let path = state.schematic_path.lock().unwrap().clone();
-    match path {
-        Some(p) => {
-            Command::new(resolve_kicad_binary())
-                .arg(&p)
-                .spawn()
-                .map_err(|e| format!("Failed to launch KiCAD: {}", e))?;
-            Ok(())
-        }
-        None => Err("No schematic loaded".to_string()),
+    let root = state
+        .root_path
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or("No schematic loaded")?;
+    let active = state
+        .active_file
+        .lock()
+        .unwrap()
+        .clone()
+        .unwrap_or_else(|| root.clone());
+
+    // kicad.exe (the full GUI app, as opposed to kicad-cli) expects a
+    // .kicad_pro project file — passing a bare .kicad_sch produces "does
+    // not appear to be a KiCad project file". Prefer the project file
+    // (standard KiCad convention: same file stem as the root schematic,
+    // same directory) when it exists; otherwise fall back to opening the
+    // sheet directly, which KiCad can still do for a standalone schematic
+    // with no project file. Note: this opens the *project*, not
+    // necessarily jumping straight to whichever sub-sheet is active in the
+    // viewer — there's no reliable way to make kicad.exe do that from the
+    // command line.
+    let project = root.with_extension("kicad_pro");
+    let target = if project.exists() { project } else { active };
+
+    // KiCAD marks an open project/file with a `~<name>.lck` file in the
+    // same directory (confirmed against a real KiCAD 10 session). Spawning
+    // kicad.exe against an already-locked project produces a warning dialog
+    // that, if declined, still leaves a new blank KiCAD window running —
+    // checking first avoids that stray window entirely. Known tradeoff: a
+    // stale lock left behind by a crashed KiCAD would incorrectly block a
+    // legitimate open; not attempting to validate lock freshness here.
+    if kicad_lock_path(&target).exists() {
+        let name = target.file_name().unwrap_or_default().to_string_lossy();
+        return Err(format!(
+            "'{}' is already open in another KiCAD window — switch to that window instead of opening a new one.",
+            name
+        ));
     }
+
+    Command::new(resolve_kicad_binary())
+        .arg(&target)
+        .spawn()
+        .map_err(|e| format!("Failed to launch KiCAD: {}", e))?;
+    Ok(())
 }
 
 // ─── File Watcher ───────────────────────────────────────────────────────────
 
-/// Build a watcher on the schematic's parent directory. The returned watcher
-/// keeps its own background thread alive for as long as it is held; the
-/// caller stores it in `ViewerState` so it lives exactly as long as this
-/// schematic is the open one.
+/// Build a watcher covering every sheet's parent directory. On any relevant
+/// change, re-walks the whole tree (not just re-renders one file) — an edit
+/// to the root could add or remove a sheet, so "what changed" always means
+/// "re-discover the tree, then re-render everything in it." Hierarchical
+/// designs are small in practice, so eagerly re-rendering all sheets on
+/// every change is simpler and safer than tracking per-sheet staleness.
 fn build_watcher(
     app: AppHandle,
     cli: String,
-    schematic: PathBuf,
+    root: PathBuf,
 ) -> Result<notify::RecommendedWatcher, String> {
-    let target_name = schematic.file_name().unwrap_or_default().to_os_string();
-    // Start "in the past" so the first save after opening triggers a refresh.
-    let last_event = Arc::new(Mutex::new(Instant::now() - Duration::from_secs(1)));
-    let watch_dir = schematic.parent().unwrap_or(Path::new(".")).to_path_buf();
+    let initial_dirs = compute_watch_dirs(&walk_sheet_tree(&root));
+
+    // All slow work happens on a dedicated worker thread, never in the
+    // notify callback below — see spawn_render_worker for why that split is
+    // load-bearing, not just tidy.
+    let (tx, rx) = std::sync::mpsc::channel();
+    spawn_render_worker(app, cli, root, rx);
 
     let mut watcher =
         notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| {
             let Ok(event) = res else { return };
 
-            // Only file modifications / atomic-write renames
             match event.kind {
-                EventKind::Modify(_) | EventKind::Create(_) => {}
+                EventKind::Modify(_) | EventKind::Create(_) | EventKind::Remove(_) => {}
                 _ => return,
             }
 
-            // Only our target file
-            let is_our_file = event
+            let changed: Vec<PathBuf> = event
                 .paths
                 .iter()
-                .any(|p| p.file_name().map(|n| n == target_name).unwrap_or(false));
-            if !is_our_file {
+                .filter(|p| is_relevant_sch_change(p))
+                .cloned()
+                .collect();
+            if changed.is_empty() {
                 return;
             }
 
-            // Debounce (editors and atomic writes fire bursts of events)
-            {
-                let mut last = last_event.lock().unwrap();
-                if last.elapsed() < Duration::from_millis(500) {
-                    return;
-                }
-                *last = Instant::now();
-            }
-
-            // Stale guard: if the user opened a different schematic while
-            // this event was in flight, drop it.
-            {
-                let state = app.state::<ViewerState>();
-                let current = state.schematic_path.lock().unwrap().clone();
-                if current.as_deref() != Some(schematic.as_path()) {
-                    return;
-                }
-            }
-
-            match render_to_svg(&cli, &schematic) {
-                Ok(svg) => {
-                    let _ = app.emit("schematic-updated", svg);
-                }
-                Err(e) => {
-                    let _ = app.emit("viewer-error", format!("Render failed: {}", e));
-                }
-            }
+            let _ = tx.send(changed);
         })
         .map_err(|e| format!("Failed to create file watcher: {}", e))?;
 
-    watcher
-        .watch(&watch_dir, RecursiveMode::NonRecursive)
-        .map_err(|e| format!("Failed to watch {}: {}", watch_dir.display(), e))?;
+    for dir in &initial_dirs {
+        watcher
+            .watch(dir, RecursiveMode::NonRecursive)
+            .map_err(|e| format!("Failed to watch {}: {}", dir.display(), e))?;
+    }
 
     Ok(watcher)
+}
+
+/// How long file events must stay quiet before a re-render starts. A KiCAD
+/// save rewrites every modified sheet file in a burst spread over a second
+/// or two (observed: ~24 files across 2 seconds on a real 20-sheet board),
+/// so rendering must begin *after* the burst ends, not on its first event —
+/// a leading-edge debounce reads files KiCAD is still writing.
+const QUIET_WINDOW: Duration = Duration::from_millis(600);
+
+/// Upper bound on waiting for quiet, so a pathological never-ending event
+/// stream still renders eventually instead of starving forever.
+const MAX_BURST_WAIT: Duration = Duration::from_secs(5);
+
+/// Record a batch of changed paths in both raw and canonical form. Notify's
+/// event paths and the tree walker's joined paths can disagree in shape
+/// (canonicalize on Windows yields \\?\-prefixed paths; a deleted file
+/// can't be canonicalized at all), so membership tests check both forms.
+fn note_changed(changed: &mut HashSet<PathBuf>, paths: Vec<PathBuf>) {
+    for p in paths {
+        if let Ok(c) = p.canonicalize() {
+            changed.insert(c);
+        }
+        changed.insert(p);
+    }
+}
+
+/// Absorb a burst of file events, accumulating every reported path into
+/// `changed`: keep draining until `quiet` elapses with no new event, or
+/// give up waiting once `cap` has passed since the burst began. Returns
+/// false when the channel disconnected — the watcher owning the sender was
+/// dropped, so this design is no longer current and the worker should exit.
+fn drain_until_quiet(
+    rx: &Receiver<Vec<PathBuf>>,
+    quiet: Duration,
+    cap: Duration,
+    changed: &mut HashSet<PathBuf>,
+) -> bool {
+    let burst_start = Instant::now();
+    loop {
+        if burst_start.elapsed() >= cap {
+            return true;
+        }
+        match rx.recv_timeout(quiet) {
+            Ok(paths) => note_changed(changed, paths),
+            Err(RecvTimeoutError::Timeout) => return true,
+            Err(RecvTimeoutError::Disconnected) => return false,
+        }
+    }
+}
+
+/// Which sheet files must be re-rendered for this burst: any whose path
+/// (raw or canonical) is in `changed`, plus any without a cached SVG — a
+/// newly added sheet, or one whose previous render failed. Everything else
+/// keeps its cached image untouched.
+fn files_needing_render(
+    entries: &[SheetEntry],
+    changed: &HashSet<PathBuf>,
+    cached: &HashMap<String, String>,
+) -> HashSet<String> {
+    let mut need = HashSet::new();
+    for e in entries {
+        if cached.contains_key(&e.file) {
+            let raw = PathBuf::from(&e.file);
+            let canon = raw.canonicalize().unwrap_or_else(|_| raw.clone());
+            if !changed.contains(&raw) && !changed.contains(&canon) {
+                continue;
+            }
+        }
+        need.insert(e.file.clone());
+    }
+    need
+}
+
+/// The render worker owns everything slow: it collapses each burst of file
+/// events into a single re-walk + re-render once the burst goes quiet.
+///
+/// Keeping this off the notify callback is load-bearing on Windows: while
+/// the callback runs, directory changes queue in a small fixed OS buffer
+/// (ReadDirectoryChangesW). A multi-second render inside the callback
+/// overflows that buffer and silently drops every event that arrives
+/// meanwhile — the watcher then looks permanently "deaf" even though
+/// nothing errored. The callback must return in microseconds; it forwards
+/// each event's relevant paths through `rx` and nothing more.
+///
+/// The worker exits when `rx` disconnects, which happens exactly when the
+/// watcher holding the sender is dropped (a new design was opened, or the
+/// viewer is shutting down).
+fn spawn_render_worker(app: AppHandle, cli: String, root: PathBuf, rx: Receiver<Vec<PathBuf>>) {
+    std::thread::spawn(move || {
+        while let Ok(first) = rx.recv() {
+            // Surface "the watcher noticed" immediately, before the quiet
+            // wait and the render — both take a while on a big design.
+            // Without this there is no way for the user to tell "the edit
+            // was never seen" apart from "seen, but the render failed".
+            let _ = app.emit("change-detected", ());
+
+            let mut changed = HashSet::new();
+            note_changed(&mut changed, first);
+            if !drain_until_quiet(&rx, QUIET_WINDOW, MAX_BURST_WAIT, &mut changed) {
+                return; // watcher dropped mid-burst — this design was closed
+            }
+
+            let state = app.state::<ViewerState>();
+
+            // Stale guard: if the user opened a different design while this
+            // burst was in flight, drop it.
+            {
+                let current_root = state.root_path.lock().unwrap().clone();
+                if current_root.as_deref() != Some(root.as_path()) {
+                    return;
+                }
+            }
+
+            let new_sheets = walk_sheet_tree(&root);
+
+            // Re-render only what this burst touched (plus anything not yet
+            // cached); untouched sheets keep their existing SVGs. On a big
+            // design this turns save-to-screen latency from "render the
+            // whole board" into "render the sheets you edited".
+            let old_cache = state.svg_cache.lock().unwrap().clone();
+            let need = files_needing_render(&new_sheets, &changed, &old_cache);
+            let (fresh, errors) = render_some(&cli, &root, &new_sheets, Some(&need));
+
+            // Merge: freshly rendered wins; sheets still in the tree keep
+            // their old SVG; sheets that left the tree drop out. A sheet
+            // that needed a render but failed stays absent, matching
+            // render_all's contract.
+            let mut cache: HashMap<String, String> = HashMap::new();
+            for e in &new_sheets {
+                if let Some(svg) = fresh.get(&e.file) {
+                    cache.insert(e.file.clone(), svg.clone());
+                } else if !need.contains(&e.file) {
+                    if let Some(svg) = old_cache.get(&e.file) {
+                        cache.insert(e.file.clone(), svg.clone());
+                    }
+                }
+            }
+
+            // If the previously active sheet vanished from the tree (its
+            // sheet was deleted), fall back to the root.
+            let (active_key, active_switched) = {
+                let mut active = state.active_file.lock().unwrap();
+                let prev = active.as_ref().map(|a| a.to_string_lossy().to_string());
+                let still_valid = active
+                    .as_ref()
+                    .map(|a| new_sheets.iter().any(|e| e.file == a.to_string_lossy()))
+                    .unwrap_or(false);
+                if !still_valid {
+                    *active = Some(root.clone());
+                }
+                let key = active.as_ref().unwrap().to_string_lossy().to_string();
+                let switched = prev.as_deref() != Some(key.as_str());
+                (key, switched)
+            };
+
+            // Re-derive the watch set and diff it against what's currently
+            // watched, so a sheet added in a brand-new folder gets covered
+            // without requiring the user to reopen the viewer.
+            let new_dirs = compute_watch_dirs(&new_sheets);
+            if let Some(w) = state.watcher.lock().unwrap().as_mut() {
+                let mut watched = state.watched_dirs.lock().unwrap();
+                for dir in new_dirs.difference(&watched) {
+                    let _ = w.watch(dir, RecursiveMode::NonRecursive);
+                }
+                for dir in watched.difference(&new_dirs) {
+                    let _ = w.unwatch(dir);
+                }
+                *watched = new_dirs;
+            }
+
+            *state.sheets.lock().unwrap() = new_sheets.clone();
+            *state.svg_cache.lock().unwrap() = cache.clone();
+
+            let _ = app.emit(
+                "sheets-updated",
+                &SheetsUpdated {
+                    sheets: new_sheets,
+                    active_file: active_key.clone(),
+                },
+            );
+            // Push the active sheet only when its content actually changed
+            // (it was re-rendered) or the view must switch (fallback to
+            // root after a delete); re-pushing an identical SVG would
+            // pointlessly redraw and flash "updated" for edits that only
+            // touched other sheets.
+            if active_switched || need.contains(&active_key) {
+                if let Some(svg) = cache.get(&active_key) {
+                    let _ = app.emit("schematic-updated", svg);
+                }
+            }
+            for e in &errors {
+                let _ = app.emit("viewer-error", format!("Render failed: {}", e));
+            }
+        }
+    });
 }
 
 // ─── Main ───────────────────────────────────────────────────────────────────
@@ -266,7 +858,11 @@ fn main() {
     }
 
     let state = ViewerState {
-        schematic_path: Mutex::new(None),
+        root_path: Mutex::new(None),
+        active_file: Mutex::new(None),
+        sheets: Mutex::new(Vec::new()),
+        svg_cache: Mutex::new(HashMap::new()),
+        watched_dirs: Mutex::new(HashSet::new()),
         kicad_cli: Mutex::new(resolve_kicad_cli(kicad_cli_override)),
         startup_file: Mutex::new(file_arg),
         watcher: Mutex::new(None),
@@ -277,6 +873,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             get_startup_file,
             open_schematic,
+            select_sheet,
             refresh,
             open_in_kicad
         ])
@@ -288,4 +885,386 @@ fn main() {
                 let _ = std::fs::remove_dir_all(render_temp_dir());
             }
         });
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use konnect_schematic_editor::{Schematic, Sheet};
+    use tempfile::TempDir;
+
+    fn blank_schematic(dir: &Path, name: &str) -> PathBuf {
+        let path = dir.join(name);
+        let template = "(kicad_sch\n\t(version 20250610)\n\t(generator \"konnect\")\n\t(generator_version \"10.0\")\n\t(paper \"A4\")\n\t(lib_symbols\n\t)\n)\n";
+        std::fs::write(&path, template).unwrap();
+        let sch = Schematic::load(&path).unwrap();
+        sch.overwrite().unwrap();
+        path
+    }
+
+    fn add_sheet(parent: &Path, name: &str, file: &str) {
+        let mut sch = Schematic::load(parent).unwrap();
+        sch.add_sheet(Sheet::new(name, file, 50.0, 50.0, 80.0, 50.0));
+        sch.overwrite().unwrap();
+    }
+
+    #[test]
+    fn kicad_lock_path_matches_real_kicad_convention() {
+        // Verified against a real KiCAD 10 session: opening
+        // "MultiSheet.kicad_pro" produces "~MultiSheet.kicad_pro.lck" in
+        // the same directory.
+        let path = Path::new("/proj/MultiSheet.kicad_pro");
+        assert_eq!(
+            kicad_lock_path(path),
+            PathBuf::from("/proj/~MultiSheet.kicad_pro.lck")
+        );
+    }
+
+    #[test]
+    fn is_relevant_sch_change_ignores_autosave_and_lock_files() {
+        assert!(!is_relevant_sch_change(Path::new(
+            "/proj/_autosave-Root.kicad_sch"
+        )));
+        assert!(!is_relevant_sch_change(Path::new("/proj/~Root.kicad_sch")));
+        assert!(!is_relevant_sch_change(Path::new("/proj/Root.kicad_pro"))); // wrong extension
+        assert!(is_relevant_sch_change(Path::new("/proj/Root.kicad_sch")));
+        assert!(is_relevant_sch_change(Path::new("/proj/PMS.kicad_sch")));
+    }
+
+    #[test]
+    fn walk_sheet_tree_finds_root_only_when_no_sheets() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+
+        let entries = walk_sheet_tree(&root);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].depth, 0);
+        assert_eq!(entries[0].name, "root");
+    }
+
+    #[test]
+    fn walk_sheet_tree_finds_nested_sheets_in_depth_first_order() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        blank_schematic(tmp.path(), "mid.kicad_sch");
+        blank_schematic(tmp.path(), "leaf.kicad_sch");
+        add_sheet(&root, "Mid", "mid.kicad_sch");
+        add_sheet(&tmp.path().join("mid.kicad_sch"), "Leaf", "leaf.kicad_sch");
+
+        let entries = walk_sheet_tree(&root);
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].name, "root");
+        assert_eq!(entries[0].depth, 0);
+        assert_eq!(entries[1].name, "Mid");
+        assert_eq!(entries[1].depth, 1);
+        assert_eq!(entries[2].name, "Leaf");
+        assert_eq!(entries[2].depth, 2);
+    }
+
+    #[test]
+    fn walk_sheet_tree_skips_missing_child_file_without_crashing() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        add_sheet(&root, "Gone", "does_not_exist.kicad_sch");
+
+        let entries = walk_sheet_tree(&root);
+        assert_eq!(entries.len(), 1); // just the root — missing child skipped
+    }
+
+    #[test]
+    fn walk_sheet_tree_handles_multiple_siblings() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        blank_schematic(tmp.path(), "a.kicad_sch");
+        blank_schematic(tmp.path(), "b.kicad_sch");
+        add_sheet(&root, "A", "a.kicad_sch");
+        add_sheet(&root, "B", "b.kicad_sch");
+
+        let entries = walk_sheet_tree(&root);
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[1].name, "A");
+        assert_eq!(entries[1].depth, 1);
+        assert_eq!(entries[2].name, "B");
+        assert_eq!(entries[2].depth, 1);
+    }
+
+    #[test]
+    fn walk_sheet_tree_reuse_of_same_file_is_not_treated_as_a_cycle() {
+        // Multi-instance sheets: the same child file placed twice from two
+        // different parents is legitimate (see PR #15's design note), not a
+        // reference cycle — only an actual ancestor-of-itself loop should stop.
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        blank_schematic(tmp.path(), "shared.kicad_sch");
+        add_sheet(&root, "First", "shared.kicad_sch");
+        add_sheet(&root, "Second", "shared.kicad_sch");
+
+        let entries = walk_sheet_tree(&root);
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[1].name, "First");
+        assert_eq!(entries[2].name, "Second");
+    }
+
+    #[test]
+    fn walk_sheet_tree_stops_on_genuine_cycle() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        blank_schematic(tmp.path(), "child.kicad_sch");
+        add_sheet(&root, "Child", "child.kicad_sch");
+        // Child references root — a genuine cycle.
+        add_sheet(
+            &tmp.path().join("child.kicad_sch"),
+            "Root",
+            "root.kicad_sch",
+        );
+
+        let entries = walk_sheet_tree(&root);
+        // root, child — then root-again is skipped (already an ancestor)
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn compute_watch_dirs_dedupes_siblings_in_same_folder() {
+        let entries = vec![
+            SheetEntry {
+                name: "root".into(),
+                file: "/proj/root.kicad_sch".into(),
+                depth: 0,
+            },
+            SheetEntry {
+                name: "A".into(),
+                file: "/proj/a.kicad_sch".into(),
+                depth: 1,
+            },
+            SheetEntry {
+                name: "B".into(),
+                file: "/proj/sub/b.kicad_sch".into(),
+                depth: 1,
+            },
+        ];
+        let dirs = compute_watch_dirs(&entries);
+        assert_eq!(dirs.len(), 2);
+        assert!(dirs.contains(Path::new("/proj")));
+        assert!(dirs.contains(Path::new("/proj/sub")));
+    }
+
+    #[test]
+    fn compute_watch_dirs_empty_for_no_entries() {
+        assert!(compute_watch_dirs(&[]).is_empty());
+    }
+
+    #[test]
+    fn render_all_reports_per_sheet_errors_without_stopping_the_batch() {
+        // No real kicad-cli in the test environment — every entry should
+        // fail gracefully and land in `errors`, not panic.
+        let entries = vec![
+            SheetEntry {
+                name: "root".into(),
+                file: "/nonexistent/root.kicad_sch".into(),
+                depth: 0,
+            },
+            SheetEntry {
+                name: "leaf".into(),
+                file: "/nonexistent/leaf.kicad_sch".into(),
+                depth: 1,
+            },
+        ];
+        let (cache, errors) = render_all(
+            "kicad-cli-that-does-not-exist",
+            Path::new("/nonexistent/root.kicad_sch"),
+            &entries,
+        );
+        assert!(cache.is_empty());
+        assert_eq!(errors.len(), 2);
+    }
+
+    #[test]
+    fn snapshot_tree_mirrors_relative_layout_and_copies_content() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        std::fs::create_dir_all(tmp.path().join("sub")).unwrap();
+        blank_schematic(&tmp.path().join("sub"), "child.kicad_sch");
+        add_sheet(&root, "Child", "sub/child.kicad_sch");
+
+        let entries = walk_sheet_tree(&root);
+        assert_eq!(entries.len(), 2);
+
+        let snap = TempDir::new().unwrap();
+        let map = snapshot_tree(&root, &entries, snap.path());
+
+        let snap_root = map.get(&entries[0].file).unwrap();
+        let snap_child = map.get(&entries[1].file).unwrap();
+        assert!(snap_root.starts_with(snap.path()));
+        assert!(snap_child.starts_with(snap.path()));
+        // Relative layout preserved, so parent-to-child references resolve
+        assert!(snap_child.ends_with(Path::new("sub").join("child.kicad_sch")));
+        assert_eq!(
+            std::fs::read(snap_root).unwrap(),
+            std::fs::read(&entries[0].file).unwrap()
+        );
+        // The snapshot itself walks identically to the live tree
+        assert_eq!(walk_sheet_tree(snap_root).len(), 2);
+    }
+
+    #[test]
+    fn snapshot_tree_copies_root_project_file_when_present() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        std::fs::write(tmp.path().join("root.kicad_pro"), "{}").unwrap();
+
+        let entries = walk_sheet_tree(&root);
+        let snap = TempDir::new().unwrap();
+        snapshot_tree(&root, &entries, snap.path());
+
+        assert!(snap.path().join("root.kicad_pro").exists());
+    }
+
+    #[test]
+    fn snapshot_tree_falls_back_to_live_path_for_files_outside_root_dir() {
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        let other = TempDir::new().unwrap();
+        let outside = blank_schematic(other.path(), "outside.kicad_sch");
+
+        let entries = vec![
+            SheetEntry {
+                name: "root".into(),
+                file: root.to_string_lossy().to_string(),
+                depth: 0,
+            },
+            SheetEntry {
+                name: "Out".into(),
+                file: outside.to_string_lossy().to_string(),
+                depth: 1,
+            },
+        ];
+        let snap = TempDir::new().unwrap();
+        let map = snapshot_tree(&root, &entries, snap.path());
+
+        // In-tree file is copied; out-of-tree file is left at its live path
+        assert!(map.get(&entries[0].file).unwrap().starts_with(snap.path()));
+        assert_eq!(map.get(&entries[1].file).unwrap(), &outside);
+    }
+
+    #[test]
+    fn drain_until_quiet_completes_and_accumulates_changed_paths() {
+        let (tx, rx) = std::sync::mpsc::channel::<Vec<PathBuf>>();
+        tx.send(vec![PathBuf::from("/proj/a.kicad_sch")]).unwrap();
+        tx.send(vec![PathBuf::from("/proj/b.kicad_sch")]).unwrap();
+        let mut changed = HashSet::new();
+        // Queued events get absorbed, then silence: proceed with the render
+        assert!(drain_until_quiet(
+            &rx,
+            Duration::from_millis(50),
+            Duration::from_secs(5),
+            &mut changed
+        ));
+        // Raw paths recorded even when canonicalize fails (files don't exist)
+        assert!(changed.contains(Path::new("/proj/a.kicad_sch")));
+        assert!(changed.contains(Path::new("/proj/b.kicad_sch")));
+    }
+
+    #[test]
+    fn drain_until_quiet_reports_disconnect() {
+        let (tx, rx) = std::sync::mpsc::channel::<Vec<PathBuf>>();
+        drop(tx);
+        // Sender gone means the watcher was dropped: worker must exit
+        assert!(!drain_until_quiet(
+            &rx,
+            Duration::from_millis(50),
+            Duration::from_secs(5),
+            &mut HashSet::new()
+        ));
+    }
+
+    #[test]
+    fn drain_until_quiet_gives_up_after_cap_during_constant_events() {
+        let (tx, rx) = std::sync::mpsc::channel::<Vec<PathBuf>>();
+        let sender = std::thread::spawn(move || {
+            let start = Instant::now();
+            while start.elapsed() < Duration::from_millis(400) {
+                let _ = tx.send(vec![PathBuf::from("/proj/a.kicad_sch")]);
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        });
+        let start = Instant::now();
+        // Events never go quiet, but the cap forces a render anyway
+        assert!(drain_until_quiet(
+            &rx,
+            Duration::from_millis(100),
+            Duration::from_millis(150),
+            &mut HashSet::new()
+        ));
+        assert!(start.elapsed() < Duration::from_millis(390));
+        sender.join().unwrap();
+    }
+
+    #[test]
+    fn files_needing_render_selects_changed_and_uncached_only() {
+        let tmp = TempDir::new().unwrap();
+        let a = blank_schematic(tmp.path(), "a.kicad_sch");
+        let b = blank_schematic(tmp.path(), "b.kicad_sch");
+        let c = blank_schematic(tmp.path(), "c.kicad_sch");
+        let entry = |p: &Path, n: &str| SheetEntry {
+            name: n.into(),
+            file: p.to_string_lossy().to_string(),
+            depth: 0,
+        };
+        let entries = vec![entry(&a, "A"), entry(&b, "B"), entry(&c, "C")];
+
+        let mut cached = HashMap::new();
+        cached.insert(entries[0].file.clone(), "svg".to_string());
+        cached.insert(entries[1].file.clone(), "svg".to_string());
+        // c is not cached (new sheet, or its earlier render failed)
+
+        // b changed, reported in canonical form like a real notify event
+        let mut changed = HashSet::new();
+        changed.insert(b.canonicalize().unwrap());
+
+        let need = files_needing_render(&entries, &changed, &cached);
+        assert!(!need.contains(&entries[0].file)); // cached + untouched
+        assert!(need.contains(&entries[1].file)); // changed on disk
+        assert!(need.contains(&entries[2].file)); // not cached
+    }
+
+    #[test]
+    fn files_needing_render_matches_raw_paths_when_canonicalize_unavailable() {
+        // A deleted/unreachable file can't be canonicalized on either side;
+        // raw string-path comparison must still match.
+        let entries = vec![SheetEntry {
+            name: "x".into(),
+            file: "/nope/x.kicad_sch".into(),
+            depth: 0,
+        }];
+        let cached: HashMap<String, String> =
+            [("/nope/x.kicad_sch".to_string(), "svg".to_string())]
+                .into_iter()
+                .collect();
+        let mut changed = HashSet::new();
+        changed.insert(PathBuf::from("/nope/x.kicad_sch"));
+
+        let need = files_needing_render(&entries, &changed, &cached);
+        assert!(need.contains("/nope/x.kicad_sch"));
+    }
+
+    #[test]
+    fn files_needing_render_empty_when_nothing_relevant_changed() {
+        // A burst that only touched files outside the tree (e.g. an orphan
+        // .kicad_sch in the same folder) must not trigger any renders.
+        let entries = vec![SheetEntry {
+            name: "root".into(),
+            file: "/proj/root.kicad_sch".into(),
+            depth: 0,
+        }];
+        let cached: HashMap<String, String> =
+            [("/proj/root.kicad_sch".to_string(), "svg".to_string())]
+                .into_iter()
+                .collect();
+        let mut changed = HashSet::new();
+        changed.insert(PathBuf::from("/proj/orphan.kicad_sch"));
+
+        assert!(files_needing_render(&entries, &changed, &cached).is_empty());
+    }
 }


### PR DESCRIPTION
## What this does

Closes the **Multi-sheet schematic viewer** roadmap item (unblocked by the
`sch_hierarchy` work in #15/#16).

The live schematic viewer used to render only the single `.kicad_sch` it was
given, so opening a hierarchical design showed just the root sheet. Now you point
it at the root schematic and it walks the whole sheet tree, renders every sheet
via `kicad-cli`, and shows a depth-indented sheet selector. Edits saved from
KiCAD (or made by the AI through the schematic tools) re-render only the sheets
that changed and refresh the view live.

## Why it's built the way it is

A few design decisions that aren't obvious from the diff:

- **Rendering happens against a temp-folder snapshot, never the live files.**
  `kicad-cli sch export svg` holds every `.kicad_sch` in the exported tree open
  *without write sharing* for the whole export. When the viewer rendered directly
  from the user's files, a KiCAD save that landed mid-render failed with a
  misleading *"You do not have write permissions to: …"* dialog. This was
  reproduced deliberately (a concurrent-write probe against a copy of a real
  board saw the Windows sharing violation directly during an export). Copying the
  sheets into a temp dir first and pointing `kicad-cli` at the copies removes the
  collision by construction, no matter how many renders run in parallel.

- **A Tauri 2 capability file is required for events to work at all.** Tauri's ACL
  denies core-plugin APIs by default. Custom `invoke` commands aren't gated (so
  buttons worked), but `event.listen()` is — without
  `capabilities/default.json`, every listener was silently rejected and no
  backend event ever reached the UI, which made live updates look completely
  dead. The frontend now also wraps every listener registration so a future ACL
  gap surfaces visibly instead of silently.

- **Rendering is incremental and off the watcher callback.** The notify callback
  only forwards changed paths and returns immediately; a worker thread waits for
  the save burst to go quiet, then re-renders *only* the sheets whose files
  changed (keeping every other sheet's cached SVG). Keeping the multi-second
  render off the callback matters on Windows specifically — a long-running
  callback overflows the OS directory-change buffer and later events are silently
  dropped, leaving the watcher permanently deaf.

- **Flat indented sheet list, not a tree widget.** This is a single-file
  vanilla-JS frontend with no component framework; a flat depth-indented list
  meets the roadmap's ask without inventing new frontend architecture.

## Scope / CI note

`crates/schematic-viewer` is **excluded from the Cargo workspace** (it's a Tauri
desktop app, built separately) and therefore isn't touched by CI, which runs
everything with `--workspace`. This is documented in `DEV.md` so it isn't a silent
gap. Because there's no CI here, manual validation carries more weight than usual.

## Test plan

Local (this crate):
- `cd crates/schematic-viewer && cargo test` — **20/20 passed**
- `cargo clippy -- -D warnings` — clean
- `cargo fmt -- --check` — clean

Main workspace (the one in-workspace file this touches is the `open_schematic_viewer`
tool description in `project.rs`):
- `cargo test --workspace --lib --tests` — **133/133 passed**
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Manual, against a real ~20-sheet production board:
- Live add / edit / delete of sheets reflected in both the view and the selector.
- KiCAD saves succeed with **no lock error** throughout extended use (this was the
  original regression the snapshot rendering fixes).
- "Fit" is correct on A3/A4 sheets; "Open in KiCAD" opens the project and doesn't
  spawn a stray window when it's already open.
- Incremental re-render confirmed (editing one sheet no longer re-renders all).

The unit tests cover the pure logic (`walk_sheet_tree`, `compute_watch_dirs`,
`snapshot_tree`, `drain_until_quiet`, `files_needing_render`, and `render_all`'s
per-sheet error handling). The `kicad-cli` subprocess call and the Tauri
command/event plumbing stay thin and are validated manually, matching this
codebase's existing convention for `kicad-cli`-calling code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
