### PR TITLE
docs: add macOS install section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,61 @@ Verify: open the **PCB Editor** → **Tools → External Plugins** → you shoul
 ### Build from source
 
 ```bash
-# protoc is required (protobuf code generation)
-# Windows: choco install protoc / macOS: brew install protobuf / Linux: apt install protobuf-compiler
+# protoc is required (protobuf code generation), and cmake (the nng crate
+# compiles the NNG C library with it).
+# Windows: choco install protoc cmake
+# macOS:   brew install protobuf cmake
+# Linux:   apt install protobuf-compiler cmake
 cargo build --release -p konnect
 ```
+
+### macOS
+
+The [Releases](https://github.com/mixelpixx/Konnect/releases) page ships
+standalone server binaries for both Apple Silicon (`aarch64-apple-darwin`) and
+Intel (`x86_64-apple-darwin`). They are not yet code-signed, so if you download
+one through a browser, clear the quarantine flag before first launch:
+
+```bash
+tar xzf konnect-v*-aarch64-apple-darwin.tar.gz
+xattr -d com.apple.quarantine ./konnect   # only needed for browser downloads
+./konnect --help
+```
+
+Or build from source as above (verified on Apple Silicon; the same
+`target/release/konnect` binary is the MCP server).
+
+KiCad on macOS keeps its tools inside the app bundle and they are not on
+`PATH`, so point Konnect at them in `~/Library/Application Support/konnect/config.toml`:
+
+```toml
+kicad_cli = "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli"
+kicad_binary = "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad"
+# KiCad 10's IPC socket on macOS (enable it in KiCad:
+# Preferences → Plugins → "Enable KiCad API")
+ipc_address = "ipc:///tmp/kicad/api.sock"
+```
+
+Claude Desktop's config lives at
+`~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "konnect": {
+      "command": "/path/to/konnect"
+    }
+  }
+}
+```
+
+For Claude Code, put the same snippet in a `.mcp.json` in your project root.
+
+Known macOS gaps: the PCM zip currently bundles only the Windows binary, so
+install the server via a release tarball or a source build. The schematic
+viewer compiles and launches on macOS (Tauri 2 uses the system WKWebView —
+WebView2 is only a Windows requirement) but hasn't had the same mileage as
+the Windows build yet.
 
 ## Setup with Claude Desktop
 
@@ -160,8 +211,10 @@ the main workspace — see [DEV.md](DEV.md) for build steps.
 
 ## Requirements
 
-- KiCAD 10 (Windows today; Linux and macOS builds are on the [roadmap](ROADMAP.md) —
-  the code already compiles and passes tests on all three platforms in CI)
+- KiCAD 10 (Windows is the most-tested platform; macOS works from the release
+  binaries or a source build — see the [macOS section](#macos) above. Linux
+  compiles and passes tests in CI but hasn't had per-platform QA yet; both are
+  tracked on the [roadmap](ROADMAP.md))
 - `kicad-cli` (ships with KiCAD — used for exports, ERC, DRC)
 - For PCB tools: KiCAD running with the target board open (IPC API)
 


### PR DESCRIPTION
## What

Adds a macOS subsection under Installation, and updates the Requirements line to match reality now that release tarballs for both Apple archs exist.

Covers:
- Release tarballs (`aarch64` / `x86_64-apple-darwin`) + the `xattr -d com.apple.quarantine` step browser downloads need while binaries are unsigned
- Build from source, including the **cmake** prerequisite — `nng-sys` compiles the NNG C library with cmake, which never surfaces in CI because GitHub's runners preinstall it, but a fresh Mac fails with `is 'cmake' not installed?` (added to the Windows/Linux lines too, same reason)
- `~/Library/Application Support/konnect/config.toml` example with the app-bundle `kicad-cli`/`kicad` paths and the KiCad 10 IPC socket (`ipc:///tmp/kicad/api.sock`)
- Claude Desktop config path on macOS + Claude Code `.mcp.json` pointer
- Honest gaps: PCM zip currently bundles only `konnect.exe`; the schematic viewer builds and launches on macOS (Tauri 2 → WKWebView, no WebView2 needed) but has less mileage than on Windows

## Verified on

macOS 26.5 (Apple Silicon), KiCad 10.0.3, Rust 1.97, repo at d70b561:
- `cargo build --release -p konnect` ✓ (after `brew install protobuf cmake`)
- `cargo test --workspace --lib --tests` → 225 passed, 0 failed
- MCP stdio handshake, `load_toolset` → `tools/list_changed` → tools callable ✓
- Schematic pipeline (create project, add/wire components, ERC via kicad-cli, SVG export) ✓
- Live IPC against a running KiCad 10 (`open_project` → `kicad_ui_running: true`) ✓
- `cd crates/schematic-viewer && cargo build --release` ✓

Docs-only change; no code touched. Related: #26 tracks the macOS symbol-path bug (fix PR incoming) — this README text is written to stay correct whether or not that lands, since `KICAD10_SYMBOL_DIR`/config workarounds aren't mentioned here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)