### PR TITLE
fix(pcb): use KiCAD's rotation sense for footprint-local pad coords

### DIFF
--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -417,10 +417,10 @@ async fn handle_get_component_pads(
             let pad_at = pad.find("at")?;
             let local_x = pad_at.get_f64(1)?;
             let local_y = pad_at.get_f64(2)?;
-            // Transform local pad coords to board space (simplified: only rotation)
-            let rad = fp_rot.to_radians();
-            let board_x = fp_x + local_x * rad.cos() - local_y * rad.sin();
-            let board_y = fp_y + local_x * rad.sin() + local_y * rad.cos();
+            // Transform local pad coords to board space (rotation only).
+            // Uses the canonical KiCAD transform — see konnect_sexp::geometry.
+            let (board_x, board_y) =
+                konnect_sexp::geometry::transform_pad(local_x, local_y, fp_x, fp_y, fp_rot);
             let net = pad
                 .find("net")
                 .and_then(|n| n.get(2))

--- a/crates/konnect-core/src/tools/pcb_routing.rs
+++ b/crates/konnect-core/src/tools/pcb_routing.rs
@@ -443,12 +443,11 @@ fn find_pad_board_position(
     let local_x = pad_at.get_f64(1).unwrap_or(0.0);
     let local_y = pad_at.get_f64(2).unwrap_or(0.0);
 
-    // Transform local pad coords to board space (rotation)
-    let rad = fp_rot.to_radians();
-    let board_x = fp_x + local_x * rad.cos() - local_y * rad.sin();
-    let board_y = fp_y + local_x * rad.sin() + local_y * rad.cos();
-
-    Ok((board_x, board_y))
+    // Transform local pad coords to board space (rotation only).
+    // Uses the canonical KiCAD transform — see konnect_sexp::geometry.
+    Ok(konnect_sexp::geometry::transform_pad(
+        local_x, local_y, fp_x, fp_y, fp_rot,
+    ))
 }
 
 async fn handle_add_via(

--- a/crates/konnect-sexp/src/geometry.rs
+++ b/crates/konnect-sexp/src/geometry.rs
@@ -85,6 +85,50 @@ pub fn transform_pin(pin_x: f64, pin_y: f64, t: PinTransform) -> (f64, f64) {
     (t.comp_x + rx, t.comp_y + ry)
 }
 
+/// Transform a **pad** from footprint-local space to board space.
+///
+/// This is the PCB counterpart of [`transform_pin`]. Unlike symbol pins,
+/// `.kicad_pcb` pad coordinates are already in **Y-down** board orientation,
+/// so there is no Y-up→Y-down flip — but the rotation sense is the same
+/// screen-CCW-in-Y-down convention KiCAD uses everywhere:
+///
+/// ```text
+/// board_x = fp_x + lx * cos(θ) + ly * sin(θ)
+/// board_y = fp_y - lx * sin(θ) + ly * cos(θ)
+/// ```
+///
+/// Note the sign pattern: this is **not** the textbook rotation matrix.
+/// The textbook form (`-ly*sin`, `+lx*sin`) agrees with KiCAD at 0° and 180°
+/// but reflects the footprint end-for-end about its origin at ±90°, which
+/// silently reports e.g. a connector's pin 1 at the wrong end.
+///
+/// `rotation_deg` is the footprint's `(at x y rot)` angle in degrees.
+///
+/// # Examples
+/// ```
+/// use konnect_sexp::geometry::transform_pad;
+///
+/// // Footprint at (0, 0) rotated -90°, pad at local (10, 0).
+/// let (x, y) = transform_pad(10.0, 0.0, 0.0, 0.0, -90.0);
+/// assert!((x - 0.0).abs() < 1e-9);
+/// assert!((y - 10.0).abs() < 1e-9);
+/// ```
+pub fn transform_pad(
+    local_x: f64,
+    local_y: f64,
+    fp_x: f64,
+    fp_y: f64,
+    rotation_deg: f64,
+) -> (f64, f64) {
+    let theta = rotation_deg * PI / 180.0;
+    let cos_t = theta.cos();
+    let sin_t = theta.sin();
+    (
+        fp_x + local_x * cos_t + local_y * sin_t,
+        fp_y - local_x * sin_t + local_y * cos_t,
+    )
+}
+
 /// Snap a coordinate to KiCAD's schematic grid (default 1.27 mm = 50 mil).
 pub fn snap_to_grid(value: f64, grid: f64) -> f64 {
     (value / grid).round() * grid
@@ -178,6 +222,73 @@ mod tests {
             t(100.0, 100.0, 270.0, false, false),
             (103.81, 100.0),
             "rot270",
+        );
+    }
+
+    fn assert_pad(local: (f64, f64), fp: (f64, f64, f64), expected: (f64, f64), label: &str) {
+        let (x, y) = transform_pad(local.0, local.1, fp.0, fp.1, fp.2);
+        assert!(
+            (x - expected.0).abs() < 1e-3 && (y - expected.1).abs() < 1e-3,
+            "{}: got ({}, {}), expected ({}, {})",
+            label,
+            x,
+            y,
+            expected.0,
+            expected.1
+        );
+    }
+
+    /// Ground truth for the PCB pad transform, taken from routed copper on a
+    /// fabricated, publicly available board: Antmicro's Kria K26 devboard
+    /// (Apache-2.0, github.com/antmicro/kria-k26-devboard). For each pad the
+    /// board-space position was confirmed by finding a routed track segment or
+    /// via **of the same net** within 0.05 mm of the predicted point — copper a
+    /// fab actually built, not a second calculation.
+    ///
+    /// Across that board, footprints at ±90° have 1190 net-assigned pads with
+    /// routed copper; this transform locates 900 of them (the remainder are
+    /// pads whose copper starts elsewhere, e.g. reached only through a zone).
+    /// The textbook-rotation-matrix form locates 64.
+    #[test]
+    fn pad_transform_kicad_ground_truth() {
+        // rot 0 and 180 are the cases where both conventions agree — they must
+        // keep working, and they are why this bug is invisible in most tests.
+        assert_pad((10.0, 4.0), (100.0, 100.0, 0.0), (110.0, 104.0), "rot0");
+        assert_pad((10.0, 4.0), (100.0, 100.0, 180.0), (90.0, 96.0), "rot180");
+
+        // rot 90 / 270: (x, y) -> (y, -x) and (-y, x) respectively.
+        assert_pad((10.0, 4.0), (100.0, 100.0, 90.0), (104.0, 90.0), "rot90");
+        assert_pad((10.0, 4.0), (100.0, 100.0, 270.0), (96.0, 110.0), "rot270");
+        // -90 must equal 270.
+        assert_pad((10.0, 4.0), (100.0, 100.0, -90.0), (96.0, 110.0), "rot-90");
+
+        // Real board, real copper: connector J_SOM240_1 at (91.5765, 117.6215)
+        // rotated -90 deg; pad A01 at footprint-local (18.732, -1.75), net
+        // VCC_BATT. The VCC_BATT track on F.Cu terminates at (93.3265, 136.354).
+        assert_pad(
+            (18.732, -1.75),
+            (91.5765, 117.6215, -90.0),
+            (93.3265, 136.3535),
+            "kria-k26-devboard J_SOM240_1.A01",
+        );
+    }
+
+    /// The textbook rotation matrix reflects the footprint end-for-end about
+    /// its origin at +/-90 deg. Guard against anyone reintroducing it.
+    #[test]
+    fn pad_transform_rejects_textbook_rotation() {
+        let (lx, ly) = (18.732, -1.75);
+        let (fx, fy, rot) = (91.5765, 117.6215, -90.0);
+        let (x, y) = transform_pad(lx, ly, fx, fy, rot);
+        let rad: f64 = rot.to_radians();
+        let (bad_x, bad_y) = (
+            fx + lx * rad.cos() - ly * rad.sin(),
+            fy + lx * rad.sin() + ly * rad.cos(),
+        );
+        assert!(
+            (x - bad_x).abs() + (y - bad_y).abs() > 1.0,
+            "transform_pad matches the textbook (Y-up) rotation matrix; \
+             KiCAD's Y axis points down, so the sin terms must swap sign"
         );
     }
 


### PR DESCRIPTION
Fixes #56.

The footprint-local → board-space pad transform was open-coded twice with the textbook rotation matrix. KiCAD's Y axis points down, which flips the sense of the rotation, so at ±90° both copies returned the pad position reflected end-for-end about the footprint origin. At 0° and 180° the two conventions coincide, which is why this survived.

## Changes

- **`konnect-sexp/src/geometry.rs`** — adds `transform_pad`, the PCB counterpart to the existing `transform_pin`. Pad coordinates in `.kicad_pcb` are already Y-down, so there is no Y-up→Y-down flip; only the rotation sense is shared.
- **`konnect-core/src/tools/pcb_components.rs`** — `handle_get_component_pads` now calls it. This also fixes `get_pad_position`, which delegates to it.
- **`konnect-core/src/tools/pcb_routing.rs`** — `find_pad_board_position` now calls it. This one is not just a wrong answer returned: those coordinates become the endpoints of a track `route_pad_to_pad` writes to the board.

Net effect is that the sin terms swap sign:

```
board_x = fp_x + lx*cos(θ) + ly*sin(θ)
board_y = fp_y - lx*sin(θ) + ly*cos(θ)
```

This matches the two implementations already in the tree that had it right — `geometry.rs`'s `transform_pin` (derived from eeschema's TRANSFORM matrix) and `konnect-ipc/src/transform.rs:42-48` (citing KiCAD's `RotatePoint` in `libs/kimath/src/trigo.cpp`). I put the new function next to `transform_pin` rather than adding a third private copy, in keeping with that module's "All toolset code must call these functions" header.

## Tests

Two new tests in `geometry.rs`:

- `pad_transform_kicad_ground_truth` — 0/90/180/270/−90°, plus one real case taken from routed copper on a fabricated, publicly available board (Antmicro's Kria K26 devboard, Apache-2.0).
- `pad_transform_rejects_textbook_rotation` — fails if the textbook form is reintroduced.

Worth flagging for anyone extending these: a purely **geometric** check cannot catch this bug. On a symmetric pad grid both conventions produce the same *set* of points, so only pad-name-to-position (or pad-name-to-net) identity discriminates. The tests therefore pin named pads to specific coordinates, and use pads whose local x and y are both non-zero — a pad sitting on an axis is degenerate at one of the two angles.

The board-derived assertion comes from a check described in the issue: predict each pad centre under both conventions, then look for a routed track segment, arc or via **of the same net** within 0.05 mm. Across that board's ±90° footprints, 1190 net-assigned pads have routed copper; the corrected transform locates 900 of them, the previous one locates 64.

## Build status

Run locally on `rustc 1.97.1` / macOS, on this branch:

- `cargo test -p konnect-sexp geometry` — **11 passed**, including the two new tests.
- `cargo test -p konnect-sexp --doc` — **2 passed, 1 ignored** (the new `transform_pad` doctest runs).
- `cargo check -p konnect-core` — **clean**, so both call-site substitutions compile.
- `cargo test --workspace --lib --tests` — all suites pass **except** intermittent failures in `konnect-ipc`'s mock-server tests. These look pre-existing and unrelated to this change, and I'd rather say exactly what I saw than wave at it:
  - Two separate full-workspace runs failed *different* tests (`footprint_transform_test` on one, `mock_server_test` on the next).
  - Every one of them passes when `konnect-ipc` is run on its own (`cargo test -p konnect-ipc`: 15 + 2 + 4 passed).
  - The test binary is byte-identical between this branch and `main` (same `cargo` hash), and this change touches no code that crate compiles.
  - My read is ephemeral-port/NNG timing sensitivity under parallel load rather than anything here, but I have not chased it down and it is not this PR's business to fix.
- `cargo fmt --all` — applied; only the file I touched changed.
- `cargo clippy --workspace -- -D warnings` — **does not pass on `main` either.** I captured the sorted error list on `main` and on this branch and diffed them: **identical, no new findings**. The pre-existing ones are in test code (`await_holding_lock` in `konnect-core/src/tools/sch_components.rs` tests, `bool_assert_comparison` / `len_zero` in `konnect-schematic-editor/tests/integration.rs`). I left them alone to keep this diff to one bug.

## Not investigated

I did **not** check whether footprints on `B.Cu` need mirroring in addition to the rotation fix. My evidence covers rotation only, and a passing build does not settle it. If back-side pads are also mis-transformed, that is a separate bug this PR neither fixes nor rules out — worth a look while someone is in this code.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>