### PR TITLE
fix(mcp): deliver tools/list_changed over stdio so loaded tools are callable in Claude Code

### DIFF
--- a/crates/konnect-core/src/mcp/handler.rs
+++ b/crates/konnect-core/src/mcp/handler.rs
@@ -21,6 +21,12 @@ use tracing::{debug, info, warn};
 pub struct McpHandler {
     ctx: Arc<crate::tools::ToolContext>,
     sse_senders: Arc<RwLock<Vec<mpsc::Sender<Event>>>>,
+    /// Raw-JSON-line notification sinks for non-SSE transports (stdio). A
+    /// server-initiated notification (e.g. tools/list_changed) must reach the
+    /// active transport; SSE senders only cover HTTP, so stdio registers here
+    /// to receive the same notifications. Without this, notifications are
+    /// silently dropped on stdio — the cause of issue #19.
+    notif_sinks: Arc<RwLock<Vec<mpsc::Sender<String>>>>,
     observer: CallObserver,
 }
 
@@ -42,6 +48,7 @@ impl McpHandler {
         Ok(McpHandler {
             ctx,
             sse_senders: Arc::new(RwLock::new(Vec::new())),
+            notif_sinks: Arc::new(RwLock::new(Vec::new())),
             observer,
         })
     }
@@ -54,6 +61,13 @@ impl McpHandler {
 
     pub async fn register_sse_sender(&self, tx: mpsc::Sender<Event>) {
         self.sse_senders.write().await.push(tx);
+    }
+
+    /// Register a raw-JSON-line notification sink (used by the stdio transport).
+    /// Each server-initiated notification is delivered here as a serialized
+    /// JSON-RPC string, which the transport writes to its output stream.
+    pub async fn register_notification_sink(&self, tx: mpsc::Sender<String>) {
+        self.notif_sinks.write().await.push(tx);
     }
 
     /// Process one JSON-RPC message and return an optional response.
@@ -276,10 +290,24 @@ impl McpHandler {
 
     async fn notify_tools_list_changed(&self) {
         let notification = JsonRpcNotification::new(TOOLS_LIST_CHANGED, None);
-        if let Ok(event_json) = serde_json::to_string(&notification) {
-            let event = Event::default().data(event_json);
+        let Ok(json) = serde_json::to_string(&notification) else {
+            return;
+        };
+
+        // HTTP/SSE clients: wrap the JSON in an SSE event. (Unchanged path.)
+        {
+            let event = Event::default().data(json.clone());
             let mut senders = self.sse_senders.write().await;
             senders.retain(|tx| tx.try_send(event.clone()).is_ok());
+        }
+
+        // stdio (and any other raw-line transport): deliver the JSON directly.
+        // try_send is non-blocking, so emitting a notification from inside
+        // request handling can never block on a full channel and deadlock the
+        // request that triggered it; a dropped sink is pruned like the SSE case.
+        {
+            let mut sinks = self.notif_sinks.write().await;
+            sinks.retain(|tx| tx.try_send(json.clone()).is_ok());
         }
     }
 }

--- a/crates/konnect/src/transport/stdio.rs
+++ b/crates/konnect/src/transport/stdio.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use konnect_core::mcp::{handler::McpHandler, protocol::*};
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::mpsc;
 use tracing::{debug, error, info};
 
 /// Run the MCP server over STDIO (stdin/stdout).
@@ -14,6 +15,18 @@ pub async fn run_stdio(handler: McpHandler) -> Result<()> {
     let mut reader = BufReader::new(stdin);
     let mut stdout = stdout;
     let mut line = String::new();
+
+    // Server-initiated notifications (e.g. tools/list_changed after
+    // load_toolset / unload_toolset) are queued here by the handler and
+    // flushed to stdout after the triggering message is handled. Without this
+    // sink, the handler's notification reached only the HTTP/SSE transport and
+    // was silently dropped on stdio, so stdio clients (Claude Code) never
+    // re-fetched tools/list and tools added mid-session stayed uncallable
+    // (issue #19). Notifications are only ever generated synchronously while
+    // handling a request, so draining right after each message catches them —
+    // no separate task or cancellation-prone select! over read_line is needed.
+    let (notif_tx, mut notif_rx) = mpsc::channel::<String>(16);
+    handler.register_notification_sink(notif_tx).await;
 
     loop {
         line.clear();
@@ -50,6 +63,16 @@ pub async fn run_stdio(handler: McpHandler) -> Result<()> {
             let mut json = serde_json::to_string(&resp)?;
             json.push('\n');
             debug!("STDIO send: {}", json.trim());
+            stdout.write_all(json.as_bytes()).await?;
+            stdout.flush().await?;
+        }
+
+        // Flush any notifications the handler queued while processing this
+        // message, after the response so the client sees the response first.
+        while let Ok(notif) = notif_rx.try_recv() {
+            let mut json = notif;
+            json.push('\n');
+            debug!("STDIO send notification: {}", json.trim());
             stdout.write_all(json.as_bytes()).await?;
             stdout.flush().await?;
         }

--- a/crates/konnect/tests/protocol_stdio.rs
+++ b/crates/konnect/tests/protocol_stdio.rs
@@ -78,6 +78,40 @@ impl McpProcess {
         resp["result"].clone()
     }
 
+    /// Send a `tools/call`, then a fencing `ping`, and return every line the
+    /// server emits up to and including the ping response. The fence
+    /// guarantees the read loop terminates even when the tool call emits no
+    /// notification (as in bug #19), so a test can assert on side-effect
+    /// notifications without risking a hang.
+    fn call_tool_then_fence(&mut self, name: &str, args: Value) -> Vec<Value> {
+        let call_id = self.next_id;
+        self.next_id += 1;
+        let call = json!({
+            "jsonrpc": "2.0", "id": call_id, "method": "tools/call",
+            "params": {"name": name, "arguments": args}
+        });
+        writeln!(self.stdin, "{}", call).unwrap();
+        let fence_id = self.next_id;
+        self.next_id += 1;
+        let fence = json!({"jsonrpc": "2.0", "id": fence_id, "method": "ping", "params": {}});
+        writeln!(self.stdin, "{}", fence).unwrap();
+        self.stdin.flush().unwrap();
+
+        let mut lines = Vec::new();
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).unwrap();
+            assert!(n > 0, "server closed stdout before fence response");
+            let v: Value = serde_json::from_str(line.trim()).unwrap();
+            let is_fence = v.get("id").and_then(Value::as_i64) == Some(fence_id);
+            lines.push(v);
+            if is_fence {
+                break;
+            }
+        }
+        lines
+    }
+
     /// Parse the JSON body of a tool result's first text content.
     fn tool_body(result: &Value) -> Value {
         let text = result["content"][0]["text"].as_str().unwrap_or("{}");
@@ -197,4 +231,39 @@ fn unknown_method_is_json_rpc_error_not_crash() {
     // Server must still be alive afterwards.
     let ping = p.request("ping", json!({}));
     assert!(ping.get("result").is_some());
+}
+
+/// Regression test for issue #19. After `load_toolset`, the server must emit
+/// `notifications/tools/list_changed` **over stdio** — not only over HTTP/SSE.
+/// Without it, stdio clients (Claude Code) never re-fetch `tools/list`, so
+/// every tool added by `load_toolset` stays uncallable for the session.
+#[test]
+fn load_toolset_emits_list_changed_over_stdio() {
+    let mut p = McpProcess::spawn();
+    let lines = p.call_tool_then_fence("load_toolset", json!({"name": "sch_components"}));
+    let saw_notification = lines.iter().any(|v| {
+        v.get("method").and_then(Value::as_str) == Some("notifications/tools/list_changed")
+            && v.get("id").is_none()
+    });
+    assert!(
+        saw_notification,
+        "expected notifications/tools/list_changed after load_toolset (issue #19); saw: {lines:#?}"
+    );
+}
+
+/// The same guarantee for `unload_toolset` — removing tools must also tell the
+/// client to refresh its tool list.
+#[test]
+fn unload_toolset_emits_list_changed_over_stdio() {
+    let mut p = McpProcess::spawn();
+    let _ = p.call_tool_then_fence("load_toolset", json!({"name": "sch_components"}));
+    let lines = p.call_tool_then_fence("unload_toolset", json!({"name": "sch_components"}));
+    let saw_notification = lines.iter().any(|v| {
+        v.get("method").and_then(Value::as_str) == Some("notifications/tools/list_changed")
+            && v.get("id").is_none()
+    });
+    assert!(
+        saw_notification,
+        "expected notifications/tools/list_changed after unload_toolset; saw: {lines:#?}"
+    );
 }


### PR DESCRIPTION
## What this fixes

Fixes #19 — on Claude Code (stdio transport), tools added via `load_toolset` were never callable.
The server reported the toolset active, but every newly-loaded tool returned
"No such tool available", leaving 172 of 185 tools (all schematic/PCB/review/manufacturing
editing) unreachable.

## Root cause

The server already advertises `capabilities.tools.listChanged` and calls
`notify_tools_list_changed()` after `load_toolset` / `unload_toolset` — but that function
delivered the notification **only to HTTP/SSE senders**. The stdio transport had no path for a
server-initiated notification to reach stdout, so on stdio the notification was built and
silently dropped. Claude Code therefore never received `notifications/tools/list_changed`, never
re-fetched `tools/list`, and never saw the newly-loaded tools. HTTP clients worked because SSE
delivered it; stdio had zero notification coverage.

## Fix

- `McpHandler` gains a transport-neutral raw-JSON-line notification sink (`notif_sinks`) alongside
  `sse_senders`, plus `register_notification_sink()`.
- `notify_tools_list_changed()` serializes once and fans out to both SSE (HTTP, unchanged) and the
  raw-line sinks (stdio), both via non-blocking `try_send` so emitting from inside request
  handling can't deadlock on a full channel.
- `run_stdio` registers a sink and, after handling each message, drains any queued notifications
  to stdout (after the response).

I chose drain-after-handle over a `tokio::select!` loop deliberately: notifications are only ever
generated synchronously while handling a request, and `read_line` is not cancellation-safe (a
cancelled read can lose buffered input), so draining after each message is both simpler and
correct. `capabilities.tools.listChanged` was already advertised, so `initialize` is unchanged.

**Not included on purpose:** the issue's alternative suggestion to add an "eager-load all toolsets
at startup" mode. That's a workaround that defeats the on-demand context-economy design (starter
kit ~2K tokens vs. ~23K for the full catalog). The real defect is the dropped notification; fixing
it makes on-demand loading work on Claude Code as designed. Could be a separate opt-in later for
any client that genuinely doesn't honor `list_changed`.

## Tests

Two new stdio regression tests in `crates/konnect/tests/protocol_stdio.rs` spawn the real binary,
call `load_toolset` / `unload_toolset`, and assert `notifications/tools/list_changed` actually
arrives on stdout — using a `ping` "fence" so they fail cleanly instead of hanging when no
notification is emitted. Both **fail on the pre-fix code** (reproducing #19) and **pass after**.
The existing HTTP `sse_stream_delivers_tools_list_changed` test still passes, confirming the SSE
path is untouched.

- `cargo test --workspace --lib --tests` → **205/205 passed** (203 + 2 new)
- `cargo clippy --workspace -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

## Verified in Claude Code

Built a release binary, pointed a fresh Claude Code session at it, and ran the issue's exact
repro: `load_toolset("sch_components")`, then in a new turn `create_schematic` (a tool that exists
only in `sch_components`, not the always-loaded starter kit). Claude Code invoked it successfully
and the schematic file was written to disk — where the released v0.1.3 returns
"No such tool available". So the reported scenario now works end to end in the real client.
