### PR TITLE
fix(pcb): actually create the via in add_via (was silently dropped)

### DIFF
--- a/crates/konnect-ipc/src/builders.rs
+++ b/crates/konnect-ipc/src/builders.rs
@@ -83,20 +83,57 @@ pub fn build_track(
     }
 }
 
-/// Build S-expression for a via (used with ParseAndCreateItemsFromString).
-/// Complex protobuf PadStack construction is avoided this way.
-pub fn via_sexp(
+/// Build a through-via `Via` protobuf message (F.Cu → B.Cu).
+///
+/// Mirrors [`build_track`]: the caller `pack_any`s the result and hands it to
+/// `create_items`. The earlier implementation built a bare `(via …)`
+/// S-expression string and fed it to `ParseAndCreateItemsFromString`; that
+/// paste path silently created nothing (the command returns a
+/// `CreateItemsResponse` whose overall status is `IRS_OK` even when zero items
+/// are created), so `add_via` reported success while no via ever appeared.
+/// Building the protobuf and going through `create_items` is the same path that
+/// `add_track` (and the reference `kipy` client) use, and it actually persists.
+pub fn build_via(
     net_name: &str,
     net_code: i32,
     x: f64,
     y: f64,
     drill_mm: f64,
     size_mm: f64,
-) -> String {
-    format!(
-        r#"(via (at {} {}) (size {}) (drill {}) (layers "F.Cu" "B.Cu") (net {} "{}"))"#,
-        x, y, size_mm, drill_mm, net_code, net_name
-    )
+) -> kiapi::board::types::Via {
+    use kiapi::board::types::{
+        BoardLayer, DrillProperties, PadStack, PadStackLayer, PadStackShape, PadStackType, ViaType,
+    };
+
+    // A round copper pad of `size_mm` diameter on the given layer.
+    let copper_pad = |layer: BoardLayer| kiapi::board::types::PadStackLayer {
+        layer: layer as i32,
+        shape: PadStackShape::PssCircle as i32,
+        size: Some(vec2(size_mm, size_mm)),
+        ..PadStackLayer::default()
+    };
+
+    let pad_stack = PadStack {
+        r#type: PadStackType::PstNormal as i32,
+        layers: vec![BoardLayer::BlFCu as i32, BoardLayer::BlBCu as i32],
+        drill: Some(DrillProperties {
+            start_layer: BoardLayer::BlFCu as i32,
+            end_layer: BoardLayer::BlBCu as i32,
+            diameter: Some(vec2(drill_mm, drill_mm)),
+            ..DrillProperties::default()
+        }),
+        copper_layers: vec![copper_pad(BoardLayer::BlFCu), copper_pad(BoardLayer::BlBCu)],
+        ..PadStack::default()
+    };
+
+    kiapi::board::types::Via {
+        id: None, // KiCAD assigns the ID
+        position: Some(vec2(x, y)),
+        pad_stack: Some(pad_stack),
+        locked: kiapi::common::types::LockedState::LsUnlocked as i32,
+        net: Some(net(net_name, net_code)),
+        r#type: ViaType::VtThrough as i32,
+    }
 }
 
 /// Pack a protobuf message into a prost_types::Any.
@@ -457,6 +494,45 @@ mod tests {
         match s.shape.unwrap().geometry.unwrap() {
             Geometry::Polygon(poly_set) => assert!(poly_set.polygons.is_empty()),
             _ => panic!("expected Polygon geometry"),
+        }
+    }
+
+    #[test]
+    fn via_is_a_through_via_with_position_drill_size_and_net() {
+        use kiapi::board::types::{BoardLayer, PadStackShape, PadStackType, ViaType};
+
+        let v = build_via("VCC_BATT", 7, 146.268, 89.194, 0.2, 0.45);
+
+        // Position, in nanometers.
+        let pos = v.position.expect("position");
+        assert_eq!(pos.x_nm, 146_268_000);
+        assert_eq!(pos.y_nm, 89_194_000);
+
+        // Net carried through.
+        let net = v.net.expect("net");
+        assert_eq!(net.name, "VCC_BATT");
+        assert_eq!(net.code.unwrap().value, 7);
+
+        // Through via (F.Cu → B.Cu), normal pad stack.
+        assert_eq!(v.r#type, ViaType::VtThrough as i32);
+        let ps = v.pad_stack.expect("pad_stack");
+        assert_eq!(ps.r#type, PadStackType::PstNormal as i32);
+        assert_eq!(
+            ps.layers,
+            vec![BoardLayer::BlFCu as i32, BoardLayer::BlBCu as i32]
+        );
+
+        // Drill diameter honored on both outer layers.
+        let drill = ps.drill.expect("drill");
+        assert_eq!(drill.start_layer, BoardLayer::BlFCu as i32);
+        assert_eq!(drill.end_layer, BoardLayer::BlBCu as i32);
+        assert_eq!(drill.diameter.unwrap().x_nm, 200_000);
+
+        // Copper pad on both layers, round, at the requested diameter.
+        assert_eq!(ps.copper_layers.len(), 2);
+        for layer in &ps.copper_layers {
+            assert_eq!(layer.shape, PadStackShape::PssCircle as i32);
+            assert_eq!(layer.size.unwrap().x_nm, 450_000);
         }
     }
 }

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -475,16 +475,17 @@ impl KiCadIpcClient {
         Ok(())
     }
 
-    /// Add a via to the board using S-expression string (simpler than full protobuf PadStack construction).
+    /// Add a through via (F.Cu → B.Cu) to the board.
+    ///
+    /// Uses the protobuf `Via` message via `create_items`, the same path as
+    /// [`add_track`](Self::add_track). The previous implementation sent a bare
+    /// `(via …)` S-expression through `ParseAndCreateItemsFromString`, which
+    /// returned success but never created the via (see `builders::build_via`).
     pub fn add_via(&self, net_name: &str, x: f64, y: f64, drill: f64, pad_size: f64) -> Result<()> {
         let net_code = self.resolve_net_code(net_name)?;
-        let sexp = crate::builders::via_sexp(net_name, net_code, x, y, drill, pad_size);
-        let doc = self.get_board_document()?;
-        let cmd = kiapi::common::commands::ParseAndCreateItemsFromString {
-            document: Some(doc),
-            contents: sexp,
-        };
-        self.send_command(&cmd, "kiapi.common.commands.ParseAndCreateItemsFromString")?;
+        let via = crate::builders::build_via(net_name, net_code, x, y, drill, pad_size);
+        let any = crate::builders::pack_any(&via, "kiapi.board.types.Via");
+        self.create_items(vec![any])?;
         Ok(())
     }
 


### PR DESCRIPTION
Fixes #58.

## Problem

`add_via` returned a success JSON echoing the inputs, but **no via was ever created** — nothing in the live KiCAD session, nothing in the saved `.kicad_pcb`. `route_trace` against the same socket in the same session persisted fine, and the *same via* created through the reference `kipy` client's `create_items()` against the same socket persisted fine — so the IPC server is healthy; the bug is entirely client-side in Konnect.

## Root cause

`KiCadIpcClient::add_via` did not use the protobuf `create_items` path that `add_track` uses. It built a bare `(via …)` S-expression (`builders::via_sexp`) and sent it via `ParseAndCreateItemsFromString`. That command mimics an editor **paste** and returns a `CreateItemsResponse` whose overall status "may return IRS_OK even if no items were created" (per the proto comment). The pasted string — an un-wrapped `(via …)` token carrying a pad-style `(net code "name")` node that a via/segment does not take — parsed to zero items, and the returned response was discarded, so a create-nothing outcome was indistinguishable from success. The handler then fabricated its success JSON from the input args.

## Fix

Build a proper `Via` protobuf (through via, F.Cu → B.Cu, with drill and round copper pads on both outer layers) and create it via `create_items` — the same path `add_track` and the reference kipy client already use, which is known to persist. `builders::via_sexp` is replaced by `builders::build_via`. No handler or tool-schema change is needed; the client method signature is unchanged.

## Changes

- `crates/konnect-ipc/src/builders.rs` — replace `via_sexp` (string) with `build_via` (protobuf `Via`); add a unit test asserting the message carries position, drill, pad size, net, and through-via type.
- `crates/konnect-ipc/src/client.rs` — `add_via` now packs the `Via` and calls `create_items`, mirroring `add_track`.

## Verification

- `cargo test -p konnect-ipc --lib` — 16 passed, including the new `via_is_a_through_via_with_position_drill_size_and_net`.
- `cargo build` (full workspace) and `cargo clippy -p konnect-ipc` — clean.
- Manual (against KiCAD 10.0.4): calling `add_via` now creates a through via that appears on the canvas and persists to the `.kicad_pcb` after save.

## Relationship to #57

No overlap. #57 touches `pcb_routing.rs` (`find_pad_board_position` rotation transform) and `pcb_components.rs`; this PR touches only `konnect-ipc` (`builders.rs`, `client.rs`). The two can merge in either order without conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
