### PR TITLE
feat(packaging): ship macOS and Linux PCM packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,38 @@ jobs:
       - run: pip install jsonschema
       - name: Validate repository metadata
         run: python packaging/validate-pcm.py --metadata packaging/metadata.json
-      - name: Assemble PCM zip with a stub binary and validate structure
+
+      # Stub binaries carry each platform's executable magic: the validator
+      # checks a package's bundled binary against the platform it declares,
+      # which is what stops a Windows-only zip from being offered to every OS.
+      - name: Assemble Windows PCM zip with a stub binary and validate structure
         shell: pwsh
         run: |
-          New-Item -ItemType File -Path stub-konnect.exe | Out-Null
-          Set-Content stub-konnect.exe "stub"
-          ./packaging/build-pcm.ps1 -Version 0.0.0 -BinaryPath stub-konnect.exe -OutDir dist
-          python packaging/validate-pcm.py --zip dist/konnect-pcm-v0.0.0.zip
+          [System.IO.File]::WriteAllBytes("stub-konnect.exe", [byte[]](0x4D, 0x5A, 0x90, 0x00))
+          ./packaging/build-pcm.ps1 -Version 0.0.0 -BinaryPath stub-konnect.exe `
+            -Platform windows -OutDir dist
+          python packaging/validate-pcm.py --zip dist/konnect-pcm-v0.0.0-windows.zip
+
+      # build-pcm.sh is what the macOS and Linux release packages are built
+      # with, so it gets the same structural check.
+      - name: Assemble Linux PCM zip with a stub binary and validate structure
+        run: |
+          set -euo pipefail
+          printf '\177ELF\002\001\001\000' > stub-konnect
+          ./packaging/build-pcm.sh --version 0.0.0 --binary stub-konnect \
+            --platform linux --out dist
+          python packaging/validate-pcm.py --zip dist/konnect-pcm-v0.0.0-linux.zip
+
+      - name: Reject a package whose binary contradicts its platform
+        run: |
+          set -euo pipefail
+          # The exact mistake v0.1.3 shipped: a Windows binary in a package
+          # non-Windows users are offered. The gate must fail here.
+          printf 'MZ\220\000' > stub-konnect-win
+          ./packaging/build-pcm.sh --version 0.0.0 --binary stub-konnect-win \
+            --platform linux --out dist-bad
+          if python packaging/validate-pcm.py --zip dist-bad/konnect-pcm-v0.0.0-linux.zip; then
+            echo "::error::validator accepted a Windows binary in a linux package"
+            exit 1
+          fi
+          echo "OK: mismatched binary/platform correctly rejected"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,12 +70,29 @@ jobs:
           path: ${{ env.BINARY_NAME }}-${{ github.ref_name }}-${{ matrix.target }}.*
 
   pcm-package:
-    name: KiCAD PCM plugin package
-    runs-on: windows-latest
+    name: KiCAD PCM plugin package (${{ matrix.platform }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: windows
+            os: windows-latest
+          - platform: macos
+            os: macos-latest
+          - platform: linux
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
+
+      # macOS packages ship a universal binary so one download serves both
+      # Apple Silicon and Intel — PCM has no architecture dimension, only
+      # platform, so an arm64-only "macos" package would break Intel Macs.
+      - name: Add x86_64 target (macOS universal)
+        if: matrix.platform == 'macos'
+        run: rustup target add x86_64-apple-darwin aarch64-apple-darwin
 
       - uses: arduino/setup-protoc@v3
         with:
@@ -83,35 +100,87 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: pcm-package
+          key: pcm-package-${{ matrix.platform }}
 
       - name: Build server binary
+        if: matrix.platform != 'macos'
         run: cargo build --release -p konnect
 
       - name: Build schematic viewer (optional)
+        if: matrix.platform != 'macos'
         continue-on-error: true
         run: cargo build --release --manifest-path crates/schematic-viewer/Cargo.toml
 
-      - name: Assemble PCM package
+      - name: Build universal binaries (macOS)
+        if: matrix.platform == 'macos'
+        run: |
+          set -euo pipefail
+          for target in aarch64-apple-darwin x86_64-apple-darwin; do
+            cargo build --release -p konnect --target "$target"
+          done
+          mkdir -p dist/universal
+          lipo -create -output dist/universal/konnect \
+            target/aarch64-apple-darwin/release/konnect \
+            target/x86_64-apple-darwin/release/konnect
+          lipo -info dist/universal/konnect
+
+      - name: Build universal schematic viewer (macOS, optional)
+        if: matrix.platform == 'macos'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          for target in aarch64-apple-darwin x86_64-apple-darwin; do
+            cargo build --release --manifest-path crates/schematic-viewer/Cargo.toml --target "$target"
+          done
+          lipo -create -output dist/universal/schematic-viewer \
+            crates/schematic-viewer/target/aarch64-apple-darwin/release/schematic-viewer \
+            crates/schematic-viewer/target/x86_64-apple-darwin/release/schematic-viewer
+          lipo -info dist/universal/schematic-viewer
+
+      - name: Assemble PCM package (Windows)
+        if: matrix.platform == 'windows'
         shell: pwsh
         run: |
           $version = "${{ github.ref_name }}".TrimStart('v')
           ./packaging/build-pcm.ps1 -Version $version `
             -BinaryPath target/release/konnect.exe `
             -ViewerPath crates/schematic-viewer/target/release/schematic-viewer.exe `
