### PR TITLE
fix(sch): write root UUID and eeschema-style instance paths so KiCAD forms wire-only nets

### DIFF
--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -293,6 +293,41 @@ pub fn get_path(args: &Value, key: &str) -> anyhow::Result<std::path::PathBuf> {
     Ok(std::path::PathBuf::from(s))
 }
 
+/// Project name used in symbol/sheet `(instances (project "..." ...))` entries:
+/// the schematic's file stem, matching what eeschema writes when it saves a
+/// standalone root sheet.
+pub fn project_name_for(sch_path: &std::path::Path) -> String {
+    sch_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Minimal valid blank schematic, with a freshly generated root `(uuid ...)`.
+/// The root UUID is mandatory: KiCAD's netlister resolves symbol instance
+/// paths against it and silently forms no wire-only nets when it's missing.
+pub fn blank_schematic_template() -> String {
+    format!(
+        "(kicad_sch\n\t(version 20250610)\n\t(generator \"konnect\")\n\t(generator_version \"10.0\")\n\t(uuid \"{}\")\n\t(paper \"A4\")\n\t(lib_symbols\n\t)\n)\n",
+        konnect_sexp::writer::new_uuid()
+    )
+}
+
+/// Root UUID of a loaded schematic, assigning a fresh one when the file
+/// predates Konnect writing root UUIDs — the file is repaired on its next
+/// overwrite. Instance paths are built as "/<root-uuid>[/<sheet-uuid>…]".
+pub fn ensure_root_uuid(sch: &mut konnect_schematic_editor::Schematic) -> String {
+    match &sch.uuid {
+        Some(u) => u.clone(),
+        None => {
+            let u = konnect_sexp::writer::new_uuid();
+            sch.uuid = Some(u.clone());
+            u
+        }
+    }
+}
+
 #[cfg(test)]
 mod arg_helper_tests {
     use super::*;

--- a/crates/konnect-core/src/tools/project.rs
+++ b/crates/konnect-core/src/tools/project.rs
@@ -384,8 +384,8 @@ fn blank_kicad_pro(name: &str) -> String {
     )
 }
 
-fn blank_kicad_sch() -> &'static str {
-    "(kicad_sch\n\t(version 20250610)\n\t(generator \"konnect\")\n\t(generator_version \"10.0\")\n\t(paper \"A4\")\n\t(lib_symbols\n\t)\n)\n"
+fn blank_kicad_sch() -> String {
+    crate::tools::blank_schematic_template()
 }
 
 fn blank_kicad_pcb() -> &'static str {
@@ -427,6 +427,22 @@ mod tests {
         let content = blank_kicad_sch();
         assert!(content.starts_with("(kicad_sch"));
         assert!(content.contains("(lib_symbols"));
+    }
+
+    #[test]
+    fn blank_kicad_sch_has_root_uuid() {
+        // Without a root (uuid ...) KiCAD's netlister silently drops every
+        // wire-only net (symbol instance paths can't resolve).
+        let content = blank_kicad_sch();
+        assert!(content.contains("(uuid \""));
+        let sch = {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("t.kicad_sch");
+            std::fs::write(&path, &content).unwrap();
+            konnect_schematic_editor::Schematic::load(&path).unwrap()
+        };
+        let uuid = sch.uuid.expect("blank schematic must carry a root uuid");
+        assert_eq!(uuid.len(), 36, "expected a v4 uuid, got '{uuid}'");
     }
 
     #[test]

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -6,7 +6,9 @@
 
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
-use crate::tools::{get_path, opt_f64, opt_str, require_f64, require_str, ToolContext, ToolDef};
+use crate::tools::{
+    get_path, opt_f64, opt_str, project_name_for, require_f64, require_str, ToolContext, ToolDef,
+};
 use konnect_schematic_editor as cse;
 use konnect_sexp::{
     geometry::snap_point,
@@ -282,11 +284,11 @@ async fn handle_create_schematic(
     _ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
     let path = get_path(args, "path")?;
-    // Build a minimal valid schematic and save via cse's atomic writer
-    let template = "(kicad_sch\n\t(version 20250610)\n\t(generator \"konnect\")\n\t(generator_version \"10.0\")\n\t(paper \"A4\")\n\t(lib_symbols\n\t)\n)\n";
+    // Build a minimal valid schematic and save via cse's atomic writer.
+    let template = crate::tools::blank_schematic_template();
     // Write the template then immediately load/save through cse so the file
     // is normalised to cse's writer output format.
-    write_atomic(&path, template)?;
+    write_atomic(&path, &template)?;
     let sch = cse::Schematic::load(&path)?;
     sch.overwrite()?;
     Ok(CallToolResult::json(
@@ -323,6 +325,12 @@ async fn handle_add_schematic_component(
 
     // Load via konnect-schematic-editor
     let mut sch = cse::Schematic::load(&sch_path)?;
+
+    // The instance path below must be "/<root-uuid>" — KiCAD's netlister
+    // resolves instances against the root sheet UUID and silently forms no
+    // wire-only nets for symbols whose path doesn't resolve.
+    let root_uuid = crate::tools::ensure_root_uuid(&mut sch);
+    let project_name = project_name_for(&sch_path);
 
     // Embed the library symbol definition
     cse::library::ensure_lib_symbol(&mut sch, &lib_id);
@@ -389,24 +397,9 @@ async fn handle_add_schematic_component(
     ds_prop.sub_nodes.push(effects_node(true));
     sym.properties.push(ds_prop);
 
-    // Instances node
-    let instances = cse::sexp::SexpNode::List(vec![
-        cse::sexp::atom("instances"),
-        cse::sexp::SexpNode::List(vec![
-            cse::sexp::atom("project"),
-            cse::sexp::qstr(""),
-            cse::sexp::SexpNode::List(vec![
-                cse::sexp::atom("path"),
-                cse::sexp::qstr("/"),
-                cse::sexp::SexpNode::List(vec![
-                    cse::sexp::atom("reference"),
-                    cse::sexp::qstr(ref_str),
-                ]),
-                cse::sexp::SexpNode::List(vec![cse::sexp::atom("unit"), cse::sexp::atom("1")]),
-            ]),
-        ]),
-    ]);
-    sym.raw_sub_nodes.push(instances);
+    // Instance entry, keyed to the root sheet UUID like eeschema writes it:
+    // (instances (project "<name>" (path "/<root-uuid>" (reference ...) (unit 1))))
+    sym.set_instance_path(&project_name, &format!("/{}", root_uuid), ref_str, 1);
 
     let uuid = sym.uuid.clone();
     sch.add_symbol(sym);
@@ -1082,3 +1075,106 @@ async fn handle_replace_component(
 }
 
 // Library symbol resolution moved to tools/mod.rs (shared with sch_wiring.rs)
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::ServerConfig;
+    use std::sync::Arc;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    #[tokio::test]
+    async fn create_schematic_writes_root_uuid() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fresh.kicad_sch");
+        let ctx = test_ctx();
+
+        let result = handle_create_schematic(&json!({ "path": path.display().to_string() }), &ctx)
+            .await
+            .unwrap();
+        assert!(!result.is_error);
+
+        let sch = cse::Schematic::load(&path).unwrap();
+        assert!(
+            sch.uuid.is_some(),
+            "root (uuid ...) is required for KiCAD's netlister to resolve instance paths"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_component_writes_eeschema_style_instance_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("amp.kicad_sch");
+        let ctx = test_ctx();
+
+        handle_create_schematic(&json!({ "path": path.display().to_string() }), &ctx)
+            .await
+            .unwrap();
+        let result = handle_add_schematic_component(
+            &json!({
+                "schematic": path.display().to_string(),
+                "lib_id": "Device:R",
+                "x": 100.0, "y": 80.0,
+                "reference": "R1"
+            }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error);
+
+        let sch = cse::Schematic::load(&path).unwrap();
+        let root_uuid = sch.uuid.clone().expect("root uuid present");
+        let sym = sch.symbols.by_reference("R1").unwrap();
+        // KiCAD only forms wire-only nets when the instance path is exactly
+        // "/<root-uuid>"; the project key mirrors eeschema (file stem).
+        assert!(
+            sym.has_instance_path("amp", &format!("/{}", root_uuid)),
+            "instance path must be /<root-uuid> under the file-stem project name"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_component_repairs_legacy_file_without_root_uuid() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy.kicad_sch");
+        // File shape produced by Konnect before root UUIDs were written.
+        std::fs::write(
+            &path,
+            "(kicad_sch\n\t(version 20250610)\n\t(generator \"konnect\")\n\t(generator_version \"10.0\")\n\t(paper \"A4\")\n\t(lib_symbols\n\t)\n)\n",
+        )
+        .unwrap();
+        let ctx = test_ctx();
+
+        let result = handle_add_schematic_component(
+            &json!({
+                "schematic": path.display().to_string(),
+                "lib_id": "Device:R",
+                "x": 50.0, "y": 50.0,
+                "reference": "R1"
+            }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error);
+
+        let sch = cse::Schematic::load(&path).unwrap();
+        let root_uuid = sch.uuid.clone().expect("legacy file gains a root uuid");
+        let sym = sch.symbols.by_reference("R1").unwrap();
+        assert!(sym.has_instance_path("legacy", &format!("/{}", root_uuid)));
+    }
+}

--- a/crates/konnect-core/src/tools/sch_hierarchy.rs
+++ b/crates/konnect-core/src/tools/sch_hierarchy.rs
@@ -9,7 +9,10 @@
 
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
-use crate::tools::{get_path, opt_f64, opt_str, require_f64, require_str, ToolContext, ToolDef};
+use crate::tools::{
+    ensure_root_uuid, get_path, opt_f64, opt_str, project_name_for, require_f64, require_str,
+    ToolContext, ToolDef,
+};
 use konnect_schematic_editor as cse;
 use serde_json::{json, Value};
 use std::collections::HashSet;
@@ -35,7 +38,7 @@ pub fn tools() -> Vec<ToolDef> {
                     "y": { "type": "number", "description": "Top-left Y in mm. Default: 50" },
                     "width": { "type": "number", "description": "Sheet box width in mm. Default: 80" },
                     "height": { "type": "number", "description": "Sheet box height in mm. Default: 50" },
-                    "project_name": { "type": "string", "description": "Project name key for the page-number instance entry. Default: '' (matches this codebase's existing convention for symbol instances)" }
+                    "project_name": { "type": "string", "description": "Project name key for the page-number instance entry. Default: the schematic file's stem (matching eeschema)" }
                 },
                 "required": ["schematic", "sheet_file"]
             }),
@@ -56,7 +59,7 @@ pub fn tools() -> Vec<ToolDef> {
                     "new_file": { "type": "string" },
                     "x": { "type": "number" }, "y": { "type": "number" },
                     "width": { "type": "number" }, "height": { "type": "number" },
-                    "project_name": { "type": "string", "description": "Default: ''" }
+                    "project_name": { "type": "string", "description": "Project name key for instance entries. Default: the schematic file's stem (matching eeschema)" }
                 },
                 "required": ["schematic", "sheet_name"]
             }),
@@ -105,7 +108,7 @@ pub fn tools() -> Vec<ToolDef> {
                     "source_sheet_name": { "type": "string" },
                     "new_sheet_name": { "type": "string" },
                     "new_file": { "type": "string", "description": "Filename for the copy, resolved relative to the parent's directory. Must not already exist." },
-                    "project_name": { "type": "string", "description": "Default: ''" }
+                    "project_name": { "type": "string", "description": "Project name key for instance entries. Default: the schematic file's stem (matching eeschema)" }
                 },
                 "required": ["schematic", "source_sheet_name", "new_sheet_name", "new_file"]
             }),
@@ -121,7 +124,7 @@ pub fn tools() -> Vec<ToolDef> {
                 "type": "object",
                 "properties": {
                     "schematic": { "type": "string", "description": "Root schematic to start from" },
-                    "project_name": { "type": "string", "description": "Default: ''" }
+                    "project_name": { "type": "string", "description": "Project name key for instance entries. Default: the schematic file's stem (matching eeschema)" }
                 },
                 "required": ["schematic"]
             }),
@@ -137,7 +140,7 @@ pub fn tools() -> Vec<ToolDef> {
                 "type": "object",
                 "properties": {
                     "schematic": { "type": "string", "description": "Root schematic to start from" },
-                    "project_name": { "type": "string", "description": "Default: ''" }
+                    "project_name": { "type": "string", "description": "Project name key for instance entries. Default: the schematic file's stem (matching eeschema)" }
                 },
                 "required": ["schematic"]
             }),
@@ -156,7 +159,7 @@ pub fn tools() -> Vec<ToolDef> {
                     "schematic": { "type": "string", "description": "Path to the parent .kicad_sch file" },
                     "sheet_name": { "type": "string" },
                     "side": { "type": "string", "enum": ["right", "left"], "description": "Which edge to place new pins on. Default: 'right'" },
-                    "project_name": { "type": "string", "description": "Default: ''" }
+                    "project_name": { "type": "string", "description": "Project name key for instance entries. Default: the schematic file's stem (matching eeschema)" }
                 },
                 "required": ["schematic", "sheet_name"]
             }),
