### PR TITLE
fix(sch): place schematic field properties near their owners

### DIFF
--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -1156,11 +1156,56 @@ async fn handle_add_power_symbol(
     sym.in_bom = true;
     sym.on_board = true;
     sym.uuid = uuid::Uuid::new_v4().to_string();
-    sym.properties
-        .push(cse::Property::new("Reference", &pwr_ref));
-    sym.properties.push(cse::Property::new("Value", &power_net));
-    sym.properties.push(cse::Property::new("Footprint", ""));
-    sym.properties.push(cse::Property::new("Datasheet", ""));
+
+    // Property (at …) is absolute sheet coords — same as add_schematic_component.
+    // Bare Property::new writes no (at); KiCad then defaults to (0,0) and every
+    // #PWR piles up in the top-left corner. Hide Reference like eeschema does.
+    let effects_node = |hide: bool| -> cse::sexp::SexpNode {
+        let font = cse::sexp::SexpNode::List(vec![
+            cse::sexp::atom("font"),
+            cse::sexp::SexpNode::List(vec![
+                cse::sexp::atom("size"),
+                cse::sexp::atom("1.27"),
+                cse::sexp::atom("1.27"),
+            ]),
+        ]);
+        let mut children = vec![cse::sexp::atom("effects"), font];
+        if hide {
+            children.push(cse::sexp::SexpNode::List(vec![
+                cse::sexp::atom("hide"),
+                cse::sexp::atom("yes"),
+            ]));
+        }
+        cse::sexp::SexpNode::List(children)
+    };
+    let at_node = |px: f64, py: f64, rot: f64| -> cse::sexp::SexpNode {
+        cse::sexp::SexpNode::List(vec![
+            cse::sexp::atom("at"),
+            cse::sexp::atom(cse::types::fmt_f64(px)),
+            cse::sexp::atom(cse::types::fmt_f64(py)),
+            cse::sexp::atom(cse::types::fmt_f64(rot)),
+        ])
+    };
+
+    let mut ref_prop = cse::Property::new("Reference", &pwr_ref);
+    ref_prop.sub_nodes.push(at_node(x, y - 3.81, 0.0));
+    ref_prop.sub_nodes.push(effects_node(true));
+    sym.properties.push(ref_prop);
+
+    let mut val_prop = cse::Property::new("Value", &power_net);
+    val_prop.sub_nodes.push(at_node(x, y + 3.81, 0.0));
+    val_prop.sub_nodes.push(effects_node(false));
+    sym.properties.push(val_prop);
+
+    let mut fp_prop = cse::Property::new("Footprint", "");
+    fp_prop.sub_nodes.push(at_node(x, y, 0.0));
+    fp_prop.sub_nodes.push(effects_node(true));
+    sym.properties.push(fp_prop);
+
+    let mut ds_prop = cse::Property::new("Datasheet", "");
+    ds_prop.sub_nodes.push(at_node(x, y, 0.0));
+    ds_prop.sub_nodes.push(effects_node(true));
+    sym.properties.push(ds_prop);
 
     // Instance entry, keyed to the root sheet UUID like eeschema writes it —
     // without a resolvable "/<root-uuid>" path KiCAD's netlister drops the
@@ -1996,5 +2041,83 @@ mod wire_delete_tests {
         assert_eq!(wires.len(), 2);
         assert!(after.contains("(junction"));
         assert!(!wires.iter().any(|wire| wire.x1 == 0.0 && wire.x2 == 10.0));
+    }
+}
+
+#[cfg(test)]
+mod power_symbol_tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::ServerConfig;
+    use std::sync::Arc;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    #[tokio::test]
+    async fn add_power_symbol_places_hidden_reference_near_the_symbol() {
+        // Pre-seed lib_symbols so ensure_lib_symbol succeeds without a KiCad install.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("power.kicad_sch");
+        std::fs::write(
+            &path,
+            "(kicad_sch\n  (version 20250610)\n  (generator \"konnect\")\n  (uuid \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\")\n  (paper \"A4\")\n  (lib_symbols\n    (symbol \"power:GND\"\n      (property \"Reference\" \"#PWR\" (at 0 0 0))\n      (property \"Value\" \"GND\" (at 0 0 0))\n    )\n  )\n)\n",
+        )
+        .unwrap();
+
+        let result = handle_add_power_symbol(
+            &json!({
+                "schematic": path.display().to_string(),
+                "power_net": "GND",
+                "x": 100.0,
+                "y": 80.0
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error, "{result:?}");
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        let sch = cse::Schematic::load(&path).unwrap();
+        let sym = sch
+            .symbols
+            .iter()
+            .find(|s| s.reference() == Some("#PWR001"))
+            .expect("power symbol instance");
+        let ref_prop = sym
+            .properties
+            .iter()
+            .find(|p| p.name == "Reference")
+            .unwrap();
+        let ref_sexp = cse::sexp::writer::write(&ref_prop.to_sexp());
+        assert!(
+            ref_sexp.contains("(at 100") && ref_sexp.contains("76.19"),
+            "Reference must sit near the symbol, not sheet origin: {ref_sexp}"
+        );
+        assert!(
+            ref_sexp.contains("hide"),
+            "eeschema hides #PWR references: {ref_sexp}"
+        );
+        let val_prop = sym.properties.iter().find(|p| p.name == "Value").unwrap();
+        let val_sexp = cse::sexp::writer::write(&val_prop.to_sexp());
+        assert!(
+            val_sexp.contains("(at 100") && val_sexp.contains("83.81"),
+            "Value must sit near the symbol: {val_sexp}"
+        );
+        assert!(
+            !after.contains("(property \"Reference\" \"#PWR001\")\n"),
+            "must not write a bare Reference with no (at)"
+        );
     }
 }

--- a/crates/konnect-schematic-editor/src/schematic/sheet.rs
+++ b/crates/konnect-schematic-editor/src/schematic/sheet.rs
@@ -170,6 +170,15 @@ fn default_stroke_fill() -> Vec<SexpNode> {
     ]
 }
 
