### PR TITLE
docs(skill): correct toolset and tool names in konnect SKILL.md

### DIFF
--- a/crates/konnect/assets/skills/konnect/SKILL.md
+++ b/crates/konnect/assets/skills/konnect/SKILL.md
@@ -50,12 +50,12 @@ Only to answer questions not available through exports (sheet hierarchy, title b
 | User Request | Channel | Tool / Action |
 |---|---|---|
 | "Review my schematic" | 2 | Load `sch_analysis` toolset, use analysis tools |
-| "Change R5 from 10k to 4.7k" | 1 | `load_toolset("sch_components")` then `edit_component` |
+| "Change R5 from 10k to 4.7k" | 1 | `load_toolset("sch_components")` then `edit_schematic_component` |
 | "What's connected to SCL?" | 2 | `load_toolset("sch_analysis")` then `get_net_connections` |
 | "Add a 100nF cap to U3 VCC" | 1 | `load_toolset("sch_components")` + `load_toolset("sch_wiring")` |
 | "Rename net /CLK to /SYS_CLK" | 1 | Warn about downstream effects, then MCP tools |
 | "Run DRC" | 1 | `load_toolset("verification")` then `run_drc` |
-| "Export Gerbers" | 1 | `load_toolset("export")` then export tools |
+| "Export Gerbers" | 1 | `load_toolset("pcb_export")` then `export_gerber` |
 | "Just patch line 247 of the .kicad_sch" | REFUSE | Explain risks, offer MCP alternative |
 | "Add ESD protection to USB lines" | 1 | `load_toolset("sch_components")` + `load_toolset("sch_wiring")` |
 | "Check if board is ready for fab" | 2 | Load `verification` + `design_review` toolsets |
@@ -72,7 +72,7 @@ Only to answer questions not available through exports (sheet hierarchy, title b
 
 ## Discovery — Finding Available Tools
 
-Konnect uses a meta-tool router pattern with 177 tools across 17 toolsets. Tools are loaded on demand to keep the context focused.
+Konnect uses a meta-tool router pattern with 185 tools across 18 toolsets. Tools are loaded on demand to keep the context focused.
 
 ```
 list_toolboxes          → See all available toolsets with descriptions
@@ -85,13 +85,15 @@ unload_toolset("name")  → Remove a toolset when done
 
 | Category | Toolsets |
 |----------|----------|
-| Schematic | sch_components, sch_wiring, sch_batch, sch_analysis, sch_hierarchy |
-| PCB | pcb_layout, pcb_routing, pcb_zones, pcb_components |
-| Verification | verification, design_review |
-| Libraries | libraries, templates |
-| Project | project, config |
-| Export | export |
-| Advanced | advanced |
+| Project | project |
+| Schematic | sch_components, sch_wiring, sch_analysis, sch_batch, sch_export, sch_hierarchy |
+| PCB | pcb_board, pcb_components, pcb_routing, pcb_export |
+| Library | library |
+| Integration | integration (JLCPCB parts, Freerouting, datasheets) |
+| Verification & Review | verification, design_review |
+| Config | config |
+| Templates | templates |
+| Manufacturing | manufacturing |
 
 ## Design Rules Quick Reference
 
@@ -121,7 +123,7 @@ unload_toolset("name")  → Remove a toolset when done
 2. load_toolset("sch_components")          → activate component tools
 3. add_schematic_component (repeat)        → place parts
 4. load_toolset("sch_wiring")              → activate wiring tools
-5. connect_pins / add_wire / add_net_label → wire the circuit
+5. connect_pins / add_wire / add_schematic_net_label → wire the circuit
 6. load_toolset("verification")            → activate checks
 7. run_erc / run_design_review             → validate the design
 ```


### PR DESCRIPTION
## Summary

The bundled `konnect` operating-rules skill (`crates/konnect/assets/skills/konnect/SKILL.md`, installed to `~/.claude/skills/konnect/` by `konnect init`) predates the toolset reorganization and referenced toolsets/tools that no longer exist — which steered the model toward calling nonexistent tools or loading nonexistent toolsets.

## Changes

- **Tool count**: `177 tools across 17 toolsets` → `185 tools across 18 toolsets` (matches `router/registry.rs::ALL_TOOLSETS`).
- **Toolset table**: replaced stale entries (`pcb_layout`, `pcb_zones`, `libraries`, `export`, `advanced`) with the actual 18 toolsets, grouped by category.
- **Tool names**: `edit_component` → `edit_schematic_component`, `add_net_label` → `add_schematic_net_label`.
- **Toolset refs**: `load_toolset("export")` → `load_toolset("pcb_export")` (with `export_gerber`).

## Why

A skill whose job is to route the model to the right MCP tools actively misleads if it names tools/toolsets that don't exist — the model calls them, gets `unknown_tool` / `toolset_not_loaded`, and burns a round-trip recovering.

## Verification

Doc-only change to a markdown file embedded via `include_str!`; no code or test impact. All referenced toolset and tool names now match `registry.rs::ALL_TOOLSETS` and `src/tools/*.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