+            -Platform windows `
             -OutDir dist
 
-      - name: Validate PCM package against KiCAD schema (release gate)
-        shell: pwsh
+      - name: Assemble PCM package (macOS)
+        if: matrix.platform == 'macos'
         run: |
+          version="${GITHUB_REF_NAME#v}"
+          ./packaging/build-pcm.sh --version "$version" \
+            --binary dist/universal/konnect \
+            --viewer dist/universal/schematic-viewer \
+            --platform macos --out dist
+
+      - name: Assemble PCM package (Linux)
+        if: matrix.platform == 'linux'
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          ./packaging/build-pcm.sh --version "$version" \
+            --binary target/release/konnect \
+            --viewer crates/schematic-viewer/target/release/schematic-viewer \
+            --platform linux --out dist
+
+      # Gate: the package must declare the platform it carries, and the bundled
+      # binary must actually be that platform's executable format.
+      - name: Validate PCM package against KiCAD schema (release gate)
+        shell: bash
+        run: |
+          set -euo pipefail
           pip install jsonschema
-          $version = "${{ github.ref_name }}".TrimStart('v')
-          python packaging/validate-pcm.py --zip "dist/konnect-pcm-v$version.zip"
+          version="${GITHUB_REF_NAME#v}"
+          python packaging/validate-pcm.py \
+            --zip "dist/konnect-pcm-v$version-${{ matrix.platform }}.zip"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: konnect-pcm
+          name: konnect-pcm-${{ matrix.platform }}
           path: dist/konnect-pcm-*.zip
 
   release:

--- a/README.md
+++ b/README.md
@@ -97,9 +97,12 @@ The full tool catalog is documented in [tool-directory.md](tool-directory.md).
 
 ### From the KiCAD Plugin Manager (recommended)
 
-1. Download `konnect-pcm-v<version>.zip` from [Releases](https://github.com/mixelpixx/Konnect/releases)
-   (the `konnect-pcm-*` asset is the KiCAD plugin package; the other archives are
-   standalone server binaries)
+1. Download the package for your OS from [Releases](https://github.com/mixelpixx/Konnect/releases):
+   `konnect-pcm-v<version>-windows.zip`, `-macos.zip`, or `-linux.zip`. Each
+   bundles that platform's server binary — the macOS package is a universal
+   build, so one download covers Apple Silicon and Intel. (The `konnect-pcm-*`
+   assets are the KiCAD plugin packages; the other archives are standalone
+   server binaries.)
 2. Open KiCAD 10 → **Plugin and Content Manager**
 3. Click **Install from File** and select the zip
 4. Restart KiCAD

--- a/packaging/build-pcm.ps1
+++ b/packaging/build-pcm.ps1
@@ -14,10 +14,14 @@
 #   resources/
 #     icon.png               icon shown in the PCM dialog
 #
+# The package declares the platform it carries binaries for, so KiCAD's PCM only
+# offers it to machines that can run it. A package bundles one native binary, so
+# it is never valid for "all platforms".
+#
 # Usage:
 #   ./packaging/build-pcm.ps1 -Version 0.1.0 -BinaryPath target/release/konnect.exe `
 #       [-ViewerPath crates/schematic-viewer/target/release/schematic-viewer.exe] `
