### PR TITLE
fix(sch): hide power Reference with KiCad 10 property-level hide

### DIFF
--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -360,6 +360,8 @@ async fn handle_add_schematic_component(
     sym.unit = unit;
 
     // Helper: build an effects sub-node  (font (size 1.27 1.27))  with optional (hide yes)
+    // inside effects (legacy). Prefer property-level `(hide yes)` for power refs —
+    // that is what KiCad 10's power.kicad_sym uses.
     let effects_node = |hide: bool| -> cse::sexp::SexpNode {
         let font = cse::sexp::SexpNode::List(vec![
             cse::sexp::atom("font"),
@@ -378,6 +380,10 @@ async fn handle_add_schematic_component(
         }
         cse::sexp::SexpNode::List(children)
     };
+    let hide_node = || -> cse::sexp::SexpNode {
+        cse::sexp::SexpNode::List(vec![cse::sexp::atom("hide"), cse::sexp::atom("yes")])
+    };
+    let effects_font_only = || effects_node(false);
 
     // Helper: build an (at X Y ROT) sub-node
     let at_node = |px: f64, py: f64, rot: f64| -> cse::sexp::SexpNode {
@@ -392,11 +398,17 @@ async fn handle_add_schematic_component(
     // Offset Reference above component, Value below
     let ref_y = y - 3.81;
     let val_y = y + 3.81;
+    let hide_reference = lib_id.starts_with("power:") || ref_str.starts_with("#PWR");
 
     // Reference property
     let mut ref_prop = cse::Property::new("Reference", ref_str);
     ref_prop.sub_nodes.push(at_node(x, ref_y, 0.0));
-    ref_prop.sub_nodes.push(effects_node(false));
+    if hide_reference {
+        ref_prop.sub_nodes.push(hide_node());
+        ref_prop.sub_nodes.push(effects_font_only());
+    } else {
+        ref_prop.sub_nodes.push(effects_node(false));
+    }
     sym.properties.push(ref_prop);
 
     // Value property
@@ -1696,5 +1708,60 @@ mod tests {
         let msg = format!("{:?}", result.content);
         assert!(msg.contains("Device:CP"));
         assert!(msg.contains("no embedded definition"));
+    }
+
+    #[tokio::test]
+    async fn add_schematic_component_hides_power_reference() {
+        // Pre-seed lib_symbols so ensure_lib_symbol succeeds without KiCad.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("power-via-add.kicad_sch");
+        std::fs::write(
+            &path,
+            "(kicad_sch\n  (version 20250610)\n  (generator \"konnect\")\n  (uuid \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\")\n  (paper \"A4\")\n  (lib_symbols\n    (symbol \"power:GND\"\n      (property \"Reference\" \"#PWR\" (at 0 0 0) (hide yes))\n      (property \"Value\" \"GND\" (at 0 0 0))\n    )\n  )\n)\n",
+        )
+        .unwrap();
+
+        let result = handle_add_schematic_component(
+            &json!({
+                "schematic": path.display().to_string(),
+                "lib_id": "power:GND",
+                "x": 50.0,
+                "y": 60.0,
+                "reference": "#PWR010",
+                "value": "GND"
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error, "{result:?}");
+
+        let sch = cse::Schematic::load(&path).unwrap();
+        let sym = sch
+            .symbols
+            .iter()
+            .find(|s| s.reference() == Some("#PWR010"))
+            .expect("power instance");
+        let ref_sexp = cse::sexp::writer::write(
+            &sym.properties
+                .iter()
+                .find(|p| p.name == "Reference")
+                .unwrap()
+                .to_sexp(),
+        );
+        let hide_at = ref_sexp.find("(hide yes)").expect("property-level hide");
+        let effects_at = ref_sexp.find("(effects").expect("effects");
+        assert!(
+            hide_at < effects_at,
+            "power: via add_schematic_component must hide Reference like add_power_symbol: {ref_sexp}"
+        );
+        let val_sexp = cse::sexp::writer::write(
+            &sym.properties
+                .iter()
+                .find(|p| p.name == "Value")
+                .unwrap()
+                .to_sexp(),
+        );
+        assert!(!val_sexp.contains("hide"), "Value stays visible: {val_sexp}");
     }
 }

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -1159,24 +1159,23 @@ async fn handle_add_power_symbol(
 
     // Property (at …) is absolute sheet coords — same as add_schematic_component.
     // Bare Property::new writes no (at); KiCad then defaults to (0,0) and every
-    // #PWR piles up in the top-left corner. Hide Reference like eeschema does.
-    let effects_node = |hide: bool| -> cse::sexp::SexpNode {
-        let font = cse::sexp::SexpNode::List(vec![
-            cse::sexp::atom("font"),
+    // #PWR piles up in the top-left corner. Hide Reference with KiCad 10's
+    // property-level `(hide yes)` (sibling of effects), matching power.kicad_sym.
+    let effects_node = || -> cse::sexp::SexpNode {
+        cse::sexp::SexpNode::List(vec![
+            cse::sexp::atom("effects"),
             cse::sexp::SexpNode::List(vec![
-                cse::sexp::atom("size"),
-                cse::sexp::atom("1.27"),
-                cse::sexp::atom("1.27"),
+                cse::sexp::atom("font"),
+                cse::sexp::SexpNode::List(vec![
+                    cse::sexp::atom("size"),
+                    cse::sexp::atom("1.27"),
+                    cse::sexp::atom("1.27"),
+                ]),
             ]),
-        ]);
-        let mut children = vec![cse::sexp::atom("effects"), font];
-        if hide {
-            children.push(cse::sexp::SexpNode::List(vec![
-                cse::sexp::atom("hide"),
-                cse::sexp::atom("yes"),
-            ]));
-        }
-        cse::sexp::SexpNode::List(children)
+        ])
+    };
+    let hide_node = || -> cse::sexp::SexpNode {
+        cse::sexp::SexpNode::List(vec![cse::sexp::atom("hide"), cse::sexp::atom("yes")])
     };
     let at_node = |px: f64, py: f64, rot: f64| -> cse::sexp::SexpNode {
         cse::sexp::SexpNode::List(vec![
@@ -1189,22 +1188,25 @@ async fn handle_add_power_symbol(
 
     let mut ref_prop = cse::Property::new("Reference", &pwr_ref);
     ref_prop.sub_nodes.push(at_node(x, y - 3.81, 0.0));
-    ref_prop.sub_nodes.push(effects_node(true));
+    ref_prop.sub_nodes.push(hide_node());
+    ref_prop.sub_nodes.push(effects_node());
     sym.properties.push(ref_prop);
 
     let mut val_prop = cse::Property::new("Value", &power_net);
     val_prop.sub_nodes.push(at_node(x, y + 3.81, 0.0));
-    val_prop.sub_nodes.push(effects_node(false));
+    val_prop.sub_nodes.push(effects_node());
     sym.properties.push(val_prop);
 
     let mut fp_prop = cse::Property::new("Footprint", "");
     fp_prop.sub_nodes.push(at_node(x, y, 0.0));
-    fp_prop.sub_nodes.push(effects_node(true));
+    fp_prop.sub_nodes.push(hide_node());
+    fp_prop.sub_nodes.push(effects_node());
     sym.properties.push(fp_prop);
 
     let mut ds_prop = cse::Property::new("Datasheet", "");
     ds_prop.sub_nodes.push(at_node(x, y, 0.0));
-    ds_prop.sub_nodes.push(effects_node(true));
+    ds_prop.sub_nodes.push(hide_node());
+    ds_prop.sub_nodes.push(effects_node());
     sym.properties.push(ds_prop);
 
     // Instance entry, keyed to the root sheet UUID like eeschema writes it —
@@ -2105,15 +2107,21 @@ mod power_symbol_tests {
             ref_sexp.contains("(at 100") && ref_sexp.contains("76.19"),
             "Reference must sit near the symbol, not sheet origin: {ref_sexp}"
         );
+        let hide_at = ref_sexp.find("(hide yes)").expect("KiCad 10 property-level hide");
+        let effects_at = ref_sexp.find("(effects").expect("effects");
         assert!(
-            ref_sexp.contains("hide"),
-            "eeschema hides #PWR references: {ref_sexp}"
+            hide_at < effects_at,
+            "hide must be a property sibling before effects (not inside effects): {ref_sexp}"
         );
         let val_prop = sym.properties.iter().find(|p| p.name == "Value").unwrap();
         let val_sexp = cse::sexp::writer::write(&val_prop.to_sexp());
         assert!(
             val_sexp.contains("(at 100") && val_sexp.contains("83.81"),
             "Value must sit near the symbol: {val_sexp}"
+        );
+        assert!(
+            !val_sexp.contains("hide"),
+            "Value must stay visible on power symbols: {val_sexp}"
         );
         assert!(
             !after.contains("(property \"Reference\" \"#PWR001\")\n"),


### PR DESCRIPTION
## Summary
- Depends on / stacks after #95 (field positions). Unique commit: KiCad 10 **property-level** `(hide yes)` for power symbol Reference.
- Official `power.kicad_sym` puts `(hide yes)` as a sibling of `effects`, not inside it — effects-only hide can leave `#PWR*` visible in KiCad 10.
- `add_power_symbol`: Reference / Footprint / Datasheet use property-level hide; Value stays visible.
- `add_schematic_component`: same when `lib_id` is `power:*` or reference is `#PWR*`.

## Test plan
- [x] `cargo test -p konnect-core --lib power_symbol_tests`
- [x] `cargo test -p konnect-core --lib hides_power_reference`
- [ ] In KiCad: `add_power_symbol` — `#PWR*` invisible, Value visible near symbol
- [ ] In KiCad: `add_schematic_component` with `power:GND` — same
- [ ] After #95 merges, rebase this branch onto `main` so the PR diff is only the hide commit


Made with [Cursor](https://cursor.com)