### PR TITLE
fix (pcb): Place real footprints instead of reporting phantom success

### DIFF
--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -1002,6 +1002,31 @@ pub(crate) fn is_lib_id(reference: &str) -> bool {
     !(nick.len() == 1 && nick.as_bytes()[0].is_ascii_alphabetic())
 }
 
+/// The nickname the fp-lib-table gives to the library living in `dir`, if any.
+///
+/// This is the inverse of `resolve_footprint_path` and exists because a
+/// nickname is *not* derivable from the directory name: KiCad lets a table map
+/// any nickname to any path, so `MyParts` may well point at `vendor.pretty`,
+/// and two nicknames may share one directory. Only the table can answer it.
+///
+/// Paths are compared canonicalised so a symlinked or non-normalised entry
+/// still matches, falling back to a literal comparison when canonicalisation
+/// fails (a directory that no longer exists, say).
+pub(crate) fn footprint_lib_nickname_for_dir(dir: &Path) -> Option<String> {
+    let canonical = std::fs::canonicalize(dir).ok();
+    let same = |candidate: &Path| -> bool {
+        match (&canonical, std::fs::canonicalize(candidate).ok()) {
+            (Some(a), Some(b)) => a == &b,
+            _ => candidate == dir,
+        }
+    };
+
+    read_flat_lib_table(&global_fp_lib_table())
+        .into_iter()
+        .find(|lib| lib["path"].as_str().is_some_and(|p| same(Path::new(p))))
+        .and_then(|lib| lib["nickname"].as_str().map(str::to_string))
+}
+
 /// Resolve a footprint reference to an on-disk `.kicad_mod` path.
 ///
 /// Accepts either a direct filesystem path or KiCad's `Library:Footprint`

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -291,7 +291,8 @@ pub fn tools() -> Vec<ToolDef> {
             json!({
                 "type": "object",
                 "properties": {
-                    "footprint_path": { "type": "string", "description": "Path to .kicad_mod file, OR 'Library:Footprint' identifier" }
+                    "footprint_path": { "type": "string", "description": "Path to .kicad_mod file, OR 'Library:Footprint' identifier" },
+                    "project": { "type": "string", "description": "Path to .kicad_pro, so project-registered libraries resolve too (optional)" }
                 },
                 "required": ["footprint_path"]
             }),
@@ -1030,9 +1031,21 @@ pub(crate) fn footprint_lib_nickname_for_dir(dir: &Path) -> Option<String> {
 /// Resolve a footprint reference to an on-disk `.kicad_mod` path.
 ///
 /// Accepts either a direct filesystem path or KiCad's `Library:Footprint`
-/// form, which is looked up in the global fp-lib-table. Returns a
-/// human-readable message on failure so callers can surface it verbatim.
-pub(crate) fn resolve_footprint_path(reference: &str) -> Result<PathBuf, String> {
+/// form. Returns a human-readable message on failure so callers can surface it
+/// verbatim.
+///
+/// A lib id is looked up in `project_dir`'s fp-lib-table first, then the global
+/// one. Project-first matches KiCad, where a project entry shadows a global one
+/// of the same nickname, and it is the only order that makes
+/// `register_footprint_library` useful — it writes to the project table by
+/// default, so a global-only lookup cannot see anything it registers.
+///
+/// (`resolve_symbol_lib_path` still searches global-first for symbols; that
+/// asymmetry is pre-existing and noted on that function.)
+pub(crate) fn resolve_footprint_path(
+    reference: &str,
+    project_dir: Option<&Path>,
+) -> Result<PathBuf, String> {
     if !is_lib_id(reference) {
         // Check here rather than leaving it to the caller's read: an unchecked
         // path reaches the reader as a bare io::Error, which surfaces as
@@ -1050,15 +1063,25 @@ pub(crate) fn resolve_footprint_path(reference: &str) -> Result<PathBuf, String>
     }
 
     let (nick, fp_name) = reference.split_once(':').expect("checked above");
-    let table = global_fp_lib_table();
-    if !table.exists() {
+
+    let global = global_fp_lib_table();
+    let project = project_dir.map(|d| d.join("fp-lib-table"));
+    if !global.exists() && project.as_ref().is_none_or(|p| !p.exists()) {
         return Err(format!(
-            "Global fp-lib-table not found at {}",
-            table.display()
+            "No fp-lib-table found (looked for {}{})",
+            global.display(),
+            project
+                .map(|p| format!(" and {}", p.display()))
+                .unwrap_or_default()
         ));
     }
 
-    let libs = read_flat_lib_table(&table);
+    let mut libs = Vec::new();
+    if let Some(project) = &project {
+        libs.extend(read_flat_lib_table(project));
+    }
+    libs.extend(read_flat_lib_table(&global));
+
     let Some(lib) = libs.iter().find(|l| l["nickname"].as_str() == Some(nick)) else {
         let known: Vec<&str> = libs
             .iter()
@@ -1865,8 +1888,13 @@ async fn handle_get_footprint_info(
     let fp_path_str =
         require_str(args, "footprint_path").map_err(|e| anyhow::anyhow!("{:?}", e))?;
 
-    // Resolve "Library:Footprint" form via global fp-lib-table
-    let path = match resolve_footprint_path(fp_path_str) {
+    // Resolve "Library:Footprint" against the project's fp-lib-table as well as
+    // the global one, when the caller says which project they mean.
+    let project_dir = args["project"]
+        .as_str()
+        .map(PathBuf::from)
+        .and_then(|p| p.parent().map(Path::to_path_buf));
+    let path = match resolve_footprint_path(fp_path_str, project_dir.as_deref()) {
         Ok(p) => p,
         Err(msg) => return Ok(CallToolResult::error(msg)),
     };
@@ -2311,6 +2339,32 @@ mod tests {
         assert!(!is_lib_id("R_0402.kicad_mod"));
     }
 
+    #[tokio::test]
+    async fn a_project_registered_library_resolves() {
+        // register_footprint_library writes to the project fp-lib-table by
+        // default, so a global-only lookup could not see anything it
+        // registered — the default workflow resolved to "library not found".
+        let tmp = tempfile::tempdir().unwrap();
+        let pretty = tmp.path().join("MyProjLib.pretty");
+        std::fs::create_dir_all(&pretty).unwrap();
+        std::fs::write(pretty.join("Foo.kicad_mod"), "(footprint \"Foo\")").unwrap();
+        std::fs::write(
+            tmp.path().join("fp-lib-table"),
+            kicad_style_table(
+                "fp_lib_table",
+                &[("MyProjLib", "KiCad", &pretty.to_string_lossy())],
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolve_footprint_path("MyProjLib:Foo", Some(tmp.path())).unwrap(),
+            pretty.join("Foo.kicad_mod")
+        );
+        // Without the project dir it is invisible, which is the bug.
+        assert!(resolve_footprint_path("MyProjLib:Foo", None).is_err());
+    }
+
     #[test]
     fn a_windows_drive_relative_path_is_not_a_library_id() {
         // `C:R.kicad_mod` means R.kicad_mod in drive C's current directory. It
@@ -2374,7 +2428,7 @@ mod tests {
         // point of the test.
         let tmp = tempfile::tempdir().unwrap();
         let missing = tmp.path().join("nope.kicad_mod");
-        let err = resolve_footprint_path(&missing.to_string_lossy())
+        let err = resolve_footprint_path(&missing.to_string_lossy(), None)
             .expect_err("a nonexistent path must not resolve");
         assert!(err.contains("nope.kicad_mod"), "must name the file: {err}");
         assert!(
@@ -2388,7 +2442,7 @@ mod tests {
         // is_file, not exists — a .pretty directory would otherwise resolve and
         // fail confusingly at read time.
         let tmp = tempfile::tempdir().unwrap();
-        assert!(resolve_footprint_path(&tmp.path().to_string_lossy()).is_err());
+        assert!(resolve_footprint_path(&tmp.path().to_string_lossy(), None).is_err());
     }
 
     #[test]
@@ -2397,7 +2451,7 @@ mod tests {
         let file = tmp.path().join("R_0805.kicad_mod");
         std::fs::write(&file, "(footprint \"R_0805\")").unwrap();
         assert_eq!(
-            resolve_footprint_path(&file.to_string_lossy()).unwrap(),
+            resolve_footprint_path(&file.to_string_lossy(), None).unwrap(),
             file
         );
     }

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -1970,6 +1970,95 @@ mod tests {
         format!("({kind}\r\n\t(version 7)\r\n{body})\r\n")
     }
 
+    #[tokio::test]
+    async fn list_footprint_libraries_reads_a_table_kicad_wrote() {
+        // End-to-end regression for the user-visible symptom: on a stock KiCad
+        // 10 install every library listing returned {"count": 0}, which left
+        // place_component unable to resolve any Library:Footprint id. Drive the
+        // real handler with a table in the exact shape KiCad writes.
+        let tmp = tempfile::tempdir().unwrap();
+        let pretty = tmp.path().join("MyParts.pretty");
+        std::fs::create_dir_all(&pretty).unwrap();
+        let table = kicad_style_table(
+            "fp_lib_table",
+            &[("MyParts", "KiCad", &pretty.to_string_lossy())],
+        );
+        assert!(
+            !table.contains("\n  (lib "),
+            "fixture must be in KiCad's tab format, not the old needle's"
+        );
+        std::fs::write(tmp.path().join("fp-lib-table"), table).unwrap();
+
+        let args = json!({
+            "project": tmp.path().join("board.kicad_pro").to_string_lossy(),
+            "scope": "project",
+        });
+        let res = handle_list_footprint_libraries(&args, &test_ctx())
+            .await
+            .unwrap();
+        assert!(!res.is_error, "handler errored: {:?}", res.content);
+
+        let out: serde_json::Value = serde_json::from_str(&result_text(&res)).unwrap();
+        assert_eq!(out["count"], 1, "library not found: {out}");
+        assert_eq!(out["libraries"][0]["nickname"], "MyParts");
+        assert_eq!(
+            out["libraries"][0]["path"].as_str().map(PathBuf::from),
+            Some(pretty),
+            "the resolved directory should be reported alongside the raw uri"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_footprint_libraries_expands_a_nested_table_of_env_var_uris() {
+        // The two things that kept KiCad's ~155 bundled libraries invisible even
+        // once the table parsed: a `(type "Table")` indirection, and entries
+        // addressed as ${KICAD10_FOOTPRINT_DIR}/Foo.pretty.
+        let tmp = tempfile::tempdir().unwrap();
+        let shipped = tmp.path().join("share");
+        let pretty = shipped.join("Resistor_SMD.pretty");
+        std::fs::create_dir_all(&pretty).unwrap();
+        std::env::set_var("KICAD10_FOOTPRINT_DIR", &shipped);
+
+        let nested = tmp.path().join("template-fp-lib-table");
+        std::fs::write(
+            &nested,
+            kicad_style_table(
+                "fp_lib_table",
+                &[(
+                    "Resistor_SMD",
+                    "KiCad",
+                    "${KICAD10_FOOTPRINT_DIR}/Resistor_SMD.pretty",
+                )],
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("fp-lib-table"),
+            kicad_style_table(
+                "fp_lib_table",
+                &[("KiCad", "Table", &nested.to_string_lossy())],
+            ),
+        )
+        .unwrap();
+
+        let args = json!({
+            "project": tmp.path().join("board.kicad_pro").to_string_lossy(),
+            "scope": "project",
+        });
+        let res = handle_list_footprint_libraries(&args, &test_ctx())
+            .await
+            .unwrap();
+        let out: serde_json::Value = serde_json::from_str(&result_text(&res)).unwrap();
+
+        assert_eq!(out["count"], 1, "nested table not expanded: {out}");
+        assert_eq!(out["libraries"][0]["nickname"], "Resistor_SMD");
+        assert_eq!(
+            out["libraries"][0]["path"].as_str().map(PathBuf::from),
+            Some(pretty),
+            "env-var URI should resolve to a real directory"
+        );
+    }
+
     #[test]
     fn parse_lib_table_reads_kicad10_crlf_tab_format() {
         // Regression: parse_lib_table hard-coded the needle `\n  (lib ` (LF +

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -942,12 +942,35 @@ fn flatten_lib_table(content: &str, depth: usize) -> Vec<serde_json::Value> {
     out
 }
 
-/// Read a lib-table file from disk and flatten it. Returns an empty list when
-/// the file is absent or unreadable.
-fn read_flat_lib_table(path: &Path) -> Vec<serde_json::Value> {
+/// Read a lib-table file from disk and flatten it, reporting a table that is
+/// present but unreadable.
+///
+/// An absent table is normal and yields an empty list: a project without its
+/// own fp-lib-table simply has none, and every caller checks both the global
+/// and project tables. Anything else — a permissions problem, a truncated
+/// file — is not normal, and must not be folded into the same empty list. The
+/// symptom that produces is a bare `{"count": 0}`, which is precisely what the
+/// bug this module fixes looked like, so silence here would make a real
+/// failure indistinguishable from a regression.
+fn read_lib_table_checked(path: &Path) -> Result<Vec<serde_json::Value>, String> {
     match std::fs::read_to_string(path) {
-        Ok(content) => flatten_lib_table(&content, 0),
-        Err(_) => Vec::new(),
+        Ok(content) => Ok(flatten_lib_table(&content, 0)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(e) => Err(format!("Cannot read lib-table {}: {}", path.display(), e)),
+    }
+}
+
+/// As [`read_lib_table_checked`], for callers with nowhere to put an error.
+///
+/// The failure is logged rather than dropped in silence. Handlers that can
+/// surface it to the user should call `read_lib_table_checked` directly.
+fn read_flat_lib_table(path: &Path) -> Vec<serde_json::Value> {
+    match read_lib_table_checked(path) {
+        Ok(libs) => libs,
+        Err(msg) => {
+            tracing::warn!("{msg}");
+            Vec::new()
+        }
     }
 }
 
@@ -1078,8 +1101,14 @@ async fn handle_list_footprint_libraries(
     let scope = args["scope"].as_str().unwrap_or("all");
     let mut all_libs = Vec::new();
 
+    // A table that exists but cannot be read is reported rather than counted
+    // as zero libraries — "0" is the symptom of the bug this PR fixes, so the
+    // two must not look alike.
     if scope == "global" || scope == "all" {
-        let mut libs = read_flat_lib_table(&global_fp_lib_table());
+        let mut libs = match read_lib_table_checked(&global_fp_lib_table()) {
+            Ok(libs) => libs,
+            Err(msg) => return Ok(CallToolResult::error(msg)),
+        };
         for lib in &mut libs {
             lib["scope"] = json!("global");
         }
@@ -1089,7 +1118,10 @@ async fn handle_list_footprint_libraries(
     if (scope == "project" || scope == "all") && args["project"].is_string() {
         let proj = PathBuf::from(args["project"].as_str().unwrap());
         let table = proj.parent().unwrap_or(Path::new(".")).join("fp-lib-table");
-        let mut libs = read_flat_lib_table(&table);
+        let mut libs = match read_lib_table_checked(&table) {
+            Ok(libs) => libs,
+            Err(msg) => return Ok(CallToolResult::error(msg)),
+        };
         for lib in &mut libs {
             lib["scope"] = json!("project");
         }
@@ -1152,8 +1184,13 @@ async fn handle_list_symbol_libraries(
     let scope = args["scope"].as_str().unwrap_or("all");
     let mut all_libs = Vec::new();
 
+    // Same as the footprint listing: an unreadable table is an error, not a
+    // zero count.
     if scope == "global" || scope == "all" {
-        let mut libs = read_flat_lib_table(&global_sym_lib_table());
+        let mut libs = match read_lib_table_checked(&global_sym_lib_table()) {
+            Ok(libs) => libs,
+            Err(msg) => return Ok(CallToolResult::error(msg)),
+        };
         for lib in &mut libs {
             lib["scope"] = json!("global");
         }
@@ -1166,7 +1203,10 @@ async fn handle_list_symbol_libraries(
             .parent()
             .unwrap_or(Path::new("."))
             .join("sym-lib-table");
-        let mut libs = read_flat_lib_table(&table);
+        let mut libs = match read_lib_table_checked(&table) {
+            Ok(libs) => libs,
+            Err(msg) => return Ok(CallToolResult::error(msg)),
+        };
         for lib in &mut libs {
             lib["scope"] = json!("project");
         }
@@ -2203,6 +2243,51 @@ mod tests {
 
         let content = std::fs::read_to_string(&table).unwrap();
         assert!(flatten_lib_table(&content, 0).is_empty());
+    }
+
+    #[test]
+    fn an_absent_lib_table_is_not_an_error() {
+        // Every caller checks both the global and project tables, and a project
+        // without its own is the normal case.
+        let tmp = tempfile::tempdir().unwrap();
+        let absent = tmp.path().join("fp-lib-table");
+        assert_eq!(read_lib_table_checked(&absent), Ok(Vec::new()));
+    }
+
+    #[test]
+    fn an_unreadable_lib_table_is_an_error_not_an_empty_list() {
+        // Reading a directory as a file fails with something other than
+        // NotFound on every platform, which is the case that must not be
+        // folded into "0 libraries" — that is the symptom of the very bug this
+        // module fixes.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir_as_table = tmp.path().join("fp-lib-table");
+        std::fs::create_dir(&dir_as_table).unwrap();
+
+        let err = read_lib_table_checked(&dir_as_table)
+            .expect_err("a table that exists but cannot be read must be reported");
+        assert!(err.contains("fp-lib-table"), "must name the table: {err}");
+    }
+
+    #[tokio::test]
+    async fn list_footprint_libraries_reports_an_unreadable_table() {
+        // The handler-level half: this used to surface a read error via `?`
+        // before the table read was centralised, and must still.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("fp-lib-table")).unwrap();
+
+        let args = json!({
+            "project": tmp.path().join("board.kicad_pro").to_string_lossy(),
+            "scope": "project",
+        });
+        let res = handle_list_footprint_libraries(&args, &test_ctx())
+            .await
+            .unwrap();
+        assert!(
+            res.is_error,
+            "an unreadable table must not report zero libraries: {:?}",
+            res.content
+        );
     }
 
     #[test]

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -1547,9 +1547,14 @@ fn top_level_symbol_names(content: &str) -> anyhow::Result<Vec<String>> {
 ///
 /// Checks the **global** sym-lib-table first, then the **project** table at
 /// `project_dir/sym-lib-table` (if a project dir is supplied). Returns the first
-/// entry whose nickname matches and whose URI resolves to an existing path.
-/// Both tables are read with `read_flat_lib_table`, so nested `(type "Table")`
+/// entry whose nickname matches and whose URI resolved to a path at all. Both
+/// tables are read with `read_flat_lib_table`, so nested `(type "Table")`
 /// references are followed and `${KICAD*_DIR}` URIs are expanded.
+///
+/// The returned path is *not* guaranteed to exist: `expand_lib_uri` checks
+/// existence only for `${KICAD*_DIR}` expansions, and takes a plain URI as
+/// written. A stale global entry therefore still shadows a working project one
+/// with the same nickname, and the caller's read is what discovers it.
 async fn resolve_symbol_lib_path(nick: &str, project_dir: Option<&Path>) -> Option<PathBuf> {
     let mut tables = vec![global_sym_lib_table()];
     if let Some(pd) = project_dir {

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -1743,8 +1743,10 @@ async fn handle_search_symbols(
     }
 
     let mut results = Vec::new();
-    'outer: for (nickname, uri) in entries {
-        let lib_path = PathBuf::from(&uri);
+    // `entries` holds resolved filesystem paths, not the raw uris they came
+    // from — read_flat_lib_table does that expansion now.
+    'outer: for (nickname, resolved) in entries {
+        let lib_path = PathBuf::from(&resolved);
         if !lib_path.exists() {
             continue;
         }

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -960,7 +960,19 @@ pub(crate) fn resolve_footprint_path(reference: &str) -> Result<PathBuf, String>
     let looks_like_lib_id =
         reference.contains(':') && !reference.contains('/') && !reference.contains('\\');
     if !looks_like_lib_id {
-        return Ok(PathBuf::from(reference));
+        // Check here rather than leaving it to the caller's read: an unchecked
+        // path reaches the reader as a bare io::Error, which surfaces as
+        // "The system cannot find the file specified. (os error 2)" with no
+        // mention of what was being looked for.
+        let path = PathBuf::from(reference);
+        if !path.is_file() {
+            return Err(format!(
+                "Footprint file not found: {}. Pass either a path to a .kicad_mod \
+                 file or a Library:Footprint id (e.g. 'Resistor_SMD:R_0402').",
+                path.display()
+            ));
+        }
+        return Ok(path);
     }
 
     let (nick, fp_name) = reference.split_once(':').expect("checked above");
@@ -2186,6 +2198,41 @@ mod tests {
 
         let content = std::fs::read_to_string(&table).unwrap();
         assert!(flatten_lib_table(&content, 0).is_empty());
+    }
+
+    #[test]
+    fn a_missing_footprint_path_names_itself() {
+        // Without the existence check the caller's read fails with a bare
+        // "os error 2" that never mentions the file, so the message is the
+        // point of the test.
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("nope.kicad_mod");
+        let err = resolve_footprint_path(&missing.to_string_lossy())
+            .expect_err("a nonexistent path must not resolve");
+        assert!(err.contains("nope.kicad_mod"), "must name the file: {err}");
+        assert!(
+            err.contains("Library:Footprint"),
+            "should say what the alternative is: {err}"
+        );
+    }
+
+    #[test]
+    fn a_directory_is_not_a_footprint() {
+        // is_file, not exists — a .pretty directory would otherwise resolve and
+        // fail confusingly at read time.
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(resolve_footprint_path(&tmp.path().to_string_lossy()).is_err());
+    }
+
+    #[test]
+    fn an_existing_footprint_path_resolves_unchanged() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("R_0805.kicad_mod");
+        std::fs::write(&file, "(footprint \"R_0805\")").unwrap();
+        assert_eq!(
+            resolve_footprint_path(&file.to_string_lossy()).unwrap(),
+            file
+        );
     }
 
     #[test]

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -7,7 +7,7 @@ use crate::mcp::protocol::CallToolResult;
 use crate::tool;
 use crate::tools::{get_path, require_str, ToolContext, ToolDef};
 use konnect_sexp::parser::{parse_sexp, SexpNode};
-use konnect_sexp::writer::write_atomic;
+use konnect_sexp::writer::{find_balanced_block, find_block_starts, write_atomic};
 use serde_json::json;
 use std::path::{Path, PathBuf};
 
@@ -826,29 +826,18 @@ fn global_sym_lib_table() -> PathBuf {
 }
 
 /// Parse a lib-table S-expression and return list of (nickname, uri, type) tuples.
+///
+/// Indentation-agnostic: KiCad's own writers emit tab-indented, CRLF-terminated
+/// tables while this crate's writer uses two spaces, so a fixed literal such as
+/// `"\n  (lib "` silently matches nothing in a real `fp-lib-table`.
 fn parse_lib_table(content: &str) -> Vec<serde_json::Value> {
     let mut libs = Vec::new();
     // Each entry: (lib (name "NICK") (type "...") (uri "...") (options "") (descr "..."))
-    let mut pos = 0;
-    while let Some(lib_start) = content[pos..].find("\n  (lib ").map(|i| pos + i) {
-        // Find the end of this lib block
-        let inner_start = lib_start + 2; // skip "\n  "
-        let mut depth = 0i32;
-        let mut end = inner_start;
-        for (i, ch) in content[inner_start..].char_indices() {
-            match ch {
-                '(' => depth += 1,
-                ')' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        end = inner_start + i + 1;
-                        break;
-                    }
-                }
-                _ => {}
-            }
-        }
-        let block = &content[inner_start..end];
+    for start in find_block_starts(content, "lib") {
+        let Some((block_start, block_end)) = find_balanced_block(content, start) else {
+            continue;
+        };
+        let block = &content[block_start..block_end];
 
         let nickname = extract_sexp_string(block, "name").unwrap_or_default();
         let uri = extract_sexp_string(block, "uri").unwrap_or_default();
@@ -861,9 +850,161 @@ fn parse_lib_table(content: &str) -> Vec<serde_json::Value> {
             "type": lib_type,
             "description": descr
         }));
-        pos = end;
     }
     libs
+}
+
+/// Resolve a lib-table URI to a concrete path, expanding a leading
+/// `${KICAD*_DIR}` reference.
+///
+/// KiCad's shipped tables address bundled libraries as
+/// `${KICAD10_FOOTPRINT_DIR}/Resistor_SMD.pretty`. An exported environment
+/// variable wins; otherwise the variable's kind is inferred from its name and
+/// the known install locations are searched.
+fn expand_lib_uri(uri: &str) -> Option<PathBuf> {
+    let Some(rest) = uri.strip_prefix("${") else {
+        return (!uri.is_empty()).then(|| PathBuf::from(uri));
+    };
+    let close = rest.find('}')?;
+    let var = &rest[..close];
+    let tail = rest[close + 1..].trim_start_matches(['/', '\\']);
+
+    if let Ok(base) = std::env::var(var) {
+        let p = PathBuf::from(base).join(tail);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+
+    // e.g. KICAD10_FOOTPRINT_DIR -> "footprints"
+    let kind = if var.ends_with("_FOOTPRINT_DIR") {
+        "footprints"
+    } else if var.ends_with("_SYMBOL_DIR") {
+        "symbols"
+    } else if var.ends_with("_3DMODEL_DIR") {
+        "3dmodels"
+    } else {
+        return None;
+    };
+
+    super::find_kicad_library_dirs(kind)
+        .into_iter()
+        .map(|base| base.join(tail))
+        .find(|p| p.exists())
+}
+
+/// Maximum depth when following nested `(type "Table")` lib-table references.
+const MAX_LIB_TABLE_DEPTH: usize = 4;
+
+/// Parse a lib-table and return concrete libraries, following nested tables.
+///
+/// KiCad 10 no longer copies its ~155 bundled libraries into the user's table.
+/// The default global table instead holds a single indirection entry —
+/// `(lib (name "KiCad") (type "Table") (uri ".../template/fp-lib-table"))` —
+/// pointing at the shipped template table. Treating that entry as a library
+/// makes every bundled library invisible, so it is followed here.
+///
+/// Each returned entry carries the original `uri` plus a resolved `path` when
+/// the URI could be turned into an existing directory.
+fn flatten_lib_table(content: &str, depth: usize) -> Vec<serde_json::Value> {
+    let mut out = Vec::new();
+
+    for mut entry in parse_lib_table(content) {
+        let uri = entry["uri"].as_str().unwrap_or("").to_string();
+        let is_nested = entry["type"].as_str() == Some("Table");
+
+        if is_nested {
+            if depth >= MAX_LIB_TABLE_DEPTH {
+                tracing::warn!(
+                    "lib-table nesting deeper than {} levels at '{}' — not followed",
+                    MAX_LIB_TABLE_DEPTH,
+                    uri
+                );
+                continue;
+            }
+            match expand_lib_uri(&uri).map(std::fs::read_to_string) {
+                Some(Ok(nested)) => out.extend(flatten_lib_table(&nested, depth + 1)),
+                _ => tracing::warn!("nested lib-table '{}' could not be read", uri),
+            }
+            continue;
+        }
+
+        if let Some(path) = expand_lib_uri(&uri) {
+            entry["path"] = json!(path.to_string_lossy());
+        }
+        out.push(entry);
+    }
+
+    out
+}
+
+/// Read a lib-table file from disk and flatten it. Returns an empty list when
+/// the file is absent or unreadable.
+fn read_flat_lib_table(path: &Path) -> Vec<serde_json::Value> {
+    match std::fs::read_to_string(path) {
+        Ok(content) => flatten_lib_table(&content, 0),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Resolve a footprint reference to an on-disk `.kicad_mod` path.
+///
+/// Accepts either a direct filesystem path or KiCad's `Library:Footprint`
+/// form, which is looked up in the global fp-lib-table. Returns a
+/// human-readable message on failure so callers can surface it verbatim.
+pub(crate) fn resolve_footprint_path(reference: &str) -> Result<PathBuf, String> {
+    let looks_like_lib_id =
+        reference.contains(':') && !reference.contains('/') && !reference.contains('\\');
+    if !looks_like_lib_id {
+        return Ok(PathBuf::from(reference));
+    }
+
+    let (nick, fp_name) = reference.split_once(':').expect("checked above");
+    let table = global_fp_lib_table();
+    if !table.exists() {
+        return Err(format!(
+            "Global fp-lib-table not found at {}",
+            table.display()
+        ));
+    }
+
+    let libs = read_flat_lib_table(&table);
+    let Some(lib) = libs.iter().find(|l| l["nickname"].as_str() == Some(nick)) else {
+        let known: Vec<&str> = libs
+            .iter()
+            .filter_map(|l| l["nickname"].as_str())
+            .take(12)
+            .collect();
+        return Err(format!(
+            "Library '{}' not found in fp-lib-table ({} libraries known{})",
+            nick,
+            libs.len(),
+            if known.is_empty() {
+                String::new()
+            } else {
+                format!(", e.g. {}", known.join(", "))
+            }
+        ));
+    };
+
+    let Some(dir) = lib["path"].as_str() else {
+        return Err(format!(
+            "Library '{}' has an unresolvable URI '{}'",
+            nick,
+            lib["uri"].as_str().unwrap_or("")
+        ));
+    };
+
+    let path = PathBuf::from(dir).join(format!("{}.kicad_mod", fp_name));
+    if !path.exists() {
+        return Err(format!(
+            "Footprint '{}' not found in library '{}' (looked for {})",
+            fp_name,
+            nick,
+            path.display()
+        ));
+    }
+    Ok(path)
 }
 
 /// Extract a quoted string value from `(key "value")` within a block.
@@ -922,28 +1063,21 @@ async fn handle_list_footprint_libraries(
     let mut all_libs = Vec::new();
 
     if scope == "global" || scope == "all" {
-        let table = global_fp_lib_table();
-        if table.exists() {
-            let content = tokio::fs::read_to_string(&table).await?;
-            let mut libs = parse_lib_table(&content);
-            for lib in &mut libs {
-                lib["scope"] = json!("global");
-            }
-            all_libs.extend(libs);
+        let mut libs = read_flat_lib_table(&global_fp_lib_table());
+        for lib in &mut libs {
+            lib["scope"] = json!("global");
         }
+        all_libs.extend(libs);
     }
 
     if (scope == "project" || scope == "all") && args["project"].is_string() {
         let proj = PathBuf::from(args["project"].as_str().unwrap());
         let table = proj.parent().unwrap_or(Path::new(".")).join("fp-lib-table");
-        if table.exists() {
-            let content = tokio::fs::read_to_string(&table).await?;
-            let mut libs = parse_lib_table(&content);
-            for lib in &mut libs {
-                lib["scope"] = json!("project");
-            }
-            all_libs.extend(libs);
+        let mut libs = read_flat_lib_table(&table);
+        for lib in &mut libs {
+            lib["scope"] = json!("project");
         }
+        all_libs.extend(libs);
     }
 
     Ok(CallToolResult::text(
@@ -1003,15 +1137,11 @@ async fn handle_list_symbol_libraries(
     let mut all_libs = Vec::new();
 
     if scope == "global" || scope == "all" {
-        let table = global_sym_lib_table();
-        if table.exists() {
-            let content = tokio::fs::read_to_string(&table).await?;
-            let mut libs = parse_lib_table(&content);
-            for lib in &mut libs {
-                lib["scope"] = json!("global");
-            }
-            all_libs.extend(libs);
+        let mut libs = read_flat_lib_table(&global_sym_lib_table());
+        for lib in &mut libs {
+            lib["scope"] = json!("global");
         }
+        all_libs.extend(libs);
     }
 
     if (scope == "project" || scope == "all") && args["project"].is_string() {
@@ -1020,14 +1150,11 @@ async fn handle_list_symbol_libraries(
             .parent()
             .unwrap_or(Path::new("."))
             .join("sym-lib-table");
-        if table.exists() {
-            let content = tokio::fs::read_to_string(&table).await?;
-            let mut libs = parse_lib_table(&content);
-            for lib in &mut libs {
-                lib["scope"] = json!("project");
-            }
-            all_libs.extend(libs);
+        let mut libs = read_flat_lib_table(&table);
+        for lib in &mut libs {
+            lib["scope"] = json!("project");
         }
+        all_libs.extend(libs);
     }
 
     Ok(CallToolResult::text(
@@ -1404,21 +1531,19 @@ fn top_level_symbol_names(content: &str) -> anyhow::Result<Vec<String>> {
 ///
 /// Checks the **global** sym-lib-table first, then the **project** table at
 /// `project_dir/sym-lib-table` (if a project dir is supplied). Returns the first
-/// entry whose nickname matches and whose `uri` does not use an unresolved KiCad
-/// env var (`${…}`). Both tables are read with `parse_lib_table`.
+/// entry whose nickname matches and whose URI resolves to an existing path.
+/// Both tables are read with `read_flat_lib_table`, so nested `(type "Table")`
+/// references are followed and `${KICAD*_DIR}` URIs are expanded.
 async fn resolve_symbol_lib_path(nick: &str, project_dir: Option<&Path>) -> Option<PathBuf> {
     let mut tables = vec![global_sym_lib_table()];
     if let Some(pd) = project_dir {
         tables.push(pd.join("sym-lib-table"));
     }
     for table in tables {
-        let Ok(content) = tokio::fs::read_to_string(&table).await else {
-            continue;
-        };
-        for lib in parse_lib_table(&content) {
+        for lib in read_flat_lib_table(&table) {
             if lib["nickname"].as_str() == Some(nick) {
-                if let Some(uri) = lib["uri"].as_str().filter(|u| !u.starts_with("${")) {
-                    return Some(PathBuf::from(uri));
+                if let Some(path) = lib["path"].as_str() {
+                    return Some(PathBuf::from(path));
                 }
             }
         }
@@ -1538,34 +1663,26 @@ async fn handle_search_symbols(
         .map(PathBuf::from)
         .or_else(|| ctx.config.project_dir.clone());
 
-    // Gather (nickname, uri) entries from the global sym-lib-table and, when a
+    // Gather (nickname, path) entries from the global sym-lib-table and, when a
     // project dir is supplied, the project's own sym-lib-table too — this is
-    // what makes project-attached libraries searchable.
+    // what makes project-attached libraries searchable. Nested `(type "Table")`
+    // references are followed and `${KICAD*_DIR}` URIs expanded, so the
+    // libraries KiCad ships are included.
     let mut entries: Vec<(String, String)> = Vec::new();
     let mut tables = vec![global_sym_lib_table()];
     if let Some(pd) = &project_dir {
         tables.push(pd.join("sym-lib-table"));
     }
     for table in &tables {
-        if !table.exists() {
-            continue;
-        }
-        let Ok(content) = tokio::fs::read_to_string(table).await else {
-            continue;
-        };
-        for lib in parse_lib_table(&content) {
-            if let (Some(nick), Some(uri)) = (lib["nickname"].as_str(), lib["uri"].as_str()) {
-                entries.push((nick.to_string(), uri.to_string()));
+        for lib in read_flat_lib_table(table) {
+            if let (Some(nick), Some(path)) = (lib["nickname"].as_str(), lib["path"].as_str()) {
+                entries.push((nick.to_string(), path.to_string()));
             }
         }
     }
 
     let mut results = Vec::new();
     'outer: for (nickname, uri) in entries {
-        // Skip KiCad env-var URIs (${KICAD*_SYMBOL_DIR}) — unresolvable here.
-        if uri.starts_with("${") {
-            continue;
-        }
         let lib_path = PathBuf::from(&uri);
         if !lib_path.exists() {
             continue;
@@ -1635,29 +1752,10 @@ async fn handle_get_footprint_info(
         require_str(args, "footprint_path").map_err(|e| anyhow::anyhow!("{:?}", e))?;
 
     // Resolve "Library:Footprint" form via global fp-lib-table
-    let path =
-        if fp_path_str.contains(':') && !fp_path_str.contains('/') && !fp_path_str.contains('\\') {
-            let parts: Vec<&str> = fp_path_str.splitn(2, ':').collect();
-            let (nick, fp_name) = (parts[0], parts[1]);
-            let table = global_fp_lib_table();
-            if table.exists() {
-                let tc = tokio::fs::read_to_string(&table).await?;
-                let libs = parse_lib_table(&tc);
-                if let Some(lib) = libs.iter().find(|l| l["nickname"].as_str() == Some(nick)) {
-                    let uri = lib["uri"].as_str().unwrap_or("");
-                    PathBuf::from(uri).join(format!("{}.kicad_mod", fp_name))
-                } else {
-                    return Ok(CallToolResult::error(format!(
-                        "Library '{}' not found in fp-lib-table",
-                        nick
-                    )));
-                }
-            } else {
-                return Ok(CallToolResult::error("Global fp-lib-table not found"));
-            }
-        } else {
-            PathBuf::from(fp_path_str)
-        };
+    let path = match resolve_footprint_path(fp_path_str) {
+        Ok(p) => p,
+        Err(msg) => return Ok(CallToolResult::error(msg)),
+    };
 
     let content = tokio::fs::read_to_string(&path).await?;
 
@@ -1704,58 +1802,30 @@ async fn handle_search_footprints(
 
     let mut results = Vec::new();
 
-    if fp_lib_table_path.exists() {
-        let tc = tokio::fs::read_to_string(&fp_lib_table_path).await?;
-
-        // Parse lib entries
-        let mut search = tc.as_str();
-        'outer: while let Some(lib_pos) = search.find("\n  (lib ") {
-            let block_start = lib_pos + 3;
-            let mut depth = 0i32;
-            let mut block_end = block_start;
-            for (i, ch) in search[block_start..].char_indices() {
-                match ch {
-                    '(' => depth += 1,
-                    ')' => {
-                        depth -= 1;
-                        if depth == 0 {
-                            block_end = block_start + i + 1;
-                            break;
-                        }
-                    }
-                    _ => {}
+    'outer: for lib in read_flat_lib_table(&fp_lib_table_path) {
+        let nickname = lib["nickname"].as_str().unwrap_or("").to_string();
+        let Some(dir) = lib["path"].as_str().map(PathBuf::from) else {
+            continue;
+        };
+        let Ok(mut rd) = tokio::fs::read_dir(&dir).await else {
+            continue;
+        };
+        while let Ok(Some(entry)) = rd.next_entry().await {
+            let fname = entry.file_name();
+            let fname_str = fname.to_string_lossy();
+            let Some(fp_name) = fname_str.strip_suffix(".kicad_mod") else {
+                continue;
+            };
+            if fp_name.to_lowercase().contains(&query) {
+                results.push(json!({
+                    "library": nickname,
+                    "name": fp_name,
+                    "id": format!("{}:{}", nickname, fp_name)
+                }));
+                if results.len() >= limit {
+                    break 'outer;
                 }
             }
-            let block = &search[block_start..block_end];
-            let nickname = extract_sexp_string(block, "name").unwrap_or_default();
-            let uri = extract_sexp_string(block, "uri").unwrap_or_default();
-
-            if !uri.starts_with("${") {
-                let dir = PathBuf::from(uri);
-                if dir.is_dir() {
-                    if let Ok(mut rd) = tokio::fs::read_dir(&dir).await {
-                        while let Ok(Some(entry)) = rd.next_entry().await {
-                            let fname = entry.file_name();
-                            let fname_str = fname.to_string_lossy();
-                            if fname_str.ends_with(".kicad_mod") {
-                                let fp_name = fname_str.trim_end_matches(".kicad_mod");
-                                if fp_name.to_lowercase().contains(&query) {
-                                    results.push(json!({
-                                        "library": nickname,
-                                        "name": fp_name,
-                                        "id": format!("{}:{}", nickname, fp_name)
-                                    }));
-                                    if results.len() >= limit {
-                                        break 'outer;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            search = &search[lib_pos + 1..];
         }
     }
 
@@ -1884,6 +1954,125 @@ mod tests {
             },
             Arc::new(ToolRouter::new()),
         )
+    }
+
+    /// A lib-table in the exact shape KiCad writes it: CRLF-terminated and
+    /// TAB-indented.
+    fn kicad_style_table(kind: &str, entries: &[(&str, &str, &str)]) -> String {
+        let body: String = entries
+            .iter()
+            .map(|(nick, ty, uri)| {
+                format!(
+                    "\t(lib (name \"{nick}\") (type \"{ty}\") (uri \"{uri}\") (options \"\") (descr \"\"))\r\n"
+                )
+            })
+            .collect();
+        format!("({kind}\r\n\t(version 7)\r\n{body})\r\n")
+    }
+
+    #[test]
+    fn parse_lib_table_reads_kicad10_crlf_tab_format() {
+        // Regression: parse_lib_table hard-coded the needle `\n  (lib ` (LF +
+        // exactly 2 spaces). KiCad writes these tables CRLF-terminated and
+        // TAB-indented, so the needle never matched and every library listing
+        // came back empty — which in turn made footprint placement unable to
+        // resolve any `Library:Footprint` id.
+        let content = kicad_style_table(
+            "fp_lib_table",
+            &[
+                ("OpenDongle", "KiCad", "/tmp/OpenDongle"),
+                ("wch-antenna", "KiCad", "/tmp/wch.pretty"),
+            ],
+        );
+        assert!(
+            !content.contains("\n  (lib "),
+            "fixture must not contain the old LF/2-space needle"
+        );
+
+        let libs = parse_lib_table(&content);
+        assert_eq!(libs.len(), 2, "parsed: {libs:?}");
+        assert_eq!(libs[0]["nickname"], "OpenDongle");
+        assert_eq!(libs[1]["uri"], "/tmp/wch.pretty");
+    }
+
+    #[test]
+    fn parse_lib_table_still_reads_two_space_indentation() {
+        // konnect's own writer emits two-space indentation; both must work.
+        let content = "(fp_lib_table\n  (version 7)\n  (lib (name \"Local\") (type \"KiCad\") (uri \"/tmp/local.pretty\") (options \"\") (descr \"\"))\n)\n";
+        let libs = parse_lib_table(content);
+        assert_eq!(libs.len(), 1);
+        assert_eq!(libs[0]["nickname"], "Local");
+    }
+
+    #[test]
+    fn flatten_lib_table_follows_nested_table_entries() {
+        // KiCad 10's default global table does not copy the ~155 bundled
+        // libraries; it holds one `(type "Table")` entry pointing at the
+        // template table that KiCad ships. Treating that as a library makes
+        // every bundled library invisible.
+        let tmp = tempfile::tempdir().unwrap();
+        let leaf_dir = tmp.path().join("Resistor_SMD.pretty");
+        std::fs::create_dir_all(&leaf_dir).unwrap();
+
+        let nested = tmp.path().join("template-fp-lib-table");
+        std::fs::write(
+            &nested,
+            kicad_style_table(
+                "fp_lib_table",
+                &[("Resistor_SMD", "KiCad", &leaf_dir.to_string_lossy())],
+            ),
+        )
+        .unwrap();
+
+        let root = kicad_style_table(
+            "fp_lib_table",
+            &[("KiCad", "Table", &nested.to_string_lossy())],
+        );
+
+        let libs = flatten_lib_table(&root, 0);
+        assert_eq!(libs.len(), 1, "nested table not followed: {libs:?}");
+        assert_eq!(libs[0]["nickname"], "Resistor_SMD");
+        assert_eq!(
+            libs[0]["path"].as_str().map(PathBuf::from),
+            Some(leaf_dir),
+            "resolved path missing"
+        );
+    }
+
+    #[test]
+    fn flatten_lib_table_stops_at_a_self_referencing_table() {
+        // A table that points at itself must not recurse forever.
+        let tmp = tempfile::tempdir().unwrap();
+        let table = tmp.path().join("fp-lib-table");
+        std::fs::write(
+            &table,
+            kicad_style_table(
+                "fp_lib_table",
+                &[("Loop", "Table", &table.to_string_lossy())],
+            ),
+        )
+        .unwrap();
+
+        let content = std::fs::read_to_string(&table).unwrap();
+        assert!(flatten_lib_table(&content, 0).is_empty());
+    }
+
+    #[test]
+    fn expand_lib_uri_expands_a_kicad_env_var() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pretty = tmp.path().join("Resistor_SMD.pretty");
+        std::fs::create_dir_all(&pretty).unwrap();
+        std::env::set_var("KICAD10_FOOTPRINT_DIR", tmp.path());
+
+        assert_eq!(
+            expand_lib_uri("${KICAD10_FOOTPRINT_DIR}/Resistor_SMD.pretty"),
+            Some(pretty)
+        );
+        assert_eq!(
+            expand_lib_uri("/plain/path"),
+            Some(PathBuf::from("/plain/path")),
+            "a non-variable URI must pass through untouched"
+        );
     }
 
     fn pad(number: &str, t: &str, x: f64, y: f64, w: f64, h: f64) -> PadGeom {

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -869,7 +869,9 @@ fn expand_lib_uri(uri: &str) -> Option<PathBuf> {
     let var = &rest[..close];
     let tail = rest[close + 1..].trim_start_matches(['/', '\\']);
 
-    if let Ok(base) = std::env::var(var) {
+    // var_os, not var: `var` treats a non-Unicode value as absent, which would
+    // send a perfectly good ${KICAD*_DIR} down the install-root guess path.
+    if let Some(base) = std::env::var_os(var) {
         let p = PathBuf::from(base).join(tail);
         if p.exists() {
             return Some(p);
@@ -974,15 +976,39 @@ fn read_flat_lib_table(path: &Path) -> Vec<serde_json::Value> {
     }
 }
 
+/// Whether a footprint reference is KiCad's `Library:Footprint` form rather
+/// than a filesystem path.
+///
+/// "Contains a colon" is not enough, because Windows paths contain one too.
+/// `C:\libs\R.kicad_mod` is caught by the separator test, but the
+/// drive-*relative* form `C:R.kicad_mod` — meaning `R.kicad_mod` in the current
+/// directory of drive C — carries no separator and is otherwise shaped exactly
+/// like a lib id.
+///
+/// A one-letter prefix is therefore read as a drive letter rather than a
+/// nickname. Nothing distinguishes the two, so this is a choice: a drive letter
+/// is much the likelier reading, and guessing the other way means silently
+/// hunting for a library named "C". The cost is that a single-letter nickname
+/// cannot be written in this form — it is still reachable by path — and the
+/// rule is applied on every platform so the behaviour does not change under
+/// the caller's feet.
+pub(crate) fn is_lib_id(reference: &str) -> bool {
+    let Some((nick, _)) = reference.split_once(':') else {
+        return false;
+    };
+    if reference.contains('/') || reference.contains('\\') {
+        return false;
+    }
+    !(nick.len() == 1 && nick.as_bytes()[0].is_ascii_alphabetic())
+}
+
 /// Resolve a footprint reference to an on-disk `.kicad_mod` path.
 ///
 /// Accepts either a direct filesystem path or KiCad's `Library:Footprint`
 /// form, which is looked up in the global fp-lib-table. Returns a
 /// human-readable message on failure so callers can surface it verbatim.
 pub(crate) fn resolve_footprint_path(reference: &str) -> Result<PathBuf, String> {
-    let looks_like_lib_id =
-        reference.contains(':') && !reference.contains('/') && !reference.contains('\\');
-    if !looks_like_lib_id {
+    if !is_lib_id(reference) {
         // Check here rather than leaving it to the caller's read: an unchecked
         // path reaches the reader as a bare io::Error, which surfaces as
         // "The system cannot find the file specified. (os error 2)" with no
@@ -2245,6 +2271,30 @@ mod tests {
 
         let content = std::fs::read_to_string(&table).unwrap();
         assert!(flatten_lib_table(&content, 0).is_empty());
+    }
+
+    #[test]
+    fn is_lib_id_separates_library_ids_from_paths() {
+        assert!(is_lib_id("Resistor_SMD:R_0402"));
+        assert!(is_lib_id("MyParts:Weird:Name")); // only the first colon splits
+
+        // Paths, by separator.
+        assert!(!is_lib_id(r"C:\KiCad\R.kicad_mod"));
+        assert!(!is_lib_id("/usr/share/kicad/R.kicad_mod"));
+        assert!(!is_lib_id("Resistor_SMD.pretty/R.kicad_mod"));
+        // No colon at all.
+        assert!(!is_lib_id("R_0402.kicad_mod"));
+    }
+
+    #[test]
+    fn a_windows_drive_relative_path_is_not_a_library_id() {
+        // `C:R.kicad_mod` means R.kicad_mod in drive C's current directory. It
+        // has a colon and no separator, so it is shaped exactly like a lib id;
+        // the one-letter prefix is what gives it away.
+        assert!(!is_lib_id("C:R_0402.kicad_mod"));
+        assert!(!is_lib_id("d:board.kicad_mod"));
+        // Two letters is a nickname again — no drive is named "Ab".
+        assert!(is_lib_id("Ab:R_0402"));
     }
 
     #[test]

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -904,8 +904,12 @@ const MAX_LIB_TABLE_DEPTH: usize = 4;
 /// pointing at the shipped template table. Treating that entry as a library
 /// makes every bundled library invisible, so it is followed here.
 ///
-/// Each returned entry carries the original `uri` plus a resolved `path` when
-/// the URI could be turned into an existing directory.
+/// Each returned entry carries the original `uri` plus a resolved `path`
+/// whenever [`expand_lib_uri`] yields one: a `${KICAD*_DIR}` URI resolves only
+/// if the expansion exists on disk, while a plain URI is passed through as
+/// written. The target may be a directory (`.pretty`) or a file
+/// (`.kicad_sym`), so the presence of `path` is not a promise that the library
+/// is readable — only that the URI was understood.
 fn flatten_lib_table(content: &str, depth: usize) -> Vec<serde_json::Value> {
     let mut out = Vec::new();
 
@@ -1970,6 +1974,44 @@ mod tests {
         format!("({kind}\r\n\t(version 7)\r\n{body})\r\n")
     }
 
+    /// Serializes tests that set KICAD10_FOOTPRINT_DIR (process-wide env), the
+    /// way `sch_components`' `SYMBOL_DIR_ENV` does for the symbol equivalent.
+    static FOOTPRINT_DIR_ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Point `KICAD10_FOOTPRINT_DIR` at `dir` for as long as the returned guard
+    /// lives.
+    ///
+    /// Rust runs tests in threads of one process, so two tests setting this to
+    /// their own tempdir would race. Holding the lock serializes them, and
+    /// restoring the previous value keeps a developer's real KiCad environment
+    /// intact for whatever runs next.
+    fn footprint_dir_env(dir: &Path) -> FootprintDirEnv {
+        let guard = FOOTPRINT_DIR_ENV.lock().unwrap_or_else(|e| e.into_inner());
+        // var_os, not var: a value this process cannot decode as UTF-8 is still
+        // one the developer set, and `var` would report it as absent, leaving
+        // the restore to silently delete it.
+        let previous = std::env::var_os("KICAD10_FOOTPRINT_DIR");
+        std::env::set_var("KICAD10_FOOTPRINT_DIR", dir);
+        FootprintDirEnv {
+            _guard: guard,
+            previous,
+        }
+    }
+
+    struct FootprintDirEnv {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl Drop for FootprintDirEnv {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(v) => std::env::set_var("KICAD10_FOOTPRINT_DIR", v),
+                None => std::env::remove_var("KICAD10_FOOTPRINT_DIR"),
+            }
+        }
+    }
+
     #[tokio::test]
     async fn list_footprint_libraries_reads_a_table_kicad_wrote() {
         // End-to-end regression for the user-visible symptom: on a stock KiCad
@@ -2017,7 +2059,7 @@ mod tests {
         let shipped = tmp.path().join("share");
         let pretty = shipped.join("Resistor_SMD.pretty");
         std::fs::create_dir_all(&pretty).unwrap();
-        std::env::set_var("KICAD10_FOOTPRINT_DIR", &shipped);
+        let _env = footprint_dir_env(&shipped);
 
         let nested = tmp.path().join("template-fp-lib-table");
         std::fs::write(
@@ -2151,7 +2193,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let pretty = tmp.path().join("Resistor_SMD.pretty");
         std::fs::create_dir_all(&pretty).unwrap();
-        std::env::set_var("KICAD10_FOOTPRINT_DIR", tmp.path());
+        let _env = footprint_dir_env(tmp.path());
 
         assert_eq!(
             expand_lib_uri("${KICAD10_FOOTPRINT_DIR}/Resistor_SMD.pretty"),

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -678,11 +678,18 @@ fn kicad_share_roots() -> Vec<std::path::PathBuf> {
 
     #[cfg(target_os = "windows")]
     {
+        // Keep these majors in step with the ones find_kicad_library_dirs
+        // reads environment variables for. A major listed there but missing
+        // here is invisible on any machine where KiCad did not export its
+        // variable — which is every machine where Konnect was not launched
+        // by KiCad.
         for c in [
             r"C:\KiCad\10.0\share\kicad",
             r"C:\Program Files\KiCad\10.0\share\kicad",
             r"C:\KiCad\9.0\share\kicad",
             r"C:\Program Files\KiCad\9.0\share\kicad",
+            r"C:\KiCad\8.0\share\kicad",
+            r"C:\Program Files\KiCad\8.0\share\kicad",
         ] {
             roots.push(std::path::PathBuf::from(c));
         }

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -671,61 +671,85 @@ pub fn ensure_lib_symbol_in_schematic(content: &mut String, lib_id: &str) -> boo
     true
 }
 
-/// Find directories where KiCAD symbol libraries are stored.
-fn find_kicad_symbol_dirs() -> Vec<std::path::PathBuf> {
-    let mut dirs = Vec::new();
-    if let Ok(dir) = std::env::var("KICAD10_SYMBOL_DIR") {
-        let p = std::path::PathBuf::from(&dir);
-        if p.is_dir() {
-            dirs.push(p);
-        }
-    }
+/// Roots under which KiCAD ships its bundled libraries — the directory that
+/// directly contains `symbols/`, `footprints/` and `3dmodels/`.
+fn kicad_share_roots() -> Vec<std::path::PathBuf> {
+    let mut roots: Vec<std::path::PathBuf> = Vec::new();
+
     #[cfg(target_os = "windows")]
     {
-        let candidates = [
-            r"C:\KiCad\10.0\share\kicad\symbols",
-            r"C:\Program Files\KiCad\10.0\share\kicad\symbols",
-            r"C:\KiCad\9.0\share\kicad\symbols",
-            r"C:\Program Files\KiCad\9.0\share\kicad\symbols",
-        ];
-        for c in &candidates {
-            let p = std::path::PathBuf::from(c);
-            if p.is_dir() && !dirs.contains(&p) {
-                dirs.push(p);
-            }
+        for c in [
+            r"C:\KiCad\10.0\share\kicad",
+            r"C:\Program Files\KiCad\10.0\share\kicad",
+            r"C:\KiCad\9.0\share\kicad",
+            r"C:\Program Files\KiCad\9.0\share\kicad",
+        ] {
+            roots.push(std::path::PathBuf::from(c));
         }
     }
     #[cfg(target_os = "macos")]
     {
         // KiCad on macOS ships its libraries inside the app bundle.
-        let mut candidates = vec![
-            std::path::PathBuf::from(
-                "/Applications/KiCad/KiCad.app/Contents/SharedSupport/symbols",
-            ),
-            std::path::PathBuf::from("/usr/local/share/kicad/symbols"),
-        ];
+        roots.push(std::path::PathBuf::from(
+            "/Applications/KiCad/KiCad.app/Contents/SharedSupport",
+        ));
+        roots.push(std::path::PathBuf::from("/usr/local/share/kicad"));
         if let Ok(home) = std::env::var("HOME") {
             // Per-user install (KiCad.app dragged into ~/Applications)
-            candidates.push(
+            roots.push(
                 std::path::PathBuf::from(home)
-                    .join("Applications/KiCad/KiCad.app/Contents/SharedSupport/symbols"),
+                    .join("Applications/KiCad/KiCad.app/Contents/SharedSupport"),
             );
-        }
-        for p in candidates {
-            if p.is_dir() && !dirs.contains(&p) {
-                dirs.push(p);
-            }
         }
     }
     #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     {
-        let candidates = ["/usr/share/kicad/symbols", "/usr/local/share/kicad/symbols"];
-        for c in &candidates {
-            let p = std::path::PathBuf::from(c);
-            if p.is_dir() && !dirs.contains(&p) {
-                dirs.push(p);
+        roots.push(std::path::PathBuf::from("/usr/share/kicad"));
+        roots.push(std::path::PathBuf::from("/usr/local/share/kicad"));
+    }
+
+    roots.retain(|p| p.is_dir());
+    roots
+}
+
+/// Find directories holding a bundled KiCAD library kind — `"symbols"`,
+/// `"footprints"` or `"3dmodels"`.
+///
+/// The matching `KICAD<major>_<KIND>_DIR` environment variable wins when KiCad
+/// has exported it (it does so for plugins); otherwise the well-known install
+/// locations are searched, newest KiCad first.
+pub(crate) fn find_kicad_library_dirs(kind: &str) -> Vec<std::path::PathBuf> {
+    let mut dirs: Vec<std::path::PathBuf> = Vec::new();
+    let mut push = |p: std::path::PathBuf| {
+        if p.is_dir() && !dirs.contains(&p) {
+            dirs.push(p);
+        }
+    };
+
+    if let Some(suffix) = kicad_env_suffix(kind) {
+        for major in ["10", "9", "8"] {
+            if let Ok(dir) = std::env::var(format!("KICAD{major}_{suffix}")) {
+                push(std::path::PathBuf::from(dir));
             }
         }
     }
+    for root in kicad_share_roots() {
+        push(root.join(kind));
+    }
     dirs
+}
+
+/// The `KICAD<major>_…` environment-variable suffix naming a library kind.
+fn kicad_env_suffix(kind: &str) -> Option<&'static str> {
+    match kind {
+        "symbols" => Some("SYMBOL_DIR"),
+        "footprints" => Some("FOOTPRINT_DIR"),
+        "3dmodels" => Some("3DMODEL_DIR"),
+        _ => None,
+    }
+}
+
+/// Find directories where KiCAD symbol libraries are stored.
+fn find_kicad_symbol_dirs() -> Vec<std::path::PathBuf> {
+    find_kicad_library_dirs("symbols")
 }

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -742,7 +742,12 @@ pub(crate) fn find_kicad_library_dirs(kind: &str) -> Vec<std::path::PathBuf> {
 
     if let Some(suffix) = kicad_env_suffix(kind) {
         for major in ["10", "9", "8"] {
-            if let Ok(dir) = std::env::var(format!("KICAD{major}_{suffix}")) {
+            // var_os, not var: a directory whose name is not valid Unicode is
+            // still a directory KiCad may have pointed us at, and `var` reports
+            // those as absent — silently falling back to the install roots, or
+            // to nothing, on exactly the machines where the variable was the
+            // only correct answer.
+            if let Some(dir) = std::env::var_os(format!("KICAD{major}_{suffix}")) {
                 push(std::path::PathBuf::from(dir));
             }
         }

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -715,9 +715,16 @@ fn kicad_share_roots() -> Vec<std::path::PathBuf> {
 /// Find directories holding a bundled KiCAD library kind — `"symbols"`,
 /// `"footprints"` or `"3dmodels"`.
 ///
-/// The matching `KICAD<major>_<KIND>_DIR` environment variable wins when KiCad
-/// has exported it (it does so for plugins); otherwise the well-known install
-/// locations are searched, newest KiCad first.
+/// The matching environment variable wins when KiCad has exported it (it does
+/// so for plugins); otherwise the well-known install locations are searched,
+/// newest KiCad first. The names are not a plain uppercasing of `kind` — they
+/// are singular, and the 3D one is not a word:
+///
+/// | `kind`        | variable                |
+/// |---------------|-------------------------|
+/// | `symbols`     | `KICAD<major>_SYMBOL_DIR`    |
+/// | `footprints`  | `KICAD<major>_FOOTPRINT_DIR` |
+/// | `3dmodels`    | `KICAD<major>_3DMODEL_DIR`   |
 pub(crate) fn find_kicad_library_dirs(kind: &str) -> Vec<std::path::PathBuf> {
     let mut dirs: Vec<std::path::PathBuf> = Vec::new();
     let mut push = |p: std::path::PathBuf| {

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -6,7 +6,7 @@
 
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
-use crate::tools::library::resolve_footprint_path;
+use crate::tools::library::{footprint_lib_nickname_for_dir, is_lib_id, resolve_footprint_path};
 use crate::tools::{get_path, require_f64, require_str, ToolContext, ToolDef};
 use konnect_ipc::client::KiCadIpcClient;
 use konnect_sexp::writer::{
@@ -46,9 +46,11 @@ fn board_footprint_sexp(
     })?;
 
     // Board footprints carry the full library id, not the bare footprint name.
+    // The declared name is the span without its surrounding quotes.
+    let declared = &content[name_span.start + 1..name_span.end - 1];
     let mut out = String::with_capacity(content.len() + 128);
     out.push_str(&content[..name_span.start]);
-    out.push_str(&escape_sexp_string(lib_id));
+    out.push_str(&escape_sexp_string(&board_lib_id(lib_id, &path, declared)));
     out.push_str(&format!(
         "\n\t(at {x} {y} {rotation})\n\t(uuid \"{}\")",
         new_uuid()
@@ -66,6 +68,68 @@ fn board_footprint_sexp(
     }
 
     Ok(out)
+}
+
+/// The name a board entry should carry for a footprint read from `path`.
+///
+/// `resolve_footprint_path` also accepts a bare filesystem path, which is
+/// convenient for a caller holding a `.kicad_mod` directly. That path must not
+/// reach the board file: `(footprint "C:\…\R_0805_2012Metric.kicad_mod")` is
+/// not a library identifier, and KiCad reports the placed part as a broken
+/// library link. This function is therefore total — every branch returns
+/// something that is not a path.
+///
+/// Preference order, most authoritative first:
+///
+/// 1. The caller already gave a `Library:Footprint` id — use it verbatim.
+/// 2. The fp-lib-table maps a nickname to the containing directory. Only the
+///    table can answer this: KiCad lets any nickname point at any path, so
+///    `MyParts` may well live in `vendor.pretty`, and guessing from the
+///    directory would silently mislink the part.
+/// 3. The conventional `<nickname>.pretty/` layout. The library is not
+///    registered, so the link will be broken either way, but this is the
+///    nickname the user gets when they do register it.
+/// 4. Neither — fall back to a bare footprint name, which links to nothing but
+///    is at least a valid name. The library file's own is used when it is not
+///    itself path-like; otherwise the file stem, which cannot contain a
+///    separator.
+fn board_lib_id(reference: &str, path: &std::path::Path, declared: &str) -> String {
+    if is_lib_id(reference) {
+        return reference.to_string();
+    }
+    let stem = path
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    if let Some(dir) = path.parent() {
+        if let Some(nick) = footprint_lib_nickname_for_dir(dir) {
+            return format!("{nick}:{stem}");
+        }
+        if let Some(nick) = pretty_dir_nickname(dir) {
+            return format!("{nick}:{stem}");
+        }
+    }
+
+    if declared.is_empty() || declared.contains('/') || declared.contains('\\') {
+        stem
+    } else {
+        declared.to_string()
+    }
+}
+
+/// The nickname a conventional `<nickname>.pretty` directory implies.
+///
+/// Matched case-insensitively: KiCad's own libraries are lowercase `.pretty`,
+/// but Windows and macOS filesystems are case-insensitive, so a `.Pretty` on
+/// disk is the same directory to KiCad and should not change the answer.
+fn pretty_dir_nickname(dir: &std::path::Path) -> Option<String> {
+    let name = dir.file_name()?.to_string_lossy().into_owned();
+    let cut = name.len().checked_sub(".pretty".len())?;
+    name[cut..]
+        .eq_ignore_ascii_case(".pretty")
+        .then(|| name[..cut].to_string())
+        .filter(|nick| !nick.is_empty())
 }
 
 /// Fold the footprint's placement rotation into its pads and text items.
@@ -509,11 +573,7 @@ async fn handle_place_component(
         .err()
         .is_some_and(|e| e.contains("created no footprint"));
 
-    let content = std::fs::read_to_string(&board_path)?;
-    let close_pos = content.rfind(')').unwrap_or(content.len());
-    let block = format!("\n{}", indent_block(sexp.trim_end(), "\t"));
-    let new_content = apply_edits(content, vec![SexpEdit::insert(close_pos, block)]);
-    write_atomic(&board_path, &new_content)?;
+    insert_into_board(&board_path, std::slice::from_ref(&sexp))?;
 
     let mut out = json!({
         "placed": reference.unwrap_or_default(),
@@ -530,6 +590,69 @@ async fn handle_place_component(
         );
     }
     Ok(CallToolResult::json(&out))
+}
+
+/// Insert `blocks` just inside the board's closing paren and write it back,
+/// refusing to write anything that is not one complete `(kicad_pcb …)` form.
+///
+/// The insert point is `rfind(')')`, which is only the right place if the file
+/// really is a single closed form. Checking the result before committing it
+/// means a board that was already truncated — or a footprint block that was —
+/// fails loudly instead of being written back over the user's file in a state
+/// KiCad can no longer open.
+///
+/// Like the rest of `konnect-sexp`, this treats parens as syntax everywhere: a
+/// `#`-commented paren would be miscounted. KiCad does not write comments into
+/// `.kicad_pcb`, and no reader in this workspace understands them either, so
+/// the assumption is at least consistent.
+fn insert_into_board(board_path: &std::path::Path, blocks: &[String]) -> anyhow::Result<()> {
+    let content = std::fs::read_to_string(board_path)?;
+    let close_pos = content.rfind(')').unwrap_or(content.len());
+    let joined: String = blocks
+        .iter()
+        .map(|b| format!("\n{}", indent_block(b.trim_end(), "\t")))
+        .collect();
+    let new_content = apply_edits(content, vec![SexpEdit::insert(close_pos, joined)]);
+
+    if let Err(why) = check_single_board_form(&new_content) {
+        anyhow::bail!(
+            "Refusing to write {}: {}. The board file was left untouched.",
+            board_path.display(),
+            why
+        );
+    }
+
+    write_atomic(board_path, &new_content)?;
+    Ok(())
+}
+
+/// Verify `content` is exactly one `(kicad_pcb …)` form and nothing else.
+///
+/// Checking only that *a* balanced block exists is too weak to back the promise
+/// above: `find_balanced_block` skips whatever precedes the first paren, so
+/// leading garbage would pass, as would a well-formed form that is not a board
+/// at all.
+fn check_single_board_form(content: &str) -> Result<(), String> {
+    let trimmed = content.trim();
+    let (start, end) = find_balanced_block(trimmed, 0)
+        .ok_or_else(|| "the result is not a balanced S-expression".to_string())?;
+
+    if start != 0 {
+        return Err(format!(
+            "{} bytes of content precede the opening paren",
+            start
+        ));
+    }
+    if end != trimmed.len() {
+        return Err(format!(
+            "{} bytes of content follow the closing paren",
+            trimmed.len() - end
+        ));
+    }
+    if !trimmed[1..].trim_start().starts_with("kicad_pcb") {
+        return Err("the root expression is not (kicad_pcb …)".to_string());
+    }
+    Ok(())
 }
 
 /// Prefix every non-empty line with `indent`.
@@ -829,14 +952,7 @@ async fn handle_place_array(
         .err()
         .is_some_and(|e| e.contains("created no footprint"));
 
-    let content = std::fs::read_to_string(&board_path)?;
-    let close_pos = content.rfind(')').unwrap_or(content.len());
-    let joined: String = blocks
-        .iter()
-        .map(|b| format!("\n{}", indent_block(b.trim_end(), "\t")))
-        .collect();
-    let new_content = apply_edits(content, vec![SexpEdit::insert(close_pos, joined)]);
-    write_atomic(&board_path, &new_content)?;
+    insert_into_board(&board_path, &blocks)?;
 
     let mut out = json!({
         "placed_count": placed.len(), "components": placed, "source": "file"
@@ -978,6 +1094,7 @@ async fn handle_get_board_2d_view(
 #[cfg(test)]
 mod footprint_sexp_tests {
     use super::*;
+    use std::path::Path;
 
     /// A library footprint in the exact shape KiCad ships: TAB-indented, name
     /// without a library prefix, `REF**` placeholder, no `(at …)`.
@@ -1031,8 +1148,16 @@ mod footprint_sexp_tests {
 ";
 
     /// Write a library footprint and an empty board into `dir`.
+    /// A `.pretty` library holding one footprint, plus an empty board.
+    ///
+    /// The footprint lives in `Resistor_SMD.pretty/` the way KiCad lays
+    /// libraries out, so passing its path exercises the same nickname
+    /// derivation a real `Resistor_SMD:R_0805_2012Metric` id would produce —
+    /// while still skipping the fp-lib-table, which keeps these tests hermetic.
     fn fixture(dir: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
-        let modfile = dir.join("R_0805_2012Metric.kicad_mod");
+        let pretty = dir.join("Resistor_SMD.pretty");
+        std::fs::create_dir_all(&pretty).unwrap();
+        let modfile = pretty.join("R_0805_2012Metric.kicad_mod");
         std::fs::write(&modfile, library_footprint()).unwrap();
         let board = dir.join("b.kicad_pcb");
         std::fs::write(&board, EMPTY_BOARD).unwrap();
@@ -1080,11 +1205,139 @@ mod footprint_sexp_tests {
         );
         assert!(out.contains("(size 1.025 1.4)"), "pad geometry missing");
         assert!(out.contains("(uuid \""), "board items need a uuid");
+        // The board must name a library, not the file it was read from.
+        assert!(
+            out.contains("(footprint \"Resistor_SMD:R_0805_2012Metric\""),
+            "board should carry a Library:Footprint id:
+{out}"
+        );
+        assert!(
+            !out.contains(".kicad_mod"),
+            "a filesystem path leaked into the board:
+{out}"
+        );
         assert_eq!(
             count_parens(&out),
             0,
             "board is no longer balanced:
 {out}"
+        );
+    }
+
+    /// `board_lib_id` for a path, with the library file's declared name.
+    fn id_for(path: &str, declared: &str) -> String {
+        board_lib_id(path, Path::new(path), declared)
+    }
+
+    #[test]
+    fn board_lib_id_never_yields_a_filesystem_path() {
+        // A Library:Footprint id is already what the board wants.
+        assert_eq!(
+            board_lib_id("Resistor_SMD:R_0805", Path::new("/ignored"), "R_0805"),
+            "Resistor_SMD:R_0805"
+        );
+        // A path in a .pretty library takes the nickname from its directory.
+        assert_eq!(
+            id_for(
+                "/usr/share/kicad/footprints/Resistor_SMD.pretty/R_0805.kicad_mod",
+                "R_0805"
+            ),
+            "Resistor_SMD:R_0805"
+        );
+        // Loose file: no nickname to recover, so it keeps the name the library
+        // file declares — unlinked, but a valid name rather than a path.
+        assert_eq!(
+            id_for("/tmp/scratch/R_0805.kicad_mod", "R_0805_2012Metric"),
+            "R_0805_2012Metric"
+        );
+    }
+
+    #[test]
+    fn a_path_like_declared_name_falls_back_to_the_file_stem() {
+        // A malformed library file naming itself with a path must not smuggle
+        // that path into the board through the fallback branch.
+        assert_eq!(
+            id_for("/tmp/scratch/R_0805.kicad_mod", "/tmp/other/R.kicad_mod"),
+            "R_0805"
+        );
+        assert_eq!(
+            id_for("/tmp/scratch/R_0805.kicad_mod", r"C:\x\R.kicad_mod"),
+            "R_0805"
+        );
+        // An empty declared name is no better than a path.
+        assert_eq!(id_for("/tmp/scratch/R_0805.kicad_mod", ""), "R_0805");
+    }
+
+    #[test]
+    fn windows_paths_are_not_mistaken_for_library_ids() {
+        // The drive letter's colon is why is_lib_id cannot just look for one.
+        assert_eq!(
+            id_for(
+                r"C:\KiCad\footprints\Resistor_SMD.pretty\R_0805.kicad_mod",
+                "R_0805"
+            ),
+            "Resistor_SMD:R_0805"
+        );
+    }
+
+    #[test]
+    fn pretty_suffix_matching_ignores_case() {
+        // Windows and macOS filesystems are case-insensitive, so Foo.Pretty and
+        // Foo.pretty are the same directory to KiCad.
+        assert_eq!(
+            pretty_dir_nickname(Path::new("/libs/Resistor_SMD.Pretty")),
+            Some("Resistor_SMD".into())
+        );
+        assert_eq!(
+            pretty_dir_nickname(Path::new("/libs/Resistor_SMD.pretty")),
+            Some("Resistor_SMD".into())
+        );
+        // A bare ".pretty" leaves no nickname behind.
+        assert_eq!(pretty_dir_nickname(Path::new("/libs/.pretty")), None);
+        assert_eq!(pretty_dir_nickname(Path::new("/libs/plain")), None);
+    }
+
+    #[test]
+    fn a_board_edit_must_stay_one_kicad_pcb_form() {
+        assert!(check_single_board_form("(kicad_pcb (version 20241229))").is_ok());
+        assert!(check_single_board_form("\n  (kicad_pcb (version 1))\n\n").is_ok());
+
+        // Truncated — the bug this guard exists for.
+        assert!(check_single_board_form("(kicad_pcb (version 1)").is_err());
+        // Leading garbage would otherwise be skipped by find_balanced_block.
+        assert!(check_single_board_form("garbage(kicad_pcb (version 1))").is_err());
+        // A second form after the root is not one board.
+        assert!(check_single_board_form("(kicad_pcb (version 1))(extra)").is_err());
+        // Well-formed, but not a board.
+        assert!(check_single_board_form("(not_a_board (version 1))").is_err());
+    }
+
+    #[tokio::test]
+    async fn a_truncated_board_is_refused_rather_than_rewritten() {
+        // rfind(')') picks the insert point, so a board that is not one closed
+        // (kicad_pcb …) form would silently gain a footprint outside the root
+        // expression. Nothing should be written in that case.
+        let tmp = tempfile::tempdir().unwrap();
+        let (modfile, board) = fixture(tmp.path());
+        let truncated = "(kicad_pcb (version 20241229) (generator \"test\")";
+        std::fs::write(&board, truncated).unwrap();
+
+        let args = json!({
+            "board": board.to_string_lossy(),
+            "footprint": modfile.to_string_lossy(),
+            "reference": "R1", "x": 1.0, "y": 2.0,
+        });
+        let err = handle_place_component(&args, &test_ctx())
+            .await
+            .expect_err("a malformed board must not be written back");
+        assert!(
+            err.to_string().contains("balanced"),
+            "error should explain why: {err}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&board).unwrap(),
+            truncated,
+            "board must be left exactly as it was"
         );
     }
 

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -607,10 +607,18 @@ async fn handle_place_component(
 /// the assumption is at least consistent.
 fn insert_into_board(board_path: &std::path::Path, blocks: &[String]) -> anyhow::Result<()> {
     let content = std::fs::read_to_string(board_path)?;
+    // KiCad writes these files CRLF on Windows — its bundled .kicad_mod
+    // libraries are CRLF throughout — so an inserted block joined with bare LF
+    // would leave the board with two conventions in it.
+    let eol = if content.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
     let close_pos = content.rfind(')').unwrap_or(content.len());
     let joined: String = blocks
         .iter()
-        .map(|b| format!("\n{}", indent_block(b.trim_end(), "\t")))
+        .map(|b| format!("{eol}{}", indent_block(b.trim_end(), "\t", eol)))
         .collect();
     let new_content = apply_edits(content, vec![SexpEdit::insert(close_pos, joined)]);
 
@@ -655,8 +663,11 @@ fn check_single_board_form(content: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Prefix every non-empty line with `indent`.
-fn indent_block(block: &str, indent: &str) -> String {
+/// Prefix every non-empty line with `indent`, joining them with `eol`.
+fn indent_block(block: &str, indent: &str, eol: &str) -> String {
+    // `lines()` strips a trailing \r along with the \n, so rejoining with `eol`
+    // re-imposes one convention on a block that may have arrived with another —
+    // a CRLF library footprint going into an LF board, or the reverse.
     block
         .lines()
         .map(|l| {
@@ -667,7 +678,7 @@ fn indent_block(block: &str, indent: &str) -> String {
             }
         })
         .collect::<Vec<_>>()
-        .join("\n")
+        .join(eol)
 }
 
 async fn handle_move_component(
@@ -1364,6 +1375,89 @@ mod footprint_sexp_tests {
         );
     }
 
+    /// Force LF, whatever the checkout did to this source file's literals.
+    ///
+    /// Git normalises these files to CRLF in a Windows working tree, so a
+    /// multi-line string literal here is CRLF locally and LF on CI. A test
+    /// about line endings has to state which it wants rather than inherit it.
+    fn lf(s: &str) -> String {
+        s.replace("\r\n", "\n")
+    }
+
+    /// Force CRLF, likewise.
+    fn crlf(s: &str) -> String {
+        lf(s).replace('\n', "\r\n")
+    }
+
+    #[tokio::test]
+    async fn a_crlf_board_stays_crlf() {
+        // KiCad writes these files CRLF on Windows — its bundled .kicad_mod
+        // libraries are CRLF throughout, verified against a 10.0 install — so
+        // placing into a CRLF board must not leave two conventions in it.
+        let tmp = tempfile::tempdir().unwrap();
+        let pretty = tmp.path().join("Resistor_SMD.pretty");
+        std::fs::create_dir_all(&pretty).unwrap();
+        let modfile = pretty.join("R_0805_2012Metric.kicad_mod");
+        std::fs::write(&modfile, crlf(&library_footprint())).unwrap();
+        let board = tmp.path().join("b.kicad_pcb");
+        std::fs::write(&board, crlf(EMPTY_BOARD)).unwrap();
+
+        let args = json!({
+            "board": board.to_string_lossy(),
+            "footprint": modfile.to_string_lossy(),
+            "reference": "R1", "x": 1.0, "y": 2.0,
+        });
+        let res = handle_place_component(&args, &test_ctx()).await.unwrap();
+        assert!(!res.is_error, "handler errored: {:?}", res.content);
+
+        let out = std::fs::read_to_string(&board).unwrap();
+        assert!(
+            out.contains("(pad \"1\" smd roundrect"),
+            "footprint missing"
+        );
+        let bare_lf = out
+            .match_indices('\n')
+            .filter(|(i, _)| *i == 0 || out.as_bytes()[i - 1] != b'\r')
+            .count();
+        assert_eq!(
+            bare_lf, 0,
+            "a CRLF board gained {bare_lf} bare LF line endings:
+{out:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_lf_board_stays_lf() {
+        // The reverse: a CRLF library footprint must not drag \r into an LF
+        // board, which is the common case on Linux and macOS.
+        let tmp = tempfile::tempdir().unwrap();
+        let pretty = tmp.path().join("Resistor_SMD.pretty");
+        std::fs::create_dir_all(&pretty).unwrap();
+        let modfile = pretty.join("R_0805_2012Metric.kicad_mod");
+        std::fs::write(&modfile, crlf(&library_footprint())).unwrap();
+        let board = tmp.path().join("b.kicad_pcb");
+        std::fs::write(&board, lf(EMPTY_BOARD)).unwrap();
+
+        let args = json!({
+            "board": board.to_string_lossy(),
+            "footprint": modfile.to_string_lossy(),
+            "reference": "R1", "x": 1.0, "y": 2.0,
+        });
+        let res = handle_place_component(&args, &test_ctx()).await.unwrap();
+        assert!(!res.is_error, "handler errored: {:?}", res.content);
+
+        let out = std::fs::read_to_string(&board).unwrap();
+        assert!(
+            out.contains("(pad \"1\" smd roundrect"),
+            "footprint missing"
+        );
+        assert!(
+            !out.contains('\r'),
+            "a CRLF library footprint dragged \\r into an LF board:
+{out:?}"
+        );
+    }
+
     #[tokio::test]
     async fn place_component_reports_which_path_it_took() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1581,12 +1675,20 @@ mod footprint_sexp_tests {
             indent_block(
                 "a
 
-b", "	"
+b", "	", "\n"
             ),
             "	a
 
 	b"
         );
+    }
+
+    #[test]
+    fn indent_block_reimposes_one_line_ending() {
+        // A CRLF library footprint going into an LF board and the reverse:
+        // whichever the destination uses is what comes out.
+        assert_eq!(indent_block("a\r\nb", "\t", "\n"), "\ta\n\tb");
+        assert_eq!(indent_block("a\nb", "\t", "\r\n"), "\ta\r\n\tb");
     }
 
     #[test]

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -6,9 +6,219 @@
 
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
+use crate::tools::library::resolve_footprint_path;
 use crate::tools::{get_path, require_f64, require_str, ToolContext, ToolDef};
 use konnect_ipc::client::KiCadIpcClient;
+use konnect_sexp::writer::{
+    apply_edits, find_balanced_block, find_block_starts, new_uuid, write_atomic,
+};
+use konnect_sexp::SexpEdit;
 use serde_json::json;
+
+// ─── Library footprint → board footprint ──────────────────────────────────────
+
+/// Build a board-ready `(footprint …)` block for `lib_id`.
+///
+/// A library `.kicad_mod` is a complete footprint definition sitting at the
+/// origin with a `REF**` placeholder reference. Placing it on a board means
+/// renaming it to the full `Library:Footprint` id, stamping in a position,
+/// rotation and fresh UUID, and substituting the real reference designator.
+///
+/// KiCAD's own parser then handles the pads and graphics, which is why the
+/// whole definition is forwarded rather than reconstructed.
+fn board_footprint_sexp(
+    lib_id: &str,
+    x: f64,
+    y: f64,
+    rotation: f64,
+    layer: &str,
+    reference: Option<&str>,
+) -> Result<String, String> {
+    let path = resolve_footprint_path(lib_id)?;
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Cannot read footprint {}: {}", path.display(), e))?;
+
+    let name_span = footprint_name_span(&content).ok_or_else(|| {
+        format!(
+            "{} does not start with a (footprint \"NAME\" …) block",
+            path.display()
+        )
+    })?;
+
+    // Board footprints carry the full library id, not the bare footprint name.
+    let mut out = String::with_capacity(content.len() + 128);
+    out.push_str(&content[..name_span.start]);
+    out.push_str(&escape_sexp_string(lib_id));
+    out.push_str(&format!(
+        "\n\t(at {x} {y} {rotation})\n\t(uuid \"{}\")",
+        new_uuid()
+    ));
+    out.push_str(&content[name_span.end..]);
+
+    if rotation != 0.0 {
+        out = apply_rotation_to_children(&out, rotation);
+    }
+    if let Some(reference) = reference {
+        out = replace_property_value(&out, "Reference", reference);
+    }
+    if layer != "F.Cu" {
+        out = replace_footprint_layer(&out, layer);
+    }
+
+    Ok(out)
+}
+
+/// Fold the footprint's placement rotation into its pads and text items.
+///
+/// KiCad stores each pad's and text item's *absolute* orientation while their
+/// positions stay in unrotated footprint-local coordinates — a `C_0603` placed
+/// at -90° keeps `(at -0.775 0 270)` on pad 1. Omitting this leaves the pad
+/// shapes unrotated relative to the body and makes KiCad's
+/// `lib_footprint_mismatch` check fire.
+///
+/// Text is additionally kept readable: KiCad flips an angle that would leave a
+/// label upside down by 180°, so a -90° footprint carries `90` on its reference.
+fn apply_rotation_to_children(content: &str, rotation: f64) -> String {
+    let mut out = content.to_string();
+
+    for tag in ["pad", "property", "fp_text"] {
+        let readable = tag != "pad";
+        // Rewrite back-to-front so earlier byte offsets stay valid.
+        let starts: Vec<usize> = find_block_starts(&out, tag);
+        for start in starts.into_iter().rev() {
+            let Some((bstart, bend)) = find_balanced_block(&out, start) else {
+                continue;
+            };
+            // The block's own `(at …)` is its first — nested ones (a pad's
+            // `(primitives …)`, for instance) come later.
+            let Some(at_start) = find_block_starts(&out[bstart..bend], "at")
+                .first()
+                .map(|i| bstart + i)
+            else {
+                continue;
+            };
+            let Some((astart, aend)) = find_balanced_block(&out, at_start) else {
+                continue;
+            };
+            let Some(rewritten) = rotate_at_block(&out[astart..aend], rotation, readable) else {
+                continue;
+            };
+            out.replace_range(astart..aend, &rewritten);
+        }
+    }
+    out
+}
+
+/// Rewrite `(at x y [angle])`, adding `rotation` to the angle.
+///
+/// Returns `None` when the block does not look like a positional `at`.
+fn rotate_at_block(block: &str, rotation: f64, readable: bool) -> Option<String> {
+    let inner = block.strip_prefix('(')?.strip_suffix(')')?;
+    let mut parts = inner.split_whitespace();
+    if parts.next()? != "at" {
+        return None;
+    }
+    let x: f64 = parts.next()?.parse().ok()?;
+    let y: f64 = parts.next()?.parse().ok()?;
+    let existing: f64 = parts.next().and_then(|a| a.parse().ok()).unwrap_or(0.0);
+    if parts.next().is_some() {
+        return None; // `(at …)` with unexpected extra tokens — leave alone.
+    }
+
+    let mut angle = (existing + rotation).rem_euclid(360.0);
+    if readable && angle > 90.0 && angle <= 270.0 {
+        angle -= 180.0;
+    }
+    Some(format_at(x, y, angle))
+}
+
+/// Render `(at x y angle)`, dropping a zero angle as KiCad's writer does and
+/// trimming trailing zeros from the decimals.
+fn format_at(x: f64, y: f64, angle: f64) -> String {
+    let n = |v: f64| {
+        let s = format!("{v:.6}");
+        let s = s.trim_end_matches('0').trim_end_matches('.').to_string();
+        if s == "-0" {
+            "0".to_string()
+        } else {
+            s
+        }
+    };
+    if angle == 0.0 {
+        format!("(at {} {})", n(x), n(y))
+    } else {
+        format!("(at {} {} {})", n(x), n(y), n(angle))
+    }
+}
+
+/// Byte range of the quoted name in the leading `(footprint "NAME"` header,
+/// including the surrounding quotes.
+fn footprint_name_span(content: &str) -> Option<std::ops::Range<usize>> {
+    let block = *find_block_starts(content, "footprint").first()?;
+    let after_tag = block + "(footprint".len();
+    let rel = content[after_tag..].find('"')?;
+    let start = after_tag + rel;
+    let end = start + 1 + content[start + 1..].find('"')?;
+    Some(start..end + 1)
+}
+
+/// Quote and escape `value` as an S-expression string literal.
+fn escape_sexp_string(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+/// Replace the value of the first `(property "<key>" "<value>" …)` entry.
+fn replace_property_value(content: &str, key: &str, value: &str) -> String {
+    let needle = format!("(property \"{key}\"");
+    let Some(prop) = find_block_starts(content, "property")
+        .into_iter()
+        .find(|&i| content[i..].starts_with(&needle))
+    else {
+        return content.to_string();
+    };
+    let after_key = prop + needle.len();
+    let Some(rel) = content[after_key..].find('"') else {
+        return content.to_string();
+    };
+    let vstart = after_key + rel;
+    let Some(rel_end) = content[vstart + 1..].find('"') else {
+        return content.to_string();
+    };
+    let vend = vstart + 1 + rel_end + 1;
+
+    let mut out = String::with_capacity(content.len());
+    out.push_str(&content[..vstart]);
+    out.push_str(&escape_sexp_string(value));
+    out.push_str(&content[vend..]);
+    out
+}
+
+/// Replace the footprint's own `(layer "…")` — the first `layer` block that is a
+/// direct child of the footprint, not one belonging to a pad or graphic.
+///
+/// Note this only retargets the footprint; a true F.Cu↔B.Cu flip would also
+/// have to mirror every child item, which KiCAD does itself when the user flips
+/// a placed footprint.
+fn replace_footprint_layer(content: &str, layer: &str) -> String {
+    let Some(name) = footprint_name_span(content) else {
+        return content.to_string();
+    };
+    let Some(start) = find_block_starts(content, "layer")
+        .into_iter()
+        .find(|&i| i > name.end)
+    else {
+        return content.to_string();
+    };
+    let Some((bstart, bend)) = find_balanced_block(content, start) else {
+        return content.to_string();
+    };
+
+    let mut out = String::with_capacity(content.len());
+    out.push_str(&content[..bstart]);
+    out.push_str(&format!("(layer {})", escape_sexp_string(layer)));
+    out.push_str(&content[bend..]);
+    out
+}
 
 // ─── IPC helper ───────────────────────────────────────────────────────────────
 
@@ -261,15 +471,80 @@ async fn handle_place_component(
     };
     let rotation = args["rotation"].as_f64().unwrap_or(0.0);
     let layer = args["layer"].as_str().unwrap_or("F.Cu").to_string();
+    let reference = args["reference"].as_str().map(str::to_string);
 
-    let fp = ipc!(ctx, |c| c
-        .place_footprint(&footprint, x, y, rotation, &layer));
-    Ok(CallToolResult::json(&json!({
-        "placed": fp.reference,
-        "footprint": fp.footprint,
-        "x": fp.position.x, "y": fp.position.y,
-        "rotation": fp.rotation, "layer": fp.layer
-    })))
+    let board_path = get_path(args, "board")?;
+    let sexp = match board_footprint_sexp(&footprint, x, y, rotation, &layer, reference.as_deref())
+    {
+        Ok(s) => s,
+        Err(msg) => return Ok(CallToolResult::error(msg)),
+    };
+
+    // Try IPC first, then fall back to editing the board file — the same
+    // strategy `pcb_board`'s tools use. KiCad 10.0 answers
+    // ParseAndCreateItemsFromString with an empty CreateItemsResponse and
+    // creates nothing, so in practice this always falls through; the IPC
+    // attempt is kept so the tool starts working the moment KiCad implements
+    // the command.
+    let sexp_ipc = sexp.clone();
+    let ipc_result = with_ipc(ctx.config.ipc_address.clone(), move |c| {
+        c.place_footprint(&sexp_ipc)
+    })
+    .await?;
+
+    if ipc_result.is_ok() {
+        return Ok(CallToolResult::json(&json!({
+            "placed": reference.unwrap_or_default(),
+            "footprint": footprint,
+            "x": x, "y": y, "rotation": rotation, "layer": layer,
+            "source": "ipc"
+        })));
+    }
+
+    // A "created no footprint" error means KiCad answered — so it is running and
+    // may hold this board open, in which case it cannot see a file edit and will
+    // overwrite it on its next save.
+    let kicad_reachable = ipc_result
+        .as_ref()
+        .err()
+        .is_some_and(|e| e.contains("created no footprint"));
+
+    let content = std::fs::read_to_string(&board_path)?;
+    let close_pos = content.rfind(')').unwrap_or(content.len());
+    let block = format!("\n{}", indent_block(sexp.trim_end(), "\t"));
+    let new_content = apply_edits(content, vec![SexpEdit::insert(close_pos, block)]);
+    write_atomic(&board_path, &new_content)?;
+
+    let mut out = json!({
+        "placed": reference.unwrap_or_default(),
+        "footprint": footprint,
+        "x": x, "y": y, "rotation": rotation, "layer": layer,
+        "source": "file"
+    });
+    if kicad_reachable {
+        out["warning"] = json!(
+            "KiCAD is running and could not place this over IPC (KiCAD 10.0's \
+             ParseAndCreateItemsFromString does nothing), so the board file was edited \
+             directly. If this board is open in the PCB editor, close it without saving \
+             and reopen it — otherwise KiCAD will overwrite this change."
+        );
+    }
+    Ok(CallToolResult::json(&out))
+}
+
+/// Prefix every non-empty line with `indent`.
+fn indent_block(block: &str, indent: &str) -> String {
+    block
+        .lines()
+        .map(|l| {
+            if l.trim().is_empty() {
+                String::new()
+            } else {
+                format!("{indent}{l}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 async fn handle_move_component(
@@ -512,35 +787,68 @@ async fn handle_place_array(
     let prefix = args["ref_prefix"].as_str().unwrap_or("U").to_string();
     let ref_start = args["ref_start"].as_u64().unwrap_or(1) as usize;
 
+    let board_path = get_path(args, "board")?;
+
+    // Build every block up front so a bad footprint id fails before anything is
+    // written or sent.
     let mut placed = Vec::new();
+    let mut blocks = Vec::new();
     let mut n = ref_start;
     for row in 0..count_y {
         for col in 0..count_x {
             let x = start_x + col as f64 * spacing_x;
             let y = start_y + row as f64 * spacing_y;
             let reference = format!("{prefix}{n}");
-            let fp_id = footprint.clone();
-            let ref2 = reference.clone();
-            match with_ipc(ctx.config.ipc_address.clone(), move |c| {
-                c.place_footprint(&fp_id, x, y, 0.0, "F.Cu")
-            })
-            .await?
-            {
-                Ok(fp) => placed
-                    .push(json!({ "reference": ref2, "x": fp.position.x, "y": fp.position.y })),
-                Err(e) => {
-                    return Ok(CallToolResult::error(format!(
-                        "IPC error placing {}: {}",
-                        reference, e
-                    )))
-                }
+            match board_footprint_sexp(&footprint, x, y, 0.0, "F.Cu", Some(&reference)) {
+                Ok(s) => blocks.push(s),
+                Err(msg) => return Ok(CallToolResult::error(msg)),
             }
+            placed.push(json!({ "reference": reference, "x": x, "y": y }));
             n += 1;
         }
     }
-    Ok(CallToolResult::json(
-        &json!({ "placed_count": placed.len(), "components": placed }),
-    ))
+
+    // Same IPC-then-file strategy as place_component.
+    let ipc_blocks = blocks.clone();
+    let ipc_result = with_ipc(ctx.config.ipc_address.clone(), move |c| {
+        for b in &ipc_blocks {
+            c.place_footprint(b)?;
+        }
+        Ok(())
+    })
+    .await?;
+
+    if ipc_result.is_ok() {
+        return Ok(CallToolResult::json(&json!({
+            "placed_count": placed.len(), "components": placed, "source": "ipc"
+        })));
+    }
+
+    let kicad_reachable = ipc_result
+        .as_ref()
+        .err()
+        .is_some_and(|e| e.contains("created no footprint"));
+
+    let content = std::fs::read_to_string(&board_path)?;
+    let close_pos = content.rfind(')').unwrap_or(content.len());
+    let joined: String = blocks
+        .iter()
+        .map(|b| format!("\n{}", indent_block(b.trim_end(), "\t")))
+        .collect();
+    let new_content = apply_edits(content, vec![SexpEdit::insert(close_pos, joined)]);
+    write_atomic(&board_path, &new_content)?;
+
+    let mut out = json!({
+        "placed_count": placed.len(), "components": placed, "source": "file"
+    });
+    if kicad_reachable {
+        out["warning"] = json!(
+            "KiCAD is running but cannot place footprints over IPC on KiCAD 10.0, so the \
+             board file was edited directly. If this board is open in the PCB editor, close \
+             it without saving and reopen it — otherwise KiCAD will overwrite this change."
+        );
+    }
+    Ok(CallToolResult::json(&out))
 }
 
 async fn handle_align_components(
@@ -593,7 +901,7 @@ async fn handle_duplicate_component(
         Ok(v) => v.to_string(),
         Err(e) => return Ok(e),
     };
-    let _new_reference = match require_str(args, "new_reference") {
+    let new_reference = match require_str(args, "new_reference") {
         Ok(v) => v.to_string(),
         Err(e) => return Ok(e),
     };
@@ -613,17 +921,24 @@ async fn handle_duplicate_component(
             .ok_or_else(|| anyhow::anyhow!("Footprint '{}' not found", ref_ipc))
     });
 
-    let fp = ipc!(ctx, |c| c.place_footprint(
+    let sexp = match board_footprint_sexp(
         &src.footprint,
         x,
         y,
         src.rotation,
-        &src.layer
-    ));
+        &src.layer,
+        Some(&new_reference),
+    ) {
+        Ok(s) => s,
+        Err(msg) => return Ok(CallToolResult::error(msg)),
+    };
+
+    ipc!(ctx, |c| c.place_footprint(&sexp));
     Ok(CallToolResult::json(&json!({
         "duplicated_from": reference,
-        "new_reference": fp.reference,
-        "x": fp.position.x, "y": fp.position.y
+        "new_reference": new_reference,
+        "footprint": src.footprint,
+        "x": x, "y": y, "rotation": src.rotation, "layer": src.layer
     })))
 }
 
@@ -658,4 +973,201 @@ async fn handle_get_board_2d_view(
 
     let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
     Ok(CallToolResult::image(b64, "image/png"))
+}
+
+#[cfg(test)]
+mod footprint_sexp_tests {
+    use super::*;
+
+    /// A library footprint in the exact shape KiCad ships: TAB-indented, name
+    /// without a library prefix, `REF**` placeholder, no `(at …)`.
+    fn library_footprint() -> String {
+        [
+            "(footprint \"R_0805_2012Metric\"",
+            "\t(version 20260206)",
+            "\t(generator \"kicad-footprint-generator\")",
+            "\t(layer \"F.Cu\")",
+            "\t(descr \"Resistor SMD 0805\")",
+            "\t(property \"Reference\" \"REF**\"",
+            "\t\t(at 0 -1.65 0)",
+            "\t\t(layer \"F.SilkS\")",
+            "\t)",
+            "\t(property \"Value\" \"R_0805_2012Metric\"",
+            "\t\t(at 0 1.65 0)",
+            "\t\t(layer \"F.Fab\")",
+            "\t)",
+            "\t(pad \"1\" smd roundrect",
+            "\t\t(at -0.9125 0)",
+            "\t\t(size 1.025 1.4)",
+            "\t\t(layers \"F.Cu\" \"F.Paste\" \"F.Mask\")",
+            "\t)",
+            ")",
+            "",
+        ]
+        .join("\r\n")
+    }
+
+    #[test]
+    fn name_span_covers_the_quoted_header_name() {
+        let c = library_footprint();
+        let span = footprint_name_span(&c).expect("header not found");
+        assert_eq!(&c[span], "\"R_0805_2012Metric\"");
+    }
+
+    #[test]
+    fn name_span_is_none_without_a_footprint_block() {
+        assert!(footprint_name_span("(kicad_pcb (version 20250610))").is_none());
+    }
+
+    #[test]
+    fn reference_substitution_targets_the_reference_property_only() {
+        let out = replace_property_value(&library_footprint(), "Reference", "R42");
+        assert!(out.contains("(property \"Reference\" \"R42\""), "{out}");
+        assert!(
+            out.contains("(property \"Value\" \"R_0805_2012Metric\""),
+            "Value must be untouched:\n{out}"
+        );
+        assert!(!out.contains("REF**"));
+    }
+
+    #[test]
+    fn reference_substitution_is_a_no_op_when_the_property_is_absent() {
+        let c = "(footprint \"X\"\n\t(layer \"F.Cu\")\n)";
+        assert_eq!(replace_property_value(c, "Reference", "R1"), c);
+    }
+
+    #[test]
+    fn layer_override_retargets_the_footprint_not_its_pads() {
+        let out = replace_footprint_layer(&library_footprint(), "B.Cu");
+        assert!(out.contains("(layer \"B.Cu\")"), "{out}");
+        // The pad's layer list and the silkscreen text layer must survive.
+        assert!(out.contains("(layers \"F.Cu\" \"F.Paste\" \"F.Mask\")"));
+        assert!(out.contains("(layer \"F.SilkS\")"));
+        assert_eq!(
+            out.matches("(layer \"B.Cu\")").count(),
+            1,
+            "only the footprint's own layer should change:\n{out}"
+        );
+    }
+
+    #[test]
+    fn pad_angles_absorb_the_footprint_rotation() {
+        // KiCad stores each pad's absolute orientation: a footprint placed at
+        // -90 carries 270 on its pads, while pad positions stay in unrotated
+        // footprint-local coordinates.
+        let out = apply_rotation_to_children(&library_footprint(), -90.0);
+        assert!(out.contains("(at -0.9125 0 270)"), "{out}");
+        // Position is unchanged; only the angle was added.
+        assert!(
+            !out.contains("(at 0 -0.9125"),
+            "pad position must not rotate"
+        );
+    }
+
+    #[test]
+    fn pad_angles_wrap_into_zero_to_360() {
+        let out = apply_rotation_to_children(&library_footprint(), 270.0);
+        assert!(out.contains("(at -0.9125 0 270)"), "{out}");
+        // 270 + 270 = 540 -> 180
+        let twice = apply_rotation_to_children(&out, 270.0);
+        assert!(twice.contains("(at -0.9125 0 180)"), "{twice}");
+    }
+
+    #[test]
+    fn text_angles_are_kept_readable() {
+        // A -90 footprint would put text at 270, which reads upside down, so
+        // KiCad flips it by 180 to 90 — matching what eeschema/pcbnew write.
+        let out = apply_rotation_to_children(&library_footprint(), -90.0);
+        assert!(
+            out.contains("(at 0 -1.65 90)"),
+            "reference text:
+{out}"
+        );
+        assert!(
+            out.contains("(at 0 1.65 90)"),
+            "value text:
+{out}"
+        );
+    }
+
+    #[test]
+    fn zero_rotation_is_written_without_an_angle() {
+        assert_eq!(format_at(1.5, -2.0, 0.0), "(at 1.5 -2)");
+        assert_eq!(format_at(0.0, 0.0, 90.0), "(at 0 0 90)");
+    }
+
+    #[test]
+    fn rotate_at_block_rejects_non_positional_at() {
+        assert!(rotate_at_block("(at)", 90.0, false).is_none());
+        assert!(rotate_at_block("(atomic 1 2)", 90.0, false).is_none());
+        assert!(rotate_at_block("(at 1 2 3 4)", 90.0, false).is_none());
+    }
+
+    #[test]
+    fn indent_block_prefixes_each_line_and_leaves_blanks_alone() {
+        assert_eq!(
+            indent_block(
+                "a
+
+b", "	"
+            ),
+            "	a
+
+	b"
+        );
+    }
+
+    #[test]
+    fn sexp_strings_are_escaped() {
+        // Input characters:  a " b \ c
+        // Expected output:   " a \ " b \ \ c "
+        let input = ['a', '"', 'b', '\\', 'c'].iter().collect::<String>();
+        let expected = ['"', 'a', '\\', '"', 'b', '\\', '\\', 'c', '"']
+            .iter()
+            .collect::<String>();
+        assert_eq!(escape_sexp_string(&input), expected);
+        assert_eq!(escape_sexp_string("plain"), "\"plain\"");
+    }
+
+    /// The end-to-end transform, exercised through a real library file on disk.
+    #[test]
+    fn board_footprint_carries_the_definition_position_and_reference() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pretty = tmp.path().join("Resistor_SMD.pretty");
+        std::fs::create_dir_all(&pretty).unwrap();
+        std::fs::write(
+            pretty.join("R_0805_2012Metric.kicad_mod"),
+            library_footprint(),
+        )
+        .unwrap();
+
+        // resolve_footprint_path takes a plain path when it isn't a lib id.
+        let direct = pretty.join("R_0805_2012Metric.kicad_mod");
+        let content = std::fs::read_to_string(&direct).unwrap();
+        let span = footprint_name_span(&content).unwrap();
+
+        // Reproduce board_footprint_sexp's transform on the resolved content so
+        // the assertions do not depend on the machine's fp-lib-table.
+        let mut out = String::new();
+        out.push_str(&content[..span.start]);
+        out.push_str(&escape_sexp_string("Resistor_SMD:R_0805_2012Metric"));
+        out.push_str("\n\t(at 50 60 90)\n\t(uuid \"fixed-uuid\")");
+        out.push_str(&content[span.end..]);
+        let out = replace_property_value(&out, "Reference", "R7");
+
+        // The library id replaces the bare name.
+        assert!(
+            out.starts_with("(footprint \"Resistor_SMD:R_0805_2012Metric\""),
+            "{out}"
+        );
+        // Placement is stamped in.
+        assert!(out.contains("(at 50 60 90)"));
+        assert!(out.contains("(uuid \"fixed-uuid\")"));
+        // The reference designator is real, not the placeholder.
+        assert!(out.contains("(property \"Reference\" \"R7\""));
+        // Critically, the pad definition survives — a body-less stub is exactly
+        // what made KiCad create nothing.
+        assert!(out.contains("(pad \"1\" smd roundrect"));
+        assert!(out.contains("(size 1.025 1.4)"));
+    }
 }

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -33,8 +33,9 @@ fn board_footprint_sexp(
     rotation: f64,
     layer: &str,
     reference: Option<&str>,
+    project_dir: Option<&std::path::Path>,
 ) -> Result<String, String> {
-    let path = resolve_footprint_path(lib_id)?;
+    let path = resolve_footprint_path(lib_id, project_dir)?;
     let content = std::fs::read_to_string(&path)
         .map_err(|e| format!("Cannot read footprint {}: {}", path.display(), e))?;
 
@@ -538,8 +539,17 @@ async fn handle_place_component(
     let reference = args["reference"].as_str().map(str::to_string);
 
     let board_path = get_path(args, "board")?;
-    let sexp = match board_footprint_sexp(&footprint, x, y, rotation, &layer, reference.as_deref())
-    {
+    // The board's own directory is the project, so a library registered with
+    // register_footprint_library's default project scope resolves here.
+    let sexp = match board_footprint_sexp(
+        &footprint,
+        x,
+        y,
+        rotation,
+        &layer,
+        reference.as_deref(),
+        board_path.parent(),
+    ) {
         Ok(s) => s,
         Err(msg) => return Ok(CallToolResult::error(msg)),
     };
@@ -933,7 +943,15 @@ async fn handle_place_array(
             let x = start_x + col as f64 * spacing_x;
             let y = start_y + row as f64 * spacing_y;
             let reference = format!("{prefix}{n}");
-            match board_footprint_sexp(&footprint, x, y, 0.0, "F.Cu", Some(&reference)) {
+            match board_footprint_sexp(
+                &footprint,
+                x,
+                y,
+                0.0,
+                "F.Cu",
+                Some(&reference),
+                board_path.parent(),
+            ) {
                 Ok(s) => blocks.push(s),
                 Err(msg) => return Ok(CallToolResult::error(msg)),
             }
@@ -1048,6 +1066,7 @@ async fn handle_duplicate_component(
             .ok_or_else(|| anyhow::anyhow!("Footprint '{}' not found", ref_ipc))
     });
 
+    let board_path = get_path(args, "board")?;
     let sexp = match board_footprint_sexp(
         &src.footprint,
         x,
@@ -1055,6 +1074,7 @@ async fn handle_duplicate_component(
         src.rotation,
         &src.layer,
         Some(&new_reference),
+        board_path.parent(),
     ) {
         Ok(s) => s,
         Err(msg) => return Ok(CallToolResult::error(msg)),

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -1049,13 +1049,36 @@ async fn handle_duplicate_component(
         Err(msg) => return Ok(CallToolResult::error(msg)),
     };
 
-    ipc!(ctx, |c| c.place_footprint(&sexp));
-    Ok(CallToolResult::json(&json!({
+    // Same IPC-then-file strategy as place_component. Without it this tool
+    // would be the one place that still hard-fails on KiCAD 10.0, whose
+    // ParseAndCreateItemsFromString creates nothing — and unlike the other two,
+    // reaching here already proves KiCAD is running, since the source footprint
+    // was read over IPC above.
+    let sexp_ipc = sexp.clone();
+    let ipc_result = with_ipc(ctx.config.ipc_address.clone(), move |c| {
+        c.place_footprint(&sexp_ipc)
+    })
+    .await?;
+
+    let mut out = json!({
         "duplicated_from": reference,
         "new_reference": new_reference,
         "footprint": src.footprint,
-        "x": x, "y": y, "rotation": src.rotation, "layer": src.layer
-    })))
+        "x": x, "y": y, "rotation": src.rotation, "layer": src.layer,
+        "source": if ipc_result.is_ok() { "ipc" } else { "file" }
+    });
+
+    if ipc_result.is_err() {
+        let board_path = get_path(args, "board")?;
+        insert_into_board(&board_path, std::slice::from_ref(&sexp))?;
+        out["warning"] = json!(
+            "KiCAD is running but could not duplicate this over IPC (KiCAD 10.0's \
+             ParseAndCreateItemsFromString does nothing), so the board file was edited \
+             directly. If this board is open in the PCB editor, close it without saving \
+             and reopen it — otherwise KiCAD will overwrite this change."
+        );
+    }
+    Ok(CallToolResult::json(&out))
 }
 
 async fn handle_get_board_2d_view(

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -1007,6 +1007,202 @@ mod footprint_sexp_tests {
         .join("\r\n")
     }
 
+    fn test_ctx() -> ToolContext {
+        // No IPC address: the handler's IPC attempt fails immediately and it
+        // takes the file path, which is what KiCad 10.0 forces in practice
+        // anyway (ParseAndCreateItemsFromString creates nothing).
+        ToolContext::new(
+            crate::tools::ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+            },
+            std::sync::Arc::new(crate::router::ToolRouter::new()),
+        )
+    }
+
+    const EMPTY_BOARD: &str = "(kicad_pcb
+	(version 20260206)
+	(generator \"pcbnew\")
+	(net 0 \"\")
+)
+";
+
+    /// Write a library footprint and an empty board into `dir`.
+    fn fixture(dir: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+        let modfile = dir.join("R_0805_2012Metric.kicad_mod");
+        std::fs::write(&modfile, library_footprint()).unwrap();
+        let board = dir.join("b.kicad_pcb");
+        std::fs::write(&board, EMPTY_BOARD).unwrap();
+        (modfile, board)
+    }
+
+    #[tokio::test]
+    async fn place_component_puts_a_real_footprint_on_the_board() {
+        // Regression: place_component reported success while the board stayed
+        // empty. It sent a body-less stub — (footprint "Lib:Fp") with a layer
+        // and a position and nothing else — and discarded KiCad's response, so
+        // two "successful" placements followed by a save produced a board file
+        // containing zero footprints.
+        let tmp = tempfile::tempdir().unwrap();
+        let (modfile, board) = fixture(tmp.path());
+
+        let args = json!({
+            "board": board.to_string_lossy(),
+            // A direct path skips the fp-lib-table, keeping this test hermetic.
+            "footprint": modfile.to_string_lossy(),
+            "reference": "R7",
+            "x": 50.0, "y": 60.0,
+        });
+        let res = handle_place_component(&args, &test_ctx()).await.unwrap();
+        assert!(!res.is_error, "handler errored: {:?}", res.content);
+
+        let out = std::fs::read_to_string(&board).unwrap();
+        assert_eq!(
+            out.matches("(footprint \"").count(),
+            1,
+            "no footprint:
+{out}"
+        );
+        assert!(
+            out.contains("(at 50 60 0)"),
+            "placement missing:
+{out}"
+        );
+        assert!(out.contains("(property \"Reference\" \"R7\""), "{out}");
+        // The heart of the bug: the payload must carry the real definition.
+        assert!(
+            out.contains("(pad \"1\" smd roundrect"),
+            "pads missing:
+{out}"
+        );
+        assert!(out.contains("(size 1.025 1.4)"), "pad geometry missing");
+        assert!(out.contains("(uuid \""), "board items need a uuid");
+        assert_eq!(
+            count_parens(&out),
+            0,
+            "board is no longer balanced:
+{out}"
+        );
+    }
+
+    #[tokio::test]
+    async fn place_component_reports_which_path_it_took() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (modfile, board) = fixture(tmp.path());
+        let args = json!({
+            "board": board.to_string_lossy(),
+            "footprint": modfile.to_string_lossy(),
+            "reference": "R1", "x": 1.0, "y": 2.0,
+        });
+        let res = handle_place_component(&args, &test_ctx()).await.unwrap();
+        let out: serde_json::Value = serde_json::from_str(&result_text(&res)).unwrap();
+        assert_eq!(out["source"], "file");
+        assert_eq!(out["placed"], "R1");
+        // KiCad was never reachable here, so no reopen warning is warranted.
+        assert!(out.get("warning").is_none(), "unexpected warning: {out}");
+    }
+
+    #[tokio::test]
+    async fn place_component_rejects_an_unknown_footprint_without_touching_the_board() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (_, board) = fixture(tmp.path());
+        let args = json!({
+            "board": board.to_string_lossy(),
+            "footprint": tmp.path().join("does_not_exist.kicad_mod").to_string_lossy(),
+            "reference": "R1", "x": 1.0, "y": 2.0,
+        });
+        let res = handle_place_component(&args, &test_ctx()).await.unwrap();
+        assert!(res.is_error, "a missing footprint must be an error");
+        assert_eq!(
+            std::fs::read_to_string(&board).unwrap(),
+            EMPTY_BOARD,
+            "board must be left untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn placed_rotation_reaches_the_pads() {
+        // A rotated placement whose pads keep angle 0 trips KiCad's own
+        // lib_footprint_mismatch check, so the rotation has to reach them.
+        let tmp = tempfile::tempdir().unwrap();
+        let (modfile, board) = fixture(tmp.path());
+        let args = json!({
+            "board": board.to_string_lossy(),
+            "footprint": modfile.to_string_lossy(),
+            "reference": "R1", "x": 10.0, "y": 20.0, "rotation": -90.0,
+        });
+        let res = handle_place_component(&args, &test_ctx()).await.unwrap();
+        assert!(!res.is_error, "{:?}", res.content);
+
+        let out = std::fs::read_to_string(&board).unwrap();
+        assert!(
+            out.contains("(at 10 20 -90)"),
+            "footprint angle:
+{out}"
+        );
+        assert!(
+            out.contains("(at -0.9125 0 270)"),
+            "pad angle:
+{out}"
+        );
+        assert!(
+            out.contains("(at 0 -1.65 90)"),
+            "readable text angle:
+{out}"
+        );
+    }
+
+    #[tokio::test]
+    async fn place_component_array_writes_every_instance() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (modfile, board) = fixture(tmp.path());
+        let args = json!({
+            "board": board.to_string_lossy(),
+            "footprint": modfile.to_string_lossy(),
+            "start_x": 10.0, "start_y": 10.0,
+            "count_x": 3, "count_y": 2, "spacing_x": 5.0,
+            "ref_prefix": "R", "ref_start": 1,
+        });
+        let res = handle_place_array(&args, &test_ctx()).await.unwrap();
+        assert!(!res.is_error, "{:?}", res.content);
+
+        let out = std::fs::read_to_string(&board).unwrap();
+        assert_eq!(out.matches("(footprint \"").count(), 6, "{out}");
+        for r in ["R1", "R2", "R3", "R4", "R5", "R6"] {
+            assert!(
+                out.contains(&format!("(property \"Reference\" \"{r}\"")),
+                "missing {r}"
+            );
+        }
+        assert_eq!(count_parens(&out), 0, "board is no longer balanced");
+    }
+
+    /// Net paren depth, ignoring anything inside quoted strings.
+    fn count_parens(s: &str) -> i32 {
+        let (mut depth, mut in_str, mut esc) = (0i32, false, false);
+        for ch in s.chars() {
+            match ch {
+                _ if esc => esc = false,
+                '\\' if in_str => esc = true,
+                '"' => in_str = !in_str,
+                '(' if !in_str => depth += 1,
+                ')' if !in_str => depth -= 1,
+                _ => {}
+            }
+        }
+        depth
+    }
+
+    fn result_text(res: &CallToolResult) -> String {
+        match res.content.first() {
+            Some(crate::mcp::protocol::ToolContent::Text { text }) => text.clone(),
+            other => panic!("expected text content, got {other:?}"),
+        }
+    }
+
     #[test]
     fn name_span_covers_the_quoted_header_name() {
         let c = library_footprint();

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -695,11 +695,14 @@ impl KiCadIpcClient {
         let mut outcome = CreateOutcome::default();
         for result in &resp.created_items {
             let code = result.status.as_ref().map(|s| s.code);
-            // A missing status with an item attached is treated as created:
-            // some paths populate the item and leave the status defaulted.
-            let ok = code == Some(ItemStatusCode::IscOk as i32)
-                || (code.is_none_or(|c| c == ItemStatusCode::IscUnknown as i32)
-                    && result.item.is_some());
+            // ISC_OK is the real signal. A status that is absent *or* left at
+            // the ISC_UNKNOWN zero value counts too, but only when an item is
+            // attached: some paths populate the item and never set the status,
+            // and protobuf cannot tell "unset" from "explicitly zero" anyway.
+            // Without an item there is nothing to have created, so it is a
+            // failure regardless.
+            let unset = code.is_none_or(|c| c == ItemStatusCode::IscUnknown as i32);
+            let ok = code == Some(ItemStatusCode::IscOk as i32) || (unset && result.item.is_some());
             if ok {
                 outcome.created += 1;
             } else {

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -652,46 +652,58 @@ impl KiCadIpcClient {
         self.delete_items(vec![kiid])
     }
 
-    /// Place a footprint — currently requires KiCAD's ParseAndCreateItemsFromString.
-    pub fn place_footprint(
-        &self,
-        lib_id: &str,
-        x: f64,
-        y: f64,
-        rotation: f64,
-        layer: &str,
-    ) -> Result<IpcFootprint> {
-        // KiCAD 10 IPC doesn't have a direct "place footprint from library" command.
-        // The CreateItems command requires a fully formed FootprintInstance protobuf,
-        // which needs the complete footprint definition (pads, shapes, etc.) from the library.
-        // For now, use ParseAndCreateItemsFromString with S-expression format.
-        let sexp = format!(
-            r#"(footprint "{lib_id}"
-  (layer "{layer}")
-  (at {x} {y} {rotation})
-)"#,
-            lib_id = lib_id,
-            layer = layer,
-            x = crate::builders::mm_to_nm(x) as f64 / 1_000_000.0,
-            y = crate::builders::mm_to_nm(y) as f64 / 1_000_000.0,
-            rotation = rotation,
-        );
-
+    /// Paste a fully-formed S-expression into the open board, the way the
+    /// editor's Paste action does, and report how many items KiCAD created.
+    ///
+    /// KiCAD answers with a `CreateItemsResponse` whose own documentation warns
+    /// that the overall status "may return IRS_OK even if no items were
+    /// created", so the per-item results are the only trustworthy signal. An
+    /// unparseable payload therefore looks like a success at the transport
+    /// level and must be caught by inspecting `created_items`.
+    pub fn parse_and_create_items(&self, contents: &str) -> Result<usize> {
         let doc = self.get_board_document()?;
         let cmd = kiapi::common::commands::ParseAndCreateItemsFromString {
             document: Some(doc),
-            contents: sexp,
+            contents: contents.to_string(),
         };
-        self.send_command(&cmd, "kiapi.common.commands.ParseAndCreateItemsFromString")?;
+        let resp_any =
+            self.send_command(&cmd, "kiapi.common.commands.ParseAndCreateItemsFromString")?;
 
-        Ok(IpcFootprint {
-            reference: String::new(),
-            value: String::new(),
-            footprint: lib_id.to_string(),
-            position: IpcVector2 { x, y },
-            rotation,
-            layer: layer.to_string(),
-        })
+        let Some(any) = resp_any else {
+            anyhow::bail!("KiCAD returned no response to ParseAndCreateItemsFromString");
+        };
+        let resp: kiapi::common::commands::CreateItemsResponse = unpack_any(&any)?;
+        tracing::debug!(
+            type_url = %any.type_url,
+            body_len = any.value.len(),
+            status = resp.status,
+            created = resp.created_items.len(),
+            "ParseAndCreateItemsFromString response"
+        );
+        Ok(resp.created_items.len())
+    }
+
+    /// Place a footprint on the open board from a fully-formed `(footprint …)`
+    /// S-expression.
+    ///
+    /// The caller supplies the complete block — read from the library's
+    /// `.kicad_mod` and stamped with position, rotation and reference — because
+    /// KiCAD's parser needs the real pad and graphic definitions. The previous
+    /// implementation synthesised a three-line stub naming the library id with
+    /// no body; KiCAD parsed it to nothing and, since the response was
+    /// discarded, every call reported success while the board stayed empty.
+    /// This is the same failure the `(via …)` path had before it moved to a
+    /// typed message — see [`add_via`](Self::add_via).
+    pub fn place_footprint(&self, footprint_sexp: &str) -> Result<usize> {
+        let created = self.parse_and_create_items(footprint_sexp)?;
+        if created == 0 {
+            anyhow::bail!(
+                "KiCAD accepted the request but created no footprint — the S-expression was \
+                 rejected by its parser. This usually means the library footprint could not be \
+                 read or is not valid for this KiCAD version."
+            );
+        }
+        Ok(created)
     }
 
     /// Get board extents (bounding box of all items).

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -65,6 +65,15 @@ pub struct KiCadIpcClient {
     client_name: String,
 }
 
+/// What KiCAD actually did with a `ParseAndCreateItemsFromString` payload.
+#[derive(Debug, Default)]
+pub struct CreateOutcome {
+    /// Items KiCAD reported as genuinely created.
+    pub created: usize,
+    /// Per-item rejections, as `code: message`, for the ones it did not.
+    pub failures: Vec<String>,
+}
+
 impl KiCadIpcClient {
     /// Create a client connecting to the given IPC socket path.
     /// If empty, tries KICAD_API_SOCKET environment variable.
@@ -653,14 +662,23 @@ impl KiCadIpcClient {
     }
 
     /// Paste a fully-formed S-expression into the open board, the way the
-    /// editor's Paste action does, and report how many items KiCAD created.
+    /// editor's Paste action does, and report what KiCAD made of it.
     ///
     /// KiCAD answers with a `CreateItemsResponse` whose own documentation warns
     /// that the overall status "may return IRS_OK even if no items were
     /// created", so the per-item results are the only trustworthy signal. An
     /// unparseable payload therefore looks like a success at the transport
     /// level and must be caught by inspecting `created_items`.
-    pub fn parse_and_create_items(&self, contents: &str) -> Result<usize> {
+    ///
+    /// `created_items` is not a list of successes, though: the field is
+    /// documented as "status of each item **to be** created", so a rejected
+    /// item still occupies a slot, carrying a code like `ISC_INVALID_DATA` and
+    /// no `item`. Counting the vector's length would therefore call a wholesale
+    /// rejection a success — the very phantom-success this API exists to
+    /// prevent. Only `ISC_OK` entries count.
+    pub fn parse_and_create_items(&self, contents: &str) -> Result<CreateOutcome> {
+        use kiapi::common::commands::ItemStatusCode;
+
         let doc = self.get_board_document()?;
         let cmd = kiapi::common::commands::ParseAndCreateItemsFromString {
             document: Some(doc),
@@ -673,14 +691,46 @@ impl KiCadIpcClient {
             anyhow::bail!("KiCAD returned no response to ParseAndCreateItemsFromString");
         };
         let resp: kiapi::common::commands::CreateItemsResponse = unpack_any(&any)?;
+
+        let mut outcome = CreateOutcome::default();
+        for result in &resp.created_items {
+            let code = result.status.as_ref().map(|s| s.code);
+            // A missing status with an item attached is treated as created:
+            // some paths populate the item and leave the status defaulted.
+            let ok = code == Some(ItemStatusCode::IscOk as i32)
+                || (code.is_none_or(|c| c == ItemStatusCode::IscUnknown as i32)
+                    && result.item.is_some());
+            if ok {
+                outcome.created += 1;
+            } else {
+                let message = result
+                    .status
+                    .as_ref()
+                    .map(|s| {
+                        let name = ItemStatusCode::try_from(s.code)
+                            .map(|c| format!("{c:?}"))
+                            .unwrap_or_else(|_| format!("code {}", s.code));
+                        if s.error_message.is_empty() {
+                            name
+                        } else {
+                            format!("{name}: {}", s.error_message)
+                        }
+                    })
+                    .unwrap_or_else(|| "no status reported".to_string());
+                outcome.failures.push(message);
+            }
+        }
+
         tracing::debug!(
             type_url = %any.type_url,
             body_len = any.value.len(),
             status = resp.status,
-            created = resp.created_items.len(),
+            results = resp.created_items.len(),
+            created = outcome.created,
+            failures = ?outcome.failures,
             "ParseAndCreateItemsFromString response"
         );
-        Ok(resp.created_items.len())
+        Ok(outcome)
     }
 
     /// Place a footprint on the open board from a fully-formed `(footprint …)`
@@ -695,15 +745,19 @@ impl KiCadIpcClient {
     /// This is the same failure the `(via …)` path had before it moved to a
     /// typed message — see [`add_via`](Self::add_via).
     pub fn place_footprint(&self, footprint_sexp: &str) -> Result<usize> {
-        let created = self.parse_and_create_items(footprint_sexp)?;
-        if created == 0 {
+        let outcome = self.parse_and_create_items(footprint_sexp)?;
+        if outcome.created == 0 {
+            let why = if outcome.failures.is_empty() {
+                "its parser produced no items at all".to_string()
+            } else {
+                format!("KiCAD rejected it — {}", outcome.failures.join("; "))
+            };
             anyhow::bail!(
-                "KiCAD accepted the request but created no footprint — the S-expression was \
-                 rejected by its parser. This usually means the library footprint could not be \
-                 read or is not valid for this KiCAD version."
+                "KiCAD accepted the request but created no footprint: {why}. This usually means \
+                 the library footprint could not be read or is not valid for this KiCAD version."
             );
         }
-        Ok(created)
+        Ok(outcome.created)
     }
 
     /// Get board extents (bounding box of all items).

--- a/crates/konnect-ipc/tests/mock_server_test.rs
+++ b/crates/konnect-ipc/tests/mock_server_test.rs
@@ -174,3 +174,125 @@ fn wedged_server_times_out_instead_of_hanging() {
         "expected ~30s recv timeout, got {elapsed:?}"
     );
 }
+
+// ─── ParseAndCreateItemsFromString outcome handling ───────────────────────────
+
+/// A mock KiCAD with one board open that answers every paste with `results`.
+///
+/// `place_footprint` first asks for the open document, so the mock has to
+/// answer two different commands.
+fn spawn_mock_pasting(results: Vec<kiapi::common::commands::ItemCreationResult>) -> MockKicad {
+    spawn_mock(move |req| {
+        let msg = req.message.expect("request must pack a command");
+        let body = if msg.type_url.ends_with("GetOpenDocuments") {
+            pack(
+                &kiapi::common::commands::GetOpenDocumentsResponse {
+                    documents: vec![kiapi::common::types::DocumentSpecifier::default()],
+                },
+                "kiapi.common.commands.GetOpenDocumentsResponse",
+            )
+        } else {
+            pack(
+                &kiapi::common::commands::CreateItemsResponse {
+                    header: None,
+                    // IRS_OK even though nothing was created — the response
+                    // shape the proto explicitly warns about.
+                    status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                    created_items: results.clone(),
+                },
+                "kiapi.common.commands.CreateItemsResponse",
+            )
+        };
+        Some(kiapi::common::ApiResponse {
+            message: Some(body),
+            ..ok_response()
+        })
+    })
+}
+
+fn pack<M: Message>(msg: &M, type_name: &str) -> prost_types::Any {
+    prost_types::Any {
+        type_url: format!("type.googleapis.com/{type_name}"),
+        value: msg.encode_to_vec(),
+    }
+}
+
+fn result_with(
+    code: kiapi::common::commands::ItemStatusCode,
+    message: &str,
+) -> kiapi::common::commands::ItemCreationResult {
+    kiapi::common::commands::ItemCreationResult {
+        status: Some(kiapi::common::commands::ItemStatus {
+            code: code as i32,
+            error_message: message.to_string(),
+        }),
+        item: None,
+    }
+}
+
+#[test]
+fn a_rejected_item_is_not_counted_as_created() {
+    // The regression this guards: created_items is documented as "status of
+    // each item TO BE created", so a rejection still occupies a slot. Counting
+    // the vector's length would call this a success and put the phantom back.
+    let mock = spawn_mock_pasting(vec![result_with(
+        kiapi::common::commands::ItemStatusCode::IscInvalidData,
+        "footprint has no pads",
+    )]);
+
+    let client = KiCadIpcClient::new(&mock.url);
+    let err = client
+        .place_footprint("(footprint \"Lib:Fp\")")
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        err.contains("created no footprint"),
+        "must report failure: {err}"
+    );
+    // The per-item reason is what makes this diagnosable.
+    assert!(
+        err.contains("IscInvalidData") && err.contains("footprint has no pads"),
+        "must surface KiCAD's own reason: {err}"
+    );
+}
+
+#[test]
+fn an_empty_result_list_still_reports_failure() {
+    // KiCAD 10.0's actual behaviour: an empty CreateItemsResponse.
+    let mock = spawn_mock_pasting(vec![]);
+    let client = KiCadIpcClient::new(&mock.url);
+    let err = client
+        .place_footprint("(footprint \"Lib:Fp\")")
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("created no footprint"), "unexpected: {err}");
+    assert!(err.contains("no items at all"), "unexpected: {err}");
+}
+
+#[test]
+fn a_created_item_counts() {
+    let mock = spawn_mock_pasting(vec![result_with(
+        kiapi::common::commands::ItemStatusCode::IscOk,
+        "",
+    )]);
+    let client = KiCadIpcClient::new(&mock.url);
+    assert_eq!(client.place_footprint("(footprint \"Lib:Fp\")").unwrap(), 1);
+}
+
+#[test]
+fn a_mixed_response_counts_only_the_successes() {
+    let mock = spawn_mock_pasting(vec![
+        result_with(kiapi::common::commands::ItemStatusCode::IscOk, ""),
+        result_with(
+            kiapi::common::commands::ItemStatusCode::IscInvalidData,
+            "bad",
+        ),
+    ]);
+    let client = KiCadIpcClient::new(&mock.url);
+    let outcome = client
+        .parse_and_create_items("(footprint \"Lib:Fp\")")
+        .unwrap();
+    assert_eq!(outcome.created, 1);
+    assert_eq!(outcome.failures.len(), 1);
+}

--- a/crates/konnect-ipc/tests/mock_server_test.rs
+++ b/crates/konnect-ipc/tests/mock_server_test.rs
@@ -281,6 +281,38 @@ fn a_created_item_counts() {
 }
 
 #[test]
+fn a_defaulted_status_counts_only_when_an_item_came_back() {
+    // Protobuf cannot distinguish "unset" from "explicitly zero", so an
+    // ISC_UNKNOWN status is only evidence of success if an item is attached.
+    let with_item = kiapi::common::commands::ItemCreationResult {
+        status: None,
+        item: Some(prost_types::Any::default()),
+    };
+    let mock = spawn_mock_pasting(vec![with_item]);
+    let client = KiCadIpcClient::new(&mock.url);
+    assert_eq!(
+        client.place_footprint("(footprint \"Lib:Fp\")").unwrap(),
+        1,
+        "an item with a defaulted status was still created"
+    );
+
+    // The same defaulted status with nothing attached created nothing.
+    let without_item = kiapi::common::commands::ItemCreationResult {
+        status: Some(kiapi::common::commands::ItemStatus {
+            code: kiapi::common::commands::ItemStatusCode::IscUnknown as i32,
+            error_message: String::new(),
+        }),
+        item: None,
+    };
+    let mock = spawn_mock_pasting(vec![without_item]);
+    let client = KiCadIpcClient::new(&mock.url);
+    assert!(
+        client.place_footprint("(footprint \"Lib:Fp\")").is_err(),
+        "a bare ISC_UNKNOWN with no item must not count as created"
+    );
+}
+
+#[test]
 fn a_mixed_response_counts_only_the_successes() {
     let mock = spawn_mock_pasting(vec![
         result_with(kiapi::common::commands::ItemStatusCode::IscOk, ""),


### PR DESCRIPTION
Fixes #61.

> Stacked on #65 — that PR's lib-table fix is what makes `Library:Footprint`
> ids resolve at all, so this one needs it. Review the top two commits here.

## The symptom

`place_component` reported success on every call while the board stayed empty.
Two "successful" placements followed by a save produced a `.kicad_pcb`
containing zero footprints.

## Root cause

Two independent failures that combined to hide each other.

**The payload had no body.** The tool synthesised a three-line stub — a
`(footprint "Lib:Fp")` with a layer and a position and nothing else. KiCad's
parser needs the real pad and graphic definitions; given a body-less stub it
parses it to nothing and creates no item.

**The response was discarded.** `ParseAndCreateItemsFromString` returns a
`CreateItemsResponse` whose own documentation warns that the overall status
"may return IRS_OK even if no items were created". The per-item results are the
only trustworthy signal, and they were never read — so a payload KiCad rejected
outright still looked like success at the transport level.

This is the same failure the `(via …)` path had before it moved to a typed
message; see `add_via`.

## The fix

**Send the real definition.** A library `.kicad_mod` is already a complete
footprint sitting at the origin with a `REF**` placeholder. Placing it means
renaming it to the full library id, stamping in position, rotation and a fresh
UUID, and substituting the real reference designator — then letting KiCad's own
parser handle the pads and graphics. The whole definition is forwarded rather
than reconstructed.

**Believe the response.** `place_footprint` now fails when KiCad reports zero
created items, with an error that says the S-expression was rejected by the
parser rather than claiming success.

**Rotation reaches the children.** KiCad stores each pad's and text item's
*absolute* orientation while their positions stay in unrotated footprint-local
coordinates — a part placed at -90° keeps `(at -0.775 0 270)` on pad 1. Omitting
this leaves pad shapes unrotated relative to the body and trips KiCad's own
`lib_footprint_mismatch` check. Text is additionally kept readable, matching
KiCad's 180° flip for labels that would otherwise be upside down.

**IPC first, then the file.** KiCad 10.0 answers
`ParseAndCreateItemsFromString` with an empty response and creates nothing, so
in practice this always falls through to editing the board file. The IPC attempt
is kept so the tool starts working the moment KiCad implements the command. When
KiCad is reachable but did nothing, the result carries a warning that the board
was edited on disk and must be reopened, since an open editor would otherwise
overwrite it on next save.

## Compatibility

No tool names, schema fields or config keys change, so nothing to migrate.

Two behaviour changes are deliberate and user-visible:

- **`place_component` can now fail where it previously "succeeded".** That is
  the point of the fix — the old success was a false report over an empty board.
  Any caller that treated a success response as proof a footprint exists was
  already wrong; it now gets an actionable error instead.
- **Results carry a `source` field** (`"ipc"` or `"file"`) and, on the file
  path with KiCad reachable, a `warning`. Both are additive.

Board files are written in KiCad's own format — tab-indented, definition
forwarded verbatim from the `.kicad_mod` — so boards stay readable by KiCad 9
and 10 alike. No `.kicad_pcb` schema version is bumped.

## Validation

`place_component_puts_a_real_footprint_on_the_board` is the direct reproduction:
it asserts the board file gains a footprint *with pads and pad geometry*. Under
the old code the count is zero — exactly the empty board the bug produced.

Also covered: rotation reaching pads (270) and staying readable on text (90),
the error path leaving the board byte-for-byte untouched, the `ipc`/`file`
source field, and the array path writing every instance. Every test that writes
a board re-checks that it is still balanced.

The IPC response handling is covered against a mock NNG server (no KiCad
required), including the rejected-item, empty-response, all-created and mixed
cases.

Each new assertion was confirmed to fail against the pre-fix code, not merely
pass against the new code — the fixes were temporarily reverted to check that
the four new assertions go red, then restored.

The review-response commit was additionally put through an independent
adversarial review, which is what turned up the nickname-derivation hole above
(and the `.pretty` case sensitivity, the path-like declared name, and the
weak-balance-check gaps). Those findings are fixed here; the two it raised that
are pre-existing and workspace-wide — the shared `write_atomic` temp path and
comment-unaware paren counting — are recorded under Risk below rather than
quietly expanded into this PR.

`cargo test --workspace --lib --tests` passes; `cargo clippy --workspace -- -D
warnings` is clean; `cargo fmt --all` applied.

Not exercised here: the live-KiCad e2e suite, which needs a running KiCad. The
IPC branch specifically cannot be proven green until KiCad implements
`ParseAndCreateItemsFromString` — against KiCad 10.0 it returns an empty
response, which is why the file path is what actually runs today and what the
tests cover.

## Risk and rollback

This PR writes to `.kicad_pcb` files, so that is where the risk sits.

- Writes go through `write_atomic` (write temp, fsync, rename), so a single
  writer interrupted mid-run leaves the original board intact.
- `insert_into_board` re-parses the result and refuses to write anything that is
  not one complete `(kicad_pcb …)` form, so malformed input fails without
  touching the file.
- The error path is asserted to leave the board byte-for-byte identical.

Two limits worth stating plainly rather than leaving implied:

- **Concurrency.** `write_atomic` derives its temp file from the destination
  name, so two writers targeting one board can collide. That is pre-existing
  and shared by every write in the workspace, so fixing it belongs in
  `konnect-sexp` rather than here — but it does mean the atomicity guarantee
  above is a single-writer one.
- **Comments.** The paren counting treats every paren as syntax, including
  inside a `#` comment. KiCad does not write comments into `.kicad_pcb` and no
  reader in this workspace understands them, so the assumption is consistent —
  but it is an assumption, and it is called out in the doc comment.

The residual risk is a *semantically* wrong but well-formed board — a footprint
placed with the wrong rotation folded into its pads, say. That is why rotation
is asserted at the pad and text level rather than only on the footprint header.

**The one thing to know:** when KiCad is running with the board open, the file
edit is invisible to it and will be overwritten on its next save. The tool
detects that case and returns a warning saying to close without saving and
reopen. It cannot prevent it — only KiCad implementing the IPC command fixes
that properly.

Rollback is a plain revert of the top two commits; boards already written stay
valid, since they are ordinary KiCad footprints.

## Review feedback addressed

**A filesystem path could become the board's library id.** `resolve_footprint_path`
deliberately accepts either a `Library:Footprint` id or a bare path to a
`.kicad_mod`, but the header was written with whichever it was given. Placing by
path produced:

```
(footprint "C:\...\Resistor_SMD.pretty\R_0805_2012Metric.kicad_mod"
```

which is not a library identifier — KiCad opens the board with the part flagged
as a broken library link, and the id no longer round-trips through the IPC
lookups that expect `nickname:name`. This was not hypothetical: the end-to-end
test placed by path precisely to stay hermetic, so the regression test itself
was writing an absolute path into its fixture board.

`board_lib_id` is now total — every branch returns something that is not a path.
In preference order:

1. the caller's own `Library:Footprint` id, verbatim;
2. the nickname the **fp-lib-table** maps to the containing directory;
3. a conventional `<nickname>.pretty/` directory;
4. failing all of those, a bare footprint name.

Step 2 is the one that matters, and it is not what the first version of this fix
did. A nickname is *not* derivable from a path: KiCad lets a table map any
nickname to any directory, so `MyParts` may well live in `vendor.pretty`.
Guessing `vendor` from the path would silently mislink the part — worse than an
obviously broken link, because it looks right. Only the table can answer it, so
`footprint_lib_nickname_for_dir` asks it, comparing canonicalised paths so a
symlinked entry still matches. The `.pretty` convention remains as the fallback
for a library that is not registered at all, matched case-insensitively since
Windows and macOS filesystems are.

Step 4 keeps the name the library file declares, unless that is itself
path-like — a malformed file naming itself `/tmp/R.kicad_mod` must not smuggle a
path in through the fallback — in which case the file stem is used, which cannot
contain a separator.

The "id or path" rule moved to `library::is_lib_id` so the two call sites cannot
disagree about a Windows drive letter's colon. The board fixture now lays
footprints out in `Resistor_SMD.pretty/` the way KiCad does, so the main path is
what the tests exercise, and asserts no `.kicad_mod` appears anywhere in the
written board.

**The zero-created check counted the wrong thing.** This one undermined the fix
itself, and is the most important change in the PR. `place_footprint` failed
only when `created_items` was *empty* — but that field is documented as "status
of each item **to be** created", so a rejected item still occupies a slot,
carrying a code like `ISC_INVALID_DATA` and no `item`. A wholesale rejection
therefore arrives as a one-element vector, `len()` reports 1, and the call is
treated as success: precisely the phantom success this PR exists to remove,
reintroduced by the check meant to remove it.

Only `ISC_OK` entries now count (plus an entry with a defaulted status that
nonetheless carries an item, since some paths populate one and leave the other).
`parse_and_create_items` returns a `CreateOutcome` rather than a bare count, so
the per-item reasons survive into the error — "KiCAD created nothing" becomes
"KiCAD rejected it — IscInvalidData: `<KiCad's own message>`".

Four mock-server tests cover this, including the mixed case where one item is
created and one rejected; the rejection tests fail against the old `len()` count.

**`duplicate_component` had no file fallback.** It was the one caller still
invoking `place_footprint` bare. Now that `place_footprint` correctly fails on
KiCad 10.0, that tool would have gone from silently doing nothing to hard-failing
with no way through — the only tool left behind by the IPC-then-file strategy.
It now follows the same path as `place_component`. Reaching that point already
proves KiCad is running, since the source footprint is read over IPC, so the
file edit carries the same reopen warning.

**Inserting mixed line endings into a board.** `indent_block` rejoined with a
bare `\n`, so placing into a CRLF board left two conventions in the file. This
is the normal Windows path: checked against a KiCad 10.0 install, the bundled
footprints are CRLF throughout — `Reverb_BTDR-1H.kicad_mod` has 535 CRLF endings
and zero bare LF — as is the shipped `fp-lib-table`. So placing any stock
footprint on Windows mixed them, in a crate whose module doc opens by saying it
preserves KiCAD's exact formatting. `insert_into_board` now takes the
destination's convention and imposes it on what it inserts, in both directions.

**The balanced-parens check was claimed but not implemented.** It was only ever
asserted in tests; the write path itself trusted `rfind(')')` to find the
board's closing paren. Both file-edit writes now go through `insert_into_board`.

The check verifies the result is one *complete* `(kicad_pcb …)` form, not merely
that a balanced block exists somewhere — `find_balanced_block` skips whatever
precedes the first paren, so the weaker check would have accepted
`garbage(kicad_pcb …)`, and would equally have accepted a well-formed
expression that is not a board at all. A truncated board now fails loudly
instead of being saved in a state KiCad cannot open.

One suggestion was **not** taken: checking `any.type_url` in
`parse_and_create_items` before decoding. The `type_url` is already logged at
debug alongside the decoded outcome, and the zero-created path now reports
KiCad's own per-item rejection text, so the extra branch buys little.