-#       [-OutDir dist]
+#       [-Platform windows] [-OutDir dist]
 #
 # Prints the zip path, size, and SHA256 (needed for the kicad-addons
 # repository metadata).
@@ -26,6 +30,7 @@ param(
     [Parameter(Mandatory = $true)][string]$Version,
     [Parameter(Mandatory = $true)][string]$BinaryPath,
     [string]$ViewerPath = "",
+    [ValidateSet("windows")][string]$Platform = "windows",
     [string]$OutDir = "dist"
 )
 
@@ -69,6 +74,10 @@ $metadata = Get-Content "$repoRoot/packaging/metadata.json" -Raw | ConvertFrom-J
 $metadata.versions[0].version = $Version
 $installSize = (Get-ChildItem $staging -Recurse -File | Measure-Object Length -Sum).Sum
 $metadata.versions[0] | Add-Member -NotePropertyName install_size -NotePropertyValue ([long]$installSize) -Force
+# This package carries one platform's native binary — say so, or PCM offers a
+# Windows build to a macOS user and vice versa. [string[]] keeps ConvertTo-Json
+# from collapsing the single-element array into a bare string.
+$metadata.versions[0] | Add-Member -NotePropertyName platforms -NotePropertyValue ([string[]]@($Platform)) -Force
 foreach ($field in @("download_sha256", "download_url", "download_size")) {
     $metadata.versions[0].PSObject.Properties.Remove($field)
 }
@@ -76,7 +85,7 @@ $metadata | ConvertTo-Json -Depth 10 | Set-Content "$staging/metadata.json"
 
 # Zip it
 New-Item -ItemType Directory -Path $OutDir -Force | Out-Null
-$zipPath = Join-Path (Resolve-Path $OutDir) "konnect-pcm-v$Version.zip"
+$zipPath = Join-Path (Resolve-Path $OutDir) "konnect-pcm-v$Version-$Platform.zip"
 if (Test-Path $zipPath) { Remove-Item $zipPath -Force }
 Compress-Archive -Path "$staging/*" -DestinationPath $zipPath
 
@@ -88,4 +97,5 @@ Write-Host "PCM package: $zipPath"
 Write-Host "  download_size:   $size"
 Write-Host "  install_size:    $installSize"
 Write-Host "  download_sha256: $sha"
-Write-Host "  download_url:    https://github.com/mixelpixx/Konnect/releases/download/v$Version/konnect-pcm-v$Version.zip"
+Write-Host "  platforms:       [$Platform]"
+Write-Host "  download_url:    https://github.com/mixelpixx/Konnect/releases/download/v$Version/konnect-pcm-v$Version-$Platform.zip"

--- a/packaging/build-pcm.sh
+++ b/packaging/build-pcm.sh
@@ -147,6 +147,9 @@ PY
 
 # Zip it (staged contents at the archive root, matching Compress-Archive)
 mkdir -p "$out_dir"
+# zip runs from inside $staging below; a relative --out would resolve there
+# and fail with "Could not create output file". Absolutize it first.
+out_dir="$(cd "$out_dir" && pwd)"
 zip_path="$out_dir/konnect-pcm-v$version-$platform.zip"
 rm -f "$zip_path"
 ( cd "$staging" && zip -rqX "$zip_path" metadata.json plugins resources )

