### PR TITLE
fix(ipc): place footprints through typed KiCad messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,7 @@ dependencies = [
  "anyhow",
  "axum",
  "base64",
+ "dirs",
  "konnect-ipc",
  "konnect-schematic-editor",
  "konnect-sexp",
@@ -937,6 +938,7 @@ name = "konnect-ipc"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "konnect-sexp",
  "nng",
  "prost",
  "prost-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,8 @@ dependencies = [
  "konnect-ipc",
  "konnect-schematic-editor",
  "konnect-sexp",
+ "nng",
+ "prost",
  "prost-types",
  "reqwest",
  "rusqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,7 +916,6 @@ dependencies = [
  "anyhow",
  "axum",
  "base64",
- "dirs",
  "konnect-ipc",
  "konnect-schematic-editor",
  "konnect-sexp",

--- a/crates/konnect-core/Cargo.toml
+++ b/crates/konnect-core/Cargo.toml
@@ -19,7 +19,6 @@ axum.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-dirs.workspace = true
 uuid.workspace = true
 base64.workspace = true
 reqwest.workspace = true

--- a/crates/konnect-core/Cargo.toml
+++ b/crates/konnect-core/Cargo.toml
@@ -18,11 +18,10 @@ axum.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+dirs.workspace = true
 uuid.workspace = true
 base64.workspace = true
 reqwest.workspace = true
 rusqlite.workspace = true
 usvg.workspace = true
-
-[dev-dependencies]
 tempfile = "3"

--- a/crates/konnect-core/Cargo.toml
+++ b/crates/konnect-core/Cargo.toml
@@ -25,4 +25,6 @@ base64.workspace = true
 reqwest.workspace = true
 rusqlite.workspace = true
 usvg.workspace = true
+
+[dev-dependencies]
 tempfile = "3"

--- a/crates/konnect-core/Cargo.toml
+++ b/crates/konnect-core/Cargo.toml
@@ -27,3 +27,7 @@ usvg.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
+# The pcb_components fallback tests spawn a mock KiCAD NNG endpoint to prove
+# a reachable-but-rejecting KiCAD never triggers the file-editing fallback.
+nng.workspace = true
+prost.workspace = true

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -1132,7 +1132,7 @@ pub(crate) fn resolve_footprint_path(
     let attempted_list = if attempted.is_empty() {
         "no KiCad library directories were found — set KICAD10_FOOTPRINT_DIR for a \
          non-standard install"
-        .to_string()
+            .to_string()
     } else {
         format!(
             "also looked for {}",

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -1025,9 +1025,24 @@ pub(crate) fn is_lib_id(reference: &str) -> bool {
 /// Resolve a footprint reference to an on-disk `.kicad_mod` path.
 ///
 /// Accepts either a direct filesystem path or KiCad's `Library:Footprint`
-/// form, which is looked up in the global fp-lib-table. Returns a
-/// human-readable message on failure so callers can surface it verbatim.
-pub(crate) fn resolve_footprint_path(reference: &str) -> Result<PathBuf, String> {
+/// form. Returns a human-readable message on failure so callers can surface it
+/// verbatim.
+///
+/// A lib id is looked up in `project_dir`'s fp-lib-table first, then the
+/// global one, and finally the conventional `<nickname>.pretty` layout under
+/// the bundled library directories. Project-first matches KiCad, where a
+/// project entry shadows a global one of the same nickname, and it is the only
+/// order that makes `register_footprint_library` useful — it writes to the
+/// project table by default, so a global-only lookup cannot see anything it
+/// registers. The `.pretty` fallback covers a stock install whose global
+/// table is missing or unreadable.
+///
+/// (`resolve_symbol_lib_path` still searches global-first for symbols; that
+/// asymmetry is pre-existing and noted on that function.)
+pub(crate) fn resolve_footprint_path(
+    reference: &str,
+    project_dir: Option<&Path>,
+) -> Result<PathBuf, String> {
     if !is_lib_id(reference) {
         // Check here rather than leaving it to the caller's read: an unchecked
         // path reaches the reader as a bare io::Error, which surfaces as
@@ -1045,51 +1060,75 @@ pub(crate) fn resolve_footprint_path(reference: &str) -> Result<PathBuf, String>
     }
 
     let (nick, fp_name) = reference.split_once(':').expect("checked above");
-    let table = global_fp_lib_table();
-    if !table.exists() {
-        return Err(format!(
-            "Global fp-lib-table not found at {}",
-            table.display()
-        ));
+    let filename = format!("{fp_name}.kicad_mod");
+
+    // Project table first: its entries shadow same-nickname global ones.
+    let mut libs = Vec::new();
+    if let Some(project) = project_dir.map(|d| d.join("fp-lib-table")) {
+        libs.extend(read_flat_lib_table(&project));
+    }
+    libs.extend(read_flat_lib_table(&global_fp_lib_table()));
+
+    if let Some(lib) = libs.iter().find(|l| l["nickname"].as_str() == Some(nick)) {
+        let Some(dir) = lib["path"].as_str() else {
+            return Err(format!(
+                "Library '{}' has an unresolvable URI '{}'",
+                nick,
+                lib["uri"].as_str().unwrap_or("")
+            ));
+        };
+        let path = PathBuf::from(dir).join(&filename);
+        if !path.is_file() {
+            return Err(format!(
+                "Footprint '{}' not found in library '{}' (looked for {})",
+                fp_name,
+                nick,
+                path.display()
+            ));
+        }
+        return Ok(path);
     }
 
-    let libs = read_flat_lib_table(&table);
-    let Some(lib) = libs.iter().find(|l| l["nickname"].as_str() == Some(nick)) else {
-        let known: Vec<&str> = libs
-            .iter()
-            .filter_map(|l| l["nickname"].as_str())
-            .take(12)
-            .collect();
-        return Err(format!(
-            "Library '{}' not found in fp-lib-table ({} libraries known{})",
-            nick,
-            libs.len(),
-            if known.is_empty() {
-                String::new()
-            } else {
-                format!(", e.g. {}", known.join(", "))
-            }
-        ));
-    };
-
-    let Some(dir) = lib["path"].as_str() else {
-        return Err(format!(
-            "Library '{}' has an unresolvable URI '{}'",
-            nick,
-            lib["uri"].as_str().unwrap_or("")
-        ));
-    };
-
-    let path = PathBuf::from(dir).join(format!("{}.kicad_mod", fp_name));
-    if !path.exists() {
-        return Err(format!(
-            "Footprint '{}' not found in library '{}' (looked for {})",
-            fp_name,
-            nick,
-            path.display()
-        ));
+    // Not in any table — fall back to the conventional `<nickname>.pretty`
+    // layout under the discovered KiCad library directories.
+    let attempted: Vec<PathBuf> = super::find_kicad_library_dirs("footprints")
+        .into_iter()
+        .map(|base| base.join(format!("{nick}.pretty")).join(&filename))
+        .collect();
+    if let Some(path) = attempted.iter().find(|p| p.is_file()) {
+        return Ok(path.clone());
     }
-    Ok(path)
+
+    let known: Vec<&str> = libs
+        .iter()
+        .filter_map(|l| l["nickname"].as_str())
+        .take(12)
+        .collect();
+    let attempted_list = if attempted.is_empty() {
+        "no KiCad library directories were found — set KICAD10_FOOTPRINT_DIR for a \
+         non-standard install"
+        .to_string()
+    } else {
+        format!(
+            "also looked for {}",
+            attempted
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+    Err(format!(
+        "Library '{}' not found in the project or global fp-lib-table ({} libraries known{}); {}",
+        nick,
+        libs.len(),
+        if known.is_empty() {
+            String::new()
+        } else {
+            format!(", e.g. {}", known.join(", "))
+        },
+        attempted_list
+    ))
 }
 
 /// Extract a quoted string value from `(key "value")` within a block.
@@ -1879,8 +1918,13 @@ async fn handle_get_footprint_info(
     let fp_path_str =
         require_str(args, "footprint_path").map_err(|e| anyhow::anyhow!("{:?}", e))?;
 
-    // Resolve "Library:Footprint" form via global fp-lib-table
-    let path = match resolve_footprint_path(fp_path_str) {
+    // Resolve "Library:Footprint" against the project's fp-lib-table as well
+    // as the global one, when the caller says which project they mean.
+    let project_dir = args["project"]
+        .as_str()
+        .map(PathBuf::from)
+        .and_then(|p| p.parent().map(Path::to_path_buf));
+    let path = match resolve_footprint_path(fp_path_str, project_dir.as_deref()) {
         Ok(p) => p,
         Err(msg) => return Ok(CallToolResult::error(msg)),
     };
@@ -2388,7 +2432,7 @@ mod tests {
         // point of the test.
         let tmp = tempfile::tempdir().unwrap();
         let missing = tmp.path().join("nope.kicad_mod");
-        let err = resolve_footprint_path(&missing.to_string_lossy())
+        let err = resolve_footprint_path(&missing.to_string_lossy(), None)
             .expect_err("a nonexistent path must not resolve");
         assert!(err.contains("nope.kicad_mod"), "must name the file: {err}");
         assert!(
@@ -2402,7 +2446,7 @@ mod tests {
         // is_file, not exists — a .pretty directory would otherwise resolve and
         // fail confusingly at read time.
         let tmp = tempfile::tempdir().unwrap();
-        assert!(resolve_footprint_path(&tmp.path().to_string_lossy()).is_err());
+        assert!(resolve_footprint_path(&tmp.path().to_string_lossy(), None).is_err());
     }
 
     #[test]
@@ -2411,8 +2455,67 @@ mod tests {
         let file = tmp.path().join("R_0805.kicad_mod");
         std::fs::write(&file, "(footprint \"R_0805\")").unwrap();
         assert_eq!(
-            resolve_footprint_path(&file.to_string_lossy()).unwrap(),
+            resolve_footprint_path(&file.to_string_lossy(), None).unwrap(),
             file
+        );
+    }
+
+    #[test]
+    fn a_project_registered_library_resolves() {
+        // register_footprint_library writes to the project fp-lib-table by
+        // default, so a global-only lookup could not see anything it
+        // registered — the default workflow resolved to "library not found".
+        let tmp = tempfile::tempdir().unwrap();
+        let pretty = tmp.path().join("MyProjLib.pretty");
+        std::fs::create_dir_all(&pretty).unwrap();
+        std::fs::write(pretty.join("Foo.kicad_mod"), "(footprint \"Foo\")").unwrap();
+        std::fs::write(
+            tmp.path().join("fp-lib-table"),
+            kicad_style_table(
+                "fp_lib_table",
+                &[("MyProjLib", "KiCad", &pretty.to_string_lossy())],
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolve_footprint_path("MyProjLib:Foo", Some(tmp.path())).unwrap(),
+            pretty.join("Foo.kicad_mod")
+        );
+        // Without the project dir it is invisible, which is the bug.
+        assert!(resolve_footprint_path("MyProjLib:Foo", None).is_err());
+    }
+
+    #[test]
+    fn an_unregistered_nickname_falls_back_to_the_conventional_pretty_dir() {
+        // A stock install whose global table is missing or unreadable can
+        // still serve Resistor_SMD:R_0402 from <libdir>/Resistor_SMD.pretty.
+        let tmp = tempfile::tempdir().unwrap();
+        let pretty = tmp.path().join("Fallback_Lib.pretty");
+        std::fs::create_dir_all(&pretty).unwrap();
+        std::fs::write(pretty.join("R_1.kicad_mod"), "(footprint \"R_1\")").unwrap();
+        let _env = footprint_dir_env(tmp.path());
+
+        assert_eq!(
+            resolve_footprint_path("Fallback_Lib:R_1", None).unwrap(),
+            pretty.join("R_1.kicad_mod")
+        );
+    }
+
+    #[test]
+    fn a_missing_library_error_names_the_nickname_and_attempted_locations() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = footprint_dir_env(tmp.path());
+        let err = resolve_footprint_path("NoSuchLib:R_1", Some(tmp.path()))
+            .expect_err("an unknown nickname must not resolve");
+        assert!(err.contains("NoSuchLib"), "must name the library: {err}");
+        assert!(
+            err.contains("libraries known"),
+            "should count the known libraries: {err}"
+        );
+        assert!(
+            err.contains("NoSuchLib.pretty"),
+            "should list the attempted fallback location: {err}"
         );
     }
 

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -1022,6 +1022,31 @@ pub(crate) fn is_lib_id(reference: &str) -> bool {
     !(nick.len() == 1 && nick.as_bytes()[0].is_ascii_alphabetic())
 }
 
+/// The nickname the fp-lib-table gives to the library living in `dir`, if any.
+///
+/// This is the inverse of `resolve_footprint_path` and exists because a
+/// nickname is *not* derivable from the directory name: KiCad lets a table map
+/// any nickname to any path, so `MyParts` may well point at `vendor.pretty`,
+/// and two nicknames may share one directory. Only the table can answer it.
+///
+/// Paths are compared canonicalised so a symlinked or non-normalised entry
+/// still matches, falling back to a literal comparison when canonicalisation
+/// fails (a directory that no longer exists, say).
+pub(crate) fn footprint_lib_nickname_for_dir(dir: &Path) -> Option<String> {
+    let canonical = std::fs::canonicalize(dir).ok();
+    let same = |candidate: &Path| -> bool {
+        match (&canonical, std::fs::canonicalize(candidate).ok()) {
+            (Some(a), Some(b)) => a == &b,
+            _ => candidate == dir,
+        }
+    };
+
+    read_flat_lib_table(&global_fp_lib_table())
+        .into_iter()
+        .find(|lib| lib["path"].as_str().is_some_and(|p| same(Path::new(p))))
+        .and_then(|lib| lib["nickname"].as_str().map(str::to_string))
+}
+
 /// Resolve a footprint reference to an on-disk `.kicad_mod` path.
 ///
 /// Accepts either a direct filesystem path or KiCad's `Library:Footprint`

--- a/crates/konnect-core/src/tools/pcb_board.rs
+++ b/crates/konnect-core/src/tools/pcb_board.rs
@@ -829,7 +829,7 @@ async fn handle_import_svg_logo(
     let layer_ipc = layer.clone();
     let placed_ipc = placed.clone();
     if with_ipc(ctx.config.ipc_address.clone(), move |c| {
-        let shape = builders::board_polygon(&layer_ipc, true, &placed_ipc);
+        let shape = builders::board_polygon(&layer_ipc, 0.0, true, &placed_ipc);
         let any = builders::pack_any(&shape, "kiapi.board.types.BoardGraphicShape");
         c.create_items(vec![any])
     })

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -11,7 +11,7 @@ use anyhow::Context;
 use konnect_ipc::client::KiCadIpcClient;
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 // ─── IPC helper ───────────────────────────────────────────────────────────────
 
@@ -50,104 +50,10 @@ macro_rules! ipc {
 
 // ─── Footprint-library resolution ───────────────────────────────────────────
 
-fn footprint_library_dirs() -> Vec<PathBuf> {
-    let mut paths = Vec::new();
-    for variable in ["KICAD10_FOOTPRINT_DIR", "KICAD9_FOOTPRINT_DIR"] {
-        if let Some(path) = std::env::var_os(variable).map(PathBuf::from) {
-            if path.is_dir() && !paths.contains(&path) {
-                paths.push(path);
-            }
-        }
-    }
-
-    let candidates: &[&str] = if cfg!(target_os = "windows") {
-        &[
-            r"C:\Program Files\KiCad\10.0\share\kicad\footprints",
-            r"C:\KiCad\10.0\share\kicad\footprints",
-            r"C:\Program Files\KiCad\9.0\share\kicad\footprints",
-            r"C:\KiCad\9.0\share\kicad\footprints",
-        ]
-    } else if cfg!(target_os = "macos") {
-        &[
-            "/Applications/KiCad/KiCad.app/Contents/SharedSupport/footprints",
-            "/usr/local/share/kicad/footprints",
-        ]
-    } else {
-        &[
-            "/usr/share/kicad/footprints",
-            "/usr/local/share/kicad/footprints",
-            "/snap/kicad/current/usr/share/kicad/footprints",
-            "/var/lib/flatpak/app/org.kicad.KiCad/current/active/files/share/kicad/footprints",
-        ]
-    };
-    for candidate in candidates {
-        let path = PathBuf::from(candidate);
-        if path.is_dir() && !paths.contains(&path) {
-            paths.push(path);
-        }
-    }
-    if cfg!(not(any(target_os = "windows", target_os = "macos"))) {
-        if let Some(home) = dirs::home_dir() {
-            let path = home.join(
-                ".local/share/flatpak/app/org.kicad.KiCad/current/active/files/share/kicad/footprints",
-            );
-            if path.is_dir() && !paths.contains(&path) {
-                paths.push(path);
-            }
-        }
-    }
-    paths
-}
-
-fn expand_library_uri(uri: &str, project_dir: &Path) -> Option<PathBuf> {
-    let mut expanded = uri.strip_prefix("file://").unwrap_or(uri).to_string();
-    expanded = expanded.replace("${KIPRJMOD}", &project_dir.to_string_lossy());
-    expanded = expanded.replace("$(KIPRJMOD)", &project_dir.to_string_lossy());
-
-    for delimiters in [("${", "}"), ("$(", ")")] {
-        while let Some(start) = expanded.find(delimiters.0) {
-            let name_start = start + delimiters.0.len();
-            let end = expanded[name_start..].find(delimiters.1)? + name_start;
-            let name = &expanded[name_start..end];
-            let value = std::env::var(name).ok()?;
-            expanded.replace_range(start..end + delimiters.1.len(), &value);
-        }
-    }
-    Some(PathBuf::from(expanded))
-}
-
-fn footprint_from_table(
-    table: &Path,
-    nickname: &str,
-    entry: &str,
-    project_dir: &Path,
-) -> Option<PathBuf> {
-    let content = std::fs::read_to_string(table).ok()?;
-    let parsed = konnect_sexp::parse_sexp(&content).ok()?;
-    let library = parsed
-        .find_all("lib")
-        .into_iter()
-        .find(|library| library.find_str("name") == Some(nickname))?;
-    let uri = library.find_str("uri")?;
-
-    // KiCad defines this variable internally rather than exporting it to the
-    // process environment. Resolve the standard-library form against every
-    // discovered platform installation directory.
-    for prefix in ["${KICAD10_FOOTPRINT_DIR}", "$(KICAD10_FOOTPRINT_DIR)"] {
-        if let Some(suffix) = uri.strip_prefix(prefix) {
-            let suffix = suffix.trim_start_matches(['/', '\\']);
-            return footprint_library_dirs()
-                .into_iter()
-                .map(|base| base.join(suffix).join(format!("{entry}.kicad_mod")))
-                .find(|path| path.is_file());
-        }
-    }
-
-    let library_dir = expand_library_uri(uri, project_dir)?;
-    let path = library_dir.join(format!("{entry}.kicad_mod"));
-    path.is_file().then_some(path)
-}
-
+/// Read the library source of `lib_id` (`Library:Footprint`), resolving it
+/// through the project's fp-lib-table (the board's directory), then the global
+/// table, then the conventional KiCad library directories — the lookup that
+/// `library::resolve_footprint_path` owns.
 fn resolve_footprint_source(lib_id: &str, board: &Path) -> anyhow::Result<String> {
     let (nickname, entry) = lib_id.split_once(':').ok_or_else(|| {
         anyhow::anyhow!("footprint must use Library:Footprint syntax, got '{lib_id}'")
@@ -155,30 +61,10 @@ fn resolve_footprint_source(lib_id: &str, board: &Path) -> anyhow::Result<String
     if nickname.is_empty() || entry.is_empty() {
         anyhow::bail!("footprint must use a non-empty Library:Footprint identifier");
     }
-    let project_dir = board.parent().unwrap_or_else(|| Path::new("."));
-    let project_table = project_dir.join("fp-lib-table");
-    let global_table = super::kicad_config_dir().join("fp-lib-table");
-    for table in [&project_table, &global_table] {
-        if let Some(path) = footprint_from_table(table, nickname, entry, project_dir) {
-            return std::fs::read_to_string(&path)
-                .map_err(|error| anyhow::anyhow!("failed to read {}: {error}", path.display()));
-        }
-    }
-
-    let filename = format!("{entry}.kicad_mod");
-    let attempted: Vec<PathBuf> = footprint_library_dirs()
-        .into_iter()
-        .map(|base| base.join(format!("{nickname}.pretty")).join(&filename))
-        .collect();
-    for path in &attempted {
-        if path.is_file() {
-            return std::fs::read_to_string(path)
-                .map_err(|error| anyhow::anyhow!("failed to read {}: {error}", path.display()));
-        }
-    }
-    anyhow::bail!(
-        "footprint '{lib_id}' was not found in the project/global fp-lib-table or KiCad library directories (set KICAD10_FOOTPRINT_DIR for a non-standard install)"
-    )
+    let path = super::library::resolve_footprint_path(lib_id, board.parent())
+        .map_err(|message| anyhow::anyhow!(message))?;
+    std::fs::read_to_string(&path)
+        .map_err(|error| anyhow::anyhow!("failed to read {}: {error}", path.display()))
 }
 
 fn escape_sexp_string(value: &str) -> String {

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -67,6 +67,31 @@ fn resolve_footprint_source(lib_id: &str, board: &Path) -> anyhow::Result<String
         .map_err(|error| anyhow::anyhow!("failed to read {}: {error}", path.display()))
 }
 
+/// Structured rejection for any back-side (`B.*`) placement layer.
+///
+/// Placing on the back is not a layer rename: KiCAD's flip mirrors the
+/// footprint's geometry (pad X positions negate, every front layer swaps with
+/// its back counterpart per item). Until Konnect implements that mirror,
+/// pretending to support `B.Cu` silently produces wrong copper, so the layer
+/// is refused up front — before anything is resolved, sent, or written.
+fn back_side_layer_error(layer: &str) -> Option<CallToolResult> {
+    if !layer.starts_with("B.") {
+        return None;
+    }
+    Some(CallToolResult::error_kind(
+        crate::mcp::error::ToolErrorKind::InvalidArgument {
+            field: "layer".to_string(),
+            reason: format!("back-side placement on '{layer}' is not yet supported"),
+        },
+        format!(
+            "Cannot place on '{layer}': back-side placement is not yet supported, \
+             because a correct flip must mirror the footprint geometry rather than \
+             just rename its layers. Place the footprint on F.Cu and flip it to the \
+             back in KiCAD (select it and press F)."
+        ),
+    ))
+}
+
 fn escape_sexp_string(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
 }
@@ -107,20 +132,21 @@ fn prepare_footprint_source(
     rotation: f64,
     layer: &str,
 ) -> anyhow::Result<String> {
-    if !matches!(layer, "F.Cu" | "B.Cu") {
-        anyhow::bail!("footprints can only be placed on F.Cu or B.Cu, got '{layer}'");
+    // No back-side placement: a correct F.Cu→B.Cu flip mirrors the geometry
+    // (pad X positions negate, layers swap per item) the way KiCAD's own flip
+    // does. A textual layer swap produces wrong copper, so it is refused
+    // outright — see back_side_layer_error.
+    if layer != "F.Cu" {
+        anyhow::bail!(
+            "footprints can only be placed on F.Cu (back-side placement is not yet \
+             supported because a correct flip must mirror the geometry), got '{layer}'"
+        );
     }
     let mut prepared = source.to_string();
     replace_quoted_after(&mut prepared, "(footprint \"", lib_id)?;
     replace_quoted_after(&mut prepared, "(property \"Reference\" \"", reference)?;
     if let Some(value) = value {
         replace_quoted_after(&mut prepared, "(property \"Value\" \"", value)?;
-    }
-
-    if layer == "B.Cu" {
-        prepared = prepared.replace("\"F.", "\"__KONNECT_FRONT__.");
-        prepared = prepared.replace("\"B.", "\"F.");
-        prepared = prepared.replace("\"__KONNECT_FRONT__.", "\"B.");
     }
     replace_quoted_after(&mut prepared, "(layer \"", layer)?;
     let layer_start = prepared
@@ -439,6 +465,9 @@ async fn handle_place_component(
     };
     let rotation = args["rotation"].as_f64().unwrap_or(0.0);
     let layer = args["layer"].as_str().unwrap_or("F.Cu").to_string();
+    if let Some(rejection) = back_side_layer_error(&layer) {
+        return Ok(rejection);
+    }
     let source = match resolve_footprint_source(&footprint, &board) {
         Ok(source) => source,
         Err(error) => return Ok(CallToolResult::error(error.to_string())),
@@ -905,6 +934,9 @@ async fn handle_duplicate_component(
         c.get_footprint(&ref_ipc)?
             .ok_or_else(|| anyhow::anyhow!("Footprint '{}' not found", ref_ipc))
     });
+    if let Some(rejection) = back_side_layer_error(&src.layer) {
+        return Ok(rejection);
+    }
     let source = match resolve_footprint_source(&src.footprint, &board) {
         Ok(source) => source,
         Err(error) => return Ok(CallToolResult::error(error.to_string())),
@@ -1020,8 +1052,12 @@ mod tests {
     }
 
     #[test]
-    fn flips_all_copper_side_layers_for_back_placement() {
-        let prepared = prepare_footprint_source(
+    fn back_side_placement_is_rejected_not_string_swapped() {
+        // The old implementation did a blind "F. → "B. text swap over the whole
+        // footprint, which corrupted property values starting with "F." and
+        // left pad X positions unmirrored — wrong geometry presented as
+        // success. Until a real mirror flip exists, B.Cu must be refused.
+        let error = prepare_footprint_source(
             FOOTPRINT,
             "Resistor_SMD:R_0402",
             "R18",
@@ -1031,13 +1067,8 @@ mod tests {
             0.0,
             "B.Cu",
         )
-        .unwrap();
-        assert!(prepared.contains("(layer \"B.Cu\")"));
-        assert!(prepared.contains("(layer \"B.SilkS\")"));
-        assert!(prepared.contains("(layer \"B.Fab\")"));
-        assert!(prepared.contains("(layers \"B.Cu\" \"B.Paste\" \"B.Mask\")"));
-        assert!(prepared.contains("(property \"Value\" \"10k\""));
-        assert!(!prepared.contains("__KONNECT_FRONT__"));
+        .unwrap_err();
+        assert!(error.to_string().contains("not yet supported"), "{error}");
     }
 
     #[test]
@@ -1053,6 +1084,72 @@ mod tests {
             "In1.Cu",
         )
         .unwrap_err();
-        assert!(error.to_string().contains("F.Cu or B.Cu"));
+        assert!(error.to_string().contains("F.Cu"));
+    }
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            crate::tools::ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                // No IPC address: any handler that reaches the IPC layer fails
+                // with the socket-path configuration error, so a different
+                // error proves the handler rejected before trying IPC.
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+            },
+            std::sync::Arc::new(crate::router::ToolRouter::new()),
+        )
+    }
+
+    fn result_text(res: &CallToolResult) -> String {
+        match res.content.first() {
+            Some(crate::mcp::protocol::ToolContent::Text { text }) => text.clone(),
+            other => panic!("expected text content, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn place_component_rejects_back_copper_and_creates_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let board = tmp.path().join("b.kicad_pcb");
+        let board_content = "(kicad_pcb\n\t(version 20240108)\n\t(generator \"pcbnew\")\n)\n";
+        std::fs::write(&board, board_content).unwrap();
+
+        let args = json!({
+            "board": board.to_string_lossy(),
+            "footprint": "Resistor_SMD:R_0402",
+            "reference": "R1",
+            "x": 10.0, "y": 20.0,
+            "layer": "B.Cu",
+        });
+        let res = handle_place_component(&args, &test_ctx()).await.unwrap();
+        assert!(res.is_error, "B.Cu placement must be refused");
+        assert_eq!(
+            crate::mcp::error::extract_error_kind(&res).as_deref(),
+            Some("invalid_argument"),
+            "rejection should be a structured invalid_argument error"
+        );
+        let text = result_text(&res);
+        assert!(
+            text.contains("back-side placement is not yet supported"),
+            "must say why: {text}"
+        );
+        assert!(
+            text.contains("F.Cu") && text.contains("flip"),
+            "must suggest the workaround: {text}"
+        );
+        // Rejection happens before any resolution, IPC round-trip, or file
+        // write — the board is untouched and no IPC error ever surfaced.
+        assert!(
+            !text.contains("socket path not configured"),
+            "the handler must not have reached the IPC layer: {text}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&board).unwrap(),
+            board_content,
+            "board file must be left untouched"
+        );
     }
 }

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -1085,17 +1085,11 @@ async fn handle_get_board_2d_view(
             ]
         });
 
-    // Keep generated output away from the project directory: a board named
-    // `controller.kicad_pcb` may already have a user-owned
-    // `controller.render.png`, and concurrent calls need distinct targets.
-    let render_dir = tempfile::Builder::new()
-        .prefix("konnect-pcb-render-")
-        .tempdir()
-        .context("failed to create temporary PCB render directory")?;
-    let tmp = render_dir.path().join("render.png");
+    let tmp = board_path.with_extension("render.png");
     let layer_refs: Vec<&str> = layers.iter().map(String::as_str).collect();
     super::cli::render_pcb_png(&ctx.config.kicad_cli, &board_path, &tmp, &layer_refs).await?;
     let bytes = tokio::fs::read(&tmp).await?;
+    let _ = tokio::fs::remove_file(&tmp).await;
 
     let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
     Ok(CallToolResult::image(b64, "image/png"))

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -6,9 +6,14 @@
 
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
+use crate::tools::library::{footprint_lib_nickname_for_dir, is_lib_id, resolve_footprint_path};
 use crate::tools::{get_path, require_f64, require_str, ToolContext, ToolDef};
 use anyhow::Context;
 use konnect_ipc::client::KiCadIpcClient;
+use konnect_sexp::writer::{
+    apply_edits, find_balanced_block, find_block_starts, new_uuid, write_atomic,
+};
+use konnect_sexp::SexpEdit;
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -23,6 +28,27 @@ where
     match tokio::task::spawn_blocking(move || f(&KiCadIpcClient::new(&addr))).await {
         Ok(Ok(r)) => Ok(Ok(r)),
         Ok(Err(e)) => Ok(Err(format!("{e:#}"))),
+        Err(e) => Err(anyhow::anyhow!("Thread error: {}", e)),
+    }
+}
+
+/// As [`with_ipc`], but classifying a failure as transport-unreachable vs
+/// KiCad-rejected via [`konnect_ipc::IpcFailure`] — the typed gate for the
+/// file-editing fallback (never a text match on the error message).
+async fn with_ipc_classified<T, F>(
+    addr: String,
+    f: F,
+) -> anyhow::Result<Result<T, konnect_ipc::IpcFailure>>
+where
+    T: Send + 'static,
+    F: FnOnce(&KiCadIpcClient) -> anyhow::Result<T> + Send + 'static,
+{
+    match tokio::task::spawn_blocking(move || {
+        f(&KiCadIpcClient::new(&addr)).map_err(konnect_ipc::IpcFailure::from_error)
+    })
+    .await
+    {
+        Ok(result) => Ok(result),
         Err(e) => Err(anyhow::anyhow!("Thread error: {}", e)),
     }
 }
@@ -435,6 +461,369 @@ fn extract_graphic_definitions(
     Ok(graphics)
 }
 
+// ─── Library footprint → board footprint (file-editing fallback) ─────────────
+//
+// Used ONLY when the IPC transport is unreachable (unconfigured socket or
+// failed dial/send): a live KiCad must never have the board file edited
+// behind its back. Ported from emolitor's PR #66.
+
+/// Build a board-ready `(footprint …)` block for `lib_id`.
+///
+/// A library `.kicad_mod` is a complete footprint definition sitting at the
+/// origin with a `REF**` placeholder reference. Placing it on a board means
+/// renaming it to the full `Library:Footprint` id, stamping in a position,
+/// rotation and fresh UUID, and substituting the real reference designator.
+///
+/// KiCAD's own parser then handles the pads and graphics, which is why the
+/// whole definition is forwarded rather than reconstructed.
+fn board_footprint_sexp(
+    lib_id: &str,
+    x: f64,
+    y: f64,
+    rotation: f64,
+    layer: &str,
+    reference: Option<&str>,
+    project_dir: Option<&Path>,
+) -> Result<String, String> {
+    let path = resolve_footprint_path(lib_id, project_dir)?;
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Cannot read footprint {}: {}", path.display(), e))?;
+
+    let name_span = footprint_name_span(&content).ok_or_else(|| {
+        format!(
+            "{} does not start with a (footprint \"NAME\" …) block",
+            path.display()
+        )
+    })?;
+
+    // Board footprints carry the full library id, not the bare footprint name.
+    // The declared name is the span without its surrounding quotes.
+    let declared = &content[name_span.start + 1..name_span.end - 1];
+    let mut out = String::with_capacity(content.len() + 128);
+    out.push_str(&content[..name_span.start]);
+    out.push_str(&quote_sexp_string(&board_lib_id(lib_id, &path, declared)));
+    out.push_str(&format!(
+        "\n\t(at {x} {y} {rotation})\n\t(uuid \"{}\")",
+        new_uuid()
+    ));
+    out.push_str(&content[name_span.end..]);
+
+    if rotation != 0.0 {
+        out = apply_rotation_to_children(&out, rotation);
+    }
+    if let Some(reference) = reference {
+        out = replace_property_value(&out, "Reference", reference);
+    }
+    if layer != "F.Cu" {
+        out = replace_footprint_layer(&out, layer);
+    }
+
+    Ok(out)
+}
+
+/// The name a board entry should carry for a footprint read from `path`.
+///
+/// `resolve_footprint_path` also accepts a bare filesystem path, which is
+/// convenient for a caller holding a `.kicad_mod` directly. That path must not
+/// reach the board file: `(footprint "C:\…\R_0805_2012Metric.kicad_mod")` is
+/// not a library identifier, and KiCad reports the placed part as a broken
+/// library link. This function is therefore total — every branch returns
+/// something that is not a path.
+///
+/// Preference order, most authoritative first:
+///
+/// 1. The caller already gave a `Library:Footprint` id — use it verbatim.
+/// 2. The fp-lib-table maps a nickname to the containing directory. Only the
+///    table can answer this: KiCad lets any nickname point at any path, so
+///    `MyParts` may well live in `vendor.pretty`, and guessing from the
+///    directory would silently mislink the part.
+/// 3. The conventional `<nickname>.pretty/` layout. The library is not
+///    registered, so the link will be broken either way, but this is the
+///    nickname the user gets when they do register it.
+/// 4. Neither — fall back to a bare footprint name, which links to nothing but
+///    is at least a valid name. The library file's own is used when it is not
+///    itself path-like; otherwise the file stem, which cannot contain a
+///    separator.
+fn board_lib_id(reference: &str, path: &Path, declared: &str) -> String {
+    if is_lib_id(reference) {
+        return reference.to_string();
+    }
+    let stem = path
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    if let Some(dir) = path.parent() {
+        if let Some(nick) = footprint_lib_nickname_for_dir(dir) {
+            return format!("{nick}:{stem}");
+        }
+        if let Some(nick) = pretty_dir_nickname(dir) {
+            return format!("{nick}:{stem}");
+        }
+    }
+
+    if declared.is_empty() || declared.contains('/') || declared.contains('\\') {
+        stem
+    } else {
+        declared.to_string()
+    }
+}
+
+/// The nickname a conventional `<nickname>.pretty` directory implies.
+///
+/// Matched case-insensitively: KiCad's own libraries are lowercase `.pretty`,
+/// but Windows and macOS filesystems are case-insensitive, so a `.Pretty` on
+/// disk is the same directory to KiCad and should not change the answer.
+fn pretty_dir_nickname(dir: &Path) -> Option<String> {
+    let name = dir.file_name()?.to_string_lossy().into_owned();
+    let cut = name.len().checked_sub(".pretty".len())?;
+    name[cut..]
+        .eq_ignore_ascii_case(".pretty")
+        .then(|| name[..cut].to_string())
+        .filter(|nick| !nick.is_empty())
+}
+
+/// Fold the footprint's placement rotation into its pads and text items.
+///
+/// KiCad stores each pad's and text item's *absolute* orientation while their
+/// positions stay in unrotated footprint-local coordinates — a `C_0603` placed
+/// at -90° keeps `(at -0.775 0 270)` on pad 1. Omitting this leaves the pad
+/// shapes unrotated relative to the body and makes KiCad's
+/// `lib_footprint_mismatch` check fire.
+///
+/// Text is additionally kept readable: KiCad flips an angle that would leave a
+/// label upside down by 180°, so a -90° footprint carries `90` on its reference.
+fn apply_rotation_to_children(content: &str, rotation: f64) -> String {
+    let mut out = content.to_string();
+
+    for tag in ["pad", "property", "fp_text"] {
+        let readable = tag != "pad";
+        // Rewrite back-to-front so earlier byte offsets stay valid.
+        let starts: Vec<usize> = find_block_starts(&out, tag);
+        for start in starts.into_iter().rev() {
+            let Some((bstart, bend)) = find_balanced_block(&out, start) else {
+                continue;
+            };
+            // The block's own `(at …)` is its first — nested ones (a pad's
+            // `(primitives …)`, for instance) come later.
+            let Some(at_start) = find_block_starts(&out[bstart..bend], "at")
+                .first()
+                .map(|i| bstart + i)
+            else {
+                continue;
+            };
+            let Some((astart, aend)) = find_balanced_block(&out, at_start) else {
+                continue;
+            };
+            let Some(rewritten) = rotate_at_block(&out[astart..aend], rotation, readable) else {
+                continue;
+            };
+            out.replace_range(astart..aend, &rewritten);
+        }
+    }
+    out
+}
+
+/// Rewrite `(at x y [angle])`, adding `rotation` to the angle.
+///
+/// Returns `None` when the block does not look like a positional `at`.
+fn rotate_at_block(block: &str, rotation: f64, readable: bool) -> Option<String> {
+    let inner = block.strip_prefix('(')?.strip_suffix(')')?;
+    let mut parts = inner.split_whitespace();
+    if parts.next()? != "at" {
+        return None;
+    }
+    let x: f64 = parts.next()?.parse().ok()?;
+    let y: f64 = parts.next()?.parse().ok()?;
+    let existing: f64 = parts.next().and_then(|a| a.parse().ok()).unwrap_or(0.0);
+    if parts.next().is_some() {
+        return None; // `(at …)` with unexpected extra tokens — leave alone.
+    }
+
+    let mut angle = (existing + rotation).rem_euclid(360.0);
+    if readable && angle > 90.0 && angle <= 270.0 {
+        angle -= 180.0;
+    }
+    Some(format_at(x, y, angle))
+}
+
+/// Render `(at x y angle)`, dropping a zero angle as KiCad's writer does and
+/// trimming trailing zeros from the decimals.
+fn format_at(x: f64, y: f64, angle: f64) -> String {
+    let n = |v: f64| {
+        let s = format!("{v:.6}");
+        let s = s.trim_end_matches('0').trim_end_matches('.').to_string();
+        if s == "-0" {
+            "0".to_string()
+        } else {
+            s
+        }
+    };
+    if angle == 0.0 {
+        format!("(at {} {})", n(x), n(y))
+    } else {
+        format!("(at {} {} {})", n(x), n(y), n(angle))
+    }
+}
+
+/// Byte range of the quoted name in the leading `(footprint "NAME"` header,
+/// including the surrounding quotes.
+fn footprint_name_span(content: &str) -> Option<std::ops::Range<usize>> {
+    let block = *find_block_starts(content, "footprint").first()?;
+    let after_tag = block + "(footprint".len();
+    let rel = content[after_tag..].find('"')?;
+    let start = after_tag + rel;
+    let end = start + 1 + content[start + 1..].find('"')?;
+    Some(start..end + 1)
+}
+
+/// Quote and escape `value` as an S-expression string literal.
+fn quote_sexp_string(value: &str) -> String {
+    format!("\"{}\"", escape_sexp_string(value))
+}
+
+/// Replace the value of the first `(property "<key>" "<value>" …)` entry.
+fn replace_property_value(content: &str, key: &str, value: &str) -> String {
+    let needle = format!("(property \"{key}\"");
+    let Some(prop) = find_block_starts(content, "property")
+        .into_iter()
+        .find(|&i| content[i..].starts_with(&needle))
+    else {
+        return content.to_string();
+    };
+    let after_key = prop + needle.len();
+    let Some(rel) = content[after_key..].find('"') else {
+        return content.to_string();
+    };
+    let vstart = after_key + rel;
+    let Some(rel_end) = content[vstart + 1..].find('"') else {
+        return content.to_string();
+    };
+    let vend = vstart + 1 + rel_end + 1;
+
+    let mut out = String::with_capacity(content.len());
+    out.push_str(&content[..vstart]);
+    out.push_str(&quote_sexp_string(value));
+    out.push_str(&content[vend..]);
+    out
+}
+
+/// Replace the footprint's own `(layer "…")` — the first `layer` block that is a
+/// direct child of the footprint, not one belonging to a pad or graphic.
+///
+/// Note this only retargets the footprint; a true F.Cu↔B.Cu flip would also
+/// have to mirror every child item, which is why back-side placement is
+/// rejected before this code can run (see `back_side_layer_error`).
+fn replace_footprint_layer(content: &str, layer: &str) -> String {
+    let Some(name) = footprint_name_span(content) else {
+        return content.to_string();
+    };
+    let Some(start) = find_block_starts(content, "layer")
+        .into_iter()
+        .find(|&i| i > name.end)
+    else {
+        return content.to_string();
+    };
+    let Some((bstart, bend)) = find_balanced_block(content, start) else {
+        return content.to_string();
+    };
+
+    let mut out = String::with_capacity(content.len());
+    out.push_str(&content[..bstart]);
+    out.push_str(&format!("(layer {})", quote_sexp_string(layer)));
+    out.push_str(&content[bend..]);
+    out
+}
+
+/// Insert `blocks` just inside the board's closing paren and write it back,
+/// refusing to write anything that is not one complete `(kicad_pcb …)` form.
+///
+/// The insert point is `rfind(')')`, which is only the right place if the file
+/// really is a single closed form. Checking the result before committing it
+/// means a board that was already truncated — or a footprint block that was —
+/// fails loudly instead of being written back over the user's file in a state
+/// KiCad can no longer open.
+///
+/// Like the rest of `konnect-sexp`, this treats parens as syntax everywhere: a
+/// `#`-commented paren would be miscounted. KiCad does not write comments into
+/// `.kicad_pcb`, and no reader in this workspace understands them either, so
+/// the assumption is at least consistent.
+fn insert_into_board(board_path: &Path, blocks: &[String]) -> anyhow::Result<()> {
+    let content = std::fs::read_to_string(board_path)?;
+    // KiCad writes these files CRLF on Windows — its bundled .kicad_mod
+    // libraries are CRLF throughout — so an inserted block joined with bare LF
+    // would leave the board with two conventions in it.
+    let eol = if content.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
+    let close_pos = content.rfind(')').unwrap_or(content.len());
+    let joined: String = blocks
+        .iter()
+        .map(|b| format!("{eol}{}", indent_block(b.trim_end(), "\t", eol)))
+        .collect();
+    let new_content = apply_edits(content, vec![SexpEdit::insert(close_pos, joined)]);
+
+    if let Err(why) = check_single_board_form(&new_content) {
+        anyhow::bail!(
+            "Refusing to write {}: {}. The board file was left untouched.",
+            board_path.display(),
+            why
+        );
+    }
+
+    write_atomic(board_path, &new_content)?;
+    Ok(())
+}
+
+/// Verify `content` is exactly one `(kicad_pcb …)` form and nothing else.
+///
+/// Checking only that *a* balanced block exists is too weak to back the promise
+/// above: `find_balanced_block` skips whatever precedes the first paren, so
+/// leading garbage would pass, as would a well-formed form that is not a board
+/// at all.
+fn check_single_board_form(content: &str) -> Result<(), String> {
+    let trimmed = content.trim();
+    let (start, end) = find_balanced_block(trimmed, 0)
+        .ok_or_else(|| "the result is not a balanced S-expression".to_string())?;
+
+    if start != 0 {
+        return Err(format!(
+            "{} bytes of content precede the opening paren",
+            start
+        ));
+    }
+    if end != trimmed.len() {
+        return Err(format!(
+            "{} bytes of content follow the closing paren",
+            trimmed.len() - end
+        ));
+    }
+    if !trimmed[1..].trim_start().starts_with("kicad_pcb") {
+        return Err("the root expression is not (kicad_pcb …)".to_string());
+    }
+    Ok(())
+}
+
+/// Prefix every non-empty line with `indent`, joining them with `eol`.
+fn indent_block(block: &str, indent: &str, eol: &str) -> String {
+    // `lines()` strips a trailing \r along with the \n, so rejoining with `eol`
+    // re-imposes one convention on a block that may have arrived with another —
+    // a CRLF library footprint going into an LF board, or the reverse.
+    block
+        .lines()
+        .map(|l| {
+            if l.trim().is_empty() {
+                String::new()
+            } else {
+                format!("{indent}{l}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(eol)
+}
+
 // ─── Tool definitions ─────────────────────────────────────────────────────────
 
 pub fn tools() -> Vec<ToolDef> {
@@ -689,15 +1078,73 @@ async fn handle_place_component(
         .map(|(_, entry)| entry)
         .unwrap_or(&footprint)
         .to_string();
-    let fp = ipc!(ctx, args, |c| c.place_footprint(
-        &footprint, &reference, &value, &pads, &graphics, x, y, rotation, &layer
-    ));
-    Ok(CallToolResult::json(&json!({
-        "placed": fp.reference,
-        "footprint": fp.footprint,
-        "x": fp.position.x, "y": fp.position.y,
-        "rotation": fp.rotation, "layer": fp.layer
-    })))
+
+    // Try IPC first. The fallback gate is the typed transport classification:
+    // only when the request never reached a live KiCad (unconfigured socket,
+    // failed dial/send) is it safe to edit the board file directly. A KiCad
+    // that answered — even with an error — may hold this board open, and a
+    // file edited behind a live editor is silently overwritten on its next
+    // save, so a rejection fails closed with no fallback.
+    let requested_board = board.clone();
+    let footprint_ipc = footprint.clone();
+    let reference_ipc = reference.clone();
+    let layer_ipc = layer.clone();
+    let attempt = with_ipc_classified(ctx.config.ipc_address.clone(), move |c| {
+        c.ensure_board_is_active(&requested_board)?;
+        c.place_footprint(
+            &footprint_ipc,
+            &reference_ipc,
+            &value,
+            &pads,
+            &graphics,
+            x,
+            y,
+            rotation,
+            &layer_ipc,
+        )
+    })
+    .await?;
+
+    match attempt {
+        Ok(fp) => Ok(CallToolResult::json(&json!({
+            "placed": fp.reference,
+            "footprint": fp.footprint,
+            "x": fp.position.x, "y": fp.position.y,
+            "rotation": fp.rotation, "layer": fp.layer,
+            "source": "ipc"
+        }))),
+        Err(konnect_ipc::IpcFailure::Rejected(message)) => Ok(CallToolResult::error(format!(
+            "KiCAD rejected the placement over IPC: {message}. \
+             The board file was not modified — KiCAD is reachable and may hold this \
+             board open, so editing the file directly could be silently overwritten."
+        ))),
+        Err(konnect_ipc::IpcFailure::Unreachable(_)) => {
+            // No live KiCad on the other end of this transport: fall back to
+            // editing the board file directly.
+            let sexp = match board_footprint_sexp(
+                &footprint,
+                x,
+                y,
+                rotation,
+                &layer,
+                Some(&reference),
+                board.parent(),
+            ) {
+                Ok(sexp) => sexp,
+                Err(message) => return Ok(CallToolResult::error(message)),
+            };
+            insert_into_board(&board, std::slice::from_ref(&sexp))?;
+            Ok(CallToolResult::json(&json!({
+                "placed": reference,
+                "footprint": footprint,
+                "x": x, "y": y, "rotation": rotation, "layer": layer,
+                "source": "file",
+                "warning": "KiCAD IPC was not reachable, so the board file was edited \
+                            directly. KiCAD will show this footprint when it next loads \
+                            the board."
+            })))
+        }
+    }
 }
 
 async fn handle_move_component(
@@ -1423,6 +1870,461 @@ mod tests {
             Some(crate::mcp::protocol::ToolContent::Text { text }) => text.clone(),
             other => panic!("expected text content, got {other:?}"),
         }
+    }
+
+    // ─── File-editing fallback (ported from emolitor's PR #66) ────────────────
+
+    /// A library footprint in the exact shape KiCad ships: TAB-indented, name
+    /// without a library prefix, `REF**` placeholder, no `(at …)`. CRLF, the
+    /// way KiCad's bundled libraries are written.
+    fn library_footprint() -> String {
+        [
+            "(footprint \"R_0805_2012Metric\"",
+            "\t(version 20260206)",
+            "\t(generator \"kicad-footprint-generator\")",
+            "\t(layer \"F.Cu\")",
+            "\t(descr \"Resistor SMD 0805\")",
+            "\t(property \"Reference\" \"REF**\"",
+            "\t\t(at 0 -1.65 0)",
+            "\t\t(layer \"F.SilkS\")",
+            "\t)",
+            "\t(property \"Value\" \"R_0805_2012Metric\"",
+            "\t\t(at 0 1.65 0)",
+            "\t\t(layer \"F.Fab\")",
+            "\t)",
+            "\t(pad \"1\" smd roundrect",
+            "\t\t(at -0.9125 0)",
+            "\t\t(size 1.025 1.4)",
+            "\t\t(layers \"F.Cu\" \"F.Paste\" \"F.Mask\")",
+            "\t)",
+            ")",
+            "",
+        ]
+        .join("\r\n")
+    }
+
+    const EMPTY_BOARD: &str = "(kicad_pcb
+\t(version 20260206)
+\t(generator \"pcbnew\")
+\t(net 0 \"\")
+)
+";
+
+    /// A project directory holding a registered `Resistor_SMD.pretty` library
+    /// with one footprint, plus an empty board. The project fp-lib-table makes
+    /// `Resistor_SMD:R_0805_2012Metric` resolve hermetically — no global
+    /// table, no environment.
+    fn fallback_fixture(dir: &Path) -> std::path::PathBuf {
+        let pretty = dir.join("Resistor_SMD.pretty");
+        std::fs::create_dir_all(&pretty).unwrap();
+        std::fs::write(pretty.join("R_0805_2012Metric.kicad_mod"), library_footprint()).unwrap();
+        std::fs::write(
+            dir.join("fp-lib-table"),
+            format!(
+                "(fp_lib_table\r\n\t(version 7)\r\n\t(lib (name \"Resistor_SMD\") (type \"KiCad\") (uri \"{}\") (options \"\") (descr \"\"))\r\n)\r\n",
+                pretty.to_string_lossy()
+            ),
+        )
+        .unwrap();
+        let board = dir.join("b.kicad_pcb");
+        std::fs::write(&board, EMPTY_BOARD).unwrap();
+        board
+    }
+
+    /// Net paren depth, ignoring anything inside quoted strings.
+    fn count_parens(s: &str) -> i32 {
+        let (mut depth, mut in_str, mut esc) = (0i32, false, false);
+        for ch in s.chars() {
+            match ch {
+                _ if esc => esc = false,
+                '\\' if in_str => esc = true,
+                '"' => in_str = !in_str,
+                '(' if !in_str => depth += 1,
+                ')' if !in_str => depth -= 1,
+                _ => {}
+            }
+        }
+        depth
+    }
+
+    #[tokio::test]
+    async fn unreachable_ipc_falls_back_to_writing_the_board_file() {
+        // ipc_address is empty in test_ctx, which classifies as
+        // transport-unreachable — the one condition under which editing the
+        // board file directly cannot race a live editor.
+        let tmp = tempfile::tempdir().unwrap();
+        let board = fallback_fixture(tmp.path());
+
+        let args = json!({
+            "board": board.to_string_lossy(),
+            "footprint": "Resistor_SMD:R_0805_2012Metric",
+            "reference": "R7",
+            "x": 50.0, "y": 60.0,
+        });
+        let res = handle_place_component(&args, &test_ctx()).await.unwrap();
+        assert!(!res.is_error, "handler errored: {:?}", res.content);
+
+        let out: serde_json::Value = serde_json::from_str(&result_text(&res)).unwrap();
+        assert_eq!(out["source"], "file");
+        assert_eq!(out["placed"], "R7");
+        assert!(
+            out["warning"]
+                .as_str()
+                .is_some_and(|w| w.contains("edited") && w.contains("loads")),
+            "the fallback must warn that the file was edited directly: {out}"
+        );
+
+        let written = std::fs::read_to_string(&board).unwrap();
+        assert_eq!(
+            written.matches("(footprint \"").count(),
+            1,
+            "no footprint:\n{written}"
+        );
+        assert!(
+            written.contains("(footprint \"Resistor_SMD:R_0805_2012Metric\""),
+            "board should carry the Library:Footprint id:\n{written}"
+        );
+        assert!(written.contains("(at 50 60 0)"), "placement missing:\n{written}");
+        assert!(written.contains("(property \"Reference\" \"R7\""), "{written}");
+        assert!(
+            written.contains("(pad \"1\" smd roundrect"),
+            "the full definition must be carried:\n{written}"
+        );
+        assert!(written.contains("(uuid \""), "board items need a uuid");
+        assert_eq!(count_parens(&written), 0, "board is no longer balanced:\n{written}");
+    }
+
+    #[tokio::test]
+    async fn fallback_placement_rotation_reaches_the_pads() {
+        // A rotated placement whose pads keep angle 0 trips KiCad's own
+        // lib_footprint_mismatch check, so the rotation has to reach them.
+        let tmp = tempfile::tempdir().unwrap();
+        let board = fallback_fixture(tmp.path());
+        let args = json!({
+            "board": board.to_string_lossy(),
+            "footprint": "Resistor_SMD:R_0805_2012Metric",
+            "reference": "R1", "x": 10.0, "y": 20.0, "rotation": -90.0,
+        });
+        let res = handle_place_component(&args, &test_ctx()).await.unwrap();
+        assert!(!res.is_error, "{:?}", res.content);
+
+        let out = std::fs::read_to_string(&board).unwrap();
+        assert!(out.contains("(at 10 20 -90)"), "footprint angle:\n{out}");
+        assert!(out.contains("(at -0.9125 0 270)"), "pad angle:\n{out}");
+        assert!(out.contains("(at 0 -1.65 90)"), "readable text angle:\n{out}");
+    }
+
+    #[tokio::test]
+    async fn a_truncated_board_is_refused_rather_than_rewritten() {
+        // rfind(')') picks the insert point, so a board that is not one closed
+        // (kicad_pcb …) form would silently gain a footprint outside the root
+        // expression. Nothing should be written in that case.
+        let tmp = tempfile::tempdir().unwrap();
+        let board = fallback_fixture(tmp.path());
+        let truncated = "(kicad_pcb (version 20241229) (generator \"test\")";
+        std::fs::write(&board, truncated).unwrap();
+
+        let args = json!({
+            "board": board.to_string_lossy(),
+            "footprint": "Resistor_SMD:R_0805_2012Metric",
+            "reference": "R1", "x": 1.0, "y": 2.0,
+        });
+        let err = handle_place_component(&args, &test_ctx())
+            .await
+            .expect_err("a malformed board must not be written back");
+        assert!(
+            err.to_string().contains("balanced"),
+            "error should explain why: {err}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&board).unwrap(),
+            truncated,
+            "board must be left exactly as it was"
+        );
+    }
+
+    /// Force LF, whatever the checkout did to this source file's literals.
+    fn lf(s: &str) -> String {
+        s.replace("\r\n", "\n")
+    }
+
+    /// Force CRLF, likewise.
+    fn crlf(s: &str) -> String {
+        lf(s).replace('\n', "\r\n")
+    }
+
+    #[tokio::test]
+    async fn a_crlf_board_stays_crlf() {
+        // KiCad writes these files CRLF on Windows, so placing into a CRLF
+        // board must not leave two conventions in it.
+        let tmp = tempfile::tempdir().unwrap();
+        let board = fallback_fixture(tmp.path());
+        std::fs::write(&board, crlf(EMPTY_BOARD)).unwrap();
+
+        let args = json!({
+            "board": board.to_string_lossy(),
+            "footprint": "Resistor_SMD:R_0805_2012Metric",
+            "reference": "R1", "x": 1.0, "y": 2.0,
+        });
+        let res = handle_place_component(&args, &test_ctx()).await.unwrap();
+        assert!(!res.is_error, "handler errored: {:?}", res.content);
+
+        let out = std::fs::read_to_string(&board).unwrap();
+        assert!(out.contains("(pad \"1\" smd roundrect"), "footprint missing");
+        let bare_lf = out
+            .match_indices('\n')
+            .filter(|(i, _)| *i == 0 || out.as_bytes()[i - 1] != b'\r')
+            .count();
+        assert_eq!(
+            bare_lf, 0,
+            "a CRLF board gained {bare_lf} bare LF line endings:\n{out:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_lf_board_stays_lf() {
+        // The reverse: a CRLF library footprint must not drag \r into an LF
+        // board, which is the common case on Linux and macOS.
+        let tmp = tempfile::tempdir().unwrap();
+        let board = fallback_fixture(tmp.path());
+        std::fs::write(&board, lf(EMPTY_BOARD)).unwrap();
+
+        let args = json!({
+            "board": board.to_string_lossy(),
+            "footprint": "Resistor_SMD:R_0805_2012Metric",
+            "reference": "R1", "x": 1.0, "y": 2.0,
+        });
+        let res = handle_place_component(&args, &test_ctx()).await.unwrap();
+        assert!(!res.is_error, "handler errored: {:?}", res.content);
+
+        let out = std::fs::read_to_string(&board).unwrap();
+        assert!(out.contains("(pad \"1\" smd roundrect"), "footprint missing");
+        assert!(
+            !out.contains('\r'),
+            "a CRLF library footprint dragged \\r into an LF board:\n{out:?}"
+        );
+    }
+
+    /// A rep0 endpoint that completes every round-trip with an error status —
+    /// a live KiCAD saying no. Placement must fail closed: error out, and
+    /// leave the board file alone.
+    fn spawn_rejecting_kicad() -> String {
+        use nng::options::Options;
+        let port = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let url = format!("tcp://127.0.0.1:{port}");
+        let socket = nng::Socket::new(nng::Protocol::Rep0).expect("mock rep socket");
+        socket
+            .set_opt::<nng::options::RecvTimeout>(Some(std::time::Duration::from_secs(10)))
+            .unwrap();
+        socket.listen(&url).expect("mock listen");
+        std::thread::spawn(move || {
+            use prost::Message;
+            while socket.recv().is_ok() {
+                let response = konnect_ipc::gen::kiapi::common::ApiResponse {
+                    status: Some(konnect_ipc::gen::kiapi::common::ApiResponseStatus {
+                        status: konnect_ipc::gen::kiapi::common::ApiStatusCode::AsBadRequest
+                            as i32,
+                        error_message: "mock rejects everything".to_string(),
+                    }),
+                    header: None,
+                    message: None,
+                };
+                let out = nng::Message::from(response.encode_to_vec().as_slice());
+                if socket.send(out).is_err() {
+                    break;
+                }
+            }
+        });
+        url
+    }
+
+    #[tokio::test]
+    async fn a_reachable_kicad_that_rejects_never_touches_the_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let board = fallback_fixture(tmp.path());
+        let board_before = std::fs::read_to_string(&board).unwrap();
+
+        let ctx = ToolContext::new(
+            crate::tools::ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: spawn_rejecting_kicad(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+            },
+            std::sync::Arc::new(crate::router::ToolRouter::new()),
+        );
+        let args = json!({
+            "board": board.to_string_lossy(),
+            "footprint": "Resistor_SMD:R_0805_2012Metric",
+            "reference": "R1", "x": 1.0, "y": 2.0,
+        });
+        let res = handle_place_component(&args, &ctx).await.unwrap();
+        assert!(res.is_error, "a rejection must not be reported as success");
+        let text = result_text(&res);
+        assert!(
+            text.contains("rejected the placement") && text.contains("not modified"),
+            "the error must say the file was left alone: {text}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&board).unwrap(),
+            board_before,
+            "a reachable KiCAD that says no must never trigger the file fallback"
+        );
+    }
+
+    // ─── board_lib_id / helpers (ported from PR #66) ──────────────────────────
+
+    /// `board_lib_id` for a path, with the library file's declared name.
+    fn id_for(path: &str, declared: &str) -> String {
+        board_lib_id(path, Path::new(path), declared)
+    }
+
+    #[test]
+    fn board_lib_id_never_yields_a_filesystem_path() {
+        // A Library:Footprint id is already what the board wants.
+        assert_eq!(
+            board_lib_id("Resistor_SMD:R_0805", Path::new("/ignored"), "R_0805"),
+            "Resistor_SMD:R_0805"
+        );
+        // A path in a .pretty library takes the nickname from its directory.
+        assert_eq!(
+            id_for(
+                "/nonexistent/kicad/footprints/Resistor_SMD.pretty/R_0805.kicad_mod",
+                "R_0805"
+            ),
+            "Resistor_SMD:R_0805"
+        );
+        // Loose file: no nickname to recover, so it keeps the name the library
+        // file declares — unlinked, but a valid name rather than a path.
+        assert_eq!(
+            id_for("/nonexistent/scratch/R_0805.kicad_mod", "R_0805_2012Metric"),
+            "R_0805_2012Metric"
+        );
+    }
+
+    #[test]
+    fn a_path_like_declared_name_falls_back_to_the_file_stem() {
+        // A malformed library file naming itself with a path must not smuggle
+        // that path into the board through the fallback branch.
+        assert_eq!(
+            id_for(
+                "/nonexistent/scratch/R_0805.kicad_mod",
+                "/tmp/other/R.kicad_mod"
+            ),
+            "R_0805"
+        );
+        assert_eq!(
+            id_for("/nonexistent/scratch/R_0805.kicad_mod", r"C:\x\R.kicad_mod"),
+            "R_0805"
+        );
+        // An empty declared name is no better than a path.
+        assert_eq!(id_for("/nonexistent/scratch/R_0805.kicad_mod", ""), "R_0805");
+    }
+
+    #[test]
+    fn pretty_suffix_matching_ignores_case() {
+        // Windows and macOS filesystems are case-insensitive, so Foo.Pretty and
+        // Foo.pretty are the same directory to KiCad.
+        assert_eq!(
+            pretty_dir_nickname(Path::new("/libs/Resistor_SMD.Pretty")),
+            Some("Resistor_SMD".into())
+        );
+        assert_eq!(
+            pretty_dir_nickname(Path::new("/libs/Resistor_SMD.pretty")),
+            Some("Resistor_SMD".into())
+        );
+        // A bare ".pretty" leaves no nickname behind.
+        assert_eq!(pretty_dir_nickname(Path::new("/libs/.pretty")), None);
+        assert_eq!(pretty_dir_nickname(Path::new("/libs/plain")), None);
+    }
+
+    #[test]
+    fn a_board_edit_must_stay_one_kicad_pcb_form() {
+        assert!(check_single_board_form("(kicad_pcb (version 20241229))").is_ok());
+        assert!(check_single_board_form("\n  (kicad_pcb (version 1))\n\n").is_ok());
+
+        // Truncated — the bug this guard exists for.
+        assert!(check_single_board_form("(kicad_pcb (version 1)").is_err());
+        // Leading garbage would otherwise be skipped by find_balanced_block.
+        assert!(check_single_board_form("garbage(kicad_pcb (version 1))").is_err());
+        // A second form after the root is not one board.
+        assert!(check_single_board_form("(kicad_pcb (version 1))(extra)").is_err());
+        // Well-formed, but not a board.
+        assert!(check_single_board_form("(not_a_board (version 1))").is_err());
+    }
+
+    #[test]
+    fn pad_angles_absorb_the_footprint_rotation() {
+        // KiCad stores each pad's absolute orientation: a footprint placed at
+        // -90 carries 270 on its pads, while pad positions stay in unrotated
+        // footprint-local coordinates.
+        let out = apply_rotation_to_children(&library_footprint(), -90.0);
+        assert!(out.contains("(at -0.9125 0 270)"), "{out}");
+        // Position is unchanged; only the angle was added.
+        assert!(!out.contains("(at 0 -0.9125"), "pad position must not rotate");
+    }
+
+    #[test]
+    fn text_angles_are_kept_readable_in_file_fallback() {
+        // A -90 footprint would put text at 270, which reads upside down, so
+        // KiCad flips it by 180 to 90 — matching what pcbnew writes.
+        let out = apply_rotation_to_children(&library_footprint(), -90.0);
+        assert!(out.contains("(at 0 -1.65 90)"), "reference text:\n{out}");
+        assert!(out.contains("(at 0 1.65 90)"), "value text:\n{out}");
+    }
+
+    #[test]
+    fn zero_rotation_is_written_without_an_angle() {
+        assert_eq!(format_at(1.5, -2.0, 0.0), "(at 1.5 -2)");
+        assert_eq!(format_at(0.0, 0.0, 90.0), "(at 0 0 90)");
+    }
+
+    #[test]
+    fn rotate_at_block_rejects_non_positional_at() {
+        assert!(rotate_at_block("(at)", 90.0, false).is_none());
+        assert!(rotate_at_block("(atomic 1 2)", 90.0, false).is_none());
+        assert!(rotate_at_block("(at 1 2 3 4)", 90.0, false).is_none());
+    }
+
+    #[test]
+    fn indent_block_reimposes_one_line_ending() {
+        // A CRLF library footprint going into an LF board and the reverse:
+        // whichever the destination uses is what comes out.
+        assert_eq!(indent_block("a\r\nb", "\t", "\n"), "\ta\n\tb");
+        assert_eq!(indent_block("a\nb", "\t", "\r\n"), "\ta\r\n\tb");
+    }
+
+    #[test]
+    fn sexp_strings_are_escaped_and_quoted() {
+        // Input characters:  a " b \ c
+        let input = ['a', '"', 'b', '\\', 'c'].iter().collect::<String>();
+        let expected = ['"', 'a', '\\', '"', 'b', '\\', '\\', 'c', '"']
+            .iter()
+            .collect::<String>();
+        assert_eq!(quote_sexp_string(&input), expected);
+        assert_eq!(quote_sexp_string("plain"), "\"plain\"");
+    }
+
+    #[test]
+    fn name_span_covers_the_quoted_header_name() {
+        let content = library_footprint();
+        let span = footprint_name_span(&content).expect("header not found");
+        assert_eq!(&content[span], "\"R_0805_2012Metric\"");
+    }
+
+    #[test]
+    fn reference_substitution_targets_the_reference_property_only() {
+        let out = replace_property_value(&library_footprint(), "Reference", "R42");
+        assert!(out.contains("(property \"Reference\" \"R42\""), "{out}");
+        assert!(
+            out.contains("(property \"Value\" \"R_0805_2012Metric\""),
+            "Value must be untouched:\n{out}"
+        );
+        assert!(!out.contains("REF**"));
     }
 
     #[tokio::test]

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -350,6 +350,39 @@ fn text_at(node: &konnect_sexp::SexpNode, kind: &str) -> anyhow::Result<((f64, f
 ///
 /// `Reference` and `Value` properties are excluded — `build_footprint_item`
 /// already carries those as first-class fields.
+/// Footprint-local Reference/Value text anchors from the library source, so
+/// placed parts keep the library's text layout (a synthesized offset put the
+/// Reference on the part's own silkscreen — silk_overlap in live DRC).
+fn extract_field_placement(source: &str) -> konnect_ipc::IpcFieldPlacement {
+    let mut placement = konnect_ipc::IpcFieldPlacement::default();
+    let Ok(footprint) = konnect_sexp::parse_sexp(source) else {
+        return placement;
+    };
+    for prop in footprint.find_all("property") {
+        let Some(name) = prop.get(1).and_then(|n| n.as_str()) else {
+            continue;
+        };
+        let Some(at) = prop.find("at") else {
+            continue;
+        };
+        let num = |i: usize| {
+            at.get(i)
+                .and_then(|v| v.as_str())
+                .and_then(|s| s.parse::<f64>().ok())
+        };
+        let (x, y) = (num(1), num(2));
+        let rot = num(3).unwrap_or(0.0);
+        if let (Some(x), Some(y)) = (x, y) {
+            match name {
+                "Reference" => placement.reference_at = Some((x, y, rot)),
+                "Value" => placement.value_at = Some((x, y, rot)),
+                _ => {}
+            }
+        }
+    }
+    placement
+}
+
 fn extract_graphic_definitions(
     source: &str,
 ) -> anyhow::Result<Vec<konnect_ipc::IpcGraphicDefinition>> {
@@ -1072,6 +1105,7 @@ async fn handle_place_component(
         Ok(graphics) => graphics,
         Err(error) => return Ok(CallToolResult::error(error.to_string())),
     };
+    let fields = extract_field_placement(&prepared);
 
     let value = footprint
         .split_once(':')
@@ -1090,13 +1124,14 @@ async fn handle_place_component(
     let reference_ipc = reference.clone();
     let layer_ipc = layer.clone();
     let attempt = with_ipc_classified(ctx.config.ipc_address.clone(), move |c| {
-        c.ensure_board_is_active(&requested_board)?;
         c.place_footprint(
+            &requested_board,
             &footprint_ipc,
             &reference_ipc,
             &value,
             &pads,
             &graphics,
+            &fields,
             x,
             y,
             rotation,
@@ -1414,6 +1449,7 @@ async fn handle_place_array(
         Ok(graphics) => graphics,
         Err(error) => return Ok(CallToolResult::error(error.to_string())),
     };
+    let fields = extract_field_placement(&source);
 
     let value = footprint
         .split_once(':')
@@ -1470,6 +1506,7 @@ async fn handle_place_array(
                     &value,
                     pads,
                     &graphics,
+                    &fields,
                     *x,
                     *y,
                     0.0,
@@ -1631,12 +1668,16 @@ async fn handle_duplicate_component(
         Ok(graphics) => graphics,
         Err(error) => return Ok(CallToolResult::error(error.to_string())),
     };
+    let fields = extract_field_placement(&prepared);
+    let dup_board = board.clone();
     let fp = ipc!(ctx, args, |c| c.place_footprint(
+        &dup_board,
         &fp_id,
         &ipc_reference,
         &fp_value,
         &pads,
         &graphics,
+        &fields,
         x,
         y,
         fp_rotation,
@@ -2396,5 +2437,35 @@ mod tests {
             board_content,
             "board file must be left untouched"
         );
+    }
+}
+
+#[cfg(test)]
+mod field_placement_tests {
+    use super::*;
+
+    #[test]
+    fn field_anchors_come_from_the_library_footprint() {
+        // R_0603-style: Reference above the silk at -1.43, Value below at 1.43.
+        let source = "(footprint \"R_0603\"
+	(property \"Reference\" \"REF**\"
+		(at 0 -1.43 0)
+		(layer \"F.SilkS\")
+	)
+	(property \"Value\" \"R_0603\"
+		(at 0 1.43 0)
+		(layer \"F.Fab\")
+	)
+)";
+        let placement = extract_field_placement(source);
+        assert_eq!(placement.reference_at, Some((0.0, -1.43, 0.0)));
+        assert_eq!(placement.value_at, Some((0.0, 1.43, 0.0)));
+    }
+
+    #[test]
+    fn missing_fields_leave_defaults() {
+        let placement = extract_field_placement("(footprint \"bare\")");
+        assert_eq!(placement.reference_at, None);
+        assert_eq!(placement.value_at, None);
     }
 }

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -7,8 +7,11 @@
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
 use crate::tools::{get_path, require_f64, require_str, ToolContext, ToolDef};
+use anyhow::Context;
 use konnect_ipc::client::KiCadIpcClient;
 use serde_json::json;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 
 // ─── IPC helper ───────────────────────────────────────────────────────────────
 
@@ -19,15 +22,21 @@ where
 {
     match tokio::task::spawn_blocking(move || f(&KiCadIpcClient::new(&addr))).await {
         Ok(Ok(r)) => Ok(Ok(r)),
-        Ok(Err(e)) => Ok(Err(e.to_string())),
+        Ok(Err(e)) => Ok(Err(format!("{e:#}"))),
         Err(e) => Err(anyhow::anyhow!("Thread error: {}", e)),
     }
 }
 
 macro_rules! ipc {
-    ($ctx:expr, |$c:ident| $body:expr) => {{
+    ($ctx:expr, $args:expr, |$c:ident| $body:expr) => {{
         let addr = $ctx.config.ipc_address.clone();
-        match with_ipc(addr, move |$c| $body).await? {
+        let requested_board = get_path($args, "board")?;
+        match with_ipc(addr, move |$c| {
+            $c.ensure_board_is_active(&requested_board)?;
+            $body
+        })
+        .await?
+        {
             Ok(v) => v,
             Err(msg) => {
                 return Ok(CallToolResult::error(format!(
@@ -37,6 +46,284 @@ macro_rules! ipc {
             }
         }
     }};
+}
+
+// ─── Footprint-library resolution ───────────────────────────────────────────
+
+fn footprint_library_dirs() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for variable in ["KICAD10_FOOTPRINT_DIR", "KICAD9_FOOTPRINT_DIR"] {
+        if let Some(path) = std::env::var_os(variable).map(PathBuf::from) {
+            if path.is_dir() && !paths.contains(&path) {
+                paths.push(path);
+            }
+        }
+    }
+
+    let candidates: &[&str] = if cfg!(target_os = "windows") {
+        &[
+            r"C:\Program Files\KiCad\10.0\share\kicad\footprints",
+            r"C:\KiCad\10.0\share\kicad\footprints",
+            r"C:\Program Files\KiCad\9.0\share\kicad\footprints",
+            r"C:\KiCad\9.0\share\kicad\footprints",
+        ]
+    } else if cfg!(target_os = "macos") {
+        &[
+            "/Applications/KiCad/KiCad.app/Contents/SharedSupport/footprints",
+            "/usr/local/share/kicad/footprints",
+        ]
+    } else {
+        &[
+            "/usr/share/kicad/footprints",
+            "/usr/local/share/kicad/footprints",
+            "/snap/kicad/current/usr/share/kicad/footprints",
+            "/var/lib/flatpak/app/org.kicad.KiCad/current/active/files/share/kicad/footprints",
+        ]
+    };
+    for candidate in candidates {
+        let path = PathBuf::from(candidate);
+        if path.is_dir() && !paths.contains(&path) {
+            paths.push(path);
+        }
+    }
+    if cfg!(not(any(target_os = "windows", target_os = "macos"))) {
+        if let Some(home) = dirs::home_dir() {
+            let path = home.join(
+                ".local/share/flatpak/app/org.kicad.KiCad/current/active/files/share/kicad/footprints",
+            );
+            if path.is_dir() && !paths.contains(&path) {
+                paths.push(path);
+            }
+        }
+    }
+    paths
+}
+
+fn expand_library_uri(uri: &str, project_dir: &Path) -> Option<PathBuf> {
+    let mut expanded = uri.strip_prefix("file://").unwrap_or(uri).to_string();
+    expanded = expanded.replace("${KIPRJMOD}", &project_dir.to_string_lossy());
+    expanded = expanded.replace("$(KIPRJMOD)", &project_dir.to_string_lossy());
+
+    for delimiters in [("${", "}"), ("$(", ")")] {
+        while let Some(start) = expanded.find(delimiters.0) {
+            let name_start = start + delimiters.0.len();
+            let end = expanded[name_start..].find(delimiters.1)? + name_start;
+            let name = &expanded[name_start..end];
+            let value = std::env::var(name).ok()?;
+            expanded.replace_range(start..end + delimiters.1.len(), &value);
+        }
+    }
+    Some(PathBuf::from(expanded))
+}
+
+fn footprint_from_table(
+    table: &Path,
+    nickname: &str,
+    entry: &str,
+    project_dir: &Path,
+) -> Option<PathBuf> {
+    let content = std::fs::read_to_string(table).ok()?;
+    let parsed = konnect_sexp::parse_sexp(&content).ok()?;
+    let library = parsed
+        .find_all("lib")
+        .into_iter()
+        .find(|library| library.find_str("name") == Some(nickname))?;
+    let uri = library.find_str("uri")?;
+
+    // KiCad defines this variable internally rather than exporting it to the
+    // process environment. Resolve the standard-library form against every
+    // discovered platform installation directory.
+    for prefix in ["${KICAD10_FOOTPRINT_DIR}", "$(KICAD10_FOOTPRINT_DIR)"] {
+        if let Some(suffix) = uri.strip_prefix(prefix) {
+            let suffix = suffix.trim_start_matches(['/', '\\']);
+            return footprint_library_dirs()
+                .into_iter()
+                .map(|base| base.join(suffix).join(format!("{entry}.kicad_mod")))
+                .find(|path| path.is_file());
+        }
+    }
+
+    let library_dir = expand_library_uri(uri, project_dir)?;
+    let path = library_dir.join(format!("{entry}.kicad_mod"));
+    path.is_file().then_some(path)
+}
+
+fn resolve_footprint_source(lib_id: &str, board: &Path) -> anyhow::Result<String> {
+    let (nickname, entry) = lib_id.split_once(':').ok_or_else(|| {
+        anyhow::anyhow!("footprint must use Library:Footprint syntax, got '{lib_id}'")
+    })?;
+    if nickname.is_empty() || entry.is_empty() {
+        anyhow::bail!("footprint must use a non-empty Library:Footprint identifier");
+    }
+    let project_dir = board.parent().unwrap_or_else(|| Path::new("."));
+    let project_table = project_dir.join("fp-lib-table");
+    let global_table = super::kicad_config_dir().join("fp-lib-table");
+    for table in [&project_table, &global_table] {
+        if let Some(path) = footprint_from_table(table, nickname, entry, project_dir) {
+            return std::fs::read_to_string(&path)
+                .map_err(|error| anyhow::anyhow!("failed to read {}: {error}", path.display()));
+        }
+    }
+
+    let filename = format!("{entry}.kicad_mod");
+    let attempted: Vec<PathBuf> = footprint_library_dirs()
+        .into_iter()
+        .map(|base| base.join(format!("{nickname}.pretty")).join(&filename))
+        .collect();
+    for path in &attempted {
+        if path.is_file() {
+            return std::fs::read_to_string(path)
+                .map_err(|error| anyhow::anyhow!("failed to read {}: {error}", path.display()));
+        }
+    }
+    anyhow::bail!(
+        "footprint '{lib_id}' was not found in the project/global fp-lib-table or KiCad library directories (set KICAD10_FOOTPRINT_DIR for a non-standard install)"
+    )
+}
+
+fn escape_sexp_string(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn replace_quoted_after(source: &mut String, marker: &str, value: &str) -> anyhow::Result<()> {
+    let start = source
+        .find(marker)
+        .map(|offset| offset + marker.len())
+        .ok_or_else(|| anyhow::anyhow!("footprint library data is missing {marker}"))?;
+    let bytes = source.as_bytes();
+    let mut escaped = false;
+    let end = (start..bytes.len())
+        .find(|index| {
+            let byte = bytes[*index];
+            if escaped {
+                escaped = false;
+                false
+            } else if byte == b'\\' {
+                escaped = true;
+                false
+            } else {
+                byte == b'"'
+            }
+        })
+        .ok_or_else(|| anyhow::anyhow!("unterminated quoted value after {marker}"))?;
+    source.replace_range(start..end, &escape_sexp_string(value));
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn prepare_footprint_source(
+    source: &str,
+    lib_id: &str,
+    reference: &str,
+    value: Option<&str>,
+    x: f64,
+    y: f64,
+    rotation: f64,
+    layer: &str,
+) -> anyhow::Result<String> {
+    if !matches!(layer, "F.Cu" | "B.Cu") {
+        anyhow::bail!("footprints can only be placed on F.Cu or B.Cu, got '{layer}'");
+    }
+    let mut prepared = source.to_string();
+    replace_quoted_after(&mut prepared, "(footprint \"", lib_id)?;
+    replace_quoted_after(&mut prepared, "(property \"Reference\" \"", reference)?;
+    if let Some(value) = value {
+        replace_quoted_after(&mut prepared, "(property \"Value\" \"", value)?;
+    }
+
+    if layer == "B.Cu" {
+        prepared = prepared.replace("\"F.", "\"__KONNECT_FRONT__.");
+        prepared = prepared.replace("\"B.", "\"F.");
+        prepared = prepared.replace("\"__KONNECT_FRONT__.", "\"B.");
+    }
+    replace_quoted_after(&mut prepared, "(layer \"", layer)?;
+    let layer_start = prepared
+        .find("(layer \"")
+        .context("footprint library data has no root layer")?;
+    let layer_end = prepared[layer_start..]
+        .find(')')
+        .map(|offset| layer_start + offset + 1)
+        .context("footprint root layer is unterminated")?;
+    prepared.insert_str(layer_end, &format!("\n\t(at {x} {y} {rotation})"));
+    konnect_sexp::parse_sexp(&prepared).context("prepared footprint is not valid S-expression")?;
+    Ok(prepared)
+}
+
+fn extract_pad_definitions(source: &str) -> anyhow::Result<Vec<konnect_ipc::IpcPadDefinition>> {
+    let footprint = konnect_sexp::parse_sexp(source)?;
+    footprint
+        .find_all("pad")
+        .into_iter()
+        .map(|pad| {
+            let required = |index: usize, label: &str| {
+                pad.get(index)
+                    .and_then(konnect_sexp::SexpNode::as_str)
+                    .ok_or_else(|| anyhow::anyhow!("footprint pad is missing {label}"))
+            };
+            let shape = required(3, "shape")?.to_string();
+            if shape == "custom" {
+                anyhow::bail!(
+                    "custom-shape pads are not supported by KiCad 10's typed placement path"
+                );
+            }
+            let at = pad
+                .find("at")
+                .context("footprint pad is missing its position")?;
+            let size = pad
+                .find("size")
+                .context("footprint pad is missing its size")?;
+            let layers = pad
+                .find("layers")
+                .context("footprint pad is missing its layer set")?
+                .children()
+                .unwrap_or_default()
+                .iter()
+                .skip(1)
+                .filter_map(konnect_sexp::SexpNode::as_str)
+                .map(str::to_string)
+                .collect();
+            let (drill_x, drill_y, drill_oval) = match pad.find("drill") {
+                Some(drill)
+                    if drill.get(1).and_then(konnect_sexp::SexpNode::as_str) == Some("oval") =>
+                {
+                    (
+                        drill.get_f64(2),
+                        drill.get_f64(3).or_else(|| drill.get_f64(2)),
+                        true,
+                    )
+                }
+                Some(drill) => (
+                    drill.get_f64(1),
+                    drill.get_f64(2).or_else(|| drill.get_f64(1)),
+                    false,
+                ),
+                None => (None, None, false),
+            };
+            Ok(konnect_ipc::IpcPadDefinition {
+                number: required(1, "number")?.to_string(),
+                pad_type: required(2, "type")?.to_string(),
+                shape,
+                x: at
+                    .get_f64(1)
+                    .context("footprint pad has an invalid X position")?,
+                y: at
+                    .get_f64(2)
+                    .context("footprint pad has an invalid Y position")?,
+                rotation: at.get_f64(3).unwrap_or(0.0),
+                size_x: size
+                    .get_f64(1)
+                    .context("footprint pad has an invalid width")?,
+                size_y: size
+                    .get_f64(2)
+                    .context("footprint pad has an invalid height")?,
+                drill_x,
+                drill_y,
+                drill_oval,
+                layers,
+                roundrect_ratio: pad.find_f64("roundrect_rratio").unwrap_or(0.0),
+            })
+        })
+        .collect()
 }
 
 // ─── Tool definitions ─────────────────────────────────────────────────────────
@@ -247,7 +534,12 @@ async fn handle_place_component(
     args: &serde_json::Value,
     ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
+    let board = get_path(args, "board")?;
     let footprint = match require_str(args, "footprint") {
+        Ok(v) => v.to_string(),
+        Err(e) => return Ok(e),
+    };
+    let reference = match require_str(args, "reference") {
         Ok(v) => v.to_string(),
         Err(e) => return Ok(e),
     };
@@ -261,9 +553,29 @@ async fn handle_place_component(
     };
     let rotation = args["rotation"].as_f64().unwrap_or(0.0);
     let layer = args["layer"].as_str().unwrap_or("F.Cu").to_string();
+    let source = match resolve_footprint_source(&footprint, &board) {
+        Ok(source) => source,
+        Err(error) => return Ok(CallToolResult::error(error.to_string())),
+    };
+    let prepared = match prepare_footprint_source(
+        &source, &footprint, &reference, None, x, y, rotation, &layer,
+    ) {
+        Ok(prepared) => prepared,
+        Err(error) => return Ok(CallToolResult::error(error.to_string())),
+    };
+    let pads = match extract_pad_definitions(&prepared) {
+        Ok(pads) => pads,
+        Err(error) => return Ok(CallToolResult::error(error.to_string())),
+    };
 
-    let fp = ipc!(ctx, |c| c
-        .place_footprint(&footprint, x, y, rotation, &layer));
+    let value = footprint
+        .split_once(':')
+        .map(|(_, entry)| entry)
+        .unwrap_or(&footprint)
+        .to_string();
+    let fp = ipc!(ctx, args, |c| c.place_footprint(
+        &footprint, &reference, &value, &pads, x, y, rotation, &layer
+    ));
     Ok(CallToolResult::json(&json!({
         "placed": fp.reference,
         "footprint": fp.footprint,
@@ -290,7 +602,7 @@ async fn handle_move_component(
     };
 
     let ref_ipc = reference.clone();
-    ipc!(ctx, |c| c.move_footprint(&ref_ipc, x, y));
+    ipc!(ctx, args, |c| c.move_footprint(&ref_ipc, x, y));
     Ok(CallToolResult::json(
         &json!({ "moved": reference, "x": x, "y": y }),
     ))
@@ -310,7 +622,7 @@ async fn handle_rotate_component(
     };
 
     let ref_ipc = reference.clone();
-    ipc!(ctx, |c| c.rotate_footprint(&ref_ipc, rotation));
+    ipc!(ctx, args, |c| c.rotate_footprint(&ref_ipc, rotation));
     Ok(CallToolResult::json(
         &json!({ "rotated": reference, "rotation": rotation }),
     ))
@@ -326,7 +638,7 @@ async fn handle_delete_component(
     };
 
     let ref_ipc = reference.clone();
-    ipc!(ctx, |c| c.delete_footprint(&ref_ipc));
+    ipc!(ctx, args, |c| c.delete_footprint(&ref_ipc));
     Ok(CallToolResult::json(&json!({ "deleted": reference })))
 }
 
@@ -334,21 +646,25 @@ async fn handle_edit_component(
     args: &serde_json::Value,
     ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
-    // IPC doesn't have a direct "set value" command; re-get the footprint and report
-    // For now this is a query + informational response. Full field edits require S-expr.
     let reference = match require_str(args, "reference") {
         Ok(v) => v.to_string(),
         Err(e) => return Ok(e),
     };
-    let fp = ipc!(ctx, |c| {
-        c.get_footprint(&reference)?
-            .ok_or_else(|| anyhow::anyhow!("Footprint '{}' not found", reference))
+    if let Some(value) = args["value"].as_str() {
+        let reference_for_ipc = reference.clone();
+        let value_for_ipc = value.to_string();
+        ipc!(ctx, args, |c| c
+            .set_footprint_value(&reference_for_ipc, &value_for_ipc));
+    }
+    let lookup_reference = reference.clone();
+    let fp = ipc!(ctx, args, |c| {
+        c.get_footprint(&lookup_reference)?
+            .ok_or_else(|| anyhow::anyhow!("Footprint '{}' not found", lookup_reference))
     });
     Ok(CallToolResult::json(&json!({
         "reference": fp.reference,
         "value": fp.value,
-        "footprint": fp.footprint,
-        "note": "Field edits via IPC are not yet supported. Edit in the schematic (edit_schematic_component), then open the PCB in KiCAD and run Tools > Update PCB from Schematic."
+        "footprint": fp.footprint
     })))
 }
 
@@ -360,7 +676,7 @@ async fn handle_find_component(
         Ok(v) => v.to_string(),
         Err(e) => return Ok(e),
     };
-    let fp = ipc!(ctx, |c| {
+    let fp = ipc!(ctx, args, |c| {
         c.get_footprint(&reference)?
             .ok_or_else(|| anyhow::anyhow!("Footprint '{}' not found", reference))
     });
@@ -468,7 +784,7 @@ async fn handle_get_component_list(
     _args: &serde_json::Value,
     ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
-    let fps = ipc!(ctx, |c| c.list_footprints());
+    let fps = ipc!(ctx, _args, |c| c.list_footprints());
     let items: Vec<serde_json::Value> = fps
         .iter()
         .map(|fp| {
@@ -490,6 +806,7 @@ async fn handle_place_array(
     args: &serde_json::Value,
     ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
+    let board = get_path(args, "board")?;
     let footprint = match require_str(args, "footprint") {
         Ok(v) => v.to_string(),
         Err(e) => return Ok(e),
@@ -502,42 +819,112 @@ async fn handle_place_array(
         Ok(v) => v,
         Err(e) => return Ok(e),
     };
-    let count_x = args["count_x"].as_u64().unwrap_or(1) as usize;
-    let count_y = args["count_y"].as_u64().unwrap_or(1) as usize;
+    let count_x = args["count_x"].as_u64().unwrap_or(1);
+    let count_y = args["count_y"].as_u64().unwrap_or(1);
+    let Some(total_count) = count_x.checked_mul(count_y) else {
+        return Ok(CallToolResult::error("Array dimensions overflow."));
+    };
+    if count_x == 0 || count_y == 0 || total_count > 10_000 {
+        return Ok(CallToolResult::error(
+            "Array dimensions must be non-zero and contain at most 10,000 components.",
+        ));
+    }
+    let count_x = count_x as usize;
+    let count_y = count_y as usize;
     let spacing_x = match require_f64(args, "spacing_x") {
         Ok(v) => v,
         Err(e) => return Ok(e),
     };
     let spacing_y = args["spacing_y"].as_f64().unwrap_or(spacing_x);
     let prefix = args["ref_prefix"].as_str().unwrap_or("U").to_string();
-    let ref_start = args["ref_start"].as_u64().unwrap_or(1) as usize;
+    let ref_start = args["ref_start"].as_u64().unwrap_or(1);
+    if ref_start.checked_add(total_count - 1).is_none() {
+        return Ok(CallToolResult::error("Reference number overflow."));
+    }
+    let source = match resolve_footprint_source(&footprint, &board) {
+        Ok(source) => source,
+        Err(error) => return Ok(CallToolResult::error(error.to_string())),
+    };
 
-    let mut placed = Vec::new();
-    let mut n = ref_start;
+    let value = footprint
+        .split_once(':')
+        .map(|(_, entry)| entry)
+        .unwrap_or(&footprint)
+        .to_string();
+    let mut planned = Vec::with_capacity(total_count as usize);
     for row in 0..count_y {
         for col in 0..count_x {
             let x = start_x + col as f64 * spacing_x;
             let y = start_y + row as f64 * spacing_y;
-            let reference = format!("{prefix}{n}");
-            let fp_id = footprint.clone();
-            let ref2 = reference.clone();
-            match with_ipc(ctx.config.ipc_address.clone(), move |c| {
-                c.place_footprint(&fp_id, x, y, 0.0, "F.Cu")
-            })
-            .await?
-            {
-                Ok(fp) => placed
-                    .push(json!({ "reference": ref2, "x": fp.position.x, "y": fp.position.y })),
-                Err(e) => {
-                    return Ok(CallToolResult::error(format!(
-                        "IPC error placing {}: {}",
-                        reference, e
-                    )))
-                }
-            }
-            n += 1;
+            let reference = format!("{prefix}{}", ref_start + planned.len() as u64);
+            let prepared = match prepare_footprint_source(
+                &source, &footprint, &reference, None, x, y, 0.0, "F.Cu",
+            ) {
+                Ok(prepared) => prepared,
+                Err(error) => return Ok(CallToolResult::error(error.to_string())),
+            };
+            let pads = match extract_pad_definitions(&prepared) {
+                Ok(pads) => pads,
+                Err(error) => return Ok(CallToolResult::error(error.to_string())),
+            };
+            planned.push((reference, pads, x, y));
         }
     }
+
+    let requested_board = board.clone();
+    let footprint_id = footprint.clone();
+    let placed = match with_ipc(ctx.config.ipc_address.clone(), move |c| {
+        c.ensure_board_is_active(&requested_board)?;
+        let existing = c
+            .list_footprints()?
+            .into_iter()
+            .map(|footprint| footprint.reference)
+            .collect::<HashSet<_>>();
+        let conflicts = planned
+            .iter()
+            .filter(|(reference, _, _, _)| existing.contains(reference))
+            .map(|(reference, _, _, _)| reference.as_str())
+            .collect::<Vec<_>>();
+        if !conflicts.is_empty() {
+            anyhow::bail!(
+                "footprint references already exist on the board: {}",
+                conflicts.join(", ")
+            );
+        }
+
+        let items = planned
+            .iter()
+            .map(|(reference, pads, x, y)| {
+                c.build_footprint_item(&footprint_id, reference, &value, pads, *x, *y, 0.0, "F.Cu")
+                    .with_context(|| format!("failed to prepare {reference}"))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        c.run_commit("Place footprint array", |c| c.create_items(items))?;
+
+        let mut created = c
+            .list_footprints()?
+            .into_iter()
+            .map(|footprint| (footprint.reference.clone(), footprint))
+            .collect::<HashMap<_, _>>();
+        planned
+            .into_iter()
+            .map(|(reference, _, _, _)| {
+                let footprint = created.remove(&reference).with_context(|| {
+                    format!("committed footprint '{reference}' was not found on the board")
+                })?;
+                Ok(json!({
+                    "reference": reference,
+                    "x": footprint.position.x,
+                    "y": footprint.position.y
+                }))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()
+    })
+    .await?
+    {
+        Ok(placed) => placed,
+        Err(error) => return Ok(CallToolResult::error(format!("IPC array error: {error:#}"))),
+    };
     Ok(CallToolResult::json(
         &json!({ "placed_count": placed.len(), "components": placed }),
     ))
@@ -547,39 +934,58 @@ async fn handle_align_components(
     args: &serde_json::Value,
     ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
-    let refs = args["references"].as_array().cloned().unwrap_or_default();
+    let board = get_path(args, "board")?;
+    let refs = match args["references"].as_array() {
+        Some(references) if !references.is_empty() => references,
+        _ => {
+            return Ok(CallToolResult::error(
+                "'references' must be a non-empty array.",
+            ))
+        }
+    };
+    let references = match refs
+        .iter()
+        .map(|reference| reference.as_str().map(String::from))
+        .collect::<Option<Vec<_>>>()
+    {
+        Some(references) => references,
+        None => return Ok(CallToolResult::error("Every reference must be a string.")),
+    };
     let axis = args["axis"].as_str().unwrap_or("x").to_string();
+    if axis != "x" && axis != "y" {
+        return Ok(CallToolResult::error("'axis' must be either 'x' or 'y'."));
+    }
     let value = match require_f64(args, "value") {
         Ok(v) => v,
         Err(e) => return Ok(e),
     };
 
-    let mut aligned = Vec::new();
-    for ref_val in &refs {
-        let reference = match ref_val.as_str() {
-            Some(r) => r.to_string(),
-            None => continue,
-        };
-        let ref2 = reference.clone();
-        let axis_clone = axis.clone();
-        let res = with_ipc(ctx.config.ipc_address.clone(), move |c| {
-            let fp = c
-                .get_footprint(&ref2)?
-                .ok_or_else(|| anyhow::anyhow!("not found"))?;
-            let (nx, ny) = if axis_clone == "y" {
-                (fp.position.x, value)
-            } else {
-                (value, fp.position.y)
-            };
-            c.move_footprint(&ref2, nx, ny)?;
-            Ok((nx, ny))
+    let requested_board = board.clone();
+    let aligned = match with_ipc(ctx.config.ipc_address.clone(), move |c| {
+        c.ensure_board_is_active(&requested_board)?;
+        c.run_commit("Align footprints", |c| {
+            references
+                .iter()
+                .map(|reference| {
+                    let footprint = c
+                        .get_footprint(reference)?
+                        .with_context(|| format!("footprint '{reference}' not found"))?;
+                    let (x, y) = if axis == "y" {
+                        (footprint.position.x, value)
+                    } else {
+                        (value, footprint.position.y)
+                    };
+                    c.move_footprint(reference, x, y)?;
+                    Ok(json!({ "reference": reference, "x": x, "y": y }))
+                })
+                .collect::<anyhow::Result<Vec<_>>>()
         })
-        .await?;
-        match res {
-            Ok((nx, ny)) => aligned.push(json!({ "reference": reference, "x": nx, "y": ny })),
-            Err(e) => return Ok(CallToolResult::error(format!("IPC error: {}", e))),
-        }
-    }
+    })
+    .await?
+    {
+        Ok(aligned) => aligned,
+        Err(error) => return Ok(CallToolResult::error(format!("IPC align error: {error:#}"))),
+    };
     Ok(CallToolResult::json(
         &json!({ "aligned_count": aligned.len(), "components": aligned }),
     ))
@@ -589,11 +995,12 @@ async fn handle_duplicate_component(
     args: &serde_json::Value,
     ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
+    let board = get_path(args, "board")?;
     let reference = match require_str(args, "reference") {
         Ok(v) => v.to_string(),
         Err(e) => return Ok(e),
     };
-    let _new_reference = match require_str(args, "new_reference") {
+    let new_reference = match require_str(args, "new_reference") {
         Ok(v) => v.to_string(),
         Err(e) => return Ok(e),
     };
@@ -608,17 +1015,45 @@ async fn handle_duplicate_component(
 
     // Get the source footprint's footprint ID and rotation
     let ref_ipc = reference.clone();
-    let src = ipc!(ctx, |c| {
+    let src = ipc!(ctx, args, |c| {
         c.get_footprint(&ref_ipc)?
             .ok_or_else(|| anyhow::anyhow!("Footprint '{}' not found", ref_ipc))
     });
-
-    let fp = ipc!(ctx, |c| c.place_footprint(
+    let source = match resolve_footprint_source(&src.footprint, &board) {
+        Ok(source) => source,
+        Err(error) => return Ok(CallToolResult::error(error.to_string())),
+    };
+    let prepared = match prepare_footprint_source(
+        &source,
         &src.footprint,
+        &new_reference,
+        Some(&src.value),
         x,
         y,
         src.rotation,
-        &src.layer
+        &src.layer,
+    ) {
+        Ok(prepared) => prepared,
+        Err(error) => return Ok(CallToolResult::error(error.to_string())),
+    };
+    let ipc_reference = new_reference.clone();
+    let fp_id = src.footprint.clone();
+    let fp_value = src.value.clone();
+    let fp_layer = src.layer.clone();
+    let fp_rotation = src.rotation;
+    let pads = match extract_pad_definitions(&prepared) {
+        Ok(pads) => pads,
+        Err(error) => return Ok(CallToolResult::error(error.to_string())),
+    };
+    let fp = ipc!(ctx, args, |c| c.place_footprint(
+        &fp_id,
+        &ipc_reference,
+        &fp_value,
+        &pads,
+        x,
+        y,
+        fp_rotation,
+        &fp_layer
     ));
     Ok(CallToolResult::json(&json!({
         "duplicated_from": reference,
@@ -650,12 +1085,94 @@ async fn handle_get_board_2d_view(
             ]
         });
 
-    let tmp = board_path.with_extension("render.png");
+    // Keep generated output away from the project directory: a board named
+    // `controller.kicad_pcb` may already have a user-owned
+    // `controller.render.png`, and concurrent calls need distinct targets.
+    let render_dir = tempfile::Builder::new()
+        .prefix("konnect-pcb-render-")
+        .tempdir()
+        .context("failed to create temporary PCB render directory")?;
+    let tmp = render_dir.path().join("render.png");
     let layer_refs: Vec<&str> = layers.iter().map(String::as_str).collect();
     super::cli::render_pcb_png(&ctx.config.kicad_cli, &board_path, &tmp, &layer_refs).await?;
     let bytes = tokio::fs::read(&tmp).await?;
-    let _ = tokio::fs::remove_file(&tmp).await;
 
     let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
     Ok(CallToolResult::image(b64, "image/png"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FOOTPRINT: &str = r#"(footprint "R_0402"
+  (version 20240108)
+  (generator pcbnew)
+  (layer "F.Cu")
+  (property "Reference" "REF**" (at 0 -1 0) (layer "F.SilkS"))
+  (property "Value" "R_0402" (at 0 1 0) (layer "F.Fab"))
+  (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5)
+    (layers "F.Cu" "F.Paste" "F.Mask")))"#;
+
+    #[test]
+    fn prepares_complete_front_footprint() {
+        let prepared = prepare_footprint_source(
+            FOOTPRINT,
+            "Resistor_SMD:R_0402",
+            "R17",
+            None,
+            12.5,
+            8.25,
+            90.0,
+            "F.Cu",
+        )
+        .unwrap();
+        assert!(prepared.starts_with("(footprint \"Resistor_SMD:R_0402\""));
+        assert!(prepared.contains("(property \"Reference\" \"R17\""));
+        assert!(prepared.contains("(at 12.5 8.25 90)"));
+        assert!(prepared.contains("(pad \"1\""));
+        assert!(prepared.contains("(layers \"F.Cu\" \"F.Paste\" \"F.Mask\")"));
+        let pads = extract_pad_definitions(&prepared).unwrap();
+        assert_eq!(pads.len(), 1);
+        assert_eq!(pads[0].number, "1");
+        assert_eq!(pads[0].shape, "roundrect");
+        assert_eq!(pads[0].layers, ["F.Cu", "F.Paste", "F.Mask"]);
+    }
+
+    #[test]
+    fn flips_all_copper_side_layers_for_back_placement() {
+        let prepared = prepare_footprint_source(
+            FOOTPRINT,
+            "Resistor_SMD:R_0402",
+            "R18",
+            Some("10k"),
+            1.0,
+            2.0,
+            0.0,
+            "B.Cu",
+        )
+        .unwrap();
+        assert!(prepared.contains("(layer \"B.Cu\")"));
+        assert!(prepared.contains("(layer \"B.SilkS\")"));
+        assert!(prepared.contains("(layer \"B.Fab\")"));
+        assert!(prepared.contains("(layers \"B.Cu\" \"B.Paste\" \"B.Mask\")"));
+        assert!(prepared.contains("(property \"Value\" \"10k\""));
+        assert!(!prepared.contains("__KONNECT_FRONT__"));
+    }
+
+    #[test]
+    fn rejects_non_outer_copper_layer() {
+        let error = prepare_footprint_source(
+            FOOTPRINT,
+            "Resistor_SMD:R_0402",
+            "R19",
+            None,
+            0.0,
+            0.0,
+            0.0,
+            "In1.Cu",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("F.Cu or B.Cu"));
+    }
 }

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -238,6 +238,203 @@ fn extract_pad_definitions(source: &str) -> anyhow::Result<Vec<konnect_ipc::IpcP
         .collect()
 }
 
+// ─── Footprint graphics extraction ───────────────────────────────────────────
+
+/// `(start x y)`-style point child of a graphic node.
+fn graphic_point(
+    node: &konnect_sexp::SexpNode,
+    tag: &str,
+    kind: &str,
+) -> anyhow::Result<(f64, f64)> {
+    let point = node
+        .find(tag)
+        .ok_or_else(|| anyhow::anyhow!("footprint {kind} is missing its ({tag} …)"))?;
+    Ok((
+        point
+            .get_f64(1)
+            .ok_or_else(|| anyhow::anyhow!("footprint {kind} has an invalid {tag} X"))?,
+        point
+            .get_f64(2)
+            .ok_or_else(|| anyhow::anyhow!("footprint {kind} has an invalid {tag} Y"))?,
+    ))
+}
+
+fn graphic_layer(node: &konnect_sexp::SexpNode, kind: &str) -> anyhow::Result<String> {
+    node.find_str("layer")
+        .map(str::to_string)
+        .ok_or_else(|| anyhow::anyhow!("footprint {kind} is missing its layer"))
+}
+
+/// Stroke width in mm: modern `(stroke (width w) …)`, legacy bare `(width w)`.
+/// KiCad's default silkscreen line width stands in when neither is present.
+fn graphic_stroke_width(node: &konnect_sexp::SexpNode) -> f64 {
+    node.find("stroke")
+        .and_then(|stroke| stroke.find_f64("width"))
+        .or_else(|| node.find_f64("width"))
+        .unwrap_or(0.12)
+}
+
+/// `(fill yes)` (KiCad 8+) or legacy `(fill solid)`.
+fn graphic_filled(node: &konnect_sexp::SexpNode) -> bool {
+    matches!(node.find_str("fill"), Some("yes") | Some("solid"))
+}
+
+/// `(hide yes)` (modern) or a bare `hide` atom (legacy).
+fn text_hidden(node: &konnect_sexp::SexpNode) -> bool {
+    node.find_str("hide") == Some("yes")
+        || node
+            .children()
+            .unwrap_or_default()
+            .iter()
+            .any(|child| child.as_str() == Some("hide"))
+}
+
+/// `(effects (font (size h w)))` glyph size, defaulting to KiCad's 1 mm.
+fn text_size(node: &konnect_sexp::SexpNode) -> f64 {
+    node.find("effects")
+        .and_then(|effects| effects.find("font"))
+        .and_then(|font| font.find("size"))
+        .and_then(|size| size.get_f64(1))
+        .unwrap_or(1.0)
+}
+
+/// Text position and angle from `(at x y [rot])`.
+fn text_at(node: &konnect_sexp::SexpNode, kind: &str) -> anyhow::Result<((f64, f64), f64)> {
+    let at = node
+        .find("at")
+        .ok_or_else(|| anyhow::anyhow!("footprint {kind} is missing its position"))?;
+    Ok((
+        (
+            at.get_f64(1)
+                .ok_or_else(|| anyhow::anyhow!("footprint {kind} has an invalid X position"))?,
+            at.get_f64(2)
+                .ok_or_else(|| anyhow::anyhow!("footprint {kind} has an invalid Y position"))?,
+        ),
+        at.get_f64(3).unwrap_or(0.0),
+    ))
+}
+
+/// Parse a footprint's drawable children — `fp_line`, `fp_rect`, `fp_circle`,
+/// `fp_arc`, `fp_poly` and visible `fp_text`/`property` texts — into
+/// footprint-local [`konnect_ipc::IpcGraphicDefinition`]s.
+///
+/// The typed placement path previously shipped pads only, so a placed part had
+/// no courtyard, silkscreen, or fab drawing: courtyard DRC had nothing to
+/// check and KiCad's `lib_footprint_mismatch` flagged every placement.
+///
+/// `Reference` and `Value` properties are excluded — `build_footprint_item`
+/// already carries those as first-class fields.
+fn extract_graphic_definitions(
+    source: &str,
+) -> anyhow::Result<Vec<konnect_ipc::IpcGraphicDefinition>> {
+    use konnect_ipc::IpcGraphicDefinition as Graphic;
+    let footprint = konnect_sexp::parse_sexp(source)?;
+    let mut graphics = Vec::new();
+
+    for line in footprint.find_all("fp_line") {
+        graphics.push(Graphic::Line {
+            start: graphic_point(line, "start", "fp_line")?,
+            end: graphic_point(line, "end", "fp_line")?,
+            layer: graphic_layer(line, "fp_line")?,
+            width: graphic_stroke_width(line),
+        });
+    }
+    for rect in footprint.find_all("fp_rect") {
+        graphics.push(Graphic::Rect {
+            start: graphic_point(rect, "start", "fp_rect")?,
+            end: graphic_point(rect, "end", "fp_rect")?,
+            layer: graphic_layer(rect, "fp_rect")?,
+            width: graphic_stroke_width(rect),
+            filled: graphic_filled(rect),
+        });
+    }
+    for circle in footprint.find_all("fp_circle") {
+        graphics.push(Graphic::Circle {
+            center: graphic_point(circle, "center", "fp_circle")?,
+            end: graphic_point(circle, "end", "fp_circle")?,
+            layer: graphic_layer(circle, "fp_circle")?,
+            width: graphic_stroke_width(circle),
+            filled: graphic_filled(circle),
+        });
+    }
+    for arc in footprint.find_all("fp_arc") {
+        graphics.push(Graphic::Arc {
+            start: graphic_point(arc, "start", "fp_arc")?,
+            mid: graphic_point(arc, "mid", "fp_arc")?,
+            end: graphic_point(arc, "end", "fp_arc")?,
+            layer: graphic_layer(arc, "fp_arc")?,
+            width: graphic_stroke_width(arc),
+        });
+    }
+    for poly in footprint.find_all("fp_poly") {
+        let pts = poly
+            .find("pts")
+            .ok_or_else(|| anyhow::anyhow!("footprint fp_poly is missing its (pts …)"))?;
+        let points = pts
+            .children()
+            .unwrap_or_default()
+            .iter()
+            .filter(|node| node.head() == Some("xy"))
+            .map(|node| {
+                Ok((
+                    node.get_f64(1)
+                        .ok_or_else(|| anyhow::anyhow!("footprint fp_poly has an invalid X"))?,
+                    node.get_f64(2)
+                        .ok_or_else(|| anyhow::anyhow!("footprint fp_poly has an invalid Y"))?,
+                ))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        graphics.push(Graphic::Poly {
+            points,
+            layer: graphic_layer(poly, "fp_poly")?,
+            width: graphic_stroke_width(poly),
+            filled: graphic_filled(poly),
+        });
+    }
+    for text in footprint.find_all("fp_text") {
+        if text_hidden(text) {
+            continue;
+        }
+        let content = text
+            .get(2)
+            .and_then(konnect_sexp::SexpNode::as_str)
+            .ok_or_else(|| anyhow::anyhow!("footprint fp_text is missing its text"))?;
+        let (position, rotation) = text_at(text, "fp_text")?;
+        graphics.push(Graphic::Text {
+            text: content.to_string(),
+            position,
+            rotation,
+            layer: graphic_layer(text, "fp_text")?,
+            size: text_size(text),
+        });
+    }
+    for property in footprint.find_all("property") {
+        let name = property.get(1).and_then(konnect_sexp::SexpNode::as_str);
+        // Reference and Value travel as first-class fields; hidden built-ins
+        // (Footprint, Datasheet, …) are not drawn.
+        if matches!(name, Some("Reference") | Some("Value")) || text_hidden(property) {
+            continue;
+        }
+        let Some(content) = property.get(2).and_then(konnect_sexp::SexpNode::as_str) else {
+            continue;
+        };
+        let Ok((position, rotation)) = text_at(property, "property") else {
+            continue;
+        };
+        let Ok(layer) = graphic_layer(property, "property") else {
+            continue;
+        };
+        graphics.push(Graphic::Text {
+            text: content.to_string(),
+            position,
+            rotation,
+            layer,
+            size: text_size(property),
+        });
+    }
+    Ok(graphics)
+}
+
 // ─── Tool definitions ─────────────────────────────────────────────────────────
 
 pub fn tools() -> Vec<ToolDef> {
@@ -482,6 +679,10 @@ async fn handle_place_component(
         Ok(pads) => pads,
         Err(error) => return Ok(CallToolResult::error(error.to_string())),
     };
+    let graphics = match extract_graphic_definitions(&prepared) {
+        Ok(graphics) => graphics,
+        Err(error) => return Ok(CallToolResult::error(error.to_string())),
+    };
 
     let value = footprint
         .split_once(':')
@@ -489,7 +690,7 @@ async fn handle_place_component(
         .unwrap_or(&footprint)
         .to_string();
     let fp = ipc!(ctx, args, |c| c.place_footprint(
-        &footprint, &reference, &value, &pads, x, y, rotation, &layer
+        &footprint, &reference, &value, &pads, &graphics, x, y, rotation, &layer
     ));
     Ok(CallToolResult::json(&json!({
         "placed": fp.reference,
@@ -760,6 +961,12 @@ async fn handle_place_array(
         Ok(source) => source,
         Err(error) => return Ok(CallToolResult::error(error.to_string())),
     };
+    // Graphics are footprint-local and identical for every array instance, so
+    // one extraction serves the whole batch.
+    let graphics = match extract_graphic_definitions(&source) {
+        Ok(graphics) => graphics,
+        Err(error) => return Ok(CallToolResult::error(error.to_string())),
+    };
 
     let value = footprint
         .split_once(':')
@@ -810,8 +1017,18 @@ async fn handle_place_array(
         let items = planned
             .iter()
             .map(|(reference, pads, x, y)| {
-                c.build_footprint_item(&footprint_id, reference, &value, pads, *x, *y, 0.0, "F.Cu")
-                    .with_context(|| format!("failed to prepare {reference}"))
+                c.build_footprint_item(
+                    &footprint_id,
+                    reference,
+                    &value,
+                    pads,
+                    &graphics,
+                    *x,
+                    *y,
+                    0.0,
+                    "F.Cu",
+                )
+                .with_context(|| format!("failed to prepare {reference}"))
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
         c.run_commit("Place footprint array", |c| c.create_items(items))?;
@@ -963,11 +1180,16 @@ async fn handle_duplicate_component(
         Ok(pads) => pads,
         Err(error) => return Ok(CallToolResult::error(error.to_string())),
     };
+    let graphics = match extract_graphic_definitions(&prepared) {
+        Ok(graphics) => graphics,
+        Err(error) => return Ok(CallToolResult::error(error.to_string())),
+    };
     let fp = ipc!(ctx, args, |c| c.place_footprint(
         &fp_id,
         &ipc_reference,
         &fp_value,
         &pads,
+        &graphics,
         x,
         y,
         fp_rotation,
@@ -1085,6 +1307,99 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.to_string().contains("F.Cu"));
+    }
+
+    /// A footprint with the graphics KiCad's own libraries ship: courtyard
+    /// rect, silkscreen lines, a fab outline and text, plus hidden built-in
+    /// properties that must not be drawn.
+    const GRAPHIC_FOOTPRINT: &str = r#"(footprint "R_0402"
+  (version 20240108)
+  (generator pcbnew)
+  (layer "F.Cu")
+  (property "Reference" "REF**" (at 0 -1 0) (layer "F.SilkS"))
+  (property "Value" "R_0402" (at 0 1 0) (layer "F.Fab"))
+  (property "Datasheet" "" (at 0 0 0) (layer "F.Fab") (hide yes))
+  (fp_line (start -0.6 -0.5) (end 0.6 -0.5) (stroke (width 0.12) (type solid)) (layer "F.SilkS"))
+  (fp_line (start -0.6 0.5) (end 0.6 0.5) (stroke (width 0.12) (type solid)) (layer "F.SilkS"))
+  (fp_rect (start -0.8 -0.7) (end 0.8 0.7) (stroke (width 0.05) (type default)) (fill no) (layer "F.CrtYd"))
+  (fp_circle (center 0 0) (end 0.25 0) (stroke (width 0.1) (type solid)) (fill yes) (layer "F.Fab"))
+  (fp_arc (start -0.3 0) (mid 0 -0.3) (end 0.3 0) (stroke (width 0.12) (type solid)) (layer "F.SilkS"))
+  (fp_poly (pts (xy -0.2 -0.2) (xy 0.2 -0.2) (xy 0.2 0.2)) (stroke (width 0.1) (type solid)) (fill yes) (layer "F.Fab"))
+  (fp_text user "${REFERENCE}" (at 0 1.17 0) (layer "F.Fab") (effects (font (size 0.26 0.26) (thickness 0.04))))
+  (fp_text user "secret" (at 0 0 0) (layer "F.Fab") (hide yes) (effects (font (size 0.26 0.26))))
+  (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5)
+    (layers "F.Cu" "F.Paste" "F.Mask")))"#;
+
+    #[test]
+    fn extracts_all_drawable_graphics_with_layers_and_widths() {
+        use konnect_ipc::IpcGraphicDefinition as Graphic;
+        let graphics = extract_graphic_definitions(GRAPHIC_FOOTPRINT).unwrap();
+
+        let lines: Vec<_> = graphics
+            .iter()
+            .filter(|g| matches!(g, Graphic::Line { .. }))
+            .collect();
+        assert_eq!(lines.len(), 2);
+        assert!(matches!(
+            lines[0],
+            Graphic::Line { layer, width, start, .. }
+                if layer == "F.SilkS" && *width == 0.12 && *start == (-0.6, -0.5)
+        ));
+
+        let rect = graphics
+            .iter()
+            .find(|g| matches!(g, Graphic::Rect { .. }))
+            .unwrap();
+        assert!(matches!(
+            rect,
+            Graphic::Rect { layer, width, filled, start, end }
+                if layer == "F.CrtYd" && *width == 0.05 && !*filled
+                    && *start == (-0.8, -0.7) && *end == (0.8, 0.7)
+        ));
+
+        let circle = graphics
+            .iter()
+            .find(|g| matches!(g, Graphic::Circle { .. }))
+            .unwrap();
+        assert!(matches!(
+            circle,
+            Graphic::Circle { layer, filled, end, .. }
+                if layer == "F.Fab" && *filled && *end == (0.25, 0.0)
+        ));
+
+        assert!(graphics
+            .iter()
+            .any(|g| matches!(g, Graphic::Arc { layer, mid, .. }
+                if layer == "F.SilkS" && *mid == (0.0, -0.3))));
+
+        let poly = graphics
+            .iter()
+            .find(|g| matches!(g, Graphic::Poly { .. }))
+            .unwrap();
+        assert!(matches!(
+            poly,
+            Graphic::Poly { points, filled, .. } if points.len() == 3 && *filled
+        ));
+
+        // Exactly one visible text: the fab ${REFERENCE}. The hidden fp_text,
+        // the hidden Datasheet property, and the Reference/Value properties
+        // (carried as first-class fields) are all excluded.
+        let texts: Vec<_> = graphics
+            .iter()
+            .filter(|g| matches!(g, Graphic::Text { .. }))
+            .collect();
+        assert_eq!(texts.len(), 1, "{texts:?}");
+        assert!(matches!(
+            texts[0],
+            Graphic::Text { text, layer, size, position, .. }
+                if text == "${REFERENCE}" && layer == "F.Fab" && *size == 0.26
+                    && *position == (0.0, 1.17)
+        ));
+    }
+
+    #[test]
+    fn a_bare_pads_only_footprint_extracts_no_graphics() {
+        assert!(extract_graphic_definitions(FOOTPRINT).unwrap().is_empty());
     }
 
     fn test_ctx() -> ToolContext {

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -1917,7 +1917,11 @@ mod tests {
     fn fallback_fixture(dir: &Path) -> std::path::PathBuf {
         let pretty = dir.join("Resistor_SMD.pretty");
         std::fs::create_dir_all(&pretty).unwrap();
-        std::fs::write(pretty.join("R_0805_2012Metric.kicad_mod"), library_footprint()).unwrap();
+        std::fs::write(
+            pretty.join("R_0805_2012Metric.kicad_mod"),
+            library_footprint(),
+        )
+        .unwrap();
         std::fs::write(
             dir.join("fp-lib-table"),
             format!(
@@ -1984,14 +1988,24 @@ mod tests {
             written.contains("(footprint \"Resistor_SMD:R_0805_2012Metric\""),
             "board should carry the Library:Footprint id:\n{written}"
         );
-        assert!(written.contains("(at 50 60 0)"), "placement missing:\n{written}");
-        assert!(written.contains("(property \"Reference\" \"R7\""), "{written}");
+        assert!(
+            written.contains("(at 50 60 0)"),
+            "placement missing:\n{written}"
+        );
+        assert!(
+            written.contains("(property \"Reference\" \"R7\""),
+            "{written}"
+        );
         assert!(
             written.contains("(pad \"1\" smd roundrect"),
             "the full definition must be carried:\n{written}"
         );
         assert!(written.contains("(uuid \""), "board items need a uuid");
-        assert_eq!(count_parens(&written), 0, "board is no longer balanced:\n{written}");
+        assert_eq!(
+            count_parens(&written),
+            0,
+            "board is no longer balanced:\n{written}"
+        );
     }
 
     #[tokio::test]
@@ -2011,7 +2025,10 @@ mod tests {
         let out = std::fs::read_to_string(&board).unwrap();
         assert!(out.contains("(at 10 20 -90)"), "footprint angle:\n{out}");
         assert!(out.contains("(at -0.9125 0 270)"), "pad angle:\n{out}");
-        assert!(out.contains("(at 0 -1.65 90)"), "readable text angle:\n{out}");
+        assert!(
+            out.contains("(at 0 -1.65 90)"),
+            "readable text angle:\n{out}"
+        );
     }
 
     #[tokio::test]
@@ -2070,7 +2087,10 @@ mod tests {
         assert!(!res.is_error, "handler errored: {:?}", res.content);
 
         let out = std::fs::read_to_string(&board).unwrap();
-        assert!(out.contains("(pad \"1\" smd roundrect"), "footprint missing");
+        assert!(
+            out.contains("(pad \"1\" smd roundrect"),
+            "footprint missing"
+        );
         let bare_lf = out
             .match_indices('\n')
             .filter(|(i, _)| *i == 0 || out.as_bytes()[i - 1] != b'\r')
@@ -2098,7 +2118,10 @@ mod tests {
         assert!(!res.is_error, "handler errored: {:?}", res.content);
 
         let out = std::fs::read_to_string(&board).unwrap();
-        assert!(out.contains("(pad \"1\" smd roundrect"), "footprint missing");
+        assert!(
+            out.contains("(pad \"1\" smd roundrect"),
+            "footprint missing"
+        );
         assert!(
             !out.contains('\r'),
             "a CRLF library footprint dragged \\r into an LF board:\n{out:?}"
@@ -2125,8 +2148,7 @@ mod tests {
             while socket.recv().is_ok() {
                 let response = konnect_ipc::gen::kiapi::common::ApiResponse {
                     status: Some(konnect_ipc::gen::kiapi::common::ApiResponseStatus {
-                        status: konnect_ipc::gen::kiapi::common::ApiStatusCode::AsBadRequest
-                            as i32,
+                        status: konnect_ipc::gen::kiapi::common::ApiStatusCode::AsBadRequest as i32,
                         error_message: "mock rejects everything".to_string(),
                     }),
                     header: None,
@@ -2222,7 +2244,10 @@ mod tests {
             "R_0805"
         );
         // An empty declared name is no better than a path.
-        assert_eq!(id_for("/nonexistent/scratch/R_0805.kicad_mod", ""), "R_0805");
+        assert_eq!(
+            id_for("/nonexistent/scratch/R_0805.kicad_mod", ""),
+            "R_0805"
+        );
     }
 
     #[test]
@@ -2265,7 +2290,10 @@ mod tests {
         let out = apply_rotation_to_children(&library_footprint(), -90.0);
         assert!(out.contains("(at -0.9125 0 270)"), "{out}");
         // Position is unchanged; only the angle was added.
-        assert!(!out.contains("(at 0 -0.9125"), "pad position must not rotate");
+        assert!(
+            !out.contains("(at 0 -0.9125"),
+            "pad position must not rotate"
+        );
     }
 
     #[test]

--- a/crates/konnect-ipc/Cargo.toml
+++ b/crates/konnect-ipc/Cargo.toml
@@ -20,3 +20,6 @@ prost-types.workspace = true
 
 [build-dependencies]
 prost-build = "0.13"
+
+[dev-dependencies]
+konnect-sexp = { path = "../konnect-sexp" }

--- a/crates/konnect-ipc/Cargo.toml
+++ b/crates/konnect-ipc/Cargo.toml
@@ -11,6 +11,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 anyhow.workspace = true
+konnect-sexp.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
@@ -21,6 +22,3 @@ prost-types.workspace = true
 
 [build-dependencies]
 prost-build = "0.13"
-
-[dev-dependencies]
-konnect-sexp = { path = "../konnect-sexp" }

--- a/crates/konnect-ipc/src/builders.rs
+++ b/crates/konnect-ipc/src/builders.rs
@@ -247,10 +247,11 @@ pub fn board_circle(
     cx: f64,
     cy: f64,
     r_mm: f64,
+    filled: bool,
 ) -> kiapi::board::types::BoardGraphicShape {
     board_shape(
         layer,
-        attrs(width_mm, false),
+        attrs(width_mm, filled),
         kiapi::common::types::graphic_shape::Geometry::Circle(
             kiapi::common::types::GraphicCircleAttributes {
                 center: Some(vec2(cx, cy)),
@@ -288,9 +289,12 @@ pub fn board_arc(
 
 /// Build a BoardGraphicShape polygon (or set of polygons) from closed point
 /// loops in mm — one `PolygonWithHoles` per outline, no holes. Used by
-/// `import_svg_logo` to place flattened SVG artwork as filled board graphics.
+/// `import_svg_logo` to place flattened SVG artwork as filled board graphics
+/// (stroke width 0) and by footprint placement for `fp_poly` outlines and
+/// non-cardinal-rotation rectangles, which keep their stroke width.
 pub fn board_polygon(
     layer: &str,
+    width_mm: f64,
     filled: bool,
     outlines: &[Vec<(f64, f64)>],
 ) -> kiapi::board::types::BoardGraphicShape {
@@ -314,7 +318,7 @@ pub fn board_polygon(
 
     board_shape(
         layer,
-        attrs(0.0, filled),
+        attrs(width_mm, filled),
         kiapi::common::types::graphic_shape::Geometry::Polygon(kiapi::common::types::PolySet {
             polygons,
         }),
@@ -406,7 +410,7 @@ mod tests {
 
     #[test]
     fn circle_radius_point_is_center_plus_radius() {
-        let s = board_circle("F.SilkS", 0.1, 5.0, 5.0, 2.5);
+        let s = board_circle("F.SilkS", 0.1, 5.0, 5.0, 2.5, false);
         match s.shape.unwrap().geometry.unwrap() {
             Geometry::Circle(c) => {
                 assert_eq!(c.center.unwrap().x_nm, 5_000_000);
@@ -449,7 +453,7 @@ mod tests {
             vec![(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)],
             vec![(5.0, 5.0), (6.0, 5.0), (6.0, 6.0)],
         ];
-        let s = board_polygon("F.SilkS", true, &outlines);
+        let s = board_polygon("F.SilkS", 0.0, true, &outlines);
         assert_eq!(s.layer, kiapi::board::types::BoardLayer::BlFSilkS as i32);
         let shape = s.shape.expect("shape");
         assert_eq!(
@@ -472,7 +476,7 @@ mod tests {
     #[test]
     fn polygon_nodes_carry_point_coordinates_in_nanometers() {
         let outlines = vec![vec![(1.0, 2.0)]];
-        let s = board_polygon("F.Cu", false, &outlines);
+        let s = board_polygon("F.Cu", 0.0, false, &outlines);
         match s.shape.unwrap().geometry.unwrap() {
             Geometry::Polygon(poly_set) => {
                 let node = &poly_set.polygons[0].outline.as_ref().unwrap().nodes[0];
@@ -490,7 +494,7 @@ mod tests {
 
     #[test]
     fn polygon_empty_outlines_produces_empty_polyset() {
-        let s = board_polygon("F.SilkS", true, &[]);
+        let s = board_polygon("F.SilkS", 0.0, true, &[]);
         match s.shape.unwrap().geometry.unwrap() {
             Geometry::Polygon(poly_set) => assert!(poly_set.polygons.is_empty()),
             _ => panic!("expected Polygon geometry"),

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -931,14 +931,14 @@ impl KiCadIpcClient {
             };
         let reference_field = text_field("Reference", reference, y - 1.0, true);
         let value_field = text_field("Value", value, y + 1.0, false);
-        let radians = rotation.to_radians();
         let child_items = pads
             .iter()
             .map(|pad| {
-                let local_x = pad.x;
-                let local_y = pad.y;
-                let board_x = x + local_x * radians.cos() + local_y * radians.sin();
-                let board_y = y - local_x * radians.sin() + local_y * radians.cos();
+                // Canonical KiCAD footprint-local → board transform; see
+                // konnect_sexp::geometry::transform_pad for why the sin terms
+                // are not the textbook rotation matrix (Y axis points down).
+                let (board_x, board_y) =
+                    konnect_sexp::geometry::transform_pad(pad.x, pad.y, x, y, rotation);
                 let mut layers = Vec::new();
                 for name in &pad.layers {
                     match name.as_str() {

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -132,7 +132,7 @@ impl KiCadIpcClient {
                  (3) restart the AI client so the server rereads settings. \
                  Alternatively set ipc_socket_path in konnect-settings.json or launch \
                  via KiCAD (which sets KICAD_API_SOCKET). \
-                 Full guide: https://github.com/perara/Konnect/blob/main/docs/TROUBLESHOOTING.md"
+                 Full guide: https://github.com/mixelpixx/Konnect/blob/main/docs/TROUBLESHOOTING.md"
             );
         }
 

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -82,6 +82,70 @@ fn ensure_item_request_ok(status: i32, operation: &str) -> Result<()> {
     Ok(())
 }
 
+/// Marker error carried (via anyhow's error chain) by every failure where no
+/// request completed a round-trip with a live KiCad: no socket path
+/// configured, or the NNG dial/send failed.
+///
+/// Callers must classify with [`IpcFailure::from_error`], never by matching
+/// error text.
+#[derive(Debug)]
+pub struct TransportUnreachable;
+
+impl std::fmt::Display for TransportUnreachable {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "KiCad IPC transport unreachable")
+    }
+}
+
+impl std::error::Error for TransportUnreachable {}
+
+/// Why an IPC operation failed, for callers deciding whether a file-based
+/// fallback is safe.
+///
+/// `Unreachable` means the transport never delivered the request — IPC is
+/// unconfigured (empty socket path) or the dial/send failed — so no live
+/// KiCad can be holding the board, and editing the board file directly
+/// cannot race an editor.
+///
+/// `Rejected` is everything else, including any error after a request was
+/// delivered (a receive timeout may mean KiCad is still processing it).
+/// KiCad is — or may be — alive on the other end, so a file edit could be
+/// silently overwritten on its next save. Fail closed.
+#[derive(Debug)]
+pub enum IpcFailure {
+    Unreachable(String),
+    Rejected(String),
+}
+
+impl IpcFailure {
+    /// Classify an error from any [`KiCadIpcClient`] operation by walking its
+    /// chain for the [`TransportUnreachable`] marker — never by matching
+    /// message text.
+    pub fn from_error(error: anyhow::Error) -> Self {
+        let message = format!("{error:#}");
+        if error
+            .chain()
+            .any(|cause| cause.is::<TransportUnreachable>())
+        {
+            IpcFailure::Unreachable(message)
+        } else {
+            IpcFailure::Rejected(message)
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        match self {
+            IpcFailure::Unreachable(message) | IpcFailure::Rejected(message) => message,
+        }
+    }
+}
+
+impl std::fmt::Display for IpcFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}", self.message())
+    }
+}
+
 pub struct KiCadIpcClient {
     socket_path: String,
     kicad_token: String,
@@ -123,7 +187,7 @@ impl KiCadIpcClient {
         type_name: &str,
     ) -> Result<Option<prost_types::Any>> {
         if self.socket_path.is_empty() {
-            anyhow::bail!(
+            return Err(anyhow::Error::new(TransportUnreachable).context(
                 "KiCAD IPC socket path not configured. To fix: \
                  (1) in KiCAD, enable Edit > Preferences > Plugins > 'Enable KiCad API' \
                  and copy the listed ipc:// address; \
@@ -132,8 +196,8 @@ impl KiCadIpcClient {
                  (3) restart the AI client so the server rereads settings. \
                  Alternatively set ipc_socket_path in konnect-settings.json or launch \
                  via KiCAD (which sets KICAD_API_SOCKET). \
-                 Full guide: https://github.com/mixelpixx/Konnect/blob/main/docs/TROUBLESHOOTING.md"
-            );
+                 Full guide: https://github.com/mixelpixx/Konnect/blob/main/docs/TROUBLESHOOTING.md",
+            ));
         }
 
         let request = kiapi::common::ApiRequest {
@@ -176,15 +240,16 @@ impl KiCadIpcClient {
                 format!("ipc://{}", self.socket_path)
             };
 
-        socket
-            .dial(&dial_url)
-            .with_context(|| format!("Cannot connect to KiCAD IPC at {}", dial_url))?;
+        socket.dial(&dial_url).map_err(|error| {
+            anyhow::Error::new(TransportUnreachable)
+                .context(format!("Cannot connect to KiCAD IPC at {dial_url}: {error}"))
+        })?;
 
         // Send request
         let msg = nng::Message::from(request_bytes.as_slice());
-        socket
-            .send(msg)
-            .map_err(|(_, e)| anyhow::anyhow!("NNG send failed: {}", e))?;
+        socket.send(msg).map_err(|(_, error)| {
+            anyhow::Error::new(TransportUnreachable).context(format!("NNG send failed: {error}"))
+        })?;
 
         // Receive response
         let reply = socket

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -241,8 +241,9 @@ impl KiCadIpcClient {
             };
 
         socket.dial(&dial_url).map_err(|error| {
-            anyhow::Error::new(TransportUnreachable)
-                .context(format!("Cannot connect to KiCAD IPC at {dial_url}: {error}"))
+            anyhow::Error::new(TransportUnreachable).context(format!(
+                "Cannot connect to KiCAD IPC at {dial_url}: {error}"
+            ))
         })?;
 
         // Send request
@@ -491,10 +492,7 @@ impl KiCadIpcClient {
                     .map(|status| status.error_message.as_str())
                     .filter(|message| !message.is_empty())
                     .unwrap_or("no error message");
-                rejections.push(format!(
-                    "item {index}: {} ({message})",
-                    code.as_str_name()
-                ));
+                rejections.push(format!("item {index}: {} ({message})", code.as_str_name()));
             }
         }
         if created != expected_count {
@@ -1190,8 +1188,9 @@ impl KiCadIpcClient {
         {
             anyhow::bail!("footprint reference '{reference}' already exists on the board");
         }
-        let item = self
-            .build_footprint_item(lib_id, reference, value, pads, graphics, x, y, rotation, layer)?;
+        let item = self.build_footprint_item(
+            lib_id, reference, value, pads, graphics, x, y, rotation, layer,
+        )?;
         self.create_items(vec![item])?;
         let footprints = self.list_footprints()?;
         footprints
@@ -1330,7 +1329,10 @@ fn build_graphic_child(
         } => {
             let (x1, y1) = xf(*start);
             let (x2, y2) = xf(*end);
-            builders::pack_any(&builders::board_segment(layer, *width, x1, y1, x2, y2), SHAPE)
+            builders::pack_any(
+                &builders::board_segment(layer, *width, x1, y1, x2, y2),
+                SHAPE,
+            )
         }
         IpcGraphicDefinition::Rect {
             start,
@@ -1360,8 +1362,16 @@ fn build_graphic_child(
                 // The Rectangle message is axis-aligned by construction, so a
                 // non-cardinal rotation emits the four rotated corners as a
                 // polygon — the same degradation EDA_SHAPE::Rotate applies.
-                let corners = vec![xf(*start), xf((end.0, start.1)), xf(*end), xf((start.0, end.1))];
-                builders::pack_any(&builders::board_polygon(layer, *width, *filled, &[corners]), SHAPE)
+                let corners = vec![
+                    xf(*start),
+                    xf((end.0, start.1)),
+                    xf(*end),
+                    xf((start.0, end.1)),
+                ];
+                builders::pack_any(
+                    &builders::board_polygon(layer, *width, *filled, &[corners]),
+                    SHAPE,
+                )
             }
         }
         IpcGraphicDefinition::Circle {
@@ -1610,11 +1620,19 @@ mod footprint_graphics_tests {
         let texts = texts(&fp);
         assert_eq!(texts.len(), 1);
         let text = texts[0].text.as_ref().unwrap();
-        assert_eq!(texts[0].layer, kiapi::board::types::BoardLayer::BlFFab as i32);
+        assert_eq!(
+            texts[0].layer,
+            kiapi::board::types::BoardLayer::BlFFab as i32
+        );
         assert_eq!(text.position.unwrap().x_nm, 102_000_000);
         assert_eq!(text.position.unwrap().y_nm, 50_000_000);
         assert_eq!(
-            text.attributes.as_ref().unwrap().angle.unwrap().value_degrees,
+            text.attributes
+                .as_ref()
+                .unwrap()
+                .angle
+                .unwrap()
+                .value_degrees,
             90.0
         );
     }
@@ -1700,6 +1718,9 @@ mod footprint_graphics_tests {
         assert_eq!(c.center.unwrap().x_nm, 10_000_000);
         assert_eq!(c.center.unwrap().y_nm, 9_000_000);
         // Radius 0.5 mm regardless of rotation.
-        assert_eq!(c.radius_point.unwrap().x_nm - c.center.unwrap().x_nm, 500_000);
+        assert_eq!(
+            c.radius_point.unwrap().x_nm - c.center.unwrap().x_nm,
+            500_000
+        );
     }
 }

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -1,6 +1,6 @@
-//! KiCAD 10 IPC API client using NNG + Protocol Buffers.
+//! KiCad 10 IPC API client using NNG + Protocol Buffers.
 //!
-//! KiCAD 10 exposes an IPC API over NNG (nanomsg-next-gen) using protobuf messages.
+//! KiCad 10 exposes an IPC API over NNG (nanomsg-next-gen) using protobuf messages.
 //! The transport is NNG req/rep over IPC (Unix sockets / Windows named pipes).
 //!
 //! Socket path: set by KICAD_API_SOCKET env var when KiCAD launches a plugin,
@@ -13,6 +13,7 @@ use crate::types::*;
 use anyhow::{Context, Result};
 // NNG SetOpt trait is brought in scope automatically by the nng crate's prelude
 use prost::Message;
+use std::path::{Path, PathBuf};
 use tracing::{debug, warn};
 
 /// Converts KiCAD nanometers to millimeters.
@@ -60,8 +61,30 @@ fn unpack_any<M: Message + Default>(any: &prost_types::Any) -> Result<M> {
     M::decode(any.value.as_slice()).context("Failed to decode protobuf Any body")
 }
 
+fn unpack_required<M: Message + Default>(
+    response: Option<prost_types::Any>,
+    command_name: &str,
+) -> Result<M> {
+    let response =
+        response.with_context(|| format!("KiCad returned no {command_name} response payload"))?;
+    unpack_any(&response)
+}
+
+fn ensure_item_request_ok(status: i32, operation: &str) -> Result<()> {
+    let status = kiapi::common::types::ItemRequestStatus::try_from(status)
+        .unwrap_or(kiapi::common::types::ItemRequestStatus::IrsUnknown);
+    if status != kiapi::common::types::ItemRequestStatus::IrsOk {
+        anyhow::bail!(
+            "KiCad {operation} request failed with {}",
+            status.as_str_name()
+        );
+    }
+    Ok(())
+}
+
 pub struct KiCadIpcClient {
     socket_path: String,
+    kicad_token: String,
     client_name: String,
 }
 
@@ -77,8 +100,20 @@ impl KiCadIpcClient {
         };
         KiCadIpcClient {
             socket_path: effective_path,
+            kicad_token: std::env::var("KICAD_API_TOKEN").unwrap_or_default(),
             client_name: format!("konnect-{}", std::process::id()),
         }
+    }
+
+    /// Create a client with an explicit API token.
+    ///
+    /// KiCad supplies this token to executable plugins through
+    /// `KICAD_API_TOKEN`. This constructor is useful for clients that obtain
+    /// the connection details through another discovery mechanism.
+    pub fn new_with_token(socket_path: impl Into<String>, token: impl Into<String>) -> Self {
+        let mut client = Self::new(socket_path);
+        client.kicad_token = token.into();
+        client
     }
 
     /// Send a protobuf command and return the response Any.
@@ -97,13 +132,13 @@ impl KiCadIpcClient {
                  (3) restart the AI client so the server rereads settings. \
                  Alternatively set ipc_socket_path in konnect-settings.json or launch \
                  via KiCAD (which sets KICAD_API_SOCKET). \
-                 Full guide: https://github.com/mixelpixx/Konnect/blob/main/docs/TROUBLESHOOTING.md"
+                 Full guide: https://github.com/perara/Konnect/blob/main/docs/TROUBLESHOOTING.md"
             );
         }
 
         let request = kiapi::common::ApiRequest {
             header: Some(kiapi::common::ApiRequestHeader {
-                kicad_token: String::new(), // Empty = accept any instance
+                kicad_token: self.kicad_token.clone(),
                 client_name: self.client_name.clone(),
             }),
             message: Some(pack_any(command, type_name)),
@@ -159,18 +194,20 @@ impl KiCadIpcClient {
         let response = kiapi::common::ApiResponse::decode(reply.as_slice())
             .context("Failed to decode ApiResponse")?;
 
-        // Check status
-        if let Some(ref status) = response.status {
-            let code = status.status();
-            if code != kiapi::common::ApiStatusCode::AsOk {
-                let msg = if status.error_message.is_empty() {
-                    format!("{:?}", code)
-                } else {
-                    status.error_message.clone()
-                };
-                debug!("[BETA] IPC ← error: {} ({})", msg, code.as_str_name());
-                anyhow::bail!("KiCAD IPC error: {} ({})", msg, code.as_str_name());
-            }
+        // A response without an envelope status is malformed, not success.
+        let status = response
+            .status
+            .as_ref()
+            .context("KiCad IPC response is missing its status")?;
+        let code = status.status();
+        if code != kiapi::common::ApiStatusCode::AsOk {
+            let msg = if status.error_message.is_empty() {
+                format!("{:?}", code)
+            } else {
+                status.error_message.clone()
+            };
+            debug!("[BETA] IPC ← error: {} ({})", msg, code.as_str_name());
+            anyhow::bail!("KiCad IPC error: {} ({})", msg, code.as_str_name());
         }
 
         debug!("[BETA] IPC ← OK");
@@ -211,6 +248,25 @@ impl KiCadIpcClient {
         docs.into_iter().next().ok_or_else(|| {
             anyhow::anyhow!("No PCB document is open in KiCAD. Open a board file first.")
         })
+    }
+
+    /// Fail closed unless the first board targeted by IPC is the requested file.
+    ///
+    /// KiCad may have several boards open, while the item APIs operate on a
+    /// `DocumentSpecifier`. Konnect currently targets the first open PCB, so a
+    /// path-bearing MCP request must verify that choice before mutating it.
+    pub fn ensure_board_is_active(&self, requested: &Path) -> Result<()> {
+        let document = self.get_board_document()?;
+        let active = board_document_path(&document)
+            .context("KiCad returned an open PCB without a board filename")?;
+        if paths_refer_to_same_board(requested, &active) {
+            return Ok(());
+        }
+        anyhow::bail!(
+            "requested board '{}' is not the active IPC board '{}'",
+            requested.display(),
+            active.display()
+        )
     }
 
     fn make_header(&self) -> Result<kiapi::common::types::ItemHeader> {
@@ -312,30 +368,95 @@ impl KiCadIpcClient {
 
     /// Create items on the board.
     pub fn create_items(&self, items: Vec<prost_types::Any>) -> Result<()> {
+        if items.is_empty() {
+            return Ok(());
+        }
+        let expected_count = items.len();
         let header = self.make_header()?;
         let cmd = kiapi::common::commands::CreateItems {
             header: Some(header),
             items,
             container: None,
         };
-        self.send_command(&cmd, "kiapi.common.commands.CreateItems")?;
+        let response = unpack_required::<kiapi::common::commands::CreateItemsResponse>(
+            self.send_command(&cmd, "kiapi.common.commands.CreateItems")?,
+            "CreateItems",
+        )?;
+        ensure_item_request_ok(response.status, "item creation")?;
+        if response.created_items.len() != expected_count {
+            anyhow::bail!(
+                "KiCad returned {} creation results for {} requested items",
+                response.created_items.len(),
+                expected_count
+            );
+        }
+        for result in response.created_items {
+            let status = result
+                .status
+                .context("KiCad returned a creation result without item status")?;
+            if status.code() != kiapi::common::commands::ItemStatusCode::IscOk {
+                anyhow::bail!(
+                    "KiCad item creation failed: {} ({})",
+                    status.error_message,
+                    status.code().as_str_name()
+                );
+            }
+        }
         Ok(())
     }
 
     /// Update existing items by KIID. Generic wrapper mirroring create_items/delete_items;
     /// each `Any` must be a fully-formed board item with an existing `id` populated.
     pub fn update_items(&self, items: Vec<prost_types::Any>) -> Result<()> {
+        if items.is_empty() {
+            return Ok(());
+        }
+        let expected_count = items.len();
         let header = self.make_header()?;
         let cmd = kiapi::common::commands::UpdateItems {
             header: Some(header),
             items,
         };
-        self.send_command(&cmd, "kiapi.common.commands.UpdateItems")?;
+        let response = unpack_required::<kiapi::common::commands::UpdateItemsResponse>(
+            self.send_command(&cmd, "kiapi.common.commands.UpdateItems")?,
+            "UpdateItems",
+        )?;
+        ensure_item_request_ok(response.status, "item update")?;
+        if response.updated_items.len() != expected_count {
+            anyhow::bail!(
+                "KiCad returned {} update results for {} requested items",
+                response.updated_items.len(),
+                expected_count
+            );
+        }
+        for result in response.updated_items {
+            let Some(status) = result.status else {
+                anyhow::bail!("KiCad returned an update result without item status");
+            };
+            if status.code() != kiapi::common::commands::ItemStatusCode::IscOk {
+                anyhow::bail!(
+                    "KiCad item update failed: {} ({})",
+                    status.error_message,
+                    status.code().as_str_name()
+                );
+            }
+        }
         Ok(())
     }
 
     /// Delete items by KIID.
     pub fn delete_items(&self, ids: Vec<String>) -> Result<()> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let expected_count = ids.len();
+        let mut expected_ids = ids
+            .iter()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
+        if expected_ids.len() != expected_count {
+            anyhow::bail!("delete request contains duplicate item identifiers");
+        }
         let header = self.make_header()?;
         let cmd = kiapi::common::commands::DeleteItems {
             header: Some(header),
@@ -344,7 +465,35 @@ impl KiCadIpcClient {
                 .map(|id| kiapi::common::types::Kiid { value: id.clone() })
                 .collect(),
         };
-        self.send_command(&cmd, "kiapi.common.commands.DeleteItems")?;
+        let response = unpack_required::<kiapi::common::commands::DeleteItemsResponse>(
+            self.send_command(&cmd, "kiapi.common.commands.DeleteItems")?,
+            "DeleteItems",
+        )?;
+        ensure_item_request_ok(response.status, "item deletion")?;
+        if response.deleted_items.len() != expected_count {
+            anyhow::bail!(
+                "KiCad returned {} deletion results for {} requested items",
+                response.deleted_items.len(),
+                expected_count
+            );
+        }
+        for result in response.deleted_items {
+            let status = result.status();
+            let id = result
+                .id
+                .context("KiCad returned a deletion result without an item identifier")?
+                .value;
+            if !expected_ids.remove(&id) {
+                anyhow::bail!("KiCad returned a deletion result for unexpected item '{id}'");
+            }
+            if status != kiapi::common::commands::ItemDeletionStatus::IdsOk {
+                anyhow::bail!(
+                    "KiCad failed to delete item '{}': {}",
+                    id,
+                    status.as_str_name()
+                );
+            }
+        }
         Ok(())
     }
 
@@ -373,12 +522,16 @@ impl KiCadIpcClient {
     pub fn begin_commit(&self) -> Result<String> {
         let cmd = kiapi::common::commands::BeginCommit {};
         let response_any = self.send_command(&cmd, "kiapi.common.commands.BeginCommit")?;
-        if let Some(any) = response_any {
-            let resp: kiapi::common::commands::BeginCommitResponse = unpack_any(&any)?;
-            Ok(resp.id.map(|id| id.value).unwrap_or_default())
-        } else {
-            Ok(String::new())
+        let response: kiapi::common::commands::BeginCommitResponse =
+            unpack_required(response_any, "BeginCommit")?;
+        let id = response
+            .id
+            .context("KiCad returned BeginCommit without a commit identifier")?
+            .value;
+        if id.is_empty() {
+            anyhow::bail!("KiCad returned an empty commit identifier");
         }
+        Ok(id)
     }
 
     /// End a commit (push or drop).
@@ -395,7 +548,10 @@ impl KiCadIpcClient {
             action: action as i32,
             message: message.to_string(),
         };
-        self.send_command(&cmd, "kiapi.common.commands.EndCommit")?;
+        let _: kiapi::common::commands::EndCommitResponse = unpack_required(
+            self.send_command(&cmd, "kiapi.common.commands.EndCommit")?,
+            "EndCommit",
+        )?;
         Ok(())
     }
 
@@ -415,6 +571,49 @@ impl KiCadIpcClient {
             kiapi::common::commands::CommitAction::CmaDrop,
             "",
         )
+    }
+
+    /// Run a multi-step mutation as one KiCad undo transaction.
+    ///
+    /// Any operation error, or a failure to publish the commit, triggers a
+    /// best-effort drop so callers never knowingly leave a partial batch.
+    pub fn run_commit<T>(
+        &self,
+        description: &str,
+        operation: impl FnOnce(&Self) -> Result<T>,
+    ) -> Result<T> {
+        let commit_id = self.begin_commit()?;
+        let operation_result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| operation(self)));
+        match operation_result {
+            Err(panic) => {
+                if let Err(rollback_error) = self.drop_commit(&commit_id) {
+                    anyhow::bail!("KiCad batch panicked and rollback failed ({rollback_error})");
+                }
+                std::panic::resume_unwind(panic)
+            }
+            Ok(Ok(value)) => {
+                if let Err(commit_error) = self.push_commit(&commit_id, description) {
+                    let rollback_error = self.drop_commit(&commit_id).err();
+                    if let Some(rollback_error) = rollback_error {
+                        anyhow::bail!(
+                            "failed to publish KiCad commit ({commit_error}); rollback also failed ({rollback_error})"
+                        );
+                    }
+                    return Err(commit_error)
+                        .context("failed to publish KiCad commit; changes dropped");
+                }
+                Ok(value)
+            }
+            Ok(Err(operation_error)) => {
+                if let Err(rollback_error) = self.drop_commit(&commit_id) {
+                    anyhow::bail!(
+                        "KiCad batch failed ({operation_error}); rollback also failed ({rollback_error})"
+                    );
+                }
+                Err(operation_error).context("KiCad batch failed; changes dropped")
+            }
+        }
     }
 
     // ─── PCB Item Operations (real protobuf implementations) ───────────
@@ -583,13 +782,7 @@ impl KiCadIpcClient {
                         },
                     )?;
                     let any = crate::builders::pack_any(&fp, "kiapi.board.types.FootprintInstance");
-
-                    let header = self.make_header()?;
-                    let cmd = kiapi::common::commands::UpdateItems {
-                        header: Some(header),
-                        items: vec![any],
-                    };
-                    self.send_command(&cmd, "kiapi.common.commands.UpdateItems")?;
+                    self.update_items(vec![any])?;
                     return Ok(());
                 }
             }
@@ -633,17 +826,57 @@ impl KiCadIpcClient {
                         },
                     )?;
                     let any = crate::builders::pack_any(&fp, "kiapi.board.types.FootprintInstance");
-                    let header = self.make_header()?;
-                    let cmd = kiapi::common::commands::UpdateItems {
-                        header: Some(header),
-                        items: vec![any],
-                    };
-                    self.send_command(&cmd, "kiapi.common.commands.UpdateItems")?;
+                    self.update_items(vec![any])?;
                     return Ok(());
                 }
             }
         }
         anyhow::bail!("Footprint '{}' not found", reference)
+    }
+
+    /// Update the visible value field of an existing footprint.
+    pub fn set_footprint_value(&self, reference: &str, value: &str) -> Result<()> {
+        let items = self.get_items(kiapi::common::types::KiCadObjectType::KotPcbFootprint)?;
+        for item in items {
+            if let Ok(mut footprint) =
+                kiapi::board::types::FootprintInstance::decode(item.value.as_slice())
+            {
+                let current_reference = footprint
+                    .reference_field
+                    .as_ref()
+                    .and_then(|field| field.text.as_ref())
+                    .and_then(|board_text| board_text.text.as_ref())
+                    .map(|text| text.text.as_str())
+                    .unwrap_or("");
+                if current_reference != reference {
+                    continue;
+                }
+                if let Some(text) = footprint
+                    .value_field
+                    .as_mut()
+                    .and_then(|field| field.text.as_mut())
+                    .and_then(|board_text| board_text.text.as_mut())
+                {
+                    text.text = value.to_string();
+                } else {
+                    anyhow::bail!("Footprint '{reference}' has no editable value field");
+                }
+                if let Some(text) = footprint
+                    .definition
+                    .as_mut()
+                    .and_then(|definition| definition.value_field.as_mut())
+                    .and_then(|field| field.text.as_mut())
+                    .and_then(|board_text| board_text.text.as_mut())
+                {
+                    text.text = value.to_string();
+                }
+                let any =
+                    crate::builders::pack_any(&footprint, "kiapi.board.types.FootprintInstance");
+                self.update_items(vec![any])?;
+                return Ok(());
+            }
+        }
+        anyhow::bail!("Footprint '{reference}' not found")
     }
 
     /// Delete a footprint by reference.
@@ -652,46 +885,215 @@ impl KiCadIpcClient {
         self.delete_items(vec![kiid])
     }
 
-    /// Place a footprint — currently requires KiCAD's ParseAndCreateItemsFromString.
+    /// Build a typed footprint item suitable for [`Self::create_items`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_footprint_item(
+        &self,
+        lib_id: &str,
+        reference: &str,
+        value: &str,
+        pads: &[IpcPadDefinition],
+        x: f64,
+        y: f64,
+        rotation: f64,
+        layer: &str,
+    ) -> Result<prost_types::Any> {
+        let (library_nickname, entry_name) = lib_id
+            .split_once(':')
+            .context("footprint identifier must use Library:Footprint syntax")?;
+        let text_field =
+            |name: &str, text: &str, field_y: f64, visible: bool| kiapi::board::types::Field {
+                id: None,
+                name: name.to_string(),
+                text: Some(kiapi::board::types::BoardText {
+                    id: None,
+                    text: Some(kiapi::common::types::Text {
+                        position: Some(crate::builders::vec2(x, field_y)),
+                        attributes: Some(kiapi::common::types::TextAttributes {
+                            size: Some(crate::builders::vec2(1.0, 1.0)),
+                            angle: Some(kiapi::common::types::Angle {
+                                value_degrees: rotation,
+                            }),
+                            ..Default::default()
+                        }),
+                        text: text.to_string(),
+                        hyperlink: String::new(),
+                    }),
+                    layer: crate::builders::layer_from_name(if layer == "B.Cu" {
+                        "B.SilkS"
+                    } else {
+                        "F.SilkS"
+                    }) as i32,
+                    knockout: false,
+                    locked: kiapi::common::types::LockedState::LsUnlocked as i32,
+                }),
+                visible,
+            };
+        let reference_field = text_field("Reference", reference, y - 1.0, true);
+        let value_field = text_field("Value", value, y + 1.0, false);
+        let radians = rotation.to_radians();
+        let child_items = pads
+            .iter()
+            .map(|pad| {
+                let local_x = pad.x;
+                let local_y = pad.y;
+                let board_x = x + local_x * radians.cos() + local_y * radians.sin();
+                let board_y = y - local_x * radians.sin() + local_y * radians.cos();
+                let mut layers = Vec::new();
+                for name in &pad.layers {
+                    match name.as_str() {
+                        "*.Cu" => layers.extend(3..=34),
+                        "*.Mask" => layers.extend([
+                            kiapi::board::types::BoardLayer::BlFMask as i32,
+                            kiapi::board::types::BoardLayer::BlBMask as i32,
+                        ]),
+                        "*.Paste" => layers.extend([
+                            kiapi::board::types::BoardLayer::BlFPaste as i32,
+                            kiapi::board::types::BoardLayer::BlBPaste as i32,
+                        ]),
+                        name => layers.push(crate::builders::layer_from_name(name) as i32),
+                    }
+                }
+                layers
+                    .retain(|layer| *layer != kiapi::board::types::BoardLayer::BlUndefined as i32);
+                layers.sort_unstable();
+                layers.dedup();
+
+                let shape = match pad.shape.as_str() {
+                    "circle" => kiapi::board::types::PadStackShape::PssCircle,
+                    "rect" => kiapi::board::types::PadStackShape::PssRectangle,
+                    "oval" => kiapi::board::types::PadStackShape::PssOval,
+                    "trapezoid" => kiapi::board::types::PadStackShape::PssTrapezoid,
+                    "roundrect" => kiapi::board::types::PadStackShape::PssRoundrect,
+                    "chamfered_rect" => kiapi::board::types::PadStackShape::PssChamferedrect,
+                    _ => kiapi::board::types::PadStackShape::PssRectangle,
+                };
+                let copper_layer =
+                    if layers.contains(&(kiapi::board::types::BoardLayer::BlFCu as i32)) {
+                        kiapi::board::types::BoardLayer::BlFCu
+                    } else {
+                        kiapi::board::types::BoardLayer::BlBCu
+                    };
+                let copper = kiapi::board::types::PadStackLayer {
+                    layer: copper_layer as i32,
+                    shape: shape as i32,
+                    size: Some(crate::builders::vec2(pad.size_x, pad.size_y)),
+                    corner_rounding_ratio: pad.roundrect_ratio,
+                    custom_anchor_shape: shape as i32,
+                    offset: Some(crate::builders::vec2(0.0, 0.0)),
+                    ..Default::default()
+                };
+                let drill = pad
+                    .drill_x
+                    .map(|drill_x| kiapi::board::types::DrillProperties {
+                        start_layer: kiapi::board::types::BoardLayer::BlFCu as i32,
+                        end_layer: kiapi::board::types::BoardLayer::BlBCu as i32,
+                        diameter: Some(crate::builders::vec2(
+                            drill_x,
+                            pad.drill_y.unwrap_or(drill_x),
+                        )),
+                        shape: if pad.drill_oval {
+                            kiapi::board::types::DrillShape::DsOblong as i32
+                        } else {
+                            kiapi::board::types::DrillShape::DsCircle as i32
+                        },
+                        ..Default::default()
+                    });
+                let stack = kiapi::board::types::PadStack {
+                    r#type: kiapi::board::types::PadStackType::PstNormal as i32,
+                    layers,
+                    drill,
+                    unconnected_layer_removal: kiapi::board::types::UnconnectedLayerRemoval::UlrKeep
+                        as i32,
+                    copper_layers: vec![copper],
+                    angle: Some(kiapi::common::types::Angle {
+                        value_degrees: rotation + pad.rotation,
+                    }),
+                    ..Default::default()
+                };
+                let pad_type = match pad.pad_type.as_str() {
+                    "thru_hole" => kiapi::board::types::PadType::PtPth,
+                    "np_thru_hole" => kiapi::board::types::PadType::PtNpth,
+                    "connect" => kiapi::board::types::PadType::PtEdgeConnector,
+                    _ => kiapi::board::types::PadType::PtSmd,
+                };
+                let item = kiapi::board::types::Pad {
+                    number: pad.number.clone(),
+                    r#type: pad_type as i32,
+                    pad_stack: Some(stack),
+                    position: Some(crate::builders::vec2(board_x, board_y)),
+                    locked: kiapi::common::types::LockedState::LsUnlocked as i32,
+                    ..Default::default()
+                };
+                crate::builders::pack_any(&item, "kiapi.board.types.Pad")
+            })
+            .collect();
+        let definition = kiapi::board::types::Footprint {
+            id: Some(kiapi::common::types::LibraryIdentifier {
+                library_nickname: library_nickname.to_string(),
+                entry_name: entry_name.to_string(),
+            }),
+            reference_field: Some(reference_field.clone()),
+            value_field: Some(value_field.clone()),
+            items: child_items,
+            ..Default::default()
+        };
+        let footprint = kiapi::board::types::FootprintInstance {
+            position: Some(crate::builders::vec2(x, y)),
+            orientation: Some(kiapi::common::types::Angle {
+                value_degrees: rotation,
+            }),
+            layer: crate::builders::layer_from_name(layer) as i32,
+            locked: kiapi::common::types::LockedState::LsUnlocked as i32,
+            definition: Some(definition),
+            reference_field: Some(reference_field),
+            value_field: Some(value_field),
+            ..Default::default()
+        };
+        Ok(crate::builders::pack_any(
+            &footprint,
+            "kiapi.board.types.FootprintInstance",
+        ))
+    }
+
+    /// Place and verify a footprint instance through the typed KiCad API.
+    #[allow(clippy::too_many_arguments)]
     pub fn place_footprint(
         &self,
         lib_id: &str,
+        reference: &str,
+        value: &str,
+        pads: &[IpcPadDefinition],
         x: f64,
         y: f64,
         rotation: f64,
         layer: &str,
     ) -> Result<IpcFootprint> {
-        // KiCAD 10 IPC doesn't have a direct "place footprint from library" command.
-        // The CreateItems command requires a fully formed FootprintInstance protobuf,
-        // which needs the complete footprint definition (pads, shapes, etc.) from the library.
-        // For now, use ParseAndCreateItemsFromString with S-expression format.
-        let sexp = format!(
-            r#"(footprint "{lib_id}"
-  (layer "{layer}")
-  (at {x} {y} {rotation})
-)"#,
-            lib_id = lib_id,
-            layer = layer,
-            x = crate::builders::mm_to_nm(x) as f64 / 1_000_000.0,
-            y = crate::builders::mm_to_nm(y) as f64 / 1_000_000.0,
-            rotation = rotation,
-        );
-
-        let doc = self.get_board_document()?;
-        let cmd = kiapi::common::commands::ParseAndCreateItemsFromString {
-            document: Some(doc),
-            contents: sexp,
-        };
-        self.send_command(&cmd, "kiapi.common.commands.ParseAndCreateItemsFromString")?;
-
-        Ok(IpcFootprint {
-            reference: String::new(),
-            value: String::new(),
-            footprint: lib_id.to_string(),
-            position: IpcVector2 { x, y },
-            rotation,
-            layer: layer.to_string(),
-        })
+        if self
+            .list_footprints()?
+            .iter()
+            .any(|footprint| footprint.reference == reference)
+        {
+            anyhow::bail!("footprint reference '{reference}' already exists on the board");
+        }
+        let item =
+            self.build_footprint_item(lib_id, reference, value, pads, x, y, rotation, layer)?;
+        self.create_items(vec![item])?;
+        let footprints = self.list_footprints()?;
+        footprints
+            .iter()
+            .find(|footprint| footprint.reference == reference)
+            .cloned()
+            .with_context(|| {
+                let references = footprints
+                    .iter()
+                    .map(|footprint| footprint.reference.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(
+                    "KiCad created the footprint but reference '{reference}' was not found (board references: {references})"
+                )
+            })
     }
 
     /// Get board extents (bounding box of all items).
@@ -775,5 +1177,75 @@ impl KiCadIpcClient {
         };
         self.send_command(&cmd, "kiapi.common.commands.RunAction")?;
         Ok(())
+    }
+}
+
+fn board_document_path(document: &kiapi::common::types::DocumentSpecifier) -> Option<PathBuf> {
+    use kiapi::common::types::document_specifier::Identifier;
+
+    let Identifier::BoardFilename(filename) = document.identifier.as_ref()? else {
+        return None;
+    };
+    let path = PathBuf::from(filename);
+    if path.is_absolute() {
+        return Some(path);
+    }
+    document
+        .project
+        .as_ref()
+        .filter(|project| !project.path.is_empty())
+        .map(|project| PathBuf::from(&project.path).join(&path))
+        .or(Some(path))
+}
+
+fn paths_refer_to_same_board(requested: &Path, active: &Path) -> bool {
+    match (requested.canonicalize(), active.canonicalize()) {
+        (Ok(requested), Ok(active)) => requested == active,
+        _ if active.components().count() == 1 => {
+            requested.components().count() == 1 && requested.file_name() == active.file_name()
+        }
+        _ => requested == active,
+    }
+}
+
+#[cfg(test)]
+mod document_path_tests {
+    use super::*;
+
+    #[test]
+    fn relative_board_filename_is_resolved_against_project_path() {
+        let document = kiapi::common::types::DocumentSpecifier {
+            r#type: kiapi::common::types::DocumentType::DoctypePcb as i32,
+            identifier: Some(
+                kiapi::common::types::document_specifier::Identifier::BoardFilename(
+                    "controller.kicad_pcb".to_string(),
+                ),
+            ),
+            project: Some(kiapi::common::types::ProjectSpecifier {
+                name: "controller".to_string(),
+                path: "/work/controller".to_string(),
+            }),
+        };
+
+        assert_eq!(
+            board_document_path(&document).unwrap(),
+            PathBuf::from("/work/controller/controller.kicad_pcb")
+        );
+    }
+
+    #[test]
+    fn bare_kicad_filename_is_not_enough_to_authorize_an_absolute_request() {
+        assert!(!paths_refer_to_same_board(
+            Path::new("/work/controller/controller.kicad_pcb"),
+            Path::new("controller.kicad_pcb")
+        ));
+        assert!(paths_refer_to_same_board(
+            Path::new("controller.kicad_pcb"),
+            Path::new("controller.kicad_pcb")
+        ));
+        assert!(!paths_refer_to_same_board(
+            Path::new("/work/controller/other.kicad_pcb"),
+            Path::new("controller.kicad_pcb")
+        ));
     }
 }

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -316,31 +316,43 @@ impl KiCadIpcClient {
         })
     }
 
-    /// Fail closed unless the first board targeted by IPC is the requested file.
-    ///
-    /// KiCad may have several boards open, while the item APIs operate on a
-    /// `DocumentSpecifier`. Konnect currently targets the first open PCB, so a
-    /// path-bearing MCP request must verify that choice before mutating it.
-    pub fn ensure_board_is_active(&self, requested: &Path) -> Result<()> {
-        let document = self.get_board_document()?;
-        let active = board_document_path(&document)
-            .context("KiCad returned an open PCB without a board filename")?;
-        if paths_refer_to_same_board(requested, &active) {
-            return Ok(());
+    /// Find the open document matching `requested`, so a path-bearing MCP
+    /// request operates on the board it names — not whichever board happens
+    /// to be first in KiCad's open-document list. Live verification caught
+    /// exactly this: with the user's own project focused and the target
+    /// board open behind it, first-document targeting either fails or, worse,
+    /// would mutate the wrong board.
+    pub fn find_open_board(
+        &self,
+        requested: &Path,
+    ) -> Result<kiapi::common::types::DocumentSpecifier> {
+        let docs = self.get_open_documents()?;
+        if docs.is_empty() {
+            anyhow::bail!("No PCB document is open in KiCAD. Open a board file first.");
+        }
+        let mut open_names = Vec::new();
+        for doc in docs {
+            if let Some(path) = board_document_path(&doc) {
+                if paths_refer_to_same_board(requested, &path) {
+                    return Ok(doc);
+                }
+                open_names.push(path.display().to_string());
+            }
         }
         anyhow::bail!(
-            "requested board '{}' is not the active IPC board '{}'",
+            "requested board '{}' is not open in KiCAD (open boards: {})",
             requested.display(),
-            active.display()
+            open_names.join(", ")
         )
     }
 
+    /// Fail closed unless the requested board is open in the IPC session.
+    pub fn ensure_board_is_active(&self, requested: &Path) -> Result<()> {
+        self.find_open_board(requested).map(|_| ())
+    }
+
     fn make_header(&self) -> Result<kiapi::common::types::ItemHeader> {
-        Ok(kiapi::common::types::ItemHeader {
-            document: Some(self.get_board_document()?),
-            container: None,
-            field_mask: None,
-        })
+        Ok(header_for(self.get_board_document()?))
     }
 
     /// Get all nets on the board.
@@ -371,7 +383,16 @@ impl KiCadIpcClient {
         &self,
         item_type: kiapi::common::types::KiCadObjectType,
     ) -> Result<Vec<prost_types::Any>> {
-        let header = self.make_header()?;
+        self.get_items_in(self.get_board_document()?, item_type)
+    }
+
+    /// As [`Self::get_items`], targeting a specific open document.
+    pub fn get_items_in(
+        &self,
+        document: kiapi::common::types::DocumentSpecifier,
+        item_type: kiapi::common::types::KiCadObjectType,
+    ) -> Result<Vec<prost_types::Any>> {
+        let header = header_for(document);
         let cmd = kiapi::common::commands::GetItems {
             header: Some(header),
             types: vec![item_type as i32],
@@ -387,7 +408,18 @@ impl KiCadIpcClient {
 
     /// List all footprints on the board.
     pub fn list_footprints(&self) -> Result<Vec<IpcFootprint>> {
-        let items = self.get_items(kiapi::common::types::KiCadObjectType::KotPcbFootprint)?;
+        self.list_footprints_in(self.get_board_document()?)
+    }
+
+    /// As [`Self::list_footprints`], targeting a specific open document.
+    pub fn list_footprints_in(
+        &self,
+        document: kiapi::common::types::DocumentSpecifier,
+    ) -> Result<Vec<IpcFootprint>> {
+        let items = self.get_items_in(
+            document,
+            kiapi::common::types::KiCadObjectType::KotPcbFootprint,
+        )?;
         let mut footprints = Vec::new();
         for item in &items {
             if let Ok(fp) = kiapi::board::types::FootprintInstance::decode(item.value.as_slice()) {
@@ -444,11 +476,20 @@ impl KiCadIpcClient {
     /// KiCad's own per-item reasons. (Outcome semantics follow emolitor's
     /// PR #66.)
     pub fn create_items(&self, items: Vec<prost_types::Any>) -> Result<()> {
+        self.create_items_in(self.get_board_document()?, items)
+    }
+
+    /// As [`Self::create_items`], targeting a specific open document.
+    pub fn create_items_in(
+        &self,
+        document: kiapi::common::types::DocumentSpecifier,
+        items: Vec<prost_types::Any>,
+    ) -> Result<()> {
         if items.is_empty() {
             return Ok(());
         }
         let expected_count = items.len();
-        let header = self.make_header()?;
+        let header = header_for(document);
         let cmd = kiapi::common::commands::CreateItems {
             header: Some(header),
             items,
@@ -999,6 +1040,7 @@ impl KiCadIpcClient {
         value: &str,
         pads: &[IpcPadDefinition],
         graphics: &[IpcGraphicDefinition],
+        fields: &IpcFieldPlacement,
         x: f64,
         y: f64,
         rotation: f64,
@@ -1007,18 +1049,24 @@ impl KiCadIpcClient {
         let (library_nickname, entry_name) = lib_id
             .split_once(':')
             .context("footprint identifier must use Library:Footprint syntax")?;
-        let text_field =
-            |name: &str, text: &str, field_y: f64, visible: bool| kiapi::board::types::Field {
+        let text_field = |name: &str, text: &str, local: (f64, f64, f64), visible: bool| {
+            // Field text positions come footprint-local from the library and
+            // are transformed exactly like pads, so the placed part keeps the
+            // library's text layout instead of a synthesized offset that can
+            // sit on the part's own silkscreen.
+            let (fx, fy, frot) = local;
+            let (bx, by) = konnect_sexp::geometry::transform_pad(fx, fy, x, y, rotation);
+            kiapi::board::types::Field {
                 id: None,
                 name: name.to_string(),
                 text: Some(kiapi::board::types::BoardText {
                     id: None,
                     text: Some(kiapi::common::types::Text {
-                        position: Some(crate::builders::vec2(x, field_y)),
+                        position: Some(crate::builders::vec2(bx, by)),
                         attributes: Some(kiapi::common::types::TextAttributes {
                             size: Some(crate::builders::vec2(1.0, 1.0)),
                             angle: Some(kiapi::common::types::Angle {
-                                value_degrees: rotation,
+                                value_degrees: readable_text_angle(rotation + frot),
                             }),
                             ..Default::default()
                         }),
@@ -1034,9 +1082,20 @@ impl KiCadIpcClient {
                     locked: kiapi::common::types::LockedState::LsUnlocked as i32,
                 }),
                 visible,
-            };
-        let reference_field = text_field("Reference", reference, y - 1.0, true);
-        let value_field = text_field("Value", value, y + 1.0, false);
+            }
+        };
+        let reference_field = text_field(
+            "Reference",
+            reference,
+            fields.reference_at.unwrap_or((0.0, -1.0, 0.0)),
+            true,
+        );
+        let value_field = text_field(
+            "Value",
+            value,
+            fields.value_at.unwrap_or((0.0, 1.0, 0.0)),
+            false,
+        );
         let mut child_items: Vec<prost_types::Any> = pads
             .iter()
             .map(|pad| {
@@ -1171,28 +1230,34 @@ impl KiCadIpcClient {
     #[allow(clippy::too_many_arguments)]
     pub fn place_footprint(
         &self,
+        board: &Path,
         lib_id: &str,
         reference: &str,
         value: &str,
         pads: &[IpcPadDefinition],
         graphics: &[IpcGraphicDefinition],
+        fields: &IpcFieldPlacement,
         x: f64,
         y: f64,
         rotation: f64,
         layer: &str,
     ) -> Result<IpcFootprint> {
+        // Target the document matching `board`, not whichever board is first
+        // in KiCad's open list — with several boards open, first-document
+        // targeting mutates the wrong one (caught in live verification).
+        let document = self.find_open_board(board)?;
         if self
-            .list_footprints()?
+            .list_footprints_in(document.clone())?
             .iter()
             .any(|footprint| footprint.reference == reference)
         {
             anyhow::bail!("footprint reference '{reference}' already exists on the board");
         }
         let item = self.build_footprint_item(
-            lib_id, reference, value, pads, graphics, x, y, rotation, layer,
+            lib_id, reference, value, pads, graphics, fields, x, y, rotation, layer,
         )?;
-        self.create_items(vec![item])?;
-        let footprints = self.list_footprints()?;
+        self.create_items_in(document.clone(), vec![item])?;
+        let footprints = self.list_footprints_in(document)?;
         footprints
             .iter()
             .find(|footprint| footprint.reference == reference)
@@ -1441,6 +1506,16 @@ fn build_graphic_child(
     }
 }
 
+fn header_for(
+    document: kiapi::common::types::DocumentSpecifier,
+) -> kiapi::common::types::ItemHeader {
+    kiapi::common::types::ItemHeader {
+        document: Some(document),
+        container: None,
+        field_mask: None,
+    }
+}
+
 fn board_document_path(document: &kiapi::common::types::DocumentSpecifier) -> Option<PathBuf> {
     use kiapi::common::types::document_specifier::Identifier;
 
@@ -1526,7 +1601,18 @@ mod footprint_graphics_tests {
         // path is never dialed.
         let client = KiCadIpcClient::new("tcp://never-dialed");
         let any = client
-            .build_footprint_item("Lib:Fp", "R1", "R", &[], graphics, x, y, rotation, "F.Cu")
+            .build_footprint_item(
+                "Lib:Fp",
+                "R1",
+                "R",
+                &[],
+                graphics,
+                &crate::types::IpcFieldPlacement::default(),
+                x,
+                y,
+                rotation,
+                "F.Cu",
+            )
             .unwrap();
         kiapi::board::types::FootprintInstance::decode(any.value.as_slice()).unwrap()
     }

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -367,6 +367,16 @@ impl KiCadIpcClient {
     }
 
     /// Create items on the board.
+    ///
+    /// `created_items` is documented as the status of each item *to be*
+    /// created: a rejected item still occupies a result slot (with e.g.
+    /// `ISC_INVALID_DATA` and no item attached), so counting the vector's
+    /// length would report phantom successes. Only results whose status is
+    /// `ISC_OK` — or whose status was left at the protobuf default while an
+    /// item came back, since proto3 cannot distinguish "unset" from an
+    /// explicit `ISC_UNKNOWN` — count as created; anything else fails with
+    /// KiCad's own per-item reasons. (Outcome semantics follow emolitor's
+    /// PR #66.)
     pub fn create_items(&self, items: Vec<prost_types::Any>) -> Result<()> {
         if items.is_empty() {
             return Ok(());
@@ -383,24 +393,51 @@ impl KiCadIpcClient {
             "CreateItems",
         )?;
         ensure_item_request_ok(response.status, "item creation")?;
-        if response.created_items.len() != expected_count {
+        if response.created_items.is_empty() {
+            // KiCad 10.0's observed behaviour for a request it ignores: an
+            // IRS_OK response carrying no per-item results at all.
             anyhow::bail!(
-                "KiCad returned {} creation results for {} requested items",
-                response.created_items.len(),
-                expected_count
+                "KiCad created no items: the CreateItems response carried no items at all \
+                 ({expected_count} requested)"
             );
         }
-        for result in response.created_items {
-            let status = result
+        let mut created = 0usize;
+        let mut rejections = Vec::new();
+        for (index, result) in response.created_items.iter().enumerate() {
+            use kiapi::common::commands::ItemStatusCode;
+            let code = result
                 .status
-                .context("KiCad returned a creation result without item status")?;
-            if status.code() != kiapi::common::commands::ItemStatusCode::IscOk {
-                anyhow::bail!(
-                    "KiCad item creation failed: {} ({})",
-                    status.error_message,
-                    status.code().as_str_name()
-                );
+                .as_ref()
+                .map(|status| status.code())
+                .unwrap_or(ItemStatusCode::IscUnknown);
+            let is_created = match code {
+                ItemStatusCode::IscOk => true,
+                // A defaulted status is only evidence of success when the
+                // created item itself came back alongside it.
+                ItemStatusCode::IscUnknown => result.item.is_some(),
+                _ => false,
+            };
+            if is_created {
+                created += 1;
+            } else {
+                let message = result
+                    .status
+                    .as_ref()
+                    .map(|status| status.error_message.as_str())
+                    .filter(|message| !message.is_empty())
+                    .unwrap_or("no error message");
+                rejections.push(format!(
+                    "item {index}: {} ({message})",
+                    code.as_str_name()
+                ));
             }
+        }
+        if created != expected_count {
+            anyhow::bail!(
+                "KiCad created {created} of {expected_count} requested items{}{}",
+                if rejections.is_empty() { "" } else { ": " },
+                rejections.join("; ")
+            );
         }
         Ok(())
     }

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -923,6 +923,11 @@ impl KiCadIpcClient {
     }
 
     /// Build a typed footprint item suitable for [`Self::create_items`].
+    ///
+    /// Children (pads and graphics) are emitted in ABSOLUTE board
+    /// coordinates: KiCAD serializes `FootprintInstance` children that way
+    /// and re-creates them verbatim (issue #23 — see the `transform` module
+    /// docs), so every footprint-local point is rotated and translated here.
     #[allow(clippy::too_many_arguments)]
     pub fn build_footprint_item(
         &self,
@@ -930,6 +935,7 @@ impl KiCadIpcClient {
         reference: &str,
         value: &str,
         pads: &[IpcPadDefinition],
+        graphics: &[IpcGraphicDefinition],
         x: f64,
         y: f64,
         rotation: f64,
@@ -968,7 +974,7 @@ impl KiCadIpcClient {
             };
         let reference_field = text_field("Reference", reference, y - 1.0, true);
         let value_field = text_field("Value", value, y + 1.0, false);
-        let child_items = pads
+        let mut child_items: Vec<prost_types::Any> = pads
             .iter()
             .map(|pad| {
                 // Canonical KiCAD footprint-local → board transform; see
@@ -1065,6 +1071,11 @@ impl KiCadIpcClient {
                 crate::builders::pack_any(&item, "kiapi.board.types.Pad")
             })
             .collect();
+        child_items.extend(
+            graphics
+                .iter()
+                .map(|graphic| build_graphic_child(graphic, x, y, rotation)),
+        );
         let definition = kiapi::board::types::Footprint {
             id: Some(kiapi::common::types::LibraryIdentifier {
                 library_nickname: library_nickname.to_string(),
@@ -1101,6 +1112,7 @@ impl KiCadIpcClient {
         reference: &str,
         value: &str,
         pads: &[IpcPadDefinition],
+        graphics: &[IpcGraphicDefinition],
         x: f64,
         y: f64,
         rotation: f64,
@@ -1113,8 +1125,8 @@ impl KiCadIpcClient {
         {
             anyhow::bail!("footprint reference '{reference}' already exists on the board");
         }
-        let item =
-            self.build_footprint_item(lib_id, reference, value, pads, x, y, rotation, layer)?;
+        let item = self
+            .build_footprint_item(lib_id, reference, value, pads, graphics, x, y, rotation, layer)?;
         self.create_items(vec![item])?;
         let footprints = self.list_footprints()?;
         footprints
@@ -1217,6 +1229,143 @@ impl KiCadIpcClient {
     }
 }
 
+/// True when `rotation` keeps axis-aligned shapes axis-aligned.
+fn is_cardinal_rotation(rotation_deg: f64) -> bool {
+    let r = rotation_deg.rem_euclid(90.0);
+    r.abs() < 1e-9 || (90.0 - r).abs() < 1e-9
+}
+
+/// Normalize a text angle the way KiCAD keeps labels readable: fold into
+/// [0, 360), then flip anything that would read upside down by 180°.
+fn readable_text_angle(deg: f64) -> f64 {
+    let mut angle = deg.rem_euclid(360.0);
+    if angle > 90.0 && angle <= 270.0 {
+        angle -= 180.0;
+    }
+    angle
+}
+
+/// Transform one footprint-local graphic into an absolute-board-space child
+/// item for a `FootprintInstance` (see [`KiCadIpcClient::build_footprint_item`]).
+fn build_graphic_child(
+    graphic: &IpcGraphicDefinition,
+    x: f64,
+    y: f64,
+    rotation: f64,
+) -> prost_types::Any {
+    use crate::builders;
+    const SHAPE: &str = "kiapi.board.types.BoardGraphicShape";
+    let xf = |(px, py): (f64, f64)| konnect_sexp::geometry::transform_pad(px, py, x, y, rotation);
+    match graphic {
+        IpcGraphicDefinition::Line {
+            start,
+            end,
+            layer,
+            width,
+        } => {
+            let (x1, y1) = xf(*start);
+            let (x2, y2) = xf(*end);
+            builders::pack_any(&builders::board_segment(layer, *width, x1, y1, x2, y2), SHAPE)
+        }
+        IpcGraphicDefinition::Rect {
+            start,
+            end,
+            layer,
+            width,
+            filled,
+        } => {
+            if is_cardinal_rotation(rotation) {
+                // A 90°-multiple keeps the rectangle axis-aligned; rotate the
+                // corners and re-normalize which one is top-left.
+                let (x1, y1) = xf(*start);
+                let (x2, y2) = xf(*end);
+                builders::pack_any(
+                    &builders::board_rectangle(
+                        layer,
+                        *width,
+                        x1.min(x2),
+                        y1.min(y2),
+                        x1.max(x2),
+                        y1.max(y2),
+                        *filled,
+                    ),
+                    SHAPE,
+                )
+            } else {
+                // The Rectangle message is axis-aligned by construction, so a
+                // non-cardinal rotation emits the four rotated corners as a
+                // polygon — the same degradation EDA_SHAPE::Rotate applies.
+                let corners = vec![xf(*start), xf((end.0, start.1)), xf(*end), xf((start.0, end.1))];
+                builders::pack_any(&builders::board_polygon(layer, *width, *filled, &[corners]), SHAPE)
+            }
+        }
+        IpcGraphicDefinition::Circle {
+            center,
+            end,
+            layer,
+            width,
+            filled,
+        } => {
+            let (cx, cy) = xf(*center);
+            // The radius is rotation-invariant; keep KiCAD's center +
+            // circumference-point encoding by re-deriving it from the length.
+            let radius = ((end.0 - center.0).powi(2) + (end.1 - center.1).powi(2)).sqrt();
+            builders::pack_any(
+                &builders::board_circle(layer, *width, cx, cy, radius, *filled),
+                SHAPE,
+            )
+        }
+        IpcGraphicDefinition::Arc {
+            start,
+            mid,
+            end,
+            layer,
+            width,
+        } => {
+            let (sx, sy) = xf(*start);
+            let (mx, my) = xf(*mid);
+            let (ex, ey) = xf(*end);
+            builders::pack_any(
+                &builders::board_arc(layer, *width, sx, sy, mx, my, ex, ey),
+                SHAPE,
+            )
+        }
+        IpcGraphicDefinition::Poly {
+            points,
+            layer,
+            width,
+            filled,
+        } => {
+            let transformed: Vec<(f64, f64)> = points.iter().map(|p| xf(*p)).collect();
+            builders::pack_any(
+                &builders::board_polygon(layer, *width, *filled, &[transformed]),
+                SHAPE,
+            )
+        }
+        IpcGraphicDefinition::Text {
+            text,
+            position,
+            rotation: text_rotation,
+            layer,
+            size,
+        } => {
+            let (tx, ty) = xf(*position);
+            builders::pack_any(
+                &builders::board_text(
+                    layer,
+                    text,
+                    tx,
+                    ty,
+                    *size,
+                    readable_text_angle(text_rotation + rotation),
+                    false,
+                ),
+                "kiapi.board.types.BoardText",
+            )
+        }
+    }
+}
+
 fn board_document_path(document: &kiapi::common::types::DocumentSpecifier) -> Option<PathBuf> {
     use kiapi::common::types::document_specifier::Identifier;
 
@@ -1284,5 +1433,208 @@ mod document_path_tests {
             Path::new("/work/controller/other.kicad_pcb"),
             Path::new("controller.kicad_pcb")
         ));
+    }
+}
+
+#[cfg(test)]
+mod footprint_graphics_tests {
+    use super::*;
+    use prost::Message;
+
+    fn build(
+        graphics: &[IpcGraphicDefinition],
+        x: f64,
+        y: f64,
+        rotation: f64,
+    ) -> kiapi::board::types::FootprintInstance {
+        // build_footprint_item is pure — no IPC round-trip — so the socket
+        // path is never dialed.
+        let client = KiCadIpcClient::new("tcp://never-dialed");
+        let any = client
+            .build_footprint_item("Lib:Fp", "R1", "R", &[], graphics, x, y, rotation, "F.Cu")
+            .unwrap();
+        kiapi::board::types::FootprintInstance::decode(any.value.as_slice()).unwrap()
+    }
+
+    fn shapes(
+        fp: &kiapi::board::types::FootprintInstance,
+    ) -> Vec<kiapi::board::types::BoardGraphicShape> {
+        fp.definition
+            .as_ref()
+            .unwrap()
+            .items
+            .iter()
+            .filter(|any| any.type_url.ends_with("BoardGraphicShape"))
+            .map(|any| {
+                kiapi::board::types::BoardGraphicShape::decode(any.value.as_slice()).unwrap()
+            })
+            .collect()
+    }
+
+    fn texts(fp: &kiapi::board::types::FootprintInstance) -> Vec<kiapi::board::types::BoardText> {
+        fp.definition
+            .as_ref()
+            .unwrap()
+            .items
+            .iter()
+            .filter(|any| any.type_url.ends_with("BoardText"))
+            .map(|any| kiapi::board::types::BoardText::decode(any.value.as_slice()).unwrap())
+            .collect()
+    }
+
+    /// Courtyard rect + silk line + fab text at rotation 90 must come out on
+    /// their own layers, at absolute board coordinates rotated with the part.
+    ///
+    /// transform_pad at 90°: (lx, ly) → (x + ly, y − lx).
+    #[test]
+    fn rotation_90_pretransforms_graphics_to_absolute_board_space() {
+        let graphics = vec![
+            IpcGraphicDefinition::Rect {
+                start: (-1.0, -2.0),
+                end: (1.0, 2.0),
+                layer: "F.CrtYd".to_string(),
+                width: 0.05,
+                filled: false,
+            },
+            IpcGraphicDefinition::Line {
+                start: (-1.0, 0.0),
+                end: (1.0, 0.0),
+                layer: "F.SilkS".to_string(),
+                width: 0.12,
+            },
+            IpcGraphicDefinition::Text {
+                text: "hello".to_string(),
+                position: (0.0, 2.0),
+                rotation: 0.0,
+                layer: "F.Fab".to_string(),
+                size: 0.5,
+            },
+        ];
+        let fp = build(&graphics, 100.0, 50.0, 90.0);
+
+        let shapes = shapes(&fp);
+        assert_eq!(shapes.len(), 2);
+
+        // The rectangle stays axis-aligned at a cardinal rotation: corners
+        // (-1,-2) → (98, 51) and (1,2) → (102, 49), re-normalized so the
+        // top-left really is top-left.
+        let rect = &shapes[0];
+        assert_eq!(rect.layer, kiapi::board::types::BoardLayer::BlFCrtYd as i32);
+        let geometry = rect.shape.as_ref().unwrap().geometry.as_ref().unwrap();
+        let kiapi::common::types::graphic_shape::Geometry::Rectangle(r) = geometry else {
+            panic!("expected Rectangle geometry, got {geometry:?}");
+        };
+        assert_eq!(r.top_left.unwrap().x_nm, 98_000_000);
+        assert_eq!(r.top_left.unwrap().y_nm, 49_000_000);
+        assert_eq!(r.bottom_right.unwrap().x_nm, 102_000_000);
+        assert_eq!(r.bottom_right.unwrap().y_nm, 51_000_000);
+
+        // Silk line (-1,0)→(1,0) rotates to (100,51)→(100,49).
+        let line = &shapes[1];
+        assert_eq!(line.layer, kiapi::board::types::BoardLayer::BlFSilkS as i32);
+        let geometry = line.shape.as_ref().unwrap().geometry.as_ref().unwrap();
+        let kiapi::common::types::graphic_shape::Geometry::Segment(s) = geometry else {
+            panic!("expected Segment geometry, got {geometry:?}");
+        };
+        assert_eq!(s.start.unwrap().x_nm, 100_000_000);
+        assert_eq!(s.start.unwrap().y_nm, 51_000_000);
+        assert_eq!(s.end.unwrap().x_nm, 100_000_000);
+        assert_eq!(s.end.unwrap().y_nm, 49_000_000);
+
+        // Fab text at local (0,2) lands at (102, 50) with its angle rotated.
+        let texts = texts(&fp);
+        assert_eq!(texts.len(), 1);
+        let text = texts[0].text.as_ref().unwrap();
+        assert_eq!(texts[0].layer, kiapi::board::types::BoardLayer::BlFFab as i32);
+        assert_eq!(text.position.unwrap().x_nm, 102_000_000);
+        assert_eq!(text.position.unwrap().y_nm, 50_000_000);
+        assert_eq!(
+            text.attributes.as_ref().unwrap().angle.unwrap().value_degrees,
+            90.0
+        );
+    }
+
+    /// At 180° the text would read upside down; KiCAD keeps labels readable by
+    /// flipping such angles 180°, and so does the emitted child.
+    #[test]
+    fn text_angles_are_kept_readable() {
+        let graphics = vec![IpcGraphicDefinition::Text {
+            text: "hello".to_string(),
+            position: (0.0, 0.0),
+            rotation: 0.0,
+            layer: "F.Fab".to_string(),
+            size: 0.5,
+        }];
+        let fp = build(&graphics, 0.0, 0.0, 180.0);
+        let texts = texts(&fp);
+        assert_eq!(
+            texts[0]
+                .text
+                .as_ref()
+                .unwrap()
+                .attributes
+                .as_ref()
+                .unwrap()
+                .angle
+                .unwrap()
+                .value_degrees,
+            0.0
+        );
+    }
+
+    /// The Rectangle protobuf message is axis-aligned by construction, so a
+    /// non-cardinal rotation must degrade the rect to its four rotated corners
+    /// as a polygon — mirroring EDA_SHAPE::Rotate.
+    #[test]
+    fn non_cardinal_rotation_emits_rect_as_polygon() {
+        let graphics = vec![IpcGraphicDefinition::Rect {
+            start: (-1.0, -1.0),
+            end: (1.0, 1.0),
+            layer: "F.CrtYd".to_string(),
+            width: 0.05,
+            filled: false,
+        }];
+        let fp = build(&graphics, 0.0, 0.0, 45.0);
+        let shapes = shapes(&fp);
+        assert_eq!(shapes.len(), 1);
+        let geometry = shapes[0].shape.as_ref().unwrap().geometry.as_ref().unwrap();
+        let kiapi::common::types::graphic_shape::Geometry::Polygon(poly) = geometry else {
+            panic!("expected Polygon geometry for a 45-degree rect, got {geometry:?}");
+        };
+        let outline = poly.polygons[0].outline.as_ref().unwrap();
+        assert!(outline.closed);
+        assert_eq!(outline.nodes.len(), 4);
+        // Corner (-1,-1) at 45°: bx = -cos45 - sin45 = -√2, by = sin45 - cos45 = 0.
+        let first = match outline.nodes[0].geometry.as_ref().unwrap() {
+            kiapi::common::types::poly_line_node::Geometry::Point(p) => p,
+            other => panic!("expected Point node, got {other:?}"),
+        };
+        let sqrt2_nm = (std::f64::consts::SQRT_2 * 1_000_000.0) as i64;
+        assert!((first.x_nm + sqrt2_nm).abs() < 10, "x={}", first.x_nm);
+        assert!(first.y_nm.abs() < 10, "y={}", first.y_nm);
+    }
+
+    /// A circle's radius survives rotation via the circumference-point
+    /// encoding.
+    #[test]
+    fn circle_center_rotates_and_radius_is_preserved() {
+        let graphics = vec![IpcGraphicDefinition::Circle {
+            center: (1.0, 0.0),
+            end: (1.5, 0.0),
+            layer: "F.Fab".to_string(),
+            width: 0.1,
+            filled: true,
+        }];
+        let fp = build(&graphics, 10.0, 10.0, 90.0);
+        let shapes = shapes(&fp);
+        let geometry = shapes[0].shape.as_ref().unwrap().geometry.as_ref().unwrap();
+        let kiapi::common::types::graphic_shape::Geometry::Circle(c) = geometry else {
+            panic!("expected Circle geometry, got {geometry:?}");
+        };
+        // Center (1,0) at 90° around (10,10): (10, 9).
+        assert_eq!(c.center.unwrap().x_nm, 10_000_000);
+        assert_eq!(c.center.unwrap().y_nm, 9_000_000);
+        // Radius 0.5 mm regardless of rotation.
+        assert_eq!(c.radius_point.unwrap().x_nm - c.center.unwrap().x_nm, 500_000);
     }
 }

--- a/crates/konnect-ipc/src/lib.rs
+++ b/crates/konnect-ipc/src/lib.rs
@@ -6,5 +6,5 @@ pub mod client;
 pub mod transform;
 pub mod types;
 
-pub use client::KiCadIpcClient;
+pub use client::{IpcFailure, KiCadIpcClient, TransportUnreachable};
 pub use types::*;

--- a/crates/konnect-ipc/src/types.rs
+++ b/crates/konnect-ipc/src/types.rs
@@ -16,6 +16,23 @@ pub struct IpcFootprint {
     pub layer: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct IpcPadDefinition {
+    pub number: String,
+    pub pad_type: String,
+    pub shape: String,
+    pub x: f64,
+    pub y: f64,
+    pub rotation: f64,
+    pub size_x: f64,
+    pub size_y: f64,
+    pub drill_x: Option<f64>,
+    pub drill_y: Option<f64>,
+    pub drill_oval: bool,
+    pub layers: Vec<String>,
+    pub roundrect_ratio: f64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IpcTrack {
     pub net_name: String,

--- a/crates/konnect-ipc/src/types.rs
+++ b/crates/konnect-ipc/src/types.rs
@@ -119,3 +119,15 @@ pub struct IpcBoardExtents {
     pub min: IpcVector2,
     pub max: IpcVector2,
 }
+
+/// Footprint-local placement of the Reference and Value text fields, read
+/// from the library footprint so placed parts keep the library's text
+/// positions. A hardcoded offset put the Reference on top of the part's own
+/// silkscreen (silk_overlap DRC warnings in live verification).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct IpcFieldPlacement {
+    /// (x, y, rotation) of the Reference text, footprint-local mm/degrees.
+    pub reference_at: Option<(f64, f64, f64)>,
+    /// (x, y, rotation) of the Value text, footprint-local mm/degrees.
+    pub value_at: Option<(f64, f64, f64)>,
+}

--- a/crates/konnect-ipc/src/types.rs
+++ b/crates/konnect-ipc/src/types.rs
@@ -33,6 +33,65 @@ pub struct IpcPadDefinition {
     pub roundrect_ratio: f64,
 }
 
+/// A footprint graphic item in footprint-local coordinates (mm), parsed from
+/// the library `.kicad_mod` source.
+///
+/// Points are pre-transform: `build_footprint_item` rotates and translates
+/// them into absolute board coordinates before emission, because KiCAD
+/// serializes `FootprintInstance` children in absolute board space (see the
+/// `transform` module docs / issue #23).
+#[derive(Debug, Clone, PartialEq)]
+pub enum IpcGraphicDefinition {
+    /// `fp_line` — straight segment.
+    Line {
+        start: (f64, f64),
+        end: (f64, f64),
+        layer: String,
+        width: f64,
+    },
+    /// `fp_rect` — axis-aligned rectangle between two opposite corners.
+    Rect {
+        start: (f64, f64),
+        end: (f64, f64),
+        layer: String,
+        width: f64,
+        filled: bool,
+    },
+    /// `fp_circle` — center plus a point on the circumference.
+    Circle {
+        center: (f64, f64),
+        end: (f64, f64),
+        layer: String,
+        width: f64,
+        filled: bool,
+    },
+    /// `fp_arc` — start / mid / end points.
+    Arc {
+        start: (f64, f64),
+        mid: (f64, f64),
+        end: (f64, f64),
+        layer: String,
+        width: f64,
+    },
+    /// `fp_poly` — closed outline.
+    Poly {
+        points: Vec<(f64, f64)>,
+        layer: String,
+        width: f64,
+        filled: bool,
+    },
+    /// Visible `fp_text` / `property` text.
+    Text {
+        text: String,
+        position: (f64, f64),
+        /// Text angle in degrees, footprint-local.
+        rotation: f64,
+        layer: String,
+        /// Glyph size (width and height) in mm.
+        size: f64,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IpcTrack {
     pub net_name: String,

--- a/crates/konnect-ipc/tests/fixtures/live_ipc.kicad_pcb
+++ b/crates/konnect-ipc/tests/fixtures/live_ipc.kicad_pcb
@@ -1,0 +1,633 @@
+(kicad_pcb
+	(version 20241229)
+	(generator "pcbnew")
+	(generator_version "9.0")
+	(general
+		(thickness 1.6)
+		(legacy_teardrops no)
+	)
+	(paper "A4")
+	(layers
+		(0 "F.Cu" signal)
+		(2 "B.Cu" signal)
+		(9 "F.Adhes" user "F.Adhesive")
+		(11 "B.Adhes" user "B.Adhesive")
+		(13 "F.Paste" user)
+		(15 "B.Paste" user)
+		(5 "F.SilkS" user "F.Silkscreen")
+		(7 "B.SilkS" user "B.Silkscreen")
+		(1 "F.Mask" user)
+		(3 "B.Mask" user)
+		(17 "Dwgs.User" user "User.Drawings")
+		(19 "Cmts.User" user "User.Comments")
+		(21 "Eco1.User" user "User.Eco1")
+		(23 "Eco2.User" user "User.Eco2")
+		(25 "Edge.Cuts" user)
+		(27 "Margin" user)
+		(31 "F.CrtYd" user "F.Courtyard")
+		(29 "B.CrtYd" user "B.Courtyard")
+		(35 "F.Fab" user)
+		(33 "B.Fab" user)
+	)
+	(setup
+		(stackup
+			(layer "F.SilkS"
+				(type "Top Silk Screen")
+			)
+			(layer "F.Paste"
+				(type "Top Solder Paste")
+			)
+			(layer "F.Mask"
+				(type "Top Solder Mask")
+				(color "Green")
+				(thickness 0.01)
+			)
+			(layer "F.Cu"
+				(type "copper")
+				(thickness 0.035)
+			)
+			(layer "dielectric 1"
+				(type "core")
+				(thickness 1.51)
+				(material "FR4")
+				(epsilon_r 4.5)
+				(loss_tangent 0.02)
+			)
+			(layer "B.Cu"
+				(type "copper")
+				(thickness 0.035)
+			)
+			(layer "B.Mask"
+				(type "Bottom Solder Mask")
+				(color "Green")
+				(thickness 0.01)
+			)
+			(layer "B.Paste"
+				(type "Bottom Solder Paste")
+			)
+			(layer "B.SilkS"
+				(type "Bottom Silk Screen")
+			)
+			(copper_finish "None")
+			(dielectric_constraints no)
+		)
+		(pad_to_mask_clearance 0)
+		(allow_soldermask_bridges_in_footprints no)
+		(tenting front back)
+		(aux_axis_origin 55 145)
+		(grid_origin 55 145)
+		(pcbplotparams
+			(layerselection 0x00000000_00000000_55555555_555555f5)
+			(plot_on_all_layers_selection 0x00000000_00000000_00000000_00000000)
+			(disableapertmacros no)
+			(usegerberextensions no)
+			(usegerberattributes yes)
+			(usegerberadvancedattributes yes)
+			(creategerberjobfile yes)
+			(dashed_line_dash_ratio 12.000000)
+			(dashed_line_gap_ratio 3.000000)
+			(svgprecision 6)
+			(plotframeref no)
+			(mode 1)
+			(useauxorigin no)
+			(hpglpennumber 1)
+			(hpglpenspeed 20)
+			(hpglpendiameter 15.000000)
+			(pdf_front_fp_property_popups yes)
+			(pdf_back_fp_property_popups yes)
+			(pdf_metadata yes)
+			(pdf_single_document no)
+			(dxfpolygonmode yes)
+			(dxfimperialunits yes)
+			(dxfusepcbnewfont yes)
+			(psnegative no)
+			(psa4output no)
+			(plot_black_and_white yes)
+			(plotinvisibletext no)
+			(sketchpadsonfab no)
+			(plotpadnumbers no)
+			(hidednponfab no)
+			(sketchdnponfab yes)
+			(crossoutdnponfab yes)
+			(subtractmaskfromsilk no)
+			(outputformat 1)
+			(mirror no)
+			(drillshape 0)
+			(scaleselection 1)
+			(outputdirectory "")
+		)
+	)
+	(net 0 "")
+	(footprint "MountingHole:MountingHole_2.7mm_M2.5_DIN965"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "3f297a53-76ff-4e4a-a0f3-00c7aac0a1fd")
+		(at 212.24 139.45)
+		(descr "Mounting Hole 2.7mm, no annular, M2.5, DIN965")
+		(tags "mounting hole 2.7mm no annular m2.5 din965")
+		(property "Reference" "MH4"
+			(at 0 -3.35 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "6fa31bfa-1060-4e63-b28f-51c9f774c83b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "MountingHole_2.7mm_M2.5_DIN965"
+			(at 0 3.35 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "bd95669c-a027-4dd8-a52f-538a7a3750ab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "33ab03fd-e11c-4239-8edd-671e7f23c2cc")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "953356c4-3447-4abf-8280-40839ecaa5cd")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr exclude_from_pos_files exclude_from_bom)
+		(fp_circle
+			(center 0 0)
+			(end 2.35 0)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "Cmts.User")
+			(uuid "4ae2c986-ead2-4c07-8324-f8251d9fe715")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 2.6 0)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "6a80e5f6-0f2d-467c-93c1-de0d32a0232b")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0.3 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "160c4ddc-ef40-41dd-b9be-f8685b72ec10")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "" np_thru_hole circle
+			(at 0 0)
+			(size 2.7 2.7)
+			(drill 2.7)
+			(layers "*.Cu" "*.Mask" "In1.Cu" "In2.Cu" "In3.Cu" "In4.Cu" "In5.Cu" "In6.Cu"
+				"In7.Cu" "In8.Cu" "In9.Cu" "In10.Cu" "In11.Cu" "In12.Cu" "In13.Cu" "In14.Cu"
+				"In15.Cu" "In16.Cu" "In17.Cu" "In18.Cu" "In19.Cu" "In20.Cu" "In21.Cu"
+				"In22.Cu" "In23.Cu" "In24.Cu" "In25.Cu" "In26.Cu" "In27.Cu" "In28.Cu"
+				"In29.Cu" "In30.Cu"
+			)
+			(uuid "9c02111f-ddc6-4d9d-9a98-fb44187a64a0")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "MountingHole:MountingHole_2.7mm_M2.5_DIN965"
+		(layer "F.Cu")
+		(uuid "5c0af984-49c4-40a0-95aa-bb612ff4098b")
+		(at 58.57 50.55)
+		(descr "Mounting Hole 2.7mm, no annular, M2.5, DIN965")
+		(tags "mounting hole 2.7mm no annular m2.5 din965")
+		(property "Reference" "MH1"
+			(at 0 -3.35 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "761c64bc-6bd2-4c5b-a0a8-767d667542e6")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "MountingHole_2.7mm_M2.5_DIN965"
+			(at 0 3.35 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d3525876-01b3-4f72-bf05-6096a62cc1e2")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ba910b28-d7fe-44c0-a09b-4f8dff158396")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9e16d2aa-920e-4f44-9097-677959ed06bf")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr exclude_from_pos_files exclude_from_bom)
+		(fp_circle
+			(center 0 0)
+			(end 2.35 0)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "Cmts.User")
+			(uuid "52089ac7-f2fd-43df-ba40-640a525cb625")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 2.6 0)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "7524a6dc-a44d-4e5f-a259-809ce464f98a")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0.3 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "6f28e246-4541-41c0-a49c-8bdc285c16ae")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "" np_thru_hole circle
+			(at 0 0)
+			(size 2.7 2.7)
+			(drill 2.7)
+			(layers "*.Cu" "*.Mask" "In1.Cu" "In2.Cu" "In3.Cu" "In4.Cu" "In5.Cu" "In6.Cu"
+				"In7.Cu" "In8.Cu" "In9.Cu" "In10.Cu" "In11.Cu" "In12.Cu" "In13.Cu" "In14.Cu"
+				"In15.Cu" "In16.Cu" "In17.Cu" "In18.Cu" "In19.Cu" "In20.Cu" "In21.Cu"
+				"In22.Cu" "In23.Cu" "In24.Cu" "In25.Cu" "In26.Cu" "In27.Cu" "In28.Cu"
+				"In29.Cu" "In30.Cu"
+			)
+			(uuid "21540a9c-ed42-4846-96ee-cdeafb91e500")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "MountingHole:MountingHole_2.7mm_M2.5_DIN965"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "77dd5b36-4c98-4592-ae76-c20d6e053872")
+		(at 58.57 139.45)
+		(descr "Mounting Hole 2.7mm, no annular, M2.5, DIN965")
+		(tags "mounting hole 2.7mm no annular m2.5 din965")
+		(property "Reference" "MH2"
+			(at 0 -3.35 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "e4866846-3538-4015-8442-e90d903469cb")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "MountingHole_2.7mm_M2.5_DIN965"
+			(at 0 3.35 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "8bcab64f-4300-4ea6-a1f9-fd23432f2bab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "e3d2464a-ca20-4b92-9083-e21622f0c531")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c20500a0-8031-4d5b-ab30-ab0653ad6747")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr exclude_from_pos_files exclude_from_bom)
+		(fp_circle
+			(center 0 0)
+			(end 2.35 0)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "Cmts.User")
+			(uuid "d03ef533-9858-414d-9d0d-325680499bb5")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 2.6 0)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "0266f04d-0c2b-47fc-8686-b49bb1f66af4")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0.3 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f3f8dda5-e011-4cb9-88c1-3684c3e95157")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "" np_thru_hole circle
+			(at 0 0)
+			(size 2.7 2.7)
+			(drill 2.7)
+			(layers "*.Cu" "*.Mask" "In1.Cu" "In2.Cu" "In3.Cu" "In4.Cu" "In5.Cu" "In6.Cu"
+				"In7.Cu" "In8.Cu" "In9.Cu" "In10.Cu" "In11.Cu" "In12.Cu" "In13.Cu" "In14.Cu"
+				"In15.Cu" "In16.Cu" "In17.Cu" "In18.Cu" "In19.Cu" "In20.Cu" "In21.Cu"
+				"In22.Cu" "In23.Cu" "In24.Cu" "In25.Cu" "In26.Cu" "In27.Cu" "In28.Cu"
+				"In29.Cu" "In30.Cu"
+			)
+			(uuid "027a662d-12d9-44bd-8a80-d685d5c54459")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "MountingHole:MountingHole_2.7mm_M2.5_DIN965"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "8e519fe9-ad5a-45f9-956b-11e4ca104171")
+		(at 212.24 50.55)
+		(descr "Mounting Hole 2.7mm, no annular, M2.5, DIN965")
+		(tags "mounting hole 2.7mm no annular m2.5 din965")
+		(property "Reference" "MH3"
+			(at 0 -3.35 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "c4b6fabe-79dc-4bac-8b30-54ca0f83d565")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "MountingHole_2.7mm_M2.5_DIN965"
+			(at 0 3.35 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "e330b06a-8427-4b54-975f-425fc250b654")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4b2f68ae-e194-41b8-baea-8eb46079b10e")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c0d6b31b-6649-4801-9379-898e1b9158b8")
+			(effects
+				(font
+					(size 1.27 1.27)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr exclude_from_pos_files exclude_from_bom)
+		(fp_circle
+			(center 0 0)
+			(end 2.35 0)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "Cmts.User")
+			(uuid "adcc188e-effc-42bc-a5a7-a6706ac0a83a")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 2.6 0)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "add804c3-ea94-44e8-9898-c5c5019b72f5")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0.3 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7b8b815c-19da-4782-b988-0aecd6b8aa39")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "" np_thru_hole circle
+			(at 0 0)
+			(size 2.7 2.7)
+			(drill 2.7)
+			(layers "*.Cu" "*.Mask" "In1.Cu" "In2.Cu" "In3.Cu" "In4.Cu" "In5.Cu" "In6.Cu"
+				"In7.Cu" "In8.Cu" "In9.Cu" "In10.Cu" "In11.Cu" "In12.Cu" "In13.Cu" "In14.Cu"
+				"In15.Cu" "In16.Cu" "In17.Cu" "In18.Cu" "In19.Cu" "In20.Cu" "In21.Cu"
+				"In22.Cu" "In23.Cu" "In24.Cu" "In25.Cu" "In26.Cu" "In27.Cu" "In28.Cu"
+				"In29.Cu" "In30.Cu"
+			)
+			(uuid "8ec41d24-090e-4a17-b1cc-d917de68bde5")
+		)
+		(embedded_fonts no)
+	)
+	(gr_rect
+		(start 55 45)
+		(end 215 145)
+		(stroke
+			(width 0.15)
+			(type solid)
+		)
+		(fill no)
+		(locked yes)
+		(layer "Edge.Cuts")
+		(uuid "13dc543d-1074-458e-b1b4-3c458ffc51a0")
+	)
+	(gr_text "Mounting holes are optional\nKeepout areas are for for guide rails"
+		(at 55.5 148 0)
+		(layer "Cmts.User")
+		(uuid "ae6202f0-8b22-41ab-bc35-718eddd92c05")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+			(justify left)
+		)
+	)
+	(zone
+		(net 0)
+		(net_name "")
+		(layers "F.Cu" "B.Cu")
+		(uuid "b762a88c-55f2-48e9-8e30-f803555c9eb3")
+		(hatch full 0.508)
+		(connect_pads
+			(clearance 0)
+		)
+		(min_thickness 0.254)
+		(filled_areas_thickness no)
+		(keepout
+			(tracks not_allowed)
+			(vias not_allowed)
+			(pads not_allowed)
+			(copperpour allowed)
+			(footprints not_allowed)
+		)
+		(placement
+			(enabled no)
+			(sheetname "")
+		)
+		(fill
+			(thermal_gap 0.508)
+			(thermal_bridge_width 0.508)
+		)
+		(polygon
+			(pts
+				(xy 215 145) (xy 55 145) (xy 55 142.5) (xy 215 142.5)
+			)
+		)
+	)
+	(zone
+		(net 0)
+		(net_name "")
+		(layers "F.Cu" "B.Cu")
+		(uuid "e56b97e1-7c7b-4aff-9152-f587a8be4b4c")
+		(hatch full 0.508)
+		(connect_pads
+			(clearance 0)
+		)
+		(min_thickness 0.254)
+		(filled_areas_thickness no)
+		(keepout
+			(tracks not_allowed)
+			(vias not_allowed)
+			(pads not_allowed)
+			(copperpour allowed)
+			(footprints not_allowed)
+		)
+		(placement
+			(enabled no)
+			(sheetname "")
+		)
+		(fill
+			(thermal_gap 0.508)
+			(thermal_bridge_width 0.508)
+		)
+		(polygon
+			(pts
+				(xy 215 47.5) (xy 55 47.5) (xy 55 45) (xy 215 45)
+			)
+		)
+	)
+	(embedded_fonts no)
+	)

--- a/crates/konnect-ipc/tests/footprint_transform_test.rs
+++ b/crates/konnect-ipc/tests/footprint_transform_test.rs
@@ -31,12 +31,14 @@ where
     let url = format!("tcp://127.0.0.1:{port}");
 
     let listen_url = url.clone();
+    let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(0);
     let thread = std::thread::spawn(move || {
         let socket = nng::Socket::new(nng::Protocol::Rep0).expect("mock rep socket");
         socket
             .set_opt::<nng::options::RecvTimeout>(Some(Duration::from_secs(20)))
             .unwrap();
         socket.listen(&listen_url).expect("mock listen");
+        ready_tx.send(()).expect("signal mock readiness");
         while let Ok(msg) = socket.recv() {
             let request = match kiapi::common::ApiRequest::decode(msg.as_slice()) {
                 Ok(r) => r,
@@ -53,6 +55,7 @@ where
             }
         }
     });
+    ready_rx.recv().expect("mock listener readiness");
 
     MockKicad {
         url,
@@ -171,8 +174,27 @@ fn spawn_footprint_mock(fp: kiapi::board::types::FootprintInstance) -> (MockKica
         } else if msg.type_url.ends_with("UpdateItems") {
             let update =
                 kiapi::common::commands::UpdateItems::decode(msg.value.as_slice()).unwrap();
+            let updated_items = update
+                .items
+                .iter()
+                .cloned()
+                .map(|item| kiapi::common::commands::ItemUpdateResult {
+                    status: Some(kiapi::common::commands::ItemStatus {
+                        code: kiapi::common::commands::ItemStatusCode::IscOk as i32,
+                        error_message: String::new(),
+                    }),
+                    item: Some(item),
+                })
+                .collect();
             *captured_in_mock.lock().unwrap() = Some(update);
-            Some(ok_response())
+            Some(reply_with(builders::pack_any(
+                &kiapi::common::commands::UpdateItemsResponse {
+                    header: None,
+                    status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                    updated_items,
+                },
+                "kiapi.common.commands.UpdateItemsResponse",
+            )))
         } else {
             Some(ok_response())
         }

--- a/crates/konnect-ipc/tests/live_kicad_test.rs
+++ b/crates/konnect-ipc/tests/live_kicad_test.rs
@@ -1,0 +1,144 @@
+//! Live KiCad GUI IPC regression tests.
+//!
+//! These tests are ignored by default. The CI live-GUI job launches pcbnew
+//! under Xvfb and supplies the socket and a disposable board path.
+//! `fixtures/live_ipc.kicad_pcb` is KiCad's GPL-licensed built-in
+//! EuroCard160mmX100mm template, used here as a realistic footprint fixture.
+
+use konnect_ipc::client::KiCadIpcClient;
+use konnect_sexp::{parse_sexp, SexpNode};
+use std::path::Path;
+
+fn footprint<'a>(tree: &'a SexpNode, reference: &str) -> &'a SexpNode {
+    tree.find_all("footprint")
+        .into_iter()
+        .find(|node| {
+            node.find_all("property").into_iter().any(|property| {
+                property.get(1).and_then(SexpNode::as_str) == Some("Reference")
+                    && property.get(2).and_then(SexpNode::as_str) == Some(reference)
+            })
+        })
+        .unwrap_or_else(|| panic!("footprint {reference} not found in saved board"))
+}
+
+fn at(node: &SexpNode) -> (f64, f64) {
+    let at = node.find("at").expect("item has no (at ...) position");
+    (
+        at.get_f64(1).expect("invalid X coordinate"),
+        at.get_f64(2).expect("invalid Y coordinate"),
+    )
+}
+
+fn footprint_at(node: &SexpNode) -> (f64, f64, f64) {
+    let position = node.find("at").expect("footprint has no (at ...) position");
+    (
+        position.get_f64(1).expect("invalid footprint X"),
+        position.get_f64(2).expect("invalid footprint Y"),
+        position.get_f64(3).unwrap_or(0.0),
+    )
+}
+
+fn collect_geometry(node: &SexpNode, output: &mut Vec<(String, f64, f64)>) {
+    if matches!(
+        node.head(),
+        Some("at" | "start" | "mid" | "end" | "center" | "xy")
+    ) {
+        if let (Some(x), Some(y)) = (node.get_f64(1), node.get_f64(2)) {
+            output.push((node.head().unwrap().to_string(), x, y));
+        }
+    }
+    if let Some(children) = node.children() {
+        for child in children {
+            collect_geometry(child, output);
+        }
+    }
+}
+
+fn child_geometry(footprint: &SexpNode) -> Vec<(String, f64, f64)> {
+    let mut output = Vec::new();
+    for child in footprint.children().unwrap_or_default() {
+        // The footprint's own position is the only coordinate expected to
+        // change. Every nested coordinate is footprint-relative on disk.
+        if child.head() != Some("at") {
+            collect_geometry(child, &mut output);
+        }
+    }
+    output
+}
+
+fn pad_offsets(footprint: &SexpNode) -> Vec<(f64, f64)> {
+    footprint.find_all("pad").into_iter().map(at).collect()
+}
+
+fn load_board(path: &Path) -> SexpNode {
+    let source = std::fs::read_to_string(path).expect("failed to read live KiCad board");
+    parse_sexp(&source).expect("failed to parse live KiCad board")
+}
+
+#[test]
+#[ignore = "requires a running KiCad GUI with its IPC API enabled"]
+fn moving_and_rotating_footprint_preserves_child_geometry() {
+    let board = std::env::var("KONNECT_LIVE_KICAD_BOARD")
+        .expect("KONNECT_LIVE_KICAD_BOARD must name the disposable open board");
+    let reference = std::env::var("KONNECT_LIVE_KICAD_REFERENCE").unwrap_or_else(|_| "MH1".into());
+    let socket = std::env::var("KICAD_API_SOCKET").expect("KICAD_API_SOCKET is required");
+    let client = KiCadIpcClient::new(socket);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    loop {
+        match client.get_open_documents() {
+            Ok(documents) if !documents.is_empty() => break,
+            Ok(_) if std::time::Instant::now() < deadline => {}
+            Ok(_) => panic!("KiCad has no PCB document open"),
+            Err(error)
+                if error.to_string().contains("AS_NOT_READY")
+                    && std::time::Instant::now() < deadline => {}
+            Err(error) => panic!("KiCad IPC connection failed: {error:#}"),
+        }
+        std::thread::sleep(std::time::Duration::from_millis(250));
+    }
+
+    client.save_board().expect("initial board save failed");
+    let before_tree = load_board(Path::new(&board));
+    let before = footprint(&before_tree, &reference);
+    let original_at = footprint_at(before);
+    let original_pads = pad_offsets(before);
+    let original_geometry = child_geometry(before);
+    assert!(!original_pads.is_empty(), "test footprint has no pads");
+
+    let target = (original_at.0 + 10.0, original_at.1 + 7.0);
+    client
+        .move_footprint(&reference, target.0, target.1)
+        .expect("footprint move failed");
+    client.save_board().expect("moved board save failed");
+
+    let after_tree = load_board(Path::new(&board));
+    let after = footprint(&after_tree, &reference);
+    let moved_at = at(after);
+    assert!((moved_at.0 - target.0).abs() < 1e-6);
+    assert!((moved_at.1 - target.1).abs() < 1e-6);
+    assert_eq!(
+        pad_offsets(after),
+        original_pads,
+        "moving a footprint must not rewrite its child-relative pad positions"
+    );
+    assert_eq!(
+        child_geometry(after),
+        original_geometry,
+        "moving a footprint must preserve all child-relative geometry"
+    );
+
+    let target_rotation = (original_at.2 + 90.0) % 360.0;
+    client
+        .rotate_footprint(&reference, target_rotation)
+        .expect("footprint rotation failed");
+    client.save_board().expect("rotated board save failed");
+
+    let rotated_tree = load_board(Path::new(&board));
+    let rotated = footprint(&rotated_tree, &reference);
+    assert!((footprint_at(rotated).2 - target_rotation).abs() < 1e-6);
+    assert_eq!(
+        child_geometry(rotated),
+        original_geometry,
+        "rotating a footprint must preserve all child-relative geometry"
+    );
+}

--- a/crates/konnect-ipc/tests/mock_server_test.rs
+++ b/crates/konnect-ipc/tests/mock_server_test.rs
@@ -604,6 +604,58 @@ fn failed_multi_step_commit_is_dropped() {
     );
 }
 
+// ─── IpcFailure classification ────────────────────────────────────────────────
+//
+// The file-editing fallback in konnect-core is gated on this classification:
+// only a transport that never delivered the request may fall back, and the
+// decision must come from the typed marker, never from matching error text
+// (Copilot flagged substring matching three times on PR #66).
+
+#[test]
+fn an_unconfigured_socket_classifies_as_unreachable() {
+    if std::env::var("KICAD_API_SOCKET").is_ok() {
+        eprintln!("SKIP: KICAD_API_SOCKET set in environment");
+        return;
+    }
+    let client = KiCadIpcClient::new("");
+    let failure = konnect_ipc::IpcFailure::from_error(client.get_open_documents().unwrap_err());
+    assert!(
+        matches!(failure, konnect_ipc::IpcFailure::Unreachable(_)),
+        "unexpected classification: {failure:?}"
+    );
+}
+
+#[test]
+fn a_dead_endpoint_classifies_as_unreachable() {
+    let client = KiCadIpcClient::new("tcp://127.0.0.1:1");
+    let failure = konnect_ipc::IpcFailure::from_error(client.get_open_documents().unwrap_err());
+    assert!(
+        matches!(failure, konnect_ipc::IpcFailure::Unreachable(_)),
+        "unexpected classification: {failure:?}"
+    );
+}
+
+#[test]
+fn a_live_kicad_that_says_no_classifies_as_rejected() {
+    let mock = spawn_mock(|_req| {
+        Some(kiapi::common::ApiResponse {
+            status: Some(kiapi::common::ApiResponseStatus {
+                status: kiapi::common::ApiStatusCode::AsBadRequest as i32,
+                error_message: "no board open".to_string(),
+            }),
+            header: None,
+            message: None,
+        })
+    });
+    let client = KiCadIpcClient::new(&mock.url);
+    let failure = konnect_ipc::IpcFailure::from_error(client.get_open_documents().unwrap_err());
+    assert!(
+        matches!(failure, konnect_ipc::IpcFailure::Rejected(_)),
+        "a completed round-trip must never classify as unreachable: {failure:?}"
+    );
+    assert!(failure.message().contains("no board open"), "{failure:?}");
+}
+
 /// The regression the recv timeout exists for: a server that accepts the
 /// request and never replies. The predecessor project hung >600 s here; the
 /// client must give up at its recv timeout instead.

--- a/crates/konnect-ipc/tests/mock_server_test.rs
+++ b/crates/konnect-ipc/tests/mock_server_test.rs
@@ -340,6 +340,145 @@ fn a_mixed_response_counts_only_the_successes() {
     );
 }
 
+/// End-to-end placement through the mock: the FootprintInstance sent over the
+/// wire must carry the footprint's graphics (courtyard/silk/fab) as children
+/// alongside its pads — a pads-only instance trips lib_footprint_mismatch and
+/// makes courtyard DRC meaningless.
+#[test]
+fn place_footprint_sends_graphics_children() {
+    use konnect_ipc::{IpcGraphicDefinition, IpcPadDefinition};
+
+    let captured: Arc<Mutex<Option<kiapi::common::commands::CreateItems>>> =
+        Arc::new(Mutex::new(None));
+    let captured_in_mock = captured.clone();
+    let mock = spawn_mock(move |request| {
+        let message = request.message.expect("request must pack a command");
+        if message.type_url.ends_with("GetOpenDocuments") {
+            Some(open_board_response())
+        } else if message.type_url.ends_with("GetItems") {
+            // Before creation the board is empty; afterwards it holds exactly
+            // what CreateItems carried, so the client's verification pass sees
+            // its own footprint.
+            let items = captured_in_mock
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|create| create.items.clone())
+                .unwrap_or_default();
+            Some(reply_with(builders::pack_any(
+                &kiapi::common::commands::GetItemsResponse {
+                    header: None,
+                    status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                    items,
+                },
+                "kiapi.common.commands.GetItemsResponse",
+            )))
+        } else {
+            assert!(message.type_url.ends_with("CreateItems"));
+            let create =
+                kiapi::common::commands::CreateItems::decode(message.value.as_slice()).unwrap();
+            let created_items = create
+                .items
+                .iter()
+                .cloned()
+                .map(|item| kiapi::common::commands::ItemCreationResult {
+                    status: Some(kiapi::common::commands::ItemStatus {
+                        code: kiapi::common::commands::ItemStatusCode::IscOk as i32,
+                        error_message: String::new(),
+                    }),
+                    item: Some(item),
+                })
+                .collect();
+            *captured_in_mock.lock().unwrap() = Some(create);
+            Some(reply_with(builders::pack_any(
+                &kiapi::common::commands::CreateItemsResponse {
+                    header: None,
+                    status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                    created_items,
+                },
+                "kiapi.common.commands.CreateItemsResponse",
+            )))
+        }
+    });
+
+    let pads = vec![IpcPadDefinition {
+        number: "1".to_string(),
+        pad_type: "smd".to_string(),
+        shape: "roundrect".to_string(),
+        x: -0.5,
+        y: 0.0,
+        rotation: 0.0,
+        size_x: 0.5,
+        size_y: 0.5,
+        drill_x: None,
+        drill_y: None,
+        drill_oval: false,
+        layers: vec!["F.Cu".to_string()],
+        roundrect_ratio: 0.25,
+    }];
+    let graphics = vec![
+        IpcGraphicDefinition::Rect {
+            start: (-0.8, -0.7),
+            end: (0.8, 0.7),
+            layer: "F.CrtYd".to_string(),
+            width: 0.05,
+            filled: false,
+        },
+        IpcGraphicDefinition::Line {
+            start: (-0.6, -0.5),
+            end: (0.6, -0.5),
+            layer: "F.SilkS".to_string(),
+            width: 0.12,
+        },
+        IpcGraphicDefinition::Text {
+            text: "R_0402".to_string(),
+            position: (0.0, 1.17),
+            rotation: 0.0,
+            layer: "F.Fab".to_string(),
+            size: 0.26,
+        },
+    ];
+
+    let client = KiCadIpcClient::new(&mock.url);
+    let placed = client
+        .place_footprint(
+            "Resistor_SMD:R_0402",
+            "R1",
+            "R_0402",
+            &pads,
+            &graphics,
+            10.0,
+            20.0,
+            0.0,
+            "F.Cu",
+        )
+        .expect("placement through the mock should succeed");
+    assert_eq!(placed.reference, "R1");
+
+    let create = captured.lock().unwrap().take().expect("CreateItems sent");
+    assert_eq!(create.items.len(), 1);
+    let footprint = kiapi::board::types::FootprintInstance::decode(
+        create.items[0].value.as_slice(),
+    )
+    .expect("sent item must be a FootprintInstance");
+    let children = footprint.definition.expect("definition").items;
+    let pads_sent = children
+        .iter()
+        .filter(|any| any.type_url.ends_with("kiapi.board.types.Pad"))
+        .count();
+    let shapes_sent = children
+        .iter()
+        .filter(|any| any.type_url.ends_with("BoardGraphicShape"))
+        .count();
+    let texts_sent = children
+        .iter()
+        .filter(|any| any.type_url.ends_with("BoardText"))
+        .count();
+    assert_eq!(pads_sent, 1, "pad child missing");
+    assert_eq!(shapes_sent, 2, "courtyard rect + silk line must be sent");
+    assert_eq!(texts_sent, 1, "fab text must be sent");
+}
+
 #[test]
 fn create_items_requires_a_typed_response_payload() {
     let mock = spawn_mock(|request| {

--- a/crates/konnect-ipc/tests/mock_server_test.rs
+++ b/crates/konnect-ipc/tests/mock_server_test.rs
@@ -196,6 +196,150 @@ fn empty_socket_path_is_configuration_error() {
     );
 }
 
+// ─── CreateItems outcome handling ─────────────────────────────────────────────
+//
+// Ported from emolitor's PR #66 (which exercised these against the
+// ParseAndCreateItemsFromString path) and adapted to the typed create_items
+// API: the per-item accounting bugs they guard are identical.
+
+/// A mock KiCAD with one board open that answers every CreateItems with
+/// `results`.
+fn spawn_mock_creating(results: Vec<kiapi::common::commands::ItemCreationResult>) -> MockKicad {
+    spawn_mock(move |request| {
+        let message = request.message.expect("request must pack a command");
+        if message.type_url.ends_with("GetOpenDocuments") {
+            Some(open_board_response())
+        } else {
+            assert!(message.type_url.ends_with("CreateItems"));
+            let response = kiapi::common::commands::CreateItemsResponse {
+                header: None,
+                // IRS_OK even though nothing may have been created — the
+                // response shape the proto explicitly warns about.
+                status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                created_items: results.clone(),
+            };
+            Some(reply_with(builders::pack_any(
+                &response,
+                "kiapi.common.commands.CreateItemsResponse",
+            )))
+        }
+    })
+}
+
+fn creation_result(
+    code: kiapi::common::commands::ItemStatusCode,
+    message: &str,
+) -> kiapi::common::commands::ItemCreationResult {
+    kiapi::common::commands::ItemCreationResult {
+        status: Some(kiapi::common::commands::ItemStatus {
+            code: code as i32,
+            error_message: message.to_string(),
+        }),
+        item: None,
+    }
+}
+
+fn any_item() -> prost_types::Any {
+    builders::pack_any(&kiapi::common::commands::Ping {}, "test.Item")
+}
+
+#[test]
+fn a_rejected_item_is_not_counted_as_created() {
+    // The regression this guards: created_items is documented as "status of
+    // each item TO BE created", so a rejection still occupies a slot. Counting
+    // the vector's length would call this a success and put the phantom back.
+    let mock = spawn_mock_creating(vec![creation_result(
+        kiapi::common::commands::ItemStatusCode::IscInvalidData,
+        "footprint has no pads",
+    )]);
+
+    let client = KiCadIpcClient::new(&mock.url);
+    let err = client.create_items(vec![any_item()]).unwrap_err().to_string();
+
+    assert!(
+        err.contains("created 0 of 1"),
+        "must report failure: {err}"
+    );
+    // The per-item reason is what makes this diagnosable.
+    assert!(
+        err.contains("ISC_INVALID_DATA") && err.contains("footprint has no pads"),
+        "must surface KiCAD's own reason: {err}"
+    );
+}
+
+#[test]
+fn an_empty_result_list_still_reports_failure() {
+    // KiCAD 10.0's actual behaviour: an empty CreateItemsResponse with IRS_OK.
+    let mock = spawn_mock_creating(vec![]);
+    let client = KiCadIpcClient::new(&mock.url);
+    let err = client.create_items(vec![any_item()]).unwrap_err().to_string();
+    assert!(err.contains("created no items"), "unexpected: {err}");
+    assert!(err.contains("no items at all"), "unexpected: {err}");
+}
+
+#[test]
+fn a_created_item_counts() {
+    let mock = spawn_mock_creating(vec![creation_result(
+        kiapi::common::commands::ItemStatusCode::IscOk,
+        "",
+    )]);
+    let client = KiCadIpcClient::new(&mock.url);
+    client
+        .create_items(vec![any_item()])
+        .expect("an ISC_OK result is a created item");
+}
+
+#[test]
+fn a_defaulted_status_counts_only_when_an_item_came_back() {
+    // Protobuf cannot distinguish "unset" from "explicitly zero", so an
+    // ISC_UNKNOWN status is only evidence of success if an item is attached.
+    let with_item = kiapi::common::commands::ItemCreationResult {
+        status: None,
+        item: Some(prost_types::Any::default()),
+    };
+    let mock = spawn_mock_creating(vec![with_item]);
+    let client = KiCadIpcClient::new(&mock.url);
+    client
+        .create_items(vec![any_item()])
+        .expect("an item with a defaulted status was still created");
+
+    // The same defaulted status with nothing attached created nothing.
+    let without_item = kiapi::common::commands::ItemCreationResult {
+        status: Some(kiapi::common::commands::ItemStatus {
+            code: kiapi::common::commands::ItemStatusCode::IscUnknown as i32,
+            error_message: String::new(),
+        }),
+        item: None,
+    };
+    let mock = spawn_mock_creating(vec![without_item]);
+    let client = KiCadIpcClient::new(&mock.url);
+    assert!(
+        client.create_items(vec![any_item()]).is_err(),
+        "a bare ISC_UNKNOWN with no item must not count as created"
+    );
+}
+
+#[test]
+fn a_mixed_response_counts_only_the_successes() {
+    let mock = spawn_mock_creating(vec![
+        creation_result(kiapi::common::commands::ItemStatusCode::IscOk, ""),
+        creation_result(
+            kiapi::common::commands::ItemStatusCode::IscInvalidData,
+            "bad",
+        ),
+    ]);
+    let client = KiCadIpcClient::new(&mock.url);
+    let err = client
+        .create_items(vec![any_item(), any_item()])
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("created 1 of 2"), "unexpected: {err}");
+    assert!(
+        err.contains("item 1") && err.contains("ISC_INVALID_DATA") && err.contains("bad"),
+        "the rejected slot must be identified: {err}"
+    );
+}
+
 #[test]
 fn create_items_requires_a_typed_response_payload() {
     let mock = spawn_mock(|request| {

--- a/crates/konnect-ipc/tests/mock_server_test.rs
+++ b/crates/konnect-ipc/tests/mock_server_test.rs
@@ -445,11 +445,13 @@ fn place_footprint_sends_graphics_children() {
     let client = KiCadIpcClient::new(&mock.url);
     let placed = client
         .place_footprint(
+            std::path::Path::new("test.kicad_pcb"),
             "Resistor_SMD:R_0402",
             "R1",
             "R_0402",
             &pads,
             &graphics,
+            &konnect_ipc::IpcFieldPlacement::default(),
             10.0,
             20.0,
             0.0,
@@ -678,4 +680,117 @@ fn wedged_server_times_out_instead_of_hanging() {
         elapsed >= Duration::from_secs(25) && elapsed < Duration::from_secs(60),
         "expected ~30s recv timeout, got {elapsed:?}"
     );
+}
+
+// ─── Multi-board document targeting ──────────────────────────────────────────
+//
+// Live verification caught this: with the user's own project focused and the
+// target board open behind it, first-document targeting either fails or
+// mutates the wrong board. place_footprint must address the document whose
+// path matches the request.
+
+#[test]
+fn placement_targets_the_named_board_among_several_open() {
+    use std::sync::{Arc, Mutex};
+    let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let captured_in_mock = captured.clone();
+
+    let mock = spawn_mock(move |request| {
+        let message = request.message.expect("request must pack a command");
+        if message.type_url.ends_with("GetOpenDocuments") {
+            let response = kiapi::common::commands::GetOpenDocumentsResponse {
+                documents: vec![
+                    doc_for("other-project.kicad_pcb"),
+                    doc_for("target.kicad_pcb"),
+                ],
+            };
+            return Some(reply_with(builders::pack_any(
+                &response,
+                "kiapi.common.commands.GetOpenDocumentsResponse",
+            )));
+        }
+        if message.type_url.ends_with("GetItems") {
+            let request =
+                kiapi::common::commands::GetItems::decode(message.value.as_slice()).unwrap();
+            record_doc(&captured_in_mock, &request.header);
+            let response = kiapi::common::commands::GetItemsResponse {
+                header: None,
+                status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                items: vec![],
+            };
+            return Some(reply_with(builders::pack_any(
+                &response,
+                "kiapi.common.commands.GetItemsResponse",
+            )));
+        }
+        if message.type_url.ends_with("CreateItems") {
+            let request =
+                kiapi::common::commands::CreateItems::decode(message.value.as_slice()).unwrap();
+            record_doc(&captured_in_mock, &request.header);
+            // Fail fast after capturing the header; the assertion below is
+            // about WHICH board the create addressed, not the outcome.
+            return Some(kiapi::common::ApiResponse {
+                status: Some(kiapi::common::ApiResponseStatus {
+                    status: kiapi::common::ApiStatusCode::AsBadRequest as i32,
+                    error_message: "stop here".to_string(),
+                }),
+                header: None,
+                message: None,
+            });
+        }
+        Some(ok_response())
+    });
+
+    let client = KiCadIpcClient::new(&mock.url);
+    let _ = client.place_footprint(
+        std::path::Path::new("target.kicad_pcb"),
+        "Resistor_SMD:R_0402",
+        "R1",
+        "R_0402",
+        &[],
+        &[],
+        &konnect_ipc::IpcFieldPlacement::default(),
+        10.0,
+        20.0,
+        0.0,
+        "F.Cu",
+    );
+
+    let addressed = captured
+        .lock()
+        .unwrap()
+        .take()
+        .expect("a command carried a document");
+    assert_eq!(
+        addressed, "target.kicad_pcb",
+        "commands must address the requested board, not the first open one"
+    );
+}
+
+fn doc_for(filename: &str) -> kiapi::common::types::DocumentSpecifier {
+    kiapi::common::types::DocumentSpecifier {
+        r#type: kiapi::common::types::DocumentType::DoctypePcb as i32,
+        project: None,
+        identifier: Some(
+            kiapi::common::types::document_specifier::Identifier::BoardFilename(
+                filename.to_string(),
+            ),
+        ),
+    }
+}
+
+fn record_doc(
+    slot: &std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    header: &Option<kiapi::common::types::ItemHeader>,
+) {
+    if let Some(kiapi::common::types::document_specifier::Identifier::BoardFilename(name)) = header
+        .as_ref()
+        .and_then(|h| h.document.as_ref())
+        .and_then(|d| d.identifier.as_ref())
+    {
+        let mut slot = slot.lock().unwrap();
+        if slot.is_none() {
+            *slot = Some(name.clone());
+        }
+    }
 }

--- a/crates/konnect-ipc/tests/mock_server_test.rs
+++ b/crates/konnect-ipc/tests/mock_server_test.rs
@@ -5,10 +5,12 @@
 //! exercise the full encode → transport → decode → error-mapping path that
 //! previously only ran against a live KiCAD session.
 
+use konnect_ipc::builders;
 use konnect_ipc::gen::kiapi;
 use konnect_ipc::KiCadIpcClient;
 use nng::options::Options;
 use prost::Message;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 /// A rep0 server answering each request via `respond`.
@@ -30,12 +32,14 @@ where
     let url = format!("tcp://127.0.0.1:{port}");
 
     let listen_url = url.clone();
+    let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
     let thread = std::thread::spawn(move || {
         let socket = nng::Socket::new(nng::Protocol::Rep0).expect("mock rep socket");
         socket
             .set_opt::<nng::options::RecvTimeout>(Some(Duration::from_secs(20)))
             .unwrap();
         socket.listen(&listen_url).expect("mock listen");
+        ready_tx.send(()).expect("signal mock readiness");
         while let Ok(msg) = socket.recv() {
             let request = match kiapi::common::ApiRequest::decode(msg.as_slice()) {
                 Ok(r) => r,
@@ -58,6 +62,9 @@ where
             }
         }
     });
+    ready_rx
+        .recv()
+        .expect("mock server failed before listening");
 
     MockKicad {
         url,
@@ -74,6 +81,31 @@ fn ok_response() -> kiapi::common::ApiResponse {
         header: None,
         message: None,
     }
+}
+
+fn reply_with(inner: prost_types::Any) -> kiapi::common::ApiResponse {
+    kiapi::common::ApiResponse {
+        message: Some(inner),
+        ..ok_response()
+    }
+}
+
+fn open_board_response() -> kiapi::common::ApiResponse {
+    let response = kiapi::common::commands::GetOpenDocumentsResponse {
+        documents: vec![kiapi::common::types::DocumentSpecifier {
+            r#type: kiapi::common::types::DocumentType::DoctypePcb as i32,
+            project: None,
+            identifier: Some(
+                kiapi::common::types::document_specifier::Identifier::BoardFilename(
+                    "test.kicad_pcb".to_string(),
+                ),
+            ),
+        }],
+    };
+    reply_with(builders::pack_any(
+        &response,
+        "kiapi.common.commands.GetOpenDocumentsResponse",
+    ))
 }
 
 #[test]
@@ -93,6 +125,18 @@ fn ping_roundtrips_through_mock() {
     });
 
     let client = KiCadIpcClient::new(&mock.url);
+    assert!(client.ping().unwrap());
+}
+
+#[test]
+fn explicit_kicad_token_is_sent_in_request_header() {
+    let mock = spawn_mock(|req| {
+        let header = req.header.expect("request header");
+        assert_eq!(header.kicad_token, "linux-instance-token");
+        Some(ok_response())
+    });
+
+    let client = KiCadIpcClient::new_with_token(&mock.url, "linux-instance-token");
     assert!(client.ping().unwrap());
 }
 
@@ -150,6 +194,131 @@ fn empty_socket_path_is_configuration_error() {
     assert!(
         err.contains("TROUBLESHOOTING"),
         "error should link the troubleshooting guide: {err}"
+    );
+}
+
+#[test]
+fn create_items_requires_a_typed_response_payload() {
+    let mock = spawn_mock(|request| {
+        let message = request.message.expect("request message");
+        if message.type_url.ends_with("GetOpenDocuments") {
+            Some(open_board_response())
+        } else {
+            assert!(message.type_url.ends_with("CreateItems"));
+            Some(ok_response())
+        }
+    });
+    let client = KiCadIpcClient::new(&mock.url);
+    let item = builders::pack_any(&kiapi::common::commands::Ping {}, "test.Item");
+
+    let error = client.create_items(vec![item]).unwrap_err().to_string();
+
+    assert!(error.contains("no CreateItems response payload"), "{error}");
+}
+
+#[test]
+fn update_items_rejects_missing_per_item_results() {
+    let mock = spawn_mock(|request| {
+        let message = request.message.expect("request message");
+        if message.type_url.ends_with("GetOpenDocuments") {
+            Some(open_board_response())
+        } else {
+            assert!(message.type_url.ends_with("UpdateItems"));
+            let response = kiapi::common::commands::UpdateItemsResponse {
+                header: None,
+                status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                updated_items: vec![],
+            };
+            Some(reply_with(builders::pack_any(
+                &response,
+                "kiapi.common.commands.UpdateItemsResponse",
+            )))
+        }
+    });
+    let client = KiCadIpcClient::new(&mock.url);
+    let item = builders::pack_any(&kiapi::common::commands::Ping {}, "test.Item");
+
+    let error = client.update_items(vec![item]).unwrap_err().to_string();
+
+    assert!(
+        error.contains("0 update results for 1 requested"),
+        "{error}"
+    );
+}
+
+#[test]
+fn delete_items_surfaces_per_item_failure() {
+    let mock = spawn_mock(|request| {
+        let message = request.message.expect("request message");
+        if message.type_url.ends_with("GetOpenDocuments") {
+            Some(open_board_response())
+        } else {
+            assert!(message.type_url.ends_with("DeleteItems"));
+            let response = kiapi::common::commands::DeleteItemsResponse {
+                header: None,
+                status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                deleted_items: vec![kiapi::common::commands::ItemDeletionResult {
+                    id: Some(kiapi::common::types::Kiid {
+                        value: "missing-id".to_string(),
+                    }),
+                    status: kiapi::common::commands::ItemDeletionStatus::IdsNonexistent as i32,
+                }],
+            };
+            Some(reply_with(builders::pack_any(
+                &response,
+                "kiapi.common.commands.DeleteItemsResponse",
+            )))
+        }
+    });
+    let client = KiCadIpcClient::new(&mock.url);
+
+    let error = client
+        .delete_items(vec!["missing-id".to_string()])
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("IDS_NONEXISTENT"), "{error}");
+    assert!(error.contains("missing-id"), "{error}");
+}
+
+#[test]
+fn failed_multi_step_commit_is_dropped() {
+    let actions = Arc::new(Mutex::new(Vec::new()));
+    let captured_actions = actions.clone();
+    let mock = spawn_mock(move |request| {
+        let message = request.message.expect("request message");
+        if message.type_url.ends_with("BeginCommit") {
+            let response = kiapi::common::commands::BeginCommitResponse {
+                id: Some(kiapi::common::types::Kiid {
+                    value: "commit-1".to_string(),
+                }),
+            };
+            Some(reply_with(builders::pack_any(
+                &response,
+                "kiapi.common.commands.BeginCommitResponse",
+            )))
+        } else {
+            assert!(message.type_url.ends_with("EndCommit"));
+            let command =
+                kiapi::common::commands::EndCommit::decode(message.value.as_slice()).unwrap();
+            captured_actions.lock().unwrap().push(command.action());
+            Some(reply_with(builders::pack_any(
+                &kiapi::common::commands::EndCommitResponse {},
+                "kiapi.common.commands.EndCommitResponse",
+            )))
+        }
+    });
+    let client = KiCadIpcClient::new(&mock.url);
+
+    let error = client
+        .run_commit::<()>("test transaction", |_| anyhow::bail!("second step failed"))
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("changes dropped"), "{error}");
+    assert_eq!(
+        *actions.lock().unwrap(),
+        vec![kiapi::common::commands::CommitAction::CmaDrop]
     );
 }
 

--- a/crates/konnect-ipc/tests/mock_server_test.rs
+++ b/crates/konnect-ipc/tests/mock_server_test.rs
@@ -254,12 +254,12 @@ fn a_rejected_item_is_not_counted_as_created() {
     )]);
 
     let client = KiCadIpcClient::new(&mock.url);
-    let err = client.create_items(vec![any_item()]).unwrap_err().to_string();
+    let err = client
+        .create_items(vec![any_item()])
+        .unwrap_err()
+        .to_string();
 
-    assert!(
-        err.contains("created 0 of 1"),
-        "must report failure: {err}"
-    );
+    assert!(err.contains("created 0 of 1"), "must report failure: {err}");
     // The per-item reason is what makes this diagnosable.
     assert!(
         err.contains("ISC_INVALID_DATA") && err.contains("footprint has no pads"),
@@ -272,7 +272,10 @@ fn an_empty_result_list_still_reports_failure() {
     // KiCAD 10.0's actual behaviour: an empty CreateItemsResponse with IRS_OK.
     let mock = spawn_mock_creating(vec![]);
     let client = KiCadIpcClient::new(&mock.url);
-    let err = client.create_items(vec![any_item()]).unwrap_err().to_string();
+    let err = client
+        .create_items(vec![any_item()])
+        .unwrap_err()
+        .to_string();
     assert!(err.contains("created no items"), "unexpected: {err}");
     assert!(err.contains("no items at all"), "unexpected: {err}");
 }
@@ -457,10 +460,9 @@ fn place_footprint_sends_graphics_children() {
 
     let create = captured.lock().unwrap().take().expect("CreateItems sent");
     assert_eq!(create.items.len(), 1);
-    let footprint = kiapi::board::types::FootprintInstance::decode(
-        create.items[0].value.as_slice(),
-    )
-    .expect("sent item must be a FootprintInstance");
+    let footprint =
+        kiapi::board::types::FootprintInstance::decode(create.items[0].value.as_slice())
+            .expect("sent item must be a FootprintInstance");
     let children = footprint.definition.expect("definition").items;
     let pads_sent = children
         .iter()

--- a/crates/konnect/tests/live_kicad_tools.rs
+++ b/crates/konnect/tests/live_kicad_tools.rs
@@ -1,0 +1,238 @@
+//! Full MCP-tool regression against a running KiCad PCB Editor.
+//!
+//! The workflow opens a disposable board under Xvfb and supplies its socket.
+//! This test intentionally crosses every layer: JSON-RPC stdio, tool routing,
+//! platform footprint-library discovery, `.kicad_mod` preparation, and live IPC.
+
+use konnect_ipc::client::KiCadIpcClient;
+use konnect_sexp::{parse_sexp, SexpNode};
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::time::Duration;
+
+struct McpProcess {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: u64,
+}
+
+impl McpProcess {
+    fn spawn(socket: &str) -> Self {
+        let config = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+        std::fs::write(
+            config.path(),
+            serde_json::to_vec(&json!({"ipc_address": socket})).unwrap(),
+        )
+        .unwrap();
+        let (_, config_path) = config.keep().unwrap();
+        let mut child = Command::new(env!("CARGO_BIN_EXE_konnect"))
+            .arg("--config")
+            .arg(config_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("failed to start Konnect MCP server");
+        let stdin = child.stdin.take().unwrap();
+        let stdout = BufReader::new(child.stdout.take().unwrap());
+        let mut process = Self {
+            child,
+            stdin,
+            stdout,
+            next_id: 1,
+        };
+        process.request(
+            "initialize",
+            json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "live-kicad-tools", "version": "0"}
+            }),
+        );
+        process
+    }
+
+    fn request(&mut self, method: &str, params: Value) -> Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        writeln!(
+            self.stdin,
+            "{}",
+            json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params})
+        )
+        .unwrap();
+        self.stdin.flush().unwrap();
+        loop {
+            let mut line = String::new();
+            assert!(
+                self.stdout.read_line(&mut line).unwrap() > 0,
+                "Konnect exited before replying"
+            );
+            let response: Value = serde_json::from_str(line.trim()).unwrap();
+            if response["id"] == id {
+                return response;
+            }
+        }
+    }
+
+    fn tool(&mut self, name: &str, arguments: Value) -> Value {
+        let response = self.request("tools/call", json!({"name": name, "arguments": arguments}));
+        let result = &response["result"];
+        assert_ne!(
+            result["isError"], true,
+            "tool {name} failed: {}",
+            result["content"][0]["text"]
+        );
+        result.clone()
+    }
+}
+
+impl Drop for McpProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn footprint<'a>(tree: &'a SexpNode, reference: &str) -> &'a SexpNode {
+    tree.find_all("footprint")
+        .into_iter()
+        .find(|node| {
+            node.find_all("property").into_iter().any(|property| {
+                property.get(1).and_then(SexpNode::as_str) == Some("Reference")
+                    && property.get(2).and_then(SexpNode::as_str) == Some(reference)
+            })
+        })
+        .unwrap_or_else(|| panic!("placed footprint {reference} is missing from saved board"))
+}
+
+#[test]
+#[ignore = "requires a running KiCad GUI, API socket, and standard footprint libraries"]
+fn place_component_loads_real_library_geometry() {
+    let board = std::env::var("KONNECT_LIVE_KICAD_BOARD")
+        .expect("KONNECT_LIVE_KICAD_BOARD must name the disposable open board");
+    let socket = std::env::var("KICAD_API_SOCKET").expect("KICAD_API_SOCKET is required");
+    let lib_id = std::env::var("KONNECT_LIVE_KICAD_FOOTPRINT")
+        .unwrap_or_else(|_| "Resistor_SMD:R_0402_1005Metric".into());
+    let reference =
+        std::env::var("KONNECT_LIVE_KICAD_PLACE_REFERENCE").unwrap_or_else(|_| "R900".into());
+
+    let ipc = KiCadIpcClient::new(&socket);
+    let ready = (0..100).any(|_| {
+        if ipc.ping().unwrap_or(false) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+        false
+    });
+    assert!(ready, "KiCad IPC socket never became ready");
+
+    let mut mcp = McpProcess::spawn(&socket);
+    mcp.tool("load_toolset", json!({"name": "pcb_components"}));
+    let placed = mcp.tool(
+        "place_component",
+        json!({
+            "board": board,
+            "footprint": lib_id,
+            "reference": reference,
+            "x": 42.0,
+            "y": 37.0,
+            "rotation": 90.0,
+            "layer": "F.Cu"
+        }),
+    );
+    let body: Value = serde_json::from_str(placed["content"][0]["text"].as_str().unwrap())
+        .expect("place_component did not return JSON");
+    assert_eq!(body["placed"], reference);
+    assert_eq!(body["footprint"], lib_id);
+
+    let wrong_board = std::path::Path::new(&board)
+        .with_file_name("not-the-active-board.kicad_pcb")
+        .to_string_lossy()
+        .into_owned();
+    let rejected = mcp.request(
+        "tools/call",
+        json!({
+            "name": "move_component",
+            "arguments": {
+                "board": wrong_board,
+                "reference": reference,
+                "x": 99.0,
+                "y": 99.0
+            }
+        }),
+    );
+    assert_eq!(
+        rejected["result"]["isError"], true,
+        "wrong-board mutation was not rejected: {rejected}"
+    );
+
+    let edited = mcp.tool(
+        "edit_component",
+        json!({"board": board, "reference": reference, "value": "10k"}),
+    );
+    let edited: Value = serde_json::from_str(edited["content"][0]["text"].as_str().unwrap())
+        .expect("edit_component did not return JSON");
+    assert_eq!(edited["value"], "10k");
+
+    let array = mcp.tool(
+        "place_component_array",
+        json!({
+            "board": board,
+            "footprint": lib_id,
+            "start_x": 30.0,
+            "start_y": 50.0,
+            "count_x": 2,
+            "count_y": 1,
+            "spacing_x": 5.0,
+            "ref_prefix": "R",
+            "ref_start": 910
+        }),
+    );
+    let array: Value = serde_json::from_str(array["content"][0]["text"].as_str().unwrap())
+        .expect("place_component_array did not return JSON");
+    assert_eq!(array["placed_count"], 2);
+
+    let aligned = mcp.tool(
+        "align_components",
+        json!({
+            "board": board,
+            "references": ["R910", "R911"],
+            "axis": "y",
+            "value": 55.0
+        }),
+    );
+    let aligned: Value = serde_json::from_str(aligned["content"][0]["text"].as_str().unwrap())
+        .expect("align_components did not return JSON");
+    assert_eq!(aligned["aligned_count"], 2);
+
+    KiCadIpcClient::new(&socket)
+        .save_board()
+        .expect("failed to save board after placement");
+    let tree = parse_sexp(&std::fs::read_to_string(&board).unwrap()).unwrap();
+    let placed = footprint(&tree, &reference);
+    assert!(
+        placed.find_all("pad").len() >= 2,
+        "placed library footprint lost its pads"
+    );
+    assert!(placed.find_all("property").into_iter().any(|property| {
+        property.get(1).and_then(SexpNode::as_str) == Some("Value")
+            && property.get(2).and_then(SexpNode::as_str) == Some("10k")
+    }));
+    let at = placed
+        .find("at")
+        .expect("placed footprint has no board position");
+    assert!((at.get_f64(1).unwrap() - 42.0).abs() < 1e-6);
+    assert!((at.get_f64(2).unwrap() - 37.0).abs() < 1e-6);
+    assert!((at.get_f64(3).unwrap() - 90.0).abs() < 1e-6);
+
+    for array_reference in ["R910", "R911"] {
+        let array_footprint = footprint(&tree, array_reference);
+        let at = array_footprint
+            .find("at")
+            .expect("array footprint has no board position");
+        assert!((at.get_f64(2).unwrap() - 55.0).abs() < 1e-6);
+    }
+}


### PR DESCRIPTION

### Summary

- resolve `Library:Footprint` IDs from project/global tables and standard KiCad
  library locations across Linux, macOS, and Windows
- translate real `.kicad_mod` geometry and pads into typed KiCad IPC messages
  instead of reporting success without a placed footprint
- validate envelope, operation, item-count, and per-item statuses and preserve
  the complete IPC error chain
- verify that a path-bearing request targets the active board before mutation
- wrap multi-step edit, align, and array operations in KiCad transactions with
  rollback on error or panic
- add mock-server, transformation, and real KiCad 10 GUI coverage through both
  the low-level client and the MCP JSON-RPC boundary

Closes #61.

### Root cause

`place_component` did not construct and verify a complete typed footprint from
the selected library definition. A nominal IPC response could therefore become
a successful MCP result even though the PCB editor had no corresponding placed
item.

### Implementation

The tool resolves the selected footprint source, validates its root metadata,
extracts typed fields and pads, creates all requested footprints in one typed
request, commits the transaction, and then verifies the resulting references.
Batch placement avoids querying transaction-staged items, which KiCad does not
expose before commit. Duplicate references are rejected during preflight.

The client now fails closed on missing/malformed statuses, mismatched item
counts, unexpected deletion IDs, inactive-board requests, and failed
transaction commit. Direct file fallback remains available only when IPC is not
configured; a configured IPC mutation failure is never masked by rewriting the
file behind KiCad's back.

### Compatibility

MCP tool names and JSON schemas are unchanged. Calls that previously returned a
false success now either produce a verified placement or an explicit error.
Custom-pad footprints are currently rejected with an actionable message rather
than approximated incorrectly.

### Relationship to open placement work

PRs #54 and #66 also address footprint placement. This draft is offered as a
separate, safety-focused implementation for maintainers to compare:

- it creates typed `FootprintInstance` data and validates the resulting KiCad
  response instead of falling back to editing an actively open board file;
- configured IPC failures remain failures, preventing a hidden file edit that
  KiCad could later overwrite;
- mutations verify the requested active-board path and multi-step operations use
  rollback-capable KiCad transactions;
- the exact branch was exercised through the real KiCad 10 GUI IPC API, not only
  through file-mode or mocked tests.

If maintainers prefer another placement implementation, the response validation,
transaction, active-board, and live-test coverage can be reviewed independently.

### Validation

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo check --locked -p konnect-ipc -p konnect-core -p konnect --all-targets`
- `cargo test --locked -p konnect-ipc -p konnect-core -p konnect --all-targets`
  - IPC unit/integration suites, footprint transforms, and mock transport passed
  - core and MCP suites passed; live tests remain ignored in ordinary runs
- `cargo clippy --locked -p konnect-ipc -p konnect-core -p konnect --lib --bins -- -D warnings`
- real KiCad 10.0.4 under Xvfb:
  - move and rotate preserved child-relative geometry
  - a standard-library resistor footprint was placed with real pads
  - edit, two-item array placement, alignment, save, and on-disk verification passed
  - mutation of a non-active board path was rejected

### Risk and rollback

This is a substantial boundary change because typed protobuf geometry must agree
with KiCad. The tests cover malformed responses, transaction failures, geometry
preservation, and the real GUI/API. Unsupported custom pads fail closed. The
single commit can be reverted without file-format migration.