+fn property_at(x: f64, y: f64) -> SexpNode {
+    SexpNode::List(vec![
+        atom("at"),
+        atom(fmt_f64(x)),
+        atom(fmt_f64(y)),
+        atom("0"),
+    ])
+}
+
 impl Sheet {
     pub fn new(
         name: impl Into<String>,
@@ -179,16 +188,22 @@ impl Sheet {
         width: f64,
         height: f64,
     ) -> Self {
+        // Property (at …) is absolute sheet coords. Bare Property::new writes
+        // no (at); KiCad then defaults to (0,0) and Sheetname/Sheetfile pile
+        // up in the top-left. Offsets match what eeschema writes for a new
+        // hierarchical sheet (name just above the box, file just below).
+        let mut sheetname = Property::new("Sheetname", name);
+        sheetname.sub_nodes.push(property_at(x, y - 0.8));
+        let mut sheetfile = Property::new("Sheetfile", file);
+        sheetfile.sub_nodes.push(property_at(x, y + height + 0.4));
+
         Sheet {
             at: At::new(x, y),
             width,
             height,
             uuid: uuid::Uuid::new_v4().to_string(),
             fields_autoplaced: true,
-            properties: vec![
-                Property::new("Sheetname", name),
-                Property::new("Sheetfile", file),
-            ],
+            properties: vec![sheetname, sheetfile],
             pins: vec![],
             instances: vec![],
             raw_sub_nodes: default_stroke_fill(),
@@ -500,6 +515,23 @@ mod tests {
         assert!(sheet.pins.is_empty());
         assert!(sheet.instances.is_empty());
         assert!(!sheet.uuid.is_empty());
+    }
+
+    #[test]
+    fn new_sheet_places_name_and_file_near_the_box() {
+        // Bare properties with no (at) default to sheet origin in KiCad — the
+        // same class of bug as power-symbol #PWR stacking in the top-left.
+        let sheet = Sheet::new("Storage", "storage.kicad_sch", 100.0, 50.0, 40.0, 30.0);
+        let name = crate::sexp::writer::write(&sheet.properties[0].to_sexp());
+        let file = crate::sexp::writer::write(&sheet.properties[1].to_sexp());
+        assert!(
+            name.contains("(at 100") && name.contains("49.2"),
+            "Sheetname must sit just above the box, got: {name}"
+        );
+        assert!(
+            file.contains("(at 100") && file.contains("80.4"),
+            "Sheetfile must sit just below the box, got: {file}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `add_power_symbol` wrote bare `Reference`/`Value` properties with no `(at …)`, so KiCad defaulted them to `(0,0)` and every `#PWR*` piled up in the top-left corner.
- `Sheet::new` (used by `add_hierarchical_sheet` / `duplicate_sheet`) had the same bug for `Sheetname` / `Sheetfile`.
- Write absolute property positions next to the owner (symbol or sheet box). Hide `#PWR` inside effects (eeschema-compatible); keep Value visible.
- Add regression tests for both paths.

## Test plan
- [x] `cargo test -p konnect-core --lib power_symbol_tests`
- [x] `cargo test -p konnect-schematic-editor --lib new_sheet_places_name_and_file_near_the_box`
- [ ] In KiCad: place a power symbol via `add_power_symbol` and confirm fields are not at sheet origin; Value appears near the symbol
- [ ] In KiCad: `add_hierarchical_sheet` and confirm Sheetname sits above the box and Sheetfile below it
- [ ] Re-open the schematic after save and confirm positions survive