--- a/packaging/build-pcm.sh
+++ b/packaging/build-pcm.sh
@@ -19,10 +19,16 @@
 # (bin/konnect) so the KiCAD 10 IPC action resolves on macOS/Linux, mirroring
 # build-pcm.ps1 which stamps bin/konnect.exe for Windows.
 #
-# Usage:
-#   packaging/build-pcm.sh [--version X.Y.Z] [--binary PATH] [--viewer PATH] [--out DIR]
+# The package declares the platform it carries binaries for, so KiCAD's PCM
+# only offers it to machines that can run it. A package bundles one native
+# binary, so it is never valid for "all platforms".
 #
-# Defaults: version from Cargo.toml, binary target/release/konnect, output dist/.
+# Usage:
+#   packaging/build-pcm.sh [--version X.Y.Z] [--binary PATH] [--viewer PATH]
+#                          [--platform macos|linux] [--out DIR]
+#
+# Defaults: version from Cargo.toml, binary target/release/konnect, platform
+# from the host, output dist/.
 # Prints the zip path, size, and SHA256 (needed for the kicad-addons metadata).
 set -euo pipefail
 
@@ -32,14 +38,17 @@ bin_name="konnect"
 version=""
 binary="$repo_root/target/release/$bin_name"
 viewer=""
+platform=""
 out_dir="$repo_root/dist"
 
 usage() {
     cat >&2 <<'EOF'
-Usage: packaging/build-pcm.sh [--version X.Y.Z] [--binary PATH] [--viewer PATH] [--out DIR]
+Usage: packaging/build-pcm.sh [--version X.Y.Z] [--binary PATH] [--viewer PATH]
+                              [--platform macos|linux] [--out DIR]
 
 Assembles the KiCAD PCM plugin zip (macOS/Linux port of build-pcm.ps1).
-Defaults: version from Cargo.toml, binary target/release/konnect, output dist/.
+Defaults: version from Cargo.toml, binary target/release/konnect, platform from
+the host, output dist/.
 EOF
 }
 
@@ -48,6 +57,7 @@ while [ $# -gt 0 ]; do
         --version) version="${2:?--version needs a value}"; shift 2;;
         --binary)  binary="${2:?--binary needs a value}";   shift 2;;
         --viewer)  viewer="${2:?--viewer needs a value}";   shift 2;;
+        --platform) platform="${2:?--platform needs a value}"; shift 2;;
         --out)     out_dir="${2:?--out needs a value}";     shift 2;;
         -h|--help) usage; exit 0;;
         *) echo "Unknown argument: $1" >&2; usage; exit 2;;
@@ -59,6 +69,20 @@ if [ -z "$version" ]; then
     version="$(sed -n 's/^version = "\(.*\)"/\1/p' "$repo_root/Cargo.toml" | head -1)"
 fi
 [ -n "$version" ] || { echo "Could not determine version; pass --version" >&2; exit 1; }
+
+# Default platform = the host we're packaging on.
+if [ -z "$platform" ]; then
+    case "$(uname -s)" in
+        Darwin) platform="macos";;
+        Linux)  platform="linux";;
+        *) echo "Cannot infer platform from $(uname -s); pass --platform" >&2; exit 1;;
+    esac
+fi
+case "$platform" in
+    macos|linux) ;;
+    windows) echo "Windows packages come from build-pcm.ps1" >&2; exit 2;;
+    *) echo "--platform must be 'macos' or 'linux' (got '$platform')" >&2; exit 2;;
+esac
 if [ ! -f "$binary" ]; then
     echo "Binary not found: $binary" >&2
     echo "Build it first: cargo build --release -p konnect" >&2
@@ -98,28 +122,32 @@ json.dump(m, open(path, "w"), indent=2)
 open(path, "a").write("\n")
 PY
 
