### PR TITLE
fix(sch): make move_labels_by_offset and component moves actually move

### DIFF
--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -1897,8 +1897,14 @@ mod label_tests {
         assert!(!result.is_error);
 
         let after = std::fs::read_to_string(&path).unwrap();
-        assert!(after.contains("(at 102.54 98.73 0)"), "first label moved: {after}");
-        assert!(after.contains("(at 202.54 98.73 0)"), "second label moved: {after}");
+        assert!(
+            after.contains("(at 102.54 98.73 0)"),
+            "first label moved: {after}"
+        );
+        assert!(
+            after.contains("(at 202.54 98.73 0)"),
+            "second label moved: {after}"
+        );
     }
 
     #[tokio::test]

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -1050,7 +1050,7 @@ async fn handle_rotate_label(
 
 async fn handle_move_labels_by_offset(
     args: &serde_json::Value,
-    ctx: &ToolContext,
+    _ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
     let sch_path = get_path(args, "schematic")?;
     let net = match require_str(args, "net") {
@@ -1066,23 +1066,45 @@ async fn handle_move_labels_by_offset(
         Err(e) => return Ok(e),
     };
 
-    let (_, tree) = read_schematic(&sch_path)?;
-    let labels = konnect_sexp::schematic::extract_labels(&tree);
-
-    let matching: Vec<_> = labels.iter().filter(|l| l.net == net).cloned().collect();
-    let mut moved = 0usize;
-
-    for label in &matching {
-        let rotate_args = json!({
-            "schematic": sch_path.display().to_string(),
-            "net": net,
-            "x": label.x + dx,
-            "y": label.y + dy,
-            "rotation": label.rotation
-        });
-        handle_rotate_label(&rotate_args, ctx).await?;
-        moved += 1;
+    let content = std::fs::read_to_string(&sch_path)?;
+    let labels = find_label_blocks(&content);
+    let matching: Vec<&LabelBlock> = labels.iter().filter(|l| l.net == net).collect();
+    if matching.is_empty() {
+        return Ok(CallToolResult::error(format!(
+            "No label named '{}' in this schematic",
+            net
+        )));
     }
+
+    // Edit each label's (at X Y ROT) anchor in place, preserving the rotation.
+    let mut edits = Vec::new();
+    for label in &matching {
+        let (block_start, block_end) = find_balanced_block(&content, label.start)
+            .ok_or_else(|| anyhow::anyhow!("Cannot parse label block"))?;
+        let block = &content[block_start..block_end];
+        let at_rel = block
+            .find("(at ")
+            .ok_or_else(|| anyhow::anyhow!("No (at) in label block"))?;
+        let at_val = block_start + at_rel + "(at ".len();
+        let at_close = content[at_val..]
+            .find(')')
+            .map(|o| at_val + o)
+            .ok_or_else(|| anyhow::anyhow!("Malformed (at)"))?;
+        let rotation = content[at_val..at_close]
+            .split_whitespace()
+            .nth(2)
+            .unwrap_or("0")
+            .to_string();
+        edits.push(SexpEdit::replace(
+            at_val,
+            at_close,
+            format!("{} {} {}", label.x + dx, label.y + dy, rotation),
+        ));
+    }
+
+    let moved = edits.len();
+    let new_content = apply_edits(content, edits);
+    write_atomic(&sch_path, &new_content)?;
 
     Ok(CallToolResult::json(
         &json!({ "moved_labels": moved, "net": net }),
@@ -1859,6 +1881,38 @@ mod label_tests {
         let (_d, path) = sch_with(TWO_PLAIN);
         let result = rotate(&path, "VCC", 555.0, 555.0, 180.0).await;
         assert!(result.is_error, "must not rotate the nearest label instead");
+    }
+
+    // ─── move by offset ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn move_labels_by_offset_actually_moves_every_matching_label() {
+        let (_d, path) = sch_with(TWO_PLAIN);
+        let result = handle_move_labels_by_offset(
+            &json!({ "schematic": path.display().to_string(), "net": "VCC", "dx": 2.54, "dy": -1.27 }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error);
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(after.contains("(at 102.54 98.73 0)"), "first label moved: {after}");
+        assert!(after.contains("(at 202.54 98.73 0)"), "second label moved: {after}");
+    }
+
+    #[tokio::test]
+    async fn move_labels_by_offset_errors_on_unknown_net() {
+        let (_d, path) = sch_with(TWO_PLAIN);
+        let before = std::fs::read_to_string(&path).unwrap();
+        let result = handle_move_labels_by_offset(
+            &json!({ "schematic": path.display().to_string(), "net": "NOPE", "dx": 1.0, "dy": 1.0 }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(result.is_error, "zero matches must not report success");
+        assert_eq!(before, std::fs::read_to_string(&path).unwrap());
     }
 }
 

--- a/crates/konnect-schematic-editor/src/schematic/symbol.rs
+++ b/crates/konnect-schematic-editor/src/schematic/symbol.rs
@@ -468,13 +468,19 @@ mod tests {
         let mut sym = Symbol::new("Device:R", 100.0, 50.0);
         let mut reference = Property::new("Reference", "R1");
         // Property (at) is absolute: text sits 2.54mm right of the symbol.
-        reference.sub_nodes.push(At::with_rotation(102.54, 50.0, 0.0).to_sexp());
+        reference
+            .sub_nodes
+            .push(At::with_rotation(102.54, 50.0, 0.0).to_sexp());
         sym.properties.push(reference);
 
         sym.move_to(110.0, 60.0);
 
         let at = At::from_sexp(&sym.properties[0].sub_nodes[0]).unwrap();
-        assert_eq!((at.x, at.y), (112.54, 60.0), "property must keep its offset");
+        assert_eq!(
+            (at.x, at.y),
+            (112.54, 60.0),
+            "property must keep its offset"
+        );
         assert_eq!((sym.at.x, sym.at.y), (110.0, 60.0));
     }
 }

--- a/crates/konnect-schematic-editor/src/schematic/symbol.rs
+++ b/crates/konnect-schematic-editor/src/schematic/symbol.rs
@@ -260,13 +260,24 @@ impl Symbol {
     }
 
     pub fn move_to(&mut self, x: f64, y: f64) {
-        self.at.x = x;
-        self.at.y = y;
+        self.translate(x - self.at.x, y - self.at.y);
     }
 
     pub fn translate(&mut self, dx: f64, dy: f64) {
         self.at.x += dx;
         self.at.y += dy;
+        // Property (at) coordinates are absolute in .kicad_sch, so the
+        // Reference/Value text must move with the symbol.
+        for prop in &mut self.properties {
+            for node in &mut prop.sub_nodes {
+                if node.tag() == Some("at") {
+                    if let Some(mut at) = At::from_sexp(node) {
+                        at.translate(dx, dy);
+                        *node = at.to_sexp();
+                    }
+                }
+            }
+        }
     }
 
     pub fn set_rotation(&mut self, rot: f64) {
@@ -446,4 +457,24 @@ impl<'a> IntoIterator for &'a mut SymbolCollection {
 fn dist(ax: f64, ay: f64, bx: f64, by: f64) -> f64 {
     let (dx, dy) = (ax - bx, ay - by);
     (dx * dx + dy * dy).sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn move_to_carries_property_text_along() {
+        let mut sym = Symbol::new("Device:R", 100.0, 50.0);
+        let mut reference = Property::new("Reference", "R1");
+        // Property (at) is absolute: text sits 2.54mm right of the symbol.
+        reference.sub_nodes.push(At::with_rotation(102.54, 50.0, 0.0).to_sexp());
+        sym.properties.push(reference);
+
+        sym.move_to(110.0, 60.0);
+
+        let at = At::from_sexp(&sym.properties[0].sub_nodes[0]).unwrap();
+        assert_eq!((at.x, at.y), (112.54, 60.0), "property must keep its offset");
+        assert_eq!((sym.at.x, sym.at.y), (110.0, 60.0));
+    }
 }


### PR DESCRIPTION
## Summary
- `move_labels_by_offset` reported `moved_labels: N` but never moved anything: it passed the *target* coordinates to `rotate_label`, which uses `x`/`y` to look up the existing label, so every lookup missed and the tool-level error was silently swallowed. The handler now edits each matching label's `(at)` anchor directly (preserving rotation) in a single atomic read/write, and returns an error when no label matches the net.
- `move_schematic_component` left property text (Reference/Value) at the old position: property `(at)` coordinates are absolute in `.kicad_sch`, but `Symbol::move_to` only updated the symbol anchor. `Symbol::translate` now shifts each property's `(at)` sub-node by the same delta, which also fixes `move_region` and `bulk_move`.

## Test plan
- [x] New unit tests: labels actually move on disk, unknown net errors without touching the file, property text keeps its offset after `move_to`
- [x] `cargo test -p konnect-core -p konnect-schematic-editor` (263 passed)

Made with [Cursor](https://cursor.com)