### PR TITLE
docs(contributing): define naming and PR standards

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## Summary
+
+<!-- What user-visible problem does this solve? Keep the scope to one reviewable outcome. -->
+
+Closes #
+
+## Approach
+
+<!-- Explain the root cause, design, and important alternatives or trade-offs. -->
+
+## Compatibility and safety
+
+<!--
+List public API/config/schema changes and their migration path.
+For file or IPC mutations, explain target validation, atomicity/rollback, and failure behavior.
+Write "No public compatibility impact" when applicable.
+-->
+
+## Validation
+
+<!-- Paste the exact commands and results. Note environment-dependent checks not run and why. -->
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo test --locked --workspace --all-targets`
+- [ ] `cargo clippy --locked --workspace --all-targets -- -D warnings`
+- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --no-deps`
+- [ ] Relevant viewer, plugin, packaging, and real-KiCad checks
+
+## Review checklist
+
+- [ ] The diff is focused and contains no generated output, personal data, or unrelated cleanup.
+- [ ] New names follow `docs/NAMING_CONVENTIONS.md`; public renames include compatibility handling.
+- [ ] New behavior and failure paths have regression coverage.
+- [ ] File mutations are atomic and preserve unrelated content.
+- [ ] IPC mutations verify the requested board and do not leave partial batches.
+- [ ] Tool counts, `tool-directory.md`, user docs, and examples are updated where applicable.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,9 +21,10 @@ Write "No public compatibility impact" when applicable.
 <!-- Paste the exact commands and results. Note environment-dependent checks not run and why. -->
 
 - [ ] `cargo fmt --all -- --check`
-- [ ] `cargo test --locked --workspace --all-targets`
-- [ ] `cargo clippy --locked --workspace --all-targets -- -D warnings`
-- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --no-deps`
+- [ ] `cargo test --workspace --locked --lib --tests` (what CI runs)
+- [ ] `cargo test --workspace --locked --doc`
+- [ ] `cargo clippy --workspace --locked -- -D warnings`
+- [ ] `cargo fmt --all -- --check`
 - [ ] Relevant viewer, plugin, packaging, and real-KiCad checks
 
 ## Review checklist
@@ -33,4 +34,4 @@ Write "No public compatibility impact" when applicable.
 - [ ] New behavior and failure paths have regression coverage.
 - [ ] File mutations are atomic and preserve unrelated content.
 - [ ] IPC mutations verify the requested board and do not leave partial batches.
-- [ ] Tool counts, `tool-directory.md`, user docs, and examples are updated where applicable.
+- [ ] If tools were added/removed: counts and docs updated per CONTRIBUTING.md (registry `tool_count`, `tool-directory.md`, DEV.md stats, README count).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@ Thanks for your interest! Bug reports, feature requests, and pull requests are w
   out of scope).
 - For anything non-trivial, open an issue first so we can agree on the approach before
   you invest time.
+- Keep each pull request focused on one reviewable outcome. Split unrelated platform,
+  protocol, feature, and documentation changes into a short PR series.
+- Read [docs/NAMING_CONVENTIONS.md](docs/NAMING_CONVENTIONS.md) before adding public
+  tools, schema fields, CLI options, environment variables, or user-facing terms.
 
 ## Development setup
 
@@ -23,11 +27,29 @@ cargo build --release -p konnect
 See [DEV.md](DEV.md) for the architecture guide, tool conventions, and how to add a
 new tool.
 
+## Pull request shape
+
+Use an imperative title such as `fix(schematic): preserve tab-indented wire blocks`.
+The description should state:
+
+1. the user-visible problem and scope;
+2. the root cause and chosen design;
+3. compatibility or migration effects;
+4. tests run, including intentionally skipped environment-dependent checks;
+5. risk and rollback notes for file formats, IPC, packaging, or release changes.
+
+Treat MCP tools, schema fields, CLI flags, environment variables, config keys, and
+documented paths as public API. Preserve compatibility or provide an explicit
+migration. Keep generated artifacts, personal settings, downloaded catalogs, build
+output, and unrelated cleanup out of the diff.
+
 ## Pull request checklist
 
 - `cargo test --workspace --lib --tests` passes
 - `cargo clippy --workspace -- -D warnings` is clean
 - `cargo fmt --all` applied
+- New names follow [the naming conventions](docs/NAMING_CONVENTIONS.md); public name
+  changes include compatibility handling and migration notes
 - If you added or removed tools: update `tool_count` in `router/registry.rs` and
   regenerate the matching section of `tool-directory.md`
 

--- a/DEV.md
+++ b/DEV.md
@@ -2,6 +2,9 @@
 
 Internal reference for developing and maintaining the Rust port.
 
+Repository-wide naming, public API, branch, and pull-request rules live in
+[docs/NAMING_CONVENTIONS.md](docs/NAMING_CONVENTIONS.md).
+
 ## Quick Start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ that teach Claude KiCAD conventions out of the box.
 
 > **Status: beta.** The core toolchain is tested and working, but this is a young
 > release and it wants real-world mileage and review. Issues and PRs are welcome —
-> see [CONTRIBUTING.md](CONTRIBUTING.md).
+> see [CONTRIBUTING.md](CONTRIBUTING.md) and the
+> [naming conventions](docs/NAMING_CONVENTIONS.md).
 
 ## Why Konnect exists
 

--- a/docs/NAMING_CONVENTIONS.md
+++ b/docs/NAMING_CONVENTIONS.md
@@ -12,7 +12,7 @@ Use the official spelling in prose, comments, errors, and UI text:
 | Use | Do not introduce | Notes |
 |---|---|---|
 | `Konnect` | `konnect` as a product name | Lowercase remains correct for binaries, crates, commands, and paths. |
-| `KiCad` | `KiCAD`, `Kicad` | Preserve legacy spellings only in external identifiers or historical repository names. |
+| `KiCad` | `KiCAD`, `Kicad` | Applies to NEW prose only — the existing codebase uses `KiCAD` widely (~400 occurrences) and is not to be mass-renamed; match surrounding style when editing existing text. |
 | `MCP` | `Mcp` in prose | Rust type names use `Mcp`, for example `McpHandler`. |
 | `IPC` | `Ipc` in prose | Rust type names use `Ipc`, for example `KiCadIpcClient`. |
 | `PCB`, `ERC`, `DRC`, `BOM` | mixed-case variants in prose | Rust identifiers treat each acronym as a word. |

--- a/docs/NAMING_CONVENTIONS.md
+++ b/docs/NAMING_CONVENTIONS.md
@@ -1,0 +1,142 @@
+# Konnect naming conventions
+
+Consistent names are part of Konnect's public API. They help contributors search the
+repository, let agents infer related operations, and prevent accidental compatibility
+breaks. New code and documentation must follow this guide. Existing public names are
+changed only with an explicit compatibility plan.
+
+## Product and protocol names
+
+Use the official spelling in prose, comments, errors, and UI text:
+
+| Use | Do not introduce | Notes |
+|---|---|---|
+| `Konnect` | `konnect` as a product name | Lowercase remains correct for binaries, crates, commands, and paths. |
+| `KiCad` | `KiCAD`, `Kicad` | Preserve legacy spellings only in external identifiers or historical repository names. |
+| `MCP` | `Mcp` in prose | Rust type names use `Mcp`, for example `McpHandler`. |
+| `IPC` | `Ipc` in prose | Rust type names use `Ipc`, for example `KiCadIpcClient`. |
+| `PCB`, `ERC`, `DRC`, `BOM` | mixed-case variants in prose | Rust identifiers treat each acronym as a word. |
+| `JLCPCB`, `LCSC` | informal abbreviations | Part IDs are called `LCSC IDs`. |
+| `S-expression` | `S-Expression`, `sexp` in prose | `sexp` remains correct in Rust module and function names. |
+
+Prefer the domain's exact term: `footprint` for a PCB instance or library item,
+`symbol` for a schematic item, `reference` for `R1`, and `value` for `10 kΩ`. Use
+`component` only for concepts that intentionally span symbols and footprints.
+
+## Rust
+
+Follow the Rust API Guidelines and `rustfmt`, with these repository-specific choices:
+
+- Crates and Cargo packages use `kebab-case`: `konnect-core`, `konnect-ipc`.
+- Modules, files, functions, methods, variables, and fields use `snake_case`:
+  `pcb_components`, `ensure_board_is_active`, `ipc_address`.
+- Types and traits use `UpperCamelCase`. Acronyms are words: `KiCadIpcClient`,
+  `McpHandler`, `IpcFootprint`, `UuidCache`.
+- Constants and environment variables use `SCREAMING_SNAKE_CASE`: `HOOK_SKILLS`,
+  `KICAD_API_SOCKET`, `KONNECT_LOG`.
+- Boolean names describe a true state with `is_`, `has_`, `can_`, or `should_` when
+  the prefix adds clarity: `is_error`, `has_pull_up`.
+- Fallible `find_*` functions return `Option` when absence is normal. `get_*` functions
+  return `Result` when retrieval can fail. Mutation verbs should be precise:
+  `create`, `add`, `update`, `move`, `delete`, `write`, or `replace`.
+
+Handlers are named `handle_<tool_name>`. A tool definition named `place_component`
+therefore maps to `handle_place_component` in the same toolset module.
+
+## Public MCP tools and JSON
+
+MCP tool names and toolset names are stable public API:
+
+- Use lowercase `snake_case`: `pcb_components`, `place_component`, `get_board_info`.
+- Begin tools with a concrete verb. Prefer `get_` for one object, `list_` for a
+  collection, `create_` for a new persisted object, and `set_` for replacement.
+- Do not encode the transport or implementation in a tool name unless it changes the
+  user-visible contract. Describe IPC or file requirements in the tool description.
+- Use the same noun across the tool name, schema, response, docs, and tests.
+- Never silently rename or reuse a tool. Add an alias/deprecation period and document
+  the migration when a public rename is unavoidable.
+
+Tool arguments and Konnect-owned JSON keys use `snake_case`. Protocol-defined JSON-RPC
+and MCP fields retain the specification's spelling, such as `jsonrpc`, `tools/list`,
+and `serverInfo`. KiCad plugin manifests retain the KiCad schema's field names.
+
+Collection responses use a plural noun plus `count` when useful:
+
+```json
+{
+  "count": 2,
+  "components": []
+}
+```
+
+Errors name the failed subject and action. Avoid a bare `not found`; prefer
+`footprint 'R17' not found on the active board`.
+
+## Units, paths, and identifiers
+
+Make ambiguous values self-describing:
+
+- Append units to non-domain-obvious values: `_mm`, `_nm`, `_degrees`, `_ms`,
+  `_bytes`. Coordinates in established PCB/schematic tool schemas are millimetres;
+  document that contract in the schema.
+- Use `_path` for a file or unresolved filesystem path and `_dir` for a directory.
+  A variable named `board` may be a public tool argument for compatibility; local Rust
+  variables should prefer `board_path` when they contain a `Path`.
+- Distinguish identifiers: `uuid` for a textual UUID, `kiid` for KiCad's item ID,
+  `lcsc_id` for an LCSC part number, `net_code` for KiCad's numeric net code, and
+  `reference` for a designator such as `U3`.
+- Use `_count` for quantities and `_index` for zero-based positions. Avoid `num` when
+  either meaning is possible.
+
+## Files, scripts, and documentation
+
+- Rust and Python source files use `snake_case`.
+- Command-line and packaging scripts use `kebab-case`: `build-pcm.sh`,
+  `validate-pcm.py`.
+- User-facing guides use uppercase names for repository-level conventions
+  (`CONTRIBUTING.md`, `DEV.md`) and descriptive uppercase or kebab-case names under
+  `docs/`. Do not rename an established guide solely to change its case.
+- Tests describe observable behavior in `snake_case`, for example
+  `delete_items_surfaces_per_item_failure`.
+- Fixtures include the behavior or issue they represent; avoid `test1` and `sample2`.
+- Generated protobuf code and vendored protocol definitions keep upstream naming.
+  Do not hand-edit generated files.
+
+## Branches, commits, and pull requests
+
+Use a short lowercase branch name with a category and topic:
+
+```text
+fix/indent-safe-wire-delete
+feat/linux-pcm-support
+docs/naming-conventions
+```
+
+Pull request titles use an imperative Conventional Commit-style prefix:
+
+```text
+fix(schematic): preserve tab-indented wire blocks
+feat(ipc): place footprints through typed KiCad messages
+docs(contributing): define naming conventions
+```
+
+Recommended types are `fix`, `feat`, `docs`, `test`, `refactor`, `build`, `ci`, and
+`chore`. Keep each pull request focused on one reviewable outcome. Use the body for
+context and issue links rather than packing them into the title.
+
+Commit subjects are imperative, specific, and under roughly 72 characters. Remove
+`fixup!`, merge noise, generated build output, and unrelated formatting before review.
+
+## Compatibility checklist
+
+Before introducing or changing a name, check:
+
+1. Is it public in MCP, CLI flags, environment variables, JSON, plugin metadata, logs,
+   or documented filesystem paths?
+2. Does the same concept already have a name elsewhere in the repository?
+3. Can users and agents infer its type, unit, and scope without reading the body?
+4. Would a rename require an alias, serde alias, migration note, or deprecation period?
+5. Are tests, tool-directory metadata, examples, and error messages updated together?
+
+When compatibility and style conflict, preserve compatibility and document the legacy
+name. Consistency is valuable; silently breaking users is worse.


### PR DESCRIPTION

### Summary

- add one canonical naming guide for product vocabulary, Rust identifiers,
  MCP/JSON fields, units, paths, IDs, files, tests, branches, commits, and PRs
- add a pull-request template that asks contributors to document compatibility,
  validation, risk, and generated-file changes
- connect the standards from the README, development guide, and contribution
  guide so contributors can find them before implementing a change

### Why

Konnect spans Rust APIs, MCP tool schemas, KiCad file formats, IPC protobufs,
Python integration, and packaging. Consistent names at those boundaries make
reviews easier and prevent accidental public-schema churn. The guide also
distinguishes preferred names for new work from legacy public names that must
remain compatible.

### Compatibility

Documentation and repository process only. This changes no runtime behavior,
public tool name, JSON field, protocol message, file format, or dependency.

### Validation

- `git diff --check`
- all local Markdown links introduced by the commit resolve inside the repository
- branch is one commit ahead of the current upstream baseline

### Risk

Low. The only enforcement is reviewer-facing guidance and a PR template; no
automated gate or source rewrite is introduced.