-# metadata.json: stamp version + install_size; download_* get schema-valid
-# placeholders (PCM ignores them for install-from-file; the printed values below
-# go into the kicad-addons repository submission). install_size is the staged
-# file total BEFORE metadata.json is written, matching build-pcm.ps1.
+# metadata.json: stamp version + install_size + platforms. download_* are
+# OMITTED inside the zip, matching build-pcm.ps1: the schema only requires
+# version/status/kicad_version, and placeholder values are lies that PCM shows
+# to users ("Download Size: 1 B"). The real values (printed below) go into the
+# kicad-addons repository submission. install_size is the staged file total
+# BEFORE metadata.json is written, matching build-pcm.ps1.
 install_size="$(python3 -c 'import os,sys; print(sum(os.path.getsize(os.path.join(d,f)) for d,_,fs in os.walk(sys.argv[1]) for f in fs))' "$staging")"
-python3 - "$repo_root/packaging/metadata.json" "$staging/metadata.json" "$version" "$install_size" <<'PY'
+python3 - "$repo_root/packaging/metadata.json" "$staging/metadata.json" "$version" "$install_size" "$platform" <<'PY'
 import json, sys
-src, dst, version, install_size = sys.argv[1:5]
+src, dst, version, install_size, platform = sys.argv[1:6]
 m = json.load(open(src))
 v = m["versions"][0]
 v["version"] = version
 v["install_size"] = int(install_size)
-v["download_sha256"] = "0" * 64
-v["download_url"] = "https://example.invalid/placeholder.zip"
-v["download_size"] = 1
+# This package carries one platform's native binary — say so, or PCM offers a
+# macOS build to a Windows user and vice versa.
+v["platforms"] = [platform]
+for field in ("download_sha256", "download_url", "download_size"):
+    v.pop(field, None)
 json.dump(m, open(dst, "w"), indent=2)
 open(dst, "a").write("\n")
 PY
 
 # Zip it (staged contents at the archive root, matching Compress-Archive)
 mkdir -p "$out_dir"
-zip_path="$out_dir/konnect-pcm-v$version.zip"
+zip_path="$out_dir/konnect-pcm-v$version-$platform.zip"
 rm -f "$zip_path"
 ( cd "$staging" && zip -rqX "$zip_path" metadata.json plugins resources )
 
@@ -135,4 +163,5 @@ echo "PCM package: $zip_path"
 echo "  download_size:   $size"
 echo "  install_size:    $install_size"
 echo "  download_sha256: $sha"
-echo "  download_url:    https://github.com/mixelpixx/Konnect/releases/download/v$version/konnect-pcm-v$version.zip"
+echo "  platforms:       [$platform]"
+echo "  download_url:    https://github.com/mixelpixx/Konnect/releases/download/v$version/konnect-pcm-v$version-$platform.zip"

--- a/packaging/validate-pcm.py
+++ b/packaging/validate-pcm.py
@@ -36,6 +36,28 @@ REQUIRED_ZIP_ENTRIES = [
     "resources/icon.png",
 ]
 
+# Executable formats, by the magic bytes each platform's loader requires. A
+# package bundles a native binary, so its declared platform is checkable rather
+# than a promise: a Windows PE in a package declaring "macos" is unrunnable.
+EXECUTABLE_MAGIC = {
+    "windows": [b"MZ"],
+    "linux": [b"\x7fELF"],
+    "macos": [
+        b"\xcf\xfa\xed\xfe",  # Mach-O 64-bit, little-endian
+        b"\xce\xfa\xed\xfe",  # Mach-O 32-bit, little-endian
+        b"\xca\xfe\xba\xbe",  # universal ("fat") binary
+        b"\xbe\xba\xfe\xca",  # universal, byte-swapped
+    ],
+}
+
+
+def identify_executable(blob: bytes) -> str | None:
+    """Name the platform whose loader can run `blob`, or None if unrecognized."""
+    for platform, magics in EXECUTABLE_MAGIC.items():
+        if any(blob.startswith(m) for m in magics):
+            return platform
+    return None
+
 
 def load_schema():
     return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
@@ -87,6 +109,45 @@ def validate_zip(zip_path: Path) -> list[str]:
                         f"omit the field or provide a real value"
                     )
 
