### PR TITLE
fix(macos): find KiCad symbol libraries and kicad-cli inside the app bundle

### DIFF
--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -544,7 +544,29 @@ fn find_kicad_symbol_dirs() -> Vec<std::path::PathBuf> {
             }
         }
     }
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
+    {
+        // KiCad on macOS ships its libraries inside the app bundle.
+        let mut candidates = vec![
+            std::path::PathBuf::from(
+                "/Applications/KiCad/KiCad.app/Contents/SharedSupport/symbols",
+            ),
+            std::path::PathBuf::from("/usr/local/share/kicad/symbols"),
+        ];
+        if let Ok(home) = std::env::var("HOME") {
+            // Per-user install (KiCad.app dragged into ~/Applications)
+            candidates.push(
+                std::path::PathBuf::from(home)
+                    .join("Applications/KiCad/KiCad.app/Contents/SharedSupport/symbols"),
+            );
+        }
+        for p in candidates {
+            if p.is_dir() && !dirs.contains(&p) {
+                dirs.push(p);
+            }
+        }
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     {
         let candidates = ["/usr/share/kicad/symbols", "/usr/local/share/kicad/symbols"];
         for c in &candidates {

--- a/crates/konnect-schematic-editor/src/library.rs
+++ b/crates/konnect-schematic-editor/src/library.rs
@@ -217,7 +217,28 @@ pub fn find_symbol_dirs() -> Vec<PathBuf> {
         }
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
+    {
+        // KiCad on macOS ships its libraries inside the app bundle.
+        let mut candidates = vec![
+            PathBuf::from("/Applications/KiCad/KiCad.app/Contents/SharedSupport/symbols"),
+            PathBuf::from("/usr/local/share/kicad/symbols"),
+        ];
+        if let Ok(home) = std::env::var("HOME") {
+            // Per-user install (KiCad.app dragged into ~/Applications)
+            candidates.push(
+                PathBuf::from(home)
+                    .join("Applications/KiCad/KiCad.app/Contents/SharedSupport/symbols"),
+            );
+        }
+        for p in candidates {
+            if p.is_dir() && !dirs.contains(&p) {
+                dirs.push(p);
+            }
+        }
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     {
         let candidates = ["/usr/share/kicad/symbols", "/usr/local/share/kicad/symbols"];
         for c in &candidates {

--- a/crates/konnect/src/install.rs
+++ b/crates/konnect/src/install.rs
@@ -11,7 +11,7 @@
 use crate::manifest::{AGENTS, HOOK_SKILLS, SKILLS};
 use anyhow::{Context, Result};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 
@@ -397,21 +397,45 @@ fn remove_hooks_from_settings() -> Result<()> {
     Ok(())
 }
 
-/// Auto-detect KiCAD installation on Windows.
-/// Checks registry and standard paths for kicad-cli.exe.
+/// Auto-detect a KiCAD installation.
+/// Checks standard per-platform paths for kicad-cli (plus the registry on Windows).
 pub fn detect_kicad() -> Option<PathBuf> {
     // Standard paths (check these first — faster than registry)
-    let standard_paths = [
+    #[cfg(target_os = "windows")]
+    let standard_paths: Vec<PathBuf> = [
         r"C:\Program Files\KiCad\10.0\bin\kicad-cli.exe",
         r"C:\Program Files (x86)\KiCad\10.0\bin\kicad-cli.exe",
         r"C:\Program Files\KiCad\9.0\bin\kicad-cli.exe",
         r"C:\Program Files (x86)\KiCad\9.0\bin\kicad-cli.exe",
+    ]
+    .iter()
+    .map(PathBuf::from)
+    .collect();
+
+    #[cfg(target_os = "macos")]
+    let standard_paths: Vec<PathBuf> = {
+        let mut paths = vec![
+            PathBuf::from("/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli"),
+            PathBuf::from("/usr/local/bin/kicad-cli"),
+        ];
+        if let Ok(home) = std::env::var("HOME") {
+            // Per-user install (KiCad.app dragged into ~/Applications)
+            paths.push(
+                PathBuf::from(home).join("Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli"),
+            );
+        }
+        paths
+    };
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    let standard_paths: Vec<PathBuf> = vec![
+        PathBuf::from("/usr/bin/kicad-cli"),
+        PathBuf::from("/usr/local/bin/kicad-cli"),
     ];
 
-    for path_str in &standard_paths {
-        let path = Path::new(path_str);
+    for path in &standard_paths {
         if path.exists() {
-            return Some(path.to_path_buf());
+            return Some(path.clone());
         }
     }
 
@@ -442,7 +466,9 @@ fn detect_kicad_from_registry() -> Option<PathBuf> {
         for line in stdout.lines() {
             if line.contains("REG_SZ") {
                 let path_str = line.split("REG_SZ").last()?.trim();
-                let cli_path = Path::new(path_str).join("bin").join("kicad-cli.exe");
+                let cli_path = std::path::Path::new(path_str)
+                    .join("bin")
+                    .join("kicad-cli.exe");
                 if cli_path.exists() {
                     return Some(cli_path);
                 }


### PR DESCRIPTION
Fixes #26.

## What

On macOS both symbol-library resolvers took the generic non-Windows branch and probed only `/usr/share/kicad/symbols` + `/usr/local/share/kicad/symbols`, so a stock KiCad install (libraries inside `KiCad.app`) was never found and `add_schematic_component` / `add_power_symbol` silently wrote schematics with an empty `lib_symbols` section (details + repro in #26).

Three symmetrical changes, no behavior change on Windows or Linux:

- `konnect-schematic-editor/src/library.rs::find_symbol_dirs()` — add a `#[cfg(target_os = "macos")]` branch probing `/Applications/KiCad/KiCad.app/Contents/SharedSupport/symbols`, `/usr/local/share/kicad/symbols`, and the per-user `~/Applications/KiCad/KiCad.app/...` variant. This is the resolver the schematic tools actually use.
- `konnect-core/src/tools/mod.rs::find_kicad_symbol_dirs()` — same fix, keeping the two copies consistent.
- `konnect/src/install.rs::detect_kicad()` — per-platform candidate lists so `konnect init`/`konnect status` recognize a standard macOS install instead of printing "Not found in standard locations" (Linux gets `/usr/bin` + `/usr/local/bin` candidates; previously there were no non-Windows candidates at all). The Windows list and registry probing are unchanged.

`KICAD10_SYMBOL_DIR` still takes priority in both resolvers, and the app-bundle path follows the precedent `conformance_test.rs::demo_dirs()` already set for the demos corpus.

## Verified

macOS 26.5 (Apple Silicon), KiCad 10.0.3:

- Before: `add_schematic_component` with `Device:R`, no env vars → reports success, `grep -c '(symbol "Device:R"'` on the output = 0
- After: same call → embedded definition present (= 1), `kicad-cli sch erc` clean on the produced schematic, power symbols embed too
- `konnect status` now prints `[+] Found: /Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli`

Checklist: `cargo test --workspace --lib --tests` (225 passed, 0 failed) / `cargo clippy --workspace -- -D warnings` clean / `cargo fmt --all` applied. No tools added or removed, so `tool_count` / `tool-directory.md` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)