@@ -256,8 +259,8 @@ fn parent_dir(sch_path: &Path) -> PathBuf {
 }
 
 fn create_blank_schematic(path: &Path) -> anyhow::Result<()> {
-    let template = "(kicad_sch\n\t(version 20250610)\n\t(generator \"konnect\")\n\t(generator_version \"10.0\")\n\t(paper \"A4\")\n\t(lib_symbols\n\t)\n)\n";
-    konnect_sexp::writer::write_atomic(path, template)?;
+    let template = crate::tools::blank_schematic_template();
+    konnect_sexp::writer::write_atomic(path, &template)?;
     // Round-trip through cse so the file is normalised to its writer's format,
     // matching the existing `create_schematic` tool's behavior.
     let sch = cse::Schematic::load(path)?;
@@ -307,12 +310,16 @@ fn link_sheet(
     patch_existing_symbols: bool,
 ) -> anyhow::Result<usize> {
     let sheet_uuid = sheet.uuid.clone();
+    let root_uuid = ensure_root_uuid(parent);
     parent.add_sheet(sheet);
 
     let mut patched = 0usize;
     if patch_existing_symbols {
         let mut child = cse::Schematic::load(child_path)?;
-        let hier_path = format!("/{}/", sheet_uuid);
+        // eeschema's path format: "/<root-uuid>/<sheet-symbol-uuid>", no
+        // trailing slash. KiCAD's netlister can't resolve any other shape and
+        // silently drops the symbol from net formation.
+        let hier_path = format!("/{}/{}", root_uuid, sheet_uuid);
         for sym in child.symbols.iter_mut() {
             if !sym.has_instance_path(project_name, &hier_path) {
                 let reference = sym.reference().unwrap_or("").to_string();
@@ -343,7 +350,9 @@ async fn handle_add_hierarchical_sheet(
     let y = opt_f64(args, "y").unwrap_or(50.0);
     let width = opt_f64(args, "width").unwrap_or(80.0);
     let height = opt_f64(args, "height").unwrap_or(50.0);
-    let project_name = opt_str(args, "project_name").unwrap_or("").to_string();
+    let project_name = opt_str(args, "project_name")
+        .map(str::to_string)
+        .unwrap_or_else(|| project_name_for(&parent_path));
 
     let dir = parent_dir(&parent_path);
     let child_path = dir.join(&sheet_file);
@@ -372,7 +381,10 @@ async fn handle_add_hierarchical_sheet(
         width,
         height,
     );
-    sheet.set_page(&project_name, "/", &page);
+    // Sheet page entries live at the parent's own instance path — for a root
+    // sheet that's "/<root-uuid>", matching what eeschema writes.
+    let root_path = format!("/{}", ensure_root_uuid(&mut parent));
+    sheet.set_page(&project_name, &root_path, &page);
 
     let patched = link_sheet(
         &mut parent,
@@ -399,7 +411,9 @@ async fn handle_edit_sheet(args: &Value, _ctx: &ToolContext) -> anyhow::Result<C
         Ok(v) => v.to_string(),
         Err(e) => return Ok(e),
     };
-    let project_name = opt_str(args, "project_name").unwrap_or("").to_string();
+    let project_name = opt_str(args, "project_name")
+        .map(str::to_string)
+        .unwrap_or_else(|| project_name_for(&sch_path));
 
     let mut sch = cse::Schematic::load(&sch_path)?;
     let sheet = match sch.sheets.by_name_mut(&sheet_name) {
@@ -518,7 +532,9 @@ async fn handle_duplicate_sheet(
         Ok(v) => v.to_string(),
         Err(e) => return Ok(e),
     };
-    let project_name = opt_str(args, "project_name").unwrap_or("").to_string();
+    let project_name = opt_str(args, "project_name")
+        .map(str::to_string)
+        .unwrap_or_else(|| project_name_for(&sch_path));
 
     let mut parent = cse::Schematic::load(&sch_path)?;
 
@@ -580,7 +596,8 @@ async fn handle_duplicate_sheet(
         src_w,
         src_h,
     );
-    new_sheet.set_page(&project_name, "/", &page);
+    let root_path = format!("/{}", ensure_root_uuid(&mut parent));
+    new_sheet.set_page(&project_name, &root_path, &page);
 
     let patched = link_sheet(&mut parent, new_sheet, &new_child, &project_name, true)?;
     parent.overwrite()?;
@@ -599,7 +616,9 @@ async fn handle_get_sheet_hierarchy(
     _ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
     let root_path = get_path(args, "schematic")?;
-    let project_name = opt_str(args, "project_name").unwrap_or("").to_string();
+    let project_name = opt_str(args, "project_name")
+        .map(str::to_string)
+        .unwrap_or_else(|| project_name_for(&root_path));
 
     if !root_path.exists() {
         return Ok(CallToolResult::error(format!(
@@ -678,7 +697,9 @@ async fn handle_renumber_sheet_pages(
     _ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
     let root_path = get_path(args, "schematic")?;
-    let project_name = opt_str(args, "project_name").unwrap_or("").to_string();
+    let project_name = opt_str(args, "project_name")
+        .map(str::to_string)
+        .unwrap_or_else(|| project_name_for(&root_path));
 
     if !root_path.exists() {
         return Ok(CallToolResult::error(format!(
@@ -687,11 +708,22 @@ async fn handle_renumber_sheet_pages(
         )));
     }
 
+    // Page paths are hierarchical instance paths rooted at the root sheet's
+    // UUID ("/<root-uuid>", then "/<root-uuid>/<sheet-uuid>" one level down),
+    // matching what eeschema writes.
+    let root_prefix = {
+        let mut root = cse::Schematic::load(&root_path)?;
+        let uuid = ensure_root_uuid(&mut root);
+        root.overwrite()?;
+        format!("/{}", uuid)
+    };
+
     let mut next_page = 2u32; // page 1 is always the root, left untouched
     let mut renumbered = Vec::new();
     let mut visited = HashSet::new();
     renumber_walk(
         &root_path,
+        &root_prefix,
         &project_name,
         &mut next_page,
         &mut renumbered,
@@ -706,6 +738,7 @@ async fn handle_renumber_sheet_pages(
 
 fn renumber_walk(
     path: &Path,
+    hier_prefix: &str,
     project_name: &str,
     next_page: &mut u32,
     renumbered: &mut Vec<Value>,
@@ -721,18 +754,18 @@ fn renumber_walk(
     let mut changed = false;
 
     // Snapshot the sheet order first: recursing below needs `sch` unborrowed.
-    let sheet_order: Vec<(String, String)> = sch
+    let sheet_order: Vec<(String, String, String)> = sch
         .sheets
         .iter()
-        .map(|s| (s.name().to_string(), s.file().to_string()))
+        .map(|s| (s.name().to_string(), s.file().to_string(), s.uuid.clone()))
         .collect();
 
-    for (name, file) in &sheet_order {
+    for (name, file, sheet_uuid) in &sheet_order {
         let page = next_page.to_string();
         *next_page += 1;
         if let Some(sheet) = sch.sheets.by_name_mut(name) {
             if sheet.page(project_name) != Some(page.as_str()) {
-                sheet.set_page(project_name, "/", &page);
+                sheet.set_page(project_name, hier_prefix, &page);
                 changed = true;
             }
         }
@@ -740,7 +773,15 @@ fn renumber_walk(
 
         let child_path = dir.join(file);
         if child_path.exists() {
-            renumber_walk(&child_path, project_name, next_page, renumbered, visited)?;
+            let child_prefix = format!("{}/{}", hier_prefix, sheet_uuid);
+            renumber_walk(
+                &child_path,
+                &child_prefix,
+                project_name,
+                next_page,
+                renumbered,
+                visited,
+            )?;
         }
     }
 
@@ -1142,8 +1183,10 @@ mod tests {
             parent.sheets.by_name("Power Supply").unwrap().file(),
             "power.kicad_sch"
         );
+        // Pages are stored under the default project name (the file stem) at
+        // the parent's "/<root-uuid>" instance path.
         assert_eq!(
-            parent.sheets.by_name("Power Supply").unwrap().page(""),
+            parent.sheets.by_name("Power Supply").unwrap().page("root"),
             Some("2")
         );
     }
@@ -1182,8 +1225,8 @@ mod tests {
         .unwrap();
 
         let parent = cse::Schematic::load(&root).unwrap();
-        assert_eq!(parent.sheets.by_name("A").unwrap().page(""), Some("2"));
-        assert_eq!(parent.sheets.by_name("B").unwrap().page(""), Some("3"));
+        assert_eq!(parent.sheets.by_name("A").unwrap().page("root"), Some("2"));
+        assert_eq!(parent.sheets.by_name("B").unwrap().page("root"), Some("3"));
     }
 
     #[tokio::test]
@@ -1458,8 +1501,8 @@ mod tests {
         assert!(!result.is_error);
 
         let parent = cse::Schematic::load(&root).unwrap();
-        assert_eq!(parent.sheets.by_name("A").unwrap().page(""), Some("2"));
-        assert_eq!(parent.sheets.by_name("C").unwrap().page(""), Some("3"));
+        assert_eq!(parent.sheets.by_name("A").unwrap().page("root"), Some("2"));
+        assert_eq!(parent.sheets.by_name("C").unwrap().page("root"), Some("3"));
     }
 
     #[tokio::test]
@@ -1489,13 +1532,15 @@ mod tests {
 
         let child = cse::Schematic::load(&child_path).unwrap();
         let sym = child.symbols.by_reference("R1").unwrap();
-        assert!(sym.has_instance_path(
-            "",
-            &format!("/{}/", {
-                let parent = cse::Schematic::load(&root).unwrap();
-                parent.sheets.by_name("Reused").unwrap().uuid.clone()
-            })
-        ));
+        // eeschema path format: "/<root-uuid>/<sheet-symbol-uuid>", keyed
+        // under the default project name (the parent file's stem).
+        let parent = cse::Schematic::load(&root).unwrap();
+        let hier_path = format!(
+            "/{}/{}",
+            parent.uuid.as_deref().expect("root uuid must exist"),
+            parent.sheets.by_name("Reused").unwrap().uuid
+        );
+        assert!(sym.has_instance_path("root", &hier_path));
     }
 
     // ─── PR-B: sheet pin lifecycle ─────────────────────────────────────────

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -5,7 +5,9 @@
 
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
-use crate::tools::{get_path, opt_f64, opt_str, require_f64, require_str, ToolContext, ToolDef};
+use crate::tools::{
+    get_path, opt_f64, opt_str, project_name_for, require_f64, require_str, ToolContext, ToolDef,
+};
 use konnect_schematic_editor as cse;
 use konnect_sexp::{
     geometry::snap_point,
@@ -937,22 +939,16 @@ async fn handle_add_power_symbol(
     sym.properties.push(cse::Property::new("Footprint", ""));
     sym.properties.push(cse::Property::new("Datasheet", ""));
 
-    // Add instances raw node
-    use cse::sexp::{atom, qstr, SexpNode};
-    let instances = SexpNode::List(vec![
-        atom("instances"),
-        SexpNode::List(vec![
-            atom("project"),
-            qstr(""),
-            SexpNode::List(vec![
-                atom("path"),
-                qstr("/"),
-                SexpNode::List(vec![atom("reference"), qstr(&pwr_ref)]),
-                SexpNode::List(vec![atom("unit"), atom("1")]),
-            ]),
-        ]),
-    ]);
-    sym.raw_sub_nodes.push(instances);
+    // Instance entry, keyed to the root sheet UUID like eeschema writes it —
+    // without a resolvable "/<root-uuid>" path KiCAD's netlister drops the
+    // symbol from net formation.
+    let root_uuid = crate::tools::ensure_root_uuid(&mut sch);
+    sym.set_instance_path(
+        &project_name_for(&sch_path),
+        &format!("/{}", root_uuid),
+        &pwr_ref,
+        1,
+    );
 
     sch.add_symbol(sym);
     sch.overwrite()?;


### PR DESCRIPTION
Fixes #29.

## What

Konnect-written schematics had no root `(uuid ...)` and hardcoded `(project "" (path "/" ...))` instance entries, so KiCAD's netlister silently dropped every wire-only net (full analysis + bisection matrix in #29). This PR makes every write path emit what eeschema emits:

- **Templates**: `create_project`, `create_schematic`, and `create_blank_schematic` now share one `blank_schematic_template()` helper (tools/mod.rs) that emits a root uuid — the same thing `schematic_builder.rs` already did on its own path.
- **Symbol + power-symbol instances**: written via the existing `Symbol::set_instance_path` as `(project "<file-stem>" (path "/<root-uuid>" (reference ...) (unit 1)))`. Files from earlier Konnect versions (no root uuid) are repaired in place on their next edit (`ensure_root_uuid`).
- **Hierarchy**: `link_sheet` writes child-symbol paths as `/<root-uuid>/<sheet-uuid>` (eeschema format — previously `/<sheet-uuid>/` with a trailing slash and no root). Sheet page entries and `renumber_sheet_pages` use the same hierarchical prefixes instead of `"/"`, threaded through the recursive walk.
- **project_name defaults**: now the schematic's file stem instead of `""` — kicad-cli ignores the key (verified), but eeschema keys instance data by it and writes the stem for standalone root sheets.

## Verification

- Ground truth, before → after on the identical tool-call sequence (two `Device:R` + a wire, no labels): `kicad-cli sch export netlist` goes from a **completely empty `(nets)` block** to `Net-(R1-Pad2)` containing R1.2 + R2.1, with correct `unconnected-*` stubs for the open pins. (Wire placed at the true pin tips; `connect_pins` output additionally needs the independent #30 fix.)
- 3 new regression tests: template carries uuid; instance path is `/<root-uuid>` under the file-stem project; legacy files without a root uuid get repaired on edit. Hierarchy tests updated to assert the eeschema path format they previously asserted the broken format for.
- `cargo test --workspace --lib --tests` 229 passed / 0 failed; clippy `-D warnings` clean; fmt applied.

## Notes for review

- Behavior change: files edited after this PR carry instance entries under the file-stem project name; pre-existing entries under `""` are left in place (eeschema prunes stale entries on save, and kicad-cli matches by path, not name). `next_free_page` scans under the new default name — a hierarchy previously built entirely with `""` entries would restart page numbering; those files were netlist-dead anyway.
- Root `sheet_instances` (`(path "/" (page "1"))`) is *not* added — verified not required by the netlister; eeschema adds it on first save. Can add for byte-parity if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)