+        errors += validate_platforms(z, meta, binaries, zip_path.name)
+
+    return errors
+
+
+def validate_platforms(z, meta: dict, binaries: list[str], label: str) -> list[str]:
+    """Every version must declare exactly the platform its binaries can run on.
+
+    Omitting `platforms` means "all platforms" to KiCAD's PCM, which is never
+    true of a package that bundles one native binary — that is how a
+    Windows-only package came to be offered to macOS and Linux users.
+    """
+    errors = []
+    for v in meta.get("versions", []):
+        declared = v.get("platforms")
+        if not declared:
+            errors.append(
+                f"{label}: version {v.get('version')} declares no 'platforms' — "
+                f"PCM would offer this native package to every OS. Declare the "
+                f"one platform its binaries are built for."
+            )
+            continue
+        if len(declared) != 1:
+            errors.append(
+                f"{label}: version {v.get('version')} declares platforms "
+                f"{declared}; a package bundles one platform's binaries"
+            )
+            continue
+
+        # The declaration must match what is actually in the zip.
+        for name in binaries:
+            actual = identify_executable(z.read(name)[:4])
+            if actual is None:
+                errors.append(f"{label}: {name} is not a recognized executable")
+            elif actual != declared[0]:
+                errors.append(
+                    f"{label}: declares platforms {declared} but {name} is a "
+                    f"{actual} executable"
+                )
     return errors
 
 


### PR DESCRIPTION
Fixes #45. Independent of my other PRs — this one is packaging/CI only, no Rust changes.

## Why

`konnect-pcm-v0.1.3.zip` contains only `konnect.exe` + `schematic-viewer.exe`, and the README calls PCM the recommended install. Every macOS and Linux user who follows it gets 24 MB of Windows binaries and a plugin that can't run — with no warning, because the package declares no `platforms` and PCM reads that as "every OS".

`packaging/build-pcm.sh` (from #7) already does the macOS/Linux packaging correctly. It was simply never wired in: the release job runs only `build-pcm.ps1` on `windows-latest`.

## What

- **`pcm-package` → per-OS matrix** (windows-latest / macos-latest / ubuntu-latest), each using the builder for its platform. `fail-fast: false` so one platform's failure doesn't mask the others.
- **Universal macOS binaries.** The job builds both Apple targets and `lipo`s them. PCM has no architecture dimension — only platform — so an arm64-only "macos" package would silently break Intel Macs.
- **`platforms` stamped** by both builders (`--platform` / `-Platform`). A package bundles one native binary, so it's never valid for all platforms.
- **Per-platform names**: `konnect-pcm-v<version>-<platform>.zip`. kicad-addons needs a distinct `download_url` per platform package anyway, and the three assets can't collide in a release. ⚠️ **This renames the Windows asset** (was `konnect-pcm-v<version>.zip`) — happy to keep the old name and only suffix the new ones if you'd rather.
- **A gate that would have caught this**: `validate-pcm.py` now requires exactly one declared platform and checks the bundled binary's magic bytes (PE / Mach-O / ELF, incl. universal) against it. Against the current release:
  ```
  FAIL: konnect-pcm-v0.1.3.zip: version 0.1.3 declares no 'platforms' —
        PCM would offer this native package to every OS
  ```
- **CI now exercises `build-pcm.sh`** (it's load-bearing for two of three packages), with stub binaries carrying real executable magic, plus a negative test asserting a Windows binary in a Linux package is rejected. The existing Windows stub is now `MZ`-prefixed so it passes the new format check.

## Verified

macOS 26.5 (Apple Silicon) / KiCad 10.0.3, building the macOS package exactly as the workflow does:

```
plugins/bin/konnect          → x86_64 arm64   (universal, +x, `--version` runs)
plugins/bin/schematic-viewer → x86_64 arm64
metadata.json                → platforms: ["macos"]
plugin.json                  → entrypoint bin/konnect
validate-pcm.py              → OK
```

The new CI packaging steps were run locally against this repo (metadata validation, Linux stub package, and the negative test) — all pass. The release-workflow matrix itself can only run on a tag; the packaging commands it invokes are the ones verified above.

Signing/notarization is the other half of the macOS roadmap item and isn't touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)