### PR TITLE
Add Docker packaging for the Konnect MCP server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Keep the build context small and reproducible.
+/target/
+crates/*/target/
+crates/schematic-viewer/
+.git/
+.github/
+.claude/
+CLAUDE.md
+*.exe
+*.dll
+*.so
+*.dylib
+dist/
+.playwright/
+.playwright-cli/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# Konnect MCP server -- containerized so it can be run without a local Rust
+# toolchain (e.g. `docker run --rm -i konnect`, the same way markitdown ships).
+#
+# Two stages: a builder with the Rust toolchain + protoc + cmake (nng builds
+# libnng via cmake, konnect-ipc runs prost-build via protoc), and a slim
+# Debian runtime that carries only the compiled binary.
+
+# ---- Builder ----------------------------------------------------------------
+FROM rust:1-bookworm AS builder
+
+# libprotobuf-dev ships the well-known protos (google/protobuf/*.proto) under
+# /usr/include; konnect-ipc's build.rs derives that include dir from $PROTOC.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev cmake \
+    && rm -rf /var/lib/apt/lists/*
+ENV PROTOC=/usr/bin/protoc
+
+WORKDIR /src
+COPY . .
+
+# Only the server binary; schematic-viewer (Tauri) is excluded from the workspace.
+RUN cargo build --release -p konnect
+
+# ---- Runtime ----------------------------------------------------------------
+FROM debian:bookworm-slim
+
+# ca-certificates for any outbound HTTPS (e.g. parts-DB lookups); curl is used
+# by the compose healthcheck to probe the HTTP /health endpoint.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -m -u 10001 konnect
+
+COPY --from=builder /src/target/release/konnect /usr/local/bin/konnect
+COPY docker/konnect.toml /etc/konnect/konnect.toml
+
+USER konnect
+ENV HOME=/home/konnect
+
+# The first-run "install" step copies skills/agents into a host Claude config,
+# which is meaningless inside the container (the Claude client lives on the
+# host). Pre-create the marker so startup skips it on every launch.
+RUN mkdir -p /home/konnect/.konnect && touch /home/konnect/.konnect/.installed
+
+# Mount your KiCAD project here (schematic-edit tools work on file paths).
+WORKDIR /work
+
+# Default: stdio MCP transport, for `docker run --rm -i konnect`.
+# For HTTP hosting, override with: konnect --config /etc/konnect/konnect.toml
+ENTRYPOINT ["konnect"]

--- a/README.md
+++ b/README.md
@@ -141,11 +141,16 @@ KiCAD project you want to work on at `/work`:
 ```
 
 **As a hosted HTTP server** (one long-running instance, many clients). Point MCP
-clients at `http://<host>:3000/mcp`:
+clients at `http://127.0.0.1:3000/mcp`:
 
 ```bash
-docker compose up -d      # uses docker/konnect.toml (HTTP, binds 0.0.0.0:3000)
+docker compose up -d      # HTTP, published to host loopback (127.0.0.1:3000)
 ```
+
+The server has no authentication and its tools edit files and run `kicad-cli`,
+so compose publishes the port to loopback only. To reach it from other machines,
+front it with an authenticating reverse proxy on a trusted network -- do not just
+publish `0.0.0.0`.
 
 The schematic-edit tools work on file paths, so mount your projects (compose maps
 `./projects`). PCB/IPC and `kicad-cli` export tools need a running KiCAD, which is

--- a/README.md
+++ b/README.md
@@ -115,6 +115,44 @@ Verify: open the **PCB Editor** → **Tools → External Plugins** → you shoul
 cargo build --release -p konnect
 ```
 
+### With Docker
+
+Runs the server with all build dependencies included -- nothing to install but Docker.
+Good for sending to a coworker or letting IT host it centrally.
+
+```bash
+docker build -t konnect .
+```
+
+**As a stdio MCP server** (like markitdown -- one container per session). Mount the
+KiCAD project you want to work on at `/work`:
+
+```json
+{
+  "mcpServers": {
+    "konnect": {
+      "command": "docker",
+      "args": ["run", "--rm", "-i",
+               "-v", "/path/to/your/project:/work",
+               "konnect"]
+    }
+  }
+}
+```
+
+**As a hosted HTTP server** (one long-running instance, many clients). Point MCP
+clients at `http://<host>:3000/mcp`:
+
+```bash
+docker compose up -d      # uses docker/konnect.toml (HTTP, binds 0.0.0.0:3000)
+```
+
+The schematic-edit tools work on file paths, so mount your projects (compose maps
+`./projects`). PCB/IPC and `kicad-cli` export tools need a running KiCAD, which is
+not in the image -- use those against a local install.
+
+Verify a build end to end (stdio + HTTP handshake) with `docker/smoke-test.sh`.
+
 ## Setup with Claude Desktop
 
 After a PCM install, the server binary lives in your KiCAD documents folder:

--- a/crates/konnect/src/config.rs
+++ b/crates/konnect/src/config.rs
@@ -259,4 +259,21 @@ mod tests {
         let c = Config::load_from(f.path()).unwrap();
         assert_eq!(c.log_level, "debug");
     }
+
+    // The config baked into the Docker image (docker/konnect.toml) must keep
+    // parsing into HTTP mode bound to 0.0.0.0 -- otherwise a hosted container
+    // would silently fall back to stdio or bind to loopback and be unreachable.
+    // Parses the real shipped file so config-schema drift breaks this test.
+    #[test]
+    fn shipped_docker_config_serves_http_on_all_interfaces() {
+        let path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docker/konnect.toml");
+        let c = Config::load_from(&path).unwrap();
+        assert!(matches!(c.transport, TransportMode::Http));
+        assert!(
+            c.http_address.starts_with("0.0.0.0:"),
+            "docker config must bind all interfaces, got {}",
+            c.http_address
+        );
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,13 @@
 # Hosted HTTP MCP server -- for a coworker or IT to run centrally.
 #   docker compose up -d
-# Point an MCP client at http://<host>:3000/mcp
+# Point an MCP client at http://127.0.0.1:3000/mcp
+#
+# SECURITY: the MCP server has no authentication, and its tools edit files and
+# run kicad-cli subprocesses. The port is published to host loopback only
+# (127.0.0.1) so it is not reachable from the network by default. To expose it
+# beyond this host, put it behind an authenticating reverse proxy on a trusted
+# network -- do NOT just change this to "3000:3000", which opens the unguarded
+# tool surface to the whole LAN.
 #
 # For the stdio use case (like markitdown) you don't need compose; just run:
 #   docker run --rm -i -v /path/to/project:/work konnect
@@ -11,7 +18,8 @@ services:
     image: konnect
     command: ["--config", "/etc/konnect/konnect.toml"]
     ports:
-      - "3000:3000"
+      # Host loopback only. See the SECURITY note above before widening.
+      - "127.0.0.1:3000:3000"
     volumes:
       # Mount KiCAD projects so the schematic-edit tools can reach them.
       - ./projects:/work

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+# Hosted HTTP MCP server -- for a coworker or IT to run centrally.
+#   docker compose up -d
+# Point an MCP client at http://<host>:3000/mcp
+#
+# For the stdio use case (like markitdown) you don't need compose; just run:
+#   docker run --rm -i -v /path/to/project:/work konnect
+
+services:
+  konnect:
+    build: .
+    image: konnect
+    command: ["--config", "/etc/konnect/konnect.toml"]
+    ports:
+      - "3000:3000"
+    volumes:
+      # Mount KiCAD projects so the schematic-edit tools can reach them.
+      - ./projects:/work
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:3000/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3

--- a/docker/konnect.toml
+++ b/docker/konnect.toml
@@ -1,0 +1,11 @@
+# Config for running Konnect as a hosted HTTP MCP server in a container.
+# Used by docker-compose.yml and available in the image at
+# /etc/konnect/konnect.toml (pass it with `konnect --config`).
+#
+# Binds 0.0.0.0 so the port is reachable from outside the container. The
+# server still rejects browser requests whose Origin is not localhost
+# (DNS-rebinding protection); non-browser MCP clients send no Origin and pass.
+
+transport = "http"
+http_address = "0.0.0.0:3000"
+log_level = "info"

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# End-to-end check that the Docker image actually serves MCP over both
+# transports. Requires Docker; run from the repo root:  docker/smoke-test.sh
+#
+# Not part of `cargo test` (CI may not have Docker). The transport logic itself
+# is covered by crates/konnect/tests/protocol_{http,stdio}.rs; this proves the
+# packaged binary starts and answers inside the container.
+set -euo pipefail
+
+# Stop git-bash (MSYS) from rewriting a leading-slash arg like the container
+# path /etc/konnect/... into a Windows path. No-op on Linux/macOS.
+export MSYS_NO_PATHCONV=1
+
+IMAGE="${IMAGE:-konnect:smoke}"
+PORT="${PORT:-3999}"
+NAME="konnect-smoke-$$"
+
+cleanup() { docker rm -f "$NAME" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "== building image =="
+docker build -t "$IMAGE" .
+
+echo "== stdio transport =="
+# Pipe one initialize request in; expect a JSON-RPC response naming the server.
+INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}'
+OUT=$(printf '%s\n' "$INIT" | docker run --rm -i "$IMAGE")
+echo "$OUT" | grep -q '"name":"konnect"' \
+    && echo "  ok: stdio handshake returned serverInfo.name=konnect" \
+    || { echo "  FAIL: unexpected stdio response: $OUT"; exit 1; }
+
+echo "== http transport =="
+docker run -d --rm --name "$NAME" -p "${PORT}:3000" \
+    "$IMAGE" --config /etc/konnect/konnect.toml >/dev/null
+
+# Wait for /health.
+for _ in $(seq 1 30); do
+    if curl -fsS "http://localhost:${PORT}/health" >/dev/null 2>&1; then break; fi
+    sleep 1
+done
+curl -fsS "http://localhost:${PORT}/health" | grep -q ok \
+    && echo "  ok: /health responded" \
+    || { echo "  FAIL: /health never came up"; exit 1; }
+
+RESP=$(curl -fsS -H 'Content-Type: application/json' \
+    -d "$INIT" "http://localhost:${PORT}/mcp")
+echo "$RESP" | grep -q '"name":"konnect"' \
+    && echo "  ok: http handshake returned serverInfo.name=konnect" \
+    || { echo "  FAIL: unexpected http response: $RESP"; exit 1; }
+
+echo "== all smoke checks passed =="


### PR DESCRIPTION
## What

A multi-stage `Dockerfile` so the server runs with no local Rust toolchain -- easy to hand to a colleague or host centrally, dependencies included.

- **Builder**: `rust:1-bookworm` + protoc + cmake + libprotobuf-dev (for `konnect-ipc`'s prost-build and the statically-built nng).
- **Runtime**: `debian:bookworm-slim` carrying just the compiled binary, non-root user.
- **stdio mode** (default entrypoint): `docker run --rm -i -v <proj>:/work konnect` -- plugs into an MCP client the same way markitdown does.
- **HTTP mode**: `docker compose up -d` uses `docker/konnect.toml` and publishes to host loopback (`127.0.0.1:3000`), with a `/health` healthcheck.
- Pre-creates the first-run install marker so the host-install step (meaningless in a container) is skipped.

## Security-conscious default

The MCP server is unauthenticated and its tools edit files / run `kicad-cli`, so compose publishes the port to loopback only; the container binds `0.0.0.0` internally (required for published ports) but the host exposure is `127.0.0.1`. Widening it is documented as requiring an auth proxy on a trusted network.

## Tests (per CONTRIBUTING.md)

- **In the cargo gate**: a `config.rs` unit test parses the *actual shipped* `docker/konnect.toml` and asserts it yields HTTP bound to all interfaces -- guards against config-schema drift. No Docker needed, so Docker does not become a dev dependency.
- **Out of the cargo gate**: `docker/smoke-test.sh` builds the image and runs a real MCP `initialize` handshake over both stdio and HTTP. Kept as a script (not a `#[test]`) on purpose; transport logic stays covered by the existing `tests/protocol_{http,stdio}.rs`.

## Verified

- Image builds clean; `smoke-test.sh` green on both transports.
- `cargo fmt --all --check` clean; `cargo clippy -p konnect --lib --tests -- -D warnings` clean.

Happy to open a tracking issue first if you'd prefer to discuss the approach per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)