### PR TITLE
fix(schematic): make wire deletion indentation-safe

### DIFF
--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -449,16 +449,22 @@ fn sexp_tag(block: &str) -> &str {
     &after_open[..end]
 }
 
+// Blocklist of structural forms, not an allowlist of item kinds: deleting a
+// drawing item (text, bus, sheet, image, polyline, …) by UUID has always
+// worked and must keep working — only the schematic's skeleton is protected.
 fn is_deletable_schematic_item(block: &str) -> bool {
-    matches!(
+    !matches!(
         sexp_tag(block),
-        "wire"
-            | "label"
-            | "global_label"
-            | "hierarchical_label"
-            | "junction"
-            | "no_connect"
-            | "symbol"
+        "version"
+            | "generator"
+            | "generator_version"
+            | "uuid"
+            | "paper"
+            | "title_block"
+            | "lib_symbols"
+            | "sheet_instances"
+            | "symbol_instances"
+            | "embedded_fonts"
     )
 }
 

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -16,9 +16,13 @@ use konnect_sexp::{
         extract_labels, extract_lib_pins, extract_symbol_instances, extract_wires,
         format_net_label, format_wire, pin_endpoint, read_schematic,
     },
-    writer::{apply_edits, find_block_with_leading_whitespace, new_uuid, write_atomic, SexpEdit},
+    writer::{
+        apply_edits, find_block_with_leading_whitespace, find_enclosing_direct_child_block,
+        new_uuid, write_atomic, SexpEdit,
+    },
 };
 use serde_json::json;
+use std::collections::HashSet;
 
 // Re-use the crate-internal net-graph primitives from sch_analysis.
 use super::sch_analysis::build_net_graph;
@@ -363,6 +367,7 @@ async fn handle_batch_delete(
     let mut edits: Vec<SexpEdit> = Vec::new();
     let mut deleted: Vec<String> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
+    let mut delete_ranges: HashSet<(usize, usize)> = HashSet::new();
 
     // Delete by UUID — walk back from uuid node to enclosing top-level block
     if let Some(uuids) = args["uuids"].as_array() {
@@ -374,14 +379,23 @@ async fn handle_batch_delete(
             let pattern = format!(r#"(uuid "{}")"#, uuid);
             match content.find(&pattern) {
                 Some(uuid_pos) => {
-                    let before = &content[..uuid_pos];
-                    // Top-level schematic items are at 2-space indent: "\n  ("
-                    match before.rfind("\n  (").map(|p| p + 1) {
-                        Some(block_start) => {
+                    match find_enclosing_direct_child_block(&content, "kicad_sch", uuid_pos) {
+                        Some((block_start, block_end)) => {
+                            let item = &content[block_start..block_end];
+                            if !is_deletable_schematic_item(item) {
+                                errors.push(format!(
+                                    "UUID '{}' belongs to protected schematic structure '{}'",
+                                    uuid,
+                                    sexp_tag(item)
+                                ));
+                                continue;
+                            }
                             match find_block_with_leading_whitespace(&content, block_start) {
                                 Some((del_start, del_end)) => {
-                                    edits.push(SexpEdit::delete(del_start, del_end));
-                                    deleted.push(uuid.to_string());
+                                    if delete_ranges.insert((del_start, del_end)) {
+                                        edits.push(SexpEdit::delete(del_start, del_end));
+                                        deleted.push(uuid.to_string());
+                                    }
                                 }
                                 None => {
                                     errors.push(format!("Cannot parse block for UUID '{}'", uuid))
@@ -405,8 +419,10 @@ async fn handle_batch_delete(
             };
             match find_symbol_block(&content, reference) {
                 Some((del_start, del_end)) => {
-                    edits.push(SexpEdit::delete(del_start, del_end));
-                    deleted.push(reference.to_string());
+                    if delete_ranges.insert((del_start, del_end)) {
+                        edits.push(SexpEdit::delete(del_start, del_end));
+                        deleted.push(reference.to_string());
+                    }
                 }
                 None => errors.push(format!("Component '{}' not found", reference)),
             }
@@ -421,6 +437,29 @@ async fn handle_batch_delete(
         "deleted": deleted,
         "errors": errors
     })))
+}
+
+fn sexp_tag(block: &str) -> &str {
+    let Some(after_open) = block.strip_prefix('(') else {
+        return "";
+    };
+    let end = after_open
+        .find(|c: char| c.is_whitespace() || c == '(' || c == ')')
+        .unwrap_or(after_open.len());
+    &after_open[..end]
+}
+
+fn is_deletable_schematic_item(block: &str) -> bool {
+    matches!(
+        sexp_tag(block),
+        "wire"
+            | "label"
+            | "global_label"
+            | "hierarchical_label"
+            | "junction"
+            | "no_connect"
+            | "symbol"
+    )
 }
 
 async fn handle_bulk_move(
@@ -975,4 +1014,57 @@ async fn handle_validate_component_connections(
         "unconnected_count": unconnected.len(),
         "unconnected_pins": unconnected
     })))
+}
+
+#[cfg(test)]
+mod batch_delete_tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::{ServerConfig, ToolContext};
+    use std::sync::Arc;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    #[tokio::test]
+    async fn batch_delete_uuid_is_tab_indentation_safe_and_deduplicated() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("batch-delete.kicad_sch");
+        let uuid = "11111111-1111-1111-1111-111111111111";
+        std::fs::write(
+            &path,
+            format!(
+                "(kicad_sch\n\t(version 20260306)\n\t(generator \"eeschema\")\n\t(uuid \"root\")\n\t(wire\n\t\t(pts (xy 0 0) (xy 10 0))\n\t\t(uuid \"{uuid}\")\n\t)\n\t(text \"keep me\" (at 5 5 0) (uuid \"text\"))\n\t(sheet_instances (path \"/\" (page \"1\")))\n)\n"
+            ),
+        )
+        .unwrap();
+
+        let result = handle_batch_delete(
+            &json!({
+                "schematic": path.display().to_string(),
+                "uuids": [uuid, "root", uuid]
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error);
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(!after.contains(uuid));
+        assert!(after.contains("(uuid \"root\")"));
+        assert!(after.contains("keep me"));
+        assert!(after.contains("(sheet_instances"));
+        assert!(konnect_sexp::parse_sexp(&after).is_ok());
+    }
 }

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -65,13 +65,16 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "delete_schematic_wire",
-            "Delete a wire segment by its UUID or by matching its start/end coordinates.",
+            "Delete a wire segment by its UUID, or by matching BOTH endpoints \
+             (all four of x1/y1/x2/y2, either direction). Fails without deleting \
+             anything when no wire matches.",
             json!({
                 "type": "object",
                 "properties": {
                     "schematic": { "type": "string" },
                     "uuid": { "type": "string", "description": "Wire UUID (preferred)" },
-                    "x1": { "type": "number" }, "y1": { "type": "number" },
+                    "x1": { "type": "number", "description": "Endpoint 1 X in mm (required with y1/x2/y2 when no uuid)" },
+                    "y1": { "type": "number" },
                     "x2": { "type": "number" }, "y2": { "type": "number" }
                 },
                 "required": ["schematic"]

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -18,7 +18,7 @@ use konnect_sexp::{
     },
     writer::{
         apply_edits, find_balanced_block, find_block_starts, find_block_with_leading_whitespace,
-        write_atomic, SexpEdit,
+        find_direct_child_blocks, find_enclosing_block, write_atomic, SexpEdit,
     },
 };
 use serde_json::json;
@@ -373,18 +373,11 @@ fn insert_before_close(content: &str, new_sexp: &str) -> String {
 /// Top-level instances have `(lib_id` as a child, while lib_symbols definitions don't.
 /// Returns the position where wires/labels should be inserted BEFORE.
 fn find_first_symbol_instance(content: &str) -> Option<usize> {
-    // Pattern: a symbol instance always contains (lib_id "...") shortly after (symbol
-    // lib_symbols definitions contain sub-symbols but NOT (lib_id
-    let mut pos = 0;
-    while let Some(found) = content[pos..].find("\n  (symbol") {
-        let abs = pos + found;
-        // Check if this symbol block contains (lib_id within the next ~200 chars
-        let lookahead = &content[abs..content.len().min(abs + 200)];
-        if lookahead.contains("(lib_id ") {
-            // This is a top-level symbol instance, not a lib_symbols definition
-            return Some(abs + 1); // +1 to skip the \n
+    for (start, end) in find_direct_child_blocks(content, "kicad_sch") {
+        let block = &content[start..end];
+        if block.starts_with("(symbol") && block.contains("(lib_id ") {
+            return Some(start);
         }
-        pos = abs + 1;
     }
     None
 }
@@ -529,25 +522,45 @@ async fn handle_delete_wire(
     let sch_path = get_path(args, "schematic")?;
     let content = std::fs::read_to_string(&sch_path)?;
 
-    let search_str = if let Some(uuid) = opt_str(args, "uuid") {
-        format!(r#"(uuid "{uuid}")"#)
+    let delete_range = if let Some(uuid) = opt_str(args, "uuid") {
+        let search = format!(r#"(uuid "{uuid}")"#);
+        let Some(wire_offset) = content.find(&search) else {
+            return Ok(CallToolResult::error(format!(
+                "Wire UUID '{uuid}' not found"
+            )));
+        };
+        wire_block_with_leading_whitespace(&content, wire_offset)
     } else {
-        let x1 = opt_f64(args, "x1").unwrap_or(0.0);
-        let y1 = opt_f64(args, "y1").unwrap_or(0.0);
-        format!("(start {x1} {y1})")
+        let Some(x1) = opt_f64(args, "x1") else {
+            return Ok(CallToolResult::error(
+                "Provide either uuid or all x1/y1/x2/y2 coordinates",
+            ));
+        };
+        let Some(y1) = opt_f64(args, "y1") else {
+            return Ok(CallToolResult::error(
+                "Provide either uuid or all x1/y1/x2/y2 coordinates",
+            ));
+        };
+        let Some(x2) = opt_f64(args, "x2") else {
+            return Ok(CallToolResult::error(
+                "Provide either uuid or all x1/y1/x2/y2 coordinates",
+            ));
+        };
+        let Some(y2) = opt_f64(args, "y2") else {
+            return Ok(CallToolResult::error(
+                "Provide either uuid or all x1/y1/x2/y2 coordinates",
+            ));
+        };
+        find_wire_block_by_endpoints(&content, x1, y1, x2, y2)
     };
 
-    let wire_offset = match content.find(&search_str) {
-        Some(o) => o,
-        None => return Ok(CallToolResult::error("Wire not found")),
-    };
-
-    // Walk back to the (wire ...) block start
-    let before = &content[..wire_offset];
-    let wire_start = before.rfind("\n  (wire").map(|p| p + 1).unwrap_or(0);
-    let (del_start, del_end) = match find_block_with_leading_whitespace(&content, wire_start) {
+    let (del_start, del_end) = match delete_range {
         Some(r) => r,
-        None => return Ok(CallToolResult::error("Cannot parse wire block")),
+        None => {
+            return Ok(CallToolResult::error(
+                "Cannot locate a wire block matching the requested identity",
+            ))
+        }
     };
 
     let edits = vec![SexpEdit::delete(del_start, del_end)];
@@ -568,31 +581,86 @@ async fn handle_batch_delete_wire(
         .filter_map(|v| v.as_str().map(String::from))
         .collect();
 
-    let mut content = std::fs::read_to_string(&sch_path)?;
-    let mut deleted = 0usize;
+    let content = std::fs::read_to_string(&sch_path)?;
+    let mut errors = Vec::new();
 
     // Collect all delete ranges first, then apply in reverse order
     let mut ranges: Vec<(usize, usize)> = Vec::new();
     for uuid in &uuids {
         let search = format!(r#"(uuid "{uuid}")"#);
-        if let Some(offset) = content.find(&search) {
-            let before = &content[..offset];
-            if let Some(wire_start) = before.rfind("\n  (wire").map(|p| p + 1) {
-                if let Some(range) = find_block_with_leading_whitespace(&content, wire_start) {
-                    ranges.push(range);
-                    deleted += 1;
-                }
-            }
+        match content.find(&search) {
+            Some(offset) => match wire_block_with_leading_whitespace(&content, offset) {
+                Some(range) => ranges.push(range),
+                None => errors.push(format!(
+                    "UUID '{uuid}' exists but is not inside a parseable wire block"
+                )),
+            },
+            None => errors.push(format!("Wire UUID '{uuid}' not found")),
         }
+    }
+    ranges.sort_unstable();
+    ranges.dedup();
+    let deleted = ranges.len();
+
+    if deleted == 0 && !uuids.is_empty() {
+        return Ok(CallToolResult::error(format!(
+            "No wires deleted: {}",
+            errors.join("; ")
+        )));
     }
 
     let edits: Vec<SexpEdit> = ranges
         .into_iter()
         .map(|(s, e)| SexpEdit::delete(s, e))
         .collect();
-    content = apply_edits(content, edits);
+    let content = apply_edits(content, edits);
     write_atomic(&sch_path, &content)?;
-    Ok(CallToolResult::json(&json!({ "deleted": deleted })))
+    Ok(CallToolResult::json(&json!({
+        "deleted": deleted,
+        "errors": errors
+    })))
+}
+
+fn wire_block_with_leading_whitespace(
+    content: &str,
+    contained_offset: usize,
+) -> Option<(usize, usize)> {
+    let (wire_start, _) = find_enclosing_block(content, "wire", contained_offset)?;
+    find_block_with_leading_whitespace(content, wire_start)
+}
+
+fn find_wire_block_by_endpoints(
+    content: &str,
+    x1: f64,
+    y1: f64,
+    x2: f64,
+    y2: f64,
+) -> Option<(usize, usize)> {
+    const TOLERANCE: f64 = 1e-6;
+    let same = |a: f64, b: f64| (a - b).abs() <= TOLERANCE;
+
+    for start in find_block_starts(content, "wire") {
+        let Some((block_start, block_end)) = find_balanced_block(content, start) else {
+            continue;
+        };
+        // `extract_wires` expects wires to be direct children of the parsed
+        // document root, so wrap this standalone block in a minimal root.
+        let wrapped = format!("(kicad_sch {})", &content[block_start..block_end]);
+        let Ok(node) = parse_sexp(&wrapped) else {
+            continue;
+        };
+        let matches = extract_wires(&node).into_iter().any(|wire| {
+            (same(wire.x1, x1) && same(wire.y1, y1) && same(wire.x2, x2) && same(wire.y2, y2))
+                || (same(wire.x1, x2)
+                    && same(wire.y1, y2)
+                    && same(wire.x2, x1)
+                    && same(wire.y2, y1))
+        });
+        if matches {
+            return find_block_with_leading_whitespace(content, block_start);
+        }
+    }
+    None
 }
 
 async fn handle_split_wire_at_point(
@@ -632,17 +700,25 @@ async fn handle_split_wire_at_point(
     let del_args = if let Some(uuid) = &w.uuid {
         json!({ "schematic": sch_path.display().to_string(), "uuid": uuid })
     } else {
-        json!({ "schematic": sch_path.display().to_string(), "x1": w.x1, "y1": w.y1 })
+        json!({
+            "schematic": sch_path.display().to_string(),
+            "x1": w.x1,
+            "y1": w.y1,
+            "x2": w.x2,
+            "y2": w.y2
+        })
     };
-    handle_delete_wire(&del_args, ctx).await?;
+    let delete_result = handle_delete_wire(&del_args, ctx).await?;
+    if delete_result.is_error {
+        return Ok(delete_result);
+    }
 
     let content = std::fs::read_to_string(&sch_path)?;
     let w1 = format_wire(w.x1, w.y1, px, py);
     let w2 = format_wire(px, py, w.x2, w.y2);
     let junc = format_junction(px, py);
-    let close = content.rfind(')').unwrap_or(content.len());
-    let edits = vec![SexpEdit::insert(close, format!("{}{}{}", w1, w2, junc))];
-    let new_content = apply_edits(content, edits);
+    let insert = format!("{w1}{w2}{junc}");
+    let new_content = insert_before_close(&content, &insert);
     write_atomic(&sch_path, &new_content)?;
 
     Ok(CallToolResult::json(&json!({
@@ -1661,5 +1737,151 @@ mod label_tests {
         let (_d, path) = sch_with(TWO_PLAIN);
         let result = rotate(&path, "VCC", 555.0, 555.0, 180.0).await;
         assert!(result.is_error, "must not rotate the nearest label instead");
+    }
+}
+
+#[cfg(test)]
+mod wire_delete_tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::ServerConfig;
+    use std::sync::Arc;
+
+    const WIRE_1: &str = "11111111-1111-1111-1111-111111111111";
+    const WIRE_2: &str = "22222222-2222-2222-2222-222222222222";
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    fn tab_indented_schematic() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wire-delete.kicad_sch");
+        std::fs::write(
+            &path,
+            format!(
+                "(kicad_sch\n\t(version 20260306)\n\t(generator \"eeschema\")\n\t(generator_version \"10.0\")\n\t(uuid \"00000000-0000-0000-0000-000000000001\")\n\t(paper \"A4\")\n\t(wire\n\t\t(pts\n\t\t\t(xy 50.8 50.8) (xy 60.96 50.8)\n\t\t)\n\t\t(stroke (width 0) (type default))\n\t\t(uuid \"{WIRE_1}\")\n\t)\n\t(wire\n\t\t(pts\n\t\t\t(xy 50.8 60.96) (xy 60.96 60.96)\n\t\t)\n\t\t(stroke (width 0) (type default))\n\t\t(uuid \"{WIRE_2}\")\n\t)\n\t(sheet_instances\n\t\t(path \"/\" (page \"1\"))\n\t)\n)\n"
+            ),
+        )
+        .unwrap();
+        (dir, path)
+    }
+
+    #[tokio::test]
+    async fn delete_wire_preserves_tab_indented_schematic_and_neighbors() {
+        let (_dir, path) = tab_indented_schematic();
+        let result = handle_delete_wire(
+            &json!({ "schematic": path.display().to_string(), "uuid": WIRE_1 }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error);
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(!after.contains(WIRE_1));
+        assert!(after.contains(WIRE_2));
+        assert!(after.contains("(sheet_instances"));
+        assert!(konnect_sexp::parse_sexp(&after).is_ok());
+    }
+
+    #[tokio::test]
+    async fn delete_wire_matches_reversed_endpoint_coordinates() {
+        let (_dir, path) = tab_indented_schematic();
+        let result = handle_delete_wire(
+            &json!({
+                "schematic": path.display().to_string(),
+                "x1": 60.96,
+                "y1": 50.8,
+                "x2": 50.8,
+                "y2": 50.8
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error);
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(!after.contains(WIRE_1));
+        assert!(after.contains(WIRE_2));
+        assert!(konnect_sexp::parse_sexp(&after).is_ok());
+    }
+
+    #[tokio::test]
+    async fn batch_delete_wire_handles_tabs_and_duplicate_requests() {
+        let (_dir, path) = tab_indented_schematic();
+        let result = handle_batch_delete_wire(
+            &json!({
+                "schematic": path.display().to_string(),
+                "uuids": [WIRE_1, WIRE_1, WIRE_2]
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error);
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(!after.contains(WIRE_1));
+        assert!(!after.contains(WIRE_2));
+        assert!(after.contains("(sheet_instances"));
+        assert!(konnect_sexp::parse_sexp(&after).is_ok());
+    }
+
+    #[tokio::test]
+    async fn batch_delete_wire_fails_closed_when_nothing_matches() {
+        let (_dir, path) = tab_indented_schematic();
+        let before = std::fs::read_to_string(&path).unwrap();
+        let result = handle_batch_delete_wire(
+            &json!({
+                "schematic": path.display().to_string(),
+                "uuids": ["ffffffff-ffff-ffff-ffff-ffffffffffff"]
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(result.is_error);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), before);
+    }
+
+    #[tokio::test]
+    async fn split_wire_without_uuid_deletes_by_complete_endpoints() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wire-split.kicad_sch");
+        std::fs::write(
+            &path,
+            "(kicad_sch\n\t(version 20260306)\n\t(generator \"eeschema\")\n\t(wire\n\t\t(pts (xy 0 0) (xy 10 0))\n\t\t(stroke (width 0) (type default))\n\t)\n)\n",
+        )
+        .unwrap();
+
+        let result = handle_split_wire_at_point(
+            &json!({
+                "schematic": path.display().to_string(),
+                "x": 5.0,
+                "y": 0.0
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error);
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        let parsed = konnect_sexp::parse_sexp(&after).unwrap();
+        let wires = extract_wires(&parsed);
+        assert_eq!(wires.len(), 2);
+        assert!(after.contains("(junction"));
+        assert!(!wires.iter().any(|wire| wire.x1 == 0.0 && wire.x2 == 10.0));
     }
 }

--- a/crates/konnect-sexp/src/writer.rs
+++ b/crates/konnect-sexp/src/writer.rs
@@ -246,6 +246,78 @@ pub fn find_enclosing_block(content: &str, tag: &str, pos: usize) -> Option<(usi
         .find_map(|start| find_balanced_block(content, start).filter(|&(_, end)| end > pos))
 }
 
+/// Byte ranges of the direct child S-expression blocks of the first
+/// `(parent_tag …)` block in `content`.
+///
+/// This is indentation-agnostic and string-aware. It is intended for KiCAD
+/// root files where callers need to distinguish top-level schematic/board
+/// items from nested library definitions or properties.
+pub fn find_direct_child_blocks(content: &str, parent_tag: &str) -> Vec<(usize, usize)> {
+    let Some(parent_start) = find_block_starts(content, parent_tag).into_iter().next() else {
+        return Vec::new();
+    };
+    let Some((_, parent_end)) = find_balanced_block(content, parent_start) else {
+        return Vec::new();
+    };
+
+    let bytes = content.as_bytes();
+    let mut out = Vec::new();
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escape_next = false;
+    let mut i = parent_start;
+
+    while i < parent_end {
+        let b = bytes[i];
+        if escape_next {
+            escape_next = false;
+        } else if in_string {
+            if b == b'\\' {
+                escape_next = true;
+            } else if b == b'"' {
+                in_string = false;
+            }
+        } else {
+            match b {
+                b'"' => in_string = true,
+                b'(' if depth == 1 => {
+                    let Some(range) = find_balanced_block(content, i) else {
+                        break;
+                    };
+                    out.push(range);
+                    i = range.1;
+                    continue;
+                }
+                b'(' => depth += 1,
+                b')' => {
+                    if depth == 0 {
+                        break;
+                    }
+                    depth -= 1;
+                }
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Byte range of the direct child of `(parent_tag …)` that encloses `pos`.
+///
+/// Unlike walking backward to a fixed indentation pattern, this cannot fall
+/// back to the root of a tab-indented file and accidentally select the entire
+/// document for deletion.
+pub fn find_enclosing_direct_child_block(
+    content: &str,
+    parent_tag: &str,
+    pos: usize,
+) -> Option<(usize, usize)> {
+    find_direct_child_blocks(content, parent_tag)
+        .into_iter()
+        .find(|&(start, end)| start <= pos && end > pos)
+}
+
 // ─── UUID Generation ─────────────────────────────────────────────────────────
 
 /// Generate a new KiCAD-compatible UUID string.
@@ -359,5 +431,37 @@ mod block_start_tests {
         // Tag that isn't present at all.
         let pos = TABS.find("\"R1\"").unwrap();
         assert!(find_enclosing_block(TABS, "wire", pos).is_none());
+    }
+
+    #[test]
+    fn direct_children_ignore_indentation_and_nested_blocks() {
+        for (label, indent, child_indent) in [("tabs", "\t", "\t\t"), ("spaces", "  ", "    ")] {
+            let content = format!(
+                "(kicad_sch\n{indent}(uuid \"root\")\n{indent}(lib_symbols\n{child_indent}(symbol \"Nested\" (uuid \"nested\"))\n{indent})\n{indent}(wire\n{child_indent}(pts (xy 0 0) (xy 1 0))\n{child_indent}(uuid \"wire\")\n{indent})\n)"
+            );
+            let blocks = find_direct_child_blocks(&content, "kicad_sch");
+            assert_eq!(blocks.len(), 3, "{label}");
+            assert!(
+                blocks
+                    .iter()
+                    .any(|&(start, end)| content[start..end].starts_with("(wire")),
+                "{label}"
+            );
+            assert!(
+                !blocks
+                    .iter()
+                    .any(|&(start, end)| content[start..end].starts_with("(symbol")),
+                "{label}: nested symbol must not be returned as a root child"
+            );
+        }
+    }
+
+    #[test]
+    fn enclosing_direct_child_selects_wire_not_root_or_neighbor() {
+        let content = "(kicad_sch\n\t(uuid \"root\")\n\t(wire\n\t\t(pts (xy 0 0) (xy 1 0))\n\t\t(uuid \"target\")\n\t)\n\t(sheet_instances (path \"/\" (page \"1\")))\n)";
+        let pos = content.find("\"target\"").unwrap();
+        let (start, end) = find_enclosing_direct_child_block(content, "kicad_sch", pos).unwrap();
+        assert!(content[start..end].starts_with("(wire"));
+        assert!(!content[start..end].contains("sheet_instances"));
     }
 }


### PR DESCRIPTION

### Summary

- replace fixed-indentation wire matching with string-aware balanced
  S-expression range discovery
- delete wires by UUID or by complete endpoints, including reversed endpoint
  order, without consuming adjacent forms
- reuse the same safe deletion path for wire splitting and batch operations
- reject malformed or structurally ambiguous edits instead of partially
  rewriting the schematic
- add regression tests for tabs, alternate indentation, escaped strings,
  reversed endpoints, duplicate requests, and protected parent structures

Closes #64. Related to #55.

### Root cause

The previous deletion code searched backward for a literal newline plus two
spaces before `(wire ...)`. Tabs or a different indentation width could move the
start offset into a neighboring form, corrupting the schematic while the tool
reported success.

### Implementation

`konnect-sexp` now exposes balanced, string-aware helpers for locating a form's
parent and direct-child ranges. Schematic wiring and batch tools use those
ranges, deduplicate targets, and fail closed when the expected structure cannot
be proven. Endpoint deletion compares the whole coordinate pair in either
direction rather than matching a partial textual fragment.

### Compatibility

Existing MCP tool names and request/response schemas are unchanged. Correctly
formatted legacy schematics remain supported; the change broadens safe support
to tabs and arbitrary indentation.

### Validation

- `git diff --check`
- `cargo test --locked -p konnect-core -p konnect-sexp`
  - `konnect-core`: 152 unit tests plus integration and conformance tests
  - `konnect-sexp`: 36 unit tests plus property tests
- targeted strict library Clippy passed for the affected crates

The upstream baseline's all-target Clippy currently reports unrelated existing
warnings (`fp_y` is unused and two tests hold a lock across an await), so those
baseline findings are not bundled into this focused fix.

### Risk and rollback

Risk is concentrated in schematic text-range selection. Coverage includes the
reported tab-indentation reproducer and adversarial nested/string cases. The
commit is self-contained and can be reverted without data migration.

