### PR TITLE
fix(sch): connect mid-wire pins via junction dots

### DIFF
--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -360,8 +360,8 @@ pub(crate) fn add_pin_midwire_junctions(
 ) -> anyhow::Result<Vec<(f64, f64)>> {
     use konnect_sexp::geometry::{point_on_segment, points_coincident};
     use konnect_sexp::schematic::{
-        extract_junctions, extract_lib_pins, extract_symbol_instances, extract_wires,
-        pin_endpoint, read_schematic,
+        extract_junctions, extract_lib_pins, extract_symbol_instances, extract_wires, pin_endpoint,
+        read_schematic,
     };
     let tol = 0.01;
     let (_, tree) = read_schematic(sch_path)?;

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -328,6 +328,90 @@ pub fn ensure_root_uuid(sch: &mut konnect_schematic_editor::Schematic) -> String
     }
 }
 
+/// All symbol pin connection points in a parsed schematic tree.
+pub(crate) fn all_pin_endpoints(tree: &konnect_sexp::SexpNode) -> Vec<(f64, f64)> {
+    use konnect_sexp::schematic::{extract_lib_pins, extract_symbol_instances, pin_endpoint};
+    let lib_syms = tree
+        .find("lib_symbols")
+        .map(|n| n.find_all("symbol"))
+        .unwrap_or_default();
+    let mut pts = Vec::new();
+    for inst in extract_symbol_instances(tree) {
+        if let Some(sym) = lib_syms
+            .iter()
+            .find(|n| n.get(1).and_then(|c| c.as_str()) == Some(&inst.lib_id))
+        {
+            let t = inst.pin_transform();
+            for pin in extract_lib_pins(sym) {
+                pts.push(pin_endpoint(&pin, t));
+            }
+        }
+    }
+    pts
+}
+
+/// Add junction dots for pins of `reference` that land mid-segment on a wire.
+/// KiCad connects a pin mid-wire only through a junction dot (verified with
+/// kicad-cli 10: a junction alone connects; splitting the wire is unnecessary).
+/// Returns the junction positions added.
+pub(crate) fn add_pin_midwire_junctions(
+    sch_path: &std::path::Path,
+    reference: &str,
+) -> anyhow::Result<Vec<(f64, f64)>> {
+    use konnect_sexp::geometry::{point_on_segment, points_coincident};
+    use konnect_sexp::schematic::{
+        extract_junctions, extract_lib_pins, extract_symbol_instances, extract_wires,
+        pin_endpoint, read_schematic,
+    };
+    let tol = 0.01;
+    let (_, tree) = read_schematic(sch_path)?;
+    let wires = extract_wires(&tree);
+    if wires.is_empty() {
+        return Ok(Vec::new());
+    }
+    let junctions = extract_junctions(&tree);
+    let lib_syms = tree
+        .find("lib_symbols")
+        .map(|n| n.find_all("symbol"))
+        .unwrap_or_default();
+    let mut to_add: Vec<(f64, f64)> = Vec::new();
+    for inst in extract_symbol_instances(&tree)
+        .iter()
+        .filter(|i| i.reference == reference)
+    {
+        let Some(sym) = lib_syms
+            .iter()
+            .find(|n| n.get(1).and_then(|c| c.as_str()) == Some(&inst.lib_id))
+        else {
+            continue;
+        };
+        let t = inst.pin_transform();
+        for pin in extract_lib_pins(sym) {
+            let (px, py) = pin_endpoint(&pin, t);
+            let mid_wire = wires.iter().any(|w| {
+                point_on_segment(px, py, w.x1, w.y1, w.x2, w.y2, tol)
+                    && !points_coincident(px, py, w.x1, w.y1, tol)
+                    && !points_coincident(px, py, w.x2, w.y2, tol)
+            });
+            let already = junctions
+                .iter()
+                .chain(to_add.iter())
+                .any(|(jx, jy)| points_coincident(px, py, *jx, *jy, tol));
+            if mid_wire && !already {
+                to_add.push((px, py));
+            }
+        }
+    }
+    if !to_add.is_empty() {
+        let mut sch = konnect_schematic_editor::Schematic::load(sch_path)?;
+        for &(x, y) in &to_add {
+            sch.add_junction(x, y);
+        }
+        sch.overwrite()?;
+    }
+    Ok(to_add)
+}
+
 /// A symbol-instance property positioned in absolute sheet coordinates, with
 /// eeschema's default 1.27mm font. The `(at)` node is mandatory: a property
 /// written without one is defaulted to the sheet origin by KiCAD, which is how

--- a/crates/konnect-core/src/tools/sch_analysis.rs
+++ b/crates/konnect-core/src/tools/sch_analysis.rs
@@ -9,7 +9,10 @@ use crate::tools::{get_path, opt_f64, require_f64, require_str, ToolContext, Too
 use konnect_schematic_editor as cse;
 use konnect_sexp::{
     geometry::{point_on_segment, points_coincident},
-    schematic::{extract_labels, extract_symbol_instances, extract_wires, read_schematic, Wire},
+    schematic::{
+        extract_junctions, extract_labels, extract_symbol_instances, extract_wires, read_schematic,
+        Wire,
+    },
 };
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
@@ -263,13 +266,29 @@ impl NetGraph {
 pub(crate) fn build_net_graph(
     wires: &[Wire],
     labels: &[konnect_sexp::schematic::Label],
+    junctions: &[(f64, f64)],
 ) -> NetGraph {
     let mut g = NetGraph::new();
     for w in wires {
         g.add_wire(w);
     }
+    // Labels and junction dots connect anywhere along a wire, not only at
+    // endpoints — union each such point with the segment it sits on.
+    // ponytail: O(P×W) scan; fine at schematic scale, index wires if it hurts.
+    let attach = |g: &mut NetGraph, x: f64, y: f64| {
+        for w in wires {
+            if point_on_segment(x, y, w.x1, w.y1, w.x2, w.y2, 0.01) {
+                g.union(pt_key(x, y), pt_key(w.x1, w.y1));
+            }
+        }
+    };
     for l in labels {
         g.add_label(l.x, l.y, &l.net);
+        attach(&mut g, l.x, l.y);
+    }
+    for &(jx, jy) in junctions {
+        g.ensure(pt_key(jx, jy));
+        attach(&mut g, jx, jy);
     }
     g
 }
@@ -348,7 +367,7 @@ async fn handle_get_net_connections(
         .filter(|l| l.net == net)
         .map(|l| json!({ "type": format!("{:?}", l.kind), "x": l.x, "y": l.y }))
         .collect();
-    let mut g = build_net_graph(&wires, &labels);
+    let mut g = build_net_graph(&wires, &labels, &super::sch_bridge::all_junctions(&sch));
     let pts = g.points_on_net(&net).len();
     Ok(CallToolResult::json(
         &json!({ "net": net, "label_count": matching.len(), "labels": matching, "connected_points": pts }),
@@ -367,7 +386,7 @@ async fn handle_get_net_connectivity(
     let sch = cse::Schematic::load(&sch_path)?;
     let wires = super::sch_bridge::all_wires_as_sexp(&sch);
     let labels = super::sch_bridge::all_labels_as_sexp(&sch);
-    let mut g = build_net_graph(&wires, &labels);
+    let mut g = build_net_graph(&wires, &labels, &super::sch_bridge::all_junctions(&sch));
     let net_pts: HashSet<(i64, i64)> = g.points_on_net(&net).into_iter().collect();
     let net_wires: Vec<_> = wires
         .iter()
@@ -436,7 +455,7 @@ async fn handle_get_pin_connections(
             )))
         }
     };
-    let mut g = build_net_graph(&wires, &labels);
+    let mut g = build_net_graph(&wires, &labels, &extract_junctions(&tree));
     Ok(CallToolResult::json(
         &json!({ "reference": reference, "pin": pin_number, "pin_x": px, "pin_y": py, "net": g.net_at(px, py) }),
     ))
@@ -466,7 +485,7 @@ async fn handle_get_component_nets(
     let lib_sym = lib_syms
         .iter()
         .find(|n| n.get(1).and_then(|c| c.as_str()) == Some(&inst.lib_id));
-    let mut g = build_net_graph(&wires, &labels);
+    let mut g = build_net_graph(&wires, &labels, &extract_junctions(&tree));
     let pins: Vec<serde_json::Value> = if let Some(sym) = lib_sym {
         let t = inst.pin_transform();
         konnect_sexp::schematic::extract_lib_pins(sym).iter().map(|p| {
@@ -498,7 +517,7 @@ async fn handle_get_net_components(
         .find("lib_symbols")
         .map(|n| n.find_all("symbol"))
         .unwrap_or_default();
-    let mut g = build_net_graph(&wires, &labels);
+    let mut g = build_net_graph(&wires, &labels, &extract_junctions(&tree));
     let net_pts: HashSet<(i64, i64)> = g.points_on_net(&net).into_iter().collect();
     let result: Vec<serde_json::Value> = instances
         .iter()
@@ -547,7 +566,7 @@ async fn handle_trace_from_point(
     let sch = cse::Schematic::load(&sch_path)?;
     let wires = super::sch_bridge::all_wires_as_sexp(&sch);
     let labels = super::sch_bridge::all_labels_as_sexp(&sch);
-    let mut g = build_net_graph(&wires, &labels);
+    let mut g = build_net_graph(&wires, &labels, &super::sch_bridge::all_junctions(&sch));
     let on_wire: Vec<_> = wires
         .iter()
         .filter(|w| {
@@ -605,7 +624,7 @@ async fn handle_find_shorted_nets(
     let sch = cse::Schematic::load(&sch_path)?;
     let wires = super::sch_bridge::all_wires_as_sexp(&sch);
     let labels = super::sch_bridge::all_labels_as_sexp(&sch);
-    let mut g = build_net_graph(&wires, &labels);
+    let mut g = build_net_graph(&wires, &labels, &super::sch_bridge::all_junctions(&sch));
     let mut root_nets: HashMap<(i64, i64), Vec<String>> = HashMap::new();
     for l in &labels {
         let root = g.find(pt_key(l.x, l.y));
@@ -684,7 +703,7 @@ async fn handle_get_connected_items(
     let lib_sym = lib_syms
         .iter()
         .find(|n| n.get(1).and_then(|c| c.as_str()) == Some(&inst.lib_id));
-    let mut g = build_net_graph(&wires, &labels);
+    let mut g = build_net_graph(&wires, &labels, &extract_junctions(&tree));
 
     // Get nets for each pin
     let mut connected_nets: HashSet<String> = HashSet::new();

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -13,8 +13,8 @@ use crate::tools::{
 use konnect_sexp::{
     geometry::{point_on_segment, points_coincident, snap_point},
     schematic::{
-        extract_labels, extract_lib_pins, extract_symbol_instances, extract_wires,
-        format_net_label, format_wire, pin_endpoint, read_schematic,
+        extract_junctions, extract_labels, extract_lib_pins, extract_symbol_instances,
+        extract_wires, format_net_label, format_wire, pin_endpoint, read_schematic,
     },
     writer::{
         apply_edits, find_block_with_leading_whitespace, find_enclosing_direct_child_block,
@@ -959,7 +959,8 @@ async fn handle_validate_component_connections(
         .collect();
 
     // Build net graph so we can check connectivity
-    let mut g = build_net_graph(&wires, &labels);
+    let junctions = extract_junctions(&tree);
+    let mut g = build_net_graph(&wires, &labels, &junctions);
     // Also build flat wire-endpoint list for direct presence checks
     let all_wire_eps: Vec<(f64, f64)> = wires
         .iter()
@@ -972,6 +973,17 @@ async fn handle_validate_component_connections(
         if all_wire_eps
             .iter()
             .any(|(wx, wy)| points_coincident(px, py, *wx, *wy, tol))
+        {
+            return true;
+        }
+        // Pin mid-wire connects only via a junction dot (KiCad semantics:
+        // verified with kicad-cli 10 — junction alone connects, no split needed)
+        if junctions
+            .iter()
+            .any(|(jx, jy)| points_coincident(px, py, *jx, *jy, tol))
+            && wires
+                .iter()
+                .any(|w| point_on_segment(px, py, w.x1, w.y1, w.x2, w.y2, tol))
         {
             return true;
         }
@@ -1072,5 +1084,70 @@ mod batch_delete_tests {
         assert!(after.contains("keep me"));
         assert!(after.contains("(sheet_instances"));
         assert!(konnect_sexp::parse_sexp(&after).is_ok());
+    }
+}
+
+#[cfg(test)]
+mod midwire_pin_tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::{ServerConfig, ToolContext};
+    use std::sync::Arc;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    /// U1 has a single pin at (100,80), sitting strictly mid-segment on a wire
+    /// from (90,80) to (110,80).
+    fn midwire_schematic(with_junction: bool) -> (tempfile::TempDir, std::path::PathBuf) {
+        let junction = if with_junction {
+            "\t(junction (at 100 80) (diameter 0) (color 0 0 0 0) (uuid \"j1\"))\n"
+        } else {
+            ""
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("midwire.kicad_sch");
+        std::fs::write(
+            &path,
+            format!(
+                "(kicad_sch\n\t(version 20260306)\n\t(generator \"eeschema\")\n\t(uuid \"root\")\n\t(lib_symbols\n\t\t(symbol \"Test:P1\"\n\t\t\t(symbol \"P1_1_1\"\n\t\t\t\t(pin passive line (at 0 0 0) (length 2.54)\n\t\t\t\t\t(name \"~\" (effects (font (size 1.27 1.27))))\n\t\t\t\t\t(number \"1\" (effects (font (size 1.27 1.27))))\n\t\t\t\t)\n\t\t\t)\n\t\t)\n\t)\n\t(wire\n\t\t(pts (xy 90 80) (xy 110 80))\n\t\t(uuid \"w1\")\n\t)\n{junction}\t(symbol\n\t\t(lib_id \"Test:P1\")\n\t\t(at 100 80 0)\n\t\t(unit 1)\n\t\t(uuid \"u1\")\n\t\t(property \"Reference\" \"U1\"\n\t\t\t(at 100 75 0)\n\t\t)\n\t)\n\t(sheet_instances (path \"/\" (page \"1\")))\n)\n"
+            ),
+        )
+        .unwrap();
+        (dir, path)
+    }
+
+    /// KiCad connects a pin mid-wire only through a junction dot; the
+    /// validator must mirror that instead of demanding a wire endpoint.
+    #[tokio::test]
+    async fn midwire_pin_connects_with_junction_only() {
+        for (with_junction, expect_valid) in [(true, true), (false, false)] {
+            let (_d, path) = midwire_schematic(with_junction);
+            let result = handle_validate_component_connections(
+                &json!({ "schematic": path.display().to_string() }),
+                &test_ctx(),
+            )
+            .await
+            .unwrap();
+            let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+                panic!("expected text content");
+            };
+            let body: serde_json::Value = serde_json::from_str(text).unwrap();
+            assert_eq!(
+                body["valid"].as_bool(),
+                Some(expect_valid),
+                "with_junction={with_junction}: {body}"
+            );
+        }
     }
 }

--- a/crates/konnect-core/src/tools/sch_bridge.rs
+++ b/crates/konnect-core/src/tools/sch_bridge.rs
@@ -69,6 +69,11 @@ pub fn all_labels_as_sexp(sch: &cse::Schematic) -> Vec<konnect_sexp::schematic::
     labels
 }
 
+/// Collect all junction dot positions from a schematic.
+pub fn all_junctions(sch: &cse::Schematic) -> Vec<(f64, f64)> {
+    sch.junctions.iter().map(|j| (j.x, j.y)).collect()
+}
+
 /// Collect all wires from a schematic into konnect-sexp Wire format.
 pub fn all_wires_as_sexp(sch: &cse::Schematic) -> Vec<konnect_sexp::schematic::Wire> {
     sch.wires.iter().map(wire_to_sexp).collect()

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -387,13 +387,18 @@ async fn handle_add_schematic_component(
     sch.add_symbol(sym);
     sch.overwrite()?;
 
+    // A pin landing mid-segment on an existing wire needs a junction dot,
+    // or KiCad ERC reports it as not connected.
+    let junctions_added = crate::tools::add_pin_midwire_junctions(&sch_path, ref_str)?;
+
     Ok(CallToolResult::json(&json!({
         "added": lib_id,
         "reference": ref_str,
         "value": val_str,
         "x": x, "y": y,
         "unit": unit,
-        "uuid": uuid
+        "uuid": uuid,
+        "junctions_added": junctions_added.iter().map(|(x, y)| json!({"x": x, "y": y})).collect::<Vec<_>>()
     })))
 }
 

--- a/crates/konnect-core/src/tools/sch_export.rs
+++ b/crates/konnect-core/src/tools/sch_export.rs
@@ -199,7 +199,11 @@ async fn handle_export_netlist_summary(
         .map(|n| n.find_all("symbol"))
         .unwrap_or_default();
 
-    let mut g = build_net_graph(&wires, &labels);
+    let mut g = build_net_graph(
+        &wires,
+        &labels,
+        &konnect_sexp::schematic::extract_junctions(&tree),
+    );
 
     // Collect distinct net names
     let mut net_names: Vec<String> = labels.iter().map(|l| l.net.clone()).collect();

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -96,7 +96,9 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "split_wire_at_point",
-            "Split a wire at a given point, creating two wire segments and a junction.",
+            "Split a wire at a given point, creating two wire segments and a junction. \
+             Note: a pin landing mid-wire only needs a junction dot to connect \
+             (see add_junction) — splitting the wire is not required.",
             json!({
                 "type": "object",
                 "properties": {
@@ -262,7 +264,9 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "add_junction",
-            "Add a junction dot at a point where wires cross or T-intersect.",
+            "Add a junction dot at a point where wires cross or T-intersect, or where \
+             a pin lands mid-wire. A junction alone connects a mid-wire pin; \
+             splitting the wire is not required.",
             json!({
                 "type": "object",
                 "properties": {
@@ -402,6 +406,21 @@ fn cse_wires_to_sexp(sch: &cse::Schematic) -> Vec<konnect_sexp::schematic::Wire>
 
 // ─── Wire insertion with T-junction detection ─────────────────────────────────
 
+/// Pin endpoints that lie strictly inside a wire segment. Each needs a
+/// junction dot: KiCad connects a mid-wire pin only through a junction
+/// (verified with kicad-cli 10 — no wire split required).
+fn pins_mid_segment(pins: &[(f64, f64)], x1: f64, y1: f64, x2: f64, y2: f64) -> Vec<(f64, f64)> {
+    let tol = 0.01;
+    pins.iter()
+        .copied()
+        .filter(|&(px, py)| {
+            konnect_sexp::geometry::point_on_segment(px, py, x1, y1, x2, y2, tol)
+                && !konnect_sexp::geometry::points_coincident(px, py, x1, y1, tol)
+                && !konnect_sexp::geometry::points_coincident(px, py, x2, y2, tol)
+        })
+        .collect()
+}
+
 fn insert_wire_with_junctions(content: String, x1: f64, y1: f64, x2: f64, y2: f64) -> String {
     // Parse existing wires to detect new T-junctions
     let tree = konnect_sexp::parse_sexp(&content).ok();
@@ -417,7 +436,25 @@ fn insert_wire_with_junctions(content: String, x1: f64, y1: f64, x2: f64, y2: f6
     };
     existing_wires.push(new_wire);
 
-    let junctions = find_t_junctions(&existing_wires, 0.01);
+    let mut junctions = find_t_junctions(&existing_wires, 0.01);
+    // Existing pins the new wire passes over also need junction dots.
+    let pins = tree
+        .as_ref()
+        .map(crate::tools::all_pin_endpoints)
+        .unwrap_or_default();
+    let existing_juncs = tree
+        .as_ref()
+        .map(konnect_sexp::schematic::extract_junctions)
+        .unwrap_or_default();
+    for (px, py) in pins_mid_segment(&pins, x1, y1, x2, y2) {
+        if !junctions
+            .iter()
+            .chain(existing_juncs.iter())
+            .any(|&(jx, jy)| konnect_sexp::geometry::points_coincident(px, py, jx, jy, 0.01))
+        {
+            junctions.push((px, py));
+        }
+    }
 
     let mut c = content;
     c = insert_before_close(&c, &format_wire(x1, y1, x2, y2));
@@ -471,6 +508,16 @@ async fn handle_add_wire(
     for (jx, jy) in &junctions {
         sch.add_junction(*jx, *jy);
     }
+    // Pins the new wire passes over mid-segment also need junction dots.
+    let (_, tree) = read_schematic(&sch_path)?;
+    let pins = crate::tools::all_pin_endpoints(&tree);
+    for (px, py) in pins_mid_segment(&pins, x1, y1, x2, y2) {
+        if !sch.junctions.iter().any(|j| {
+            konnect_sexp::geometry::points_coincident(px, py, j.x, j.y, 0.01)
+        }) {
+            sch.add_junction(px, py);
+        }
+    }
     sch.overwrite()?;
 
     Ok(CallToolResult::json(
@@ -487,6 +534,11 @@ async fn handle_batch_add_wire(
 
     let mut sch = cse::Schematic::load(&sch_path)?;
     let mut added = 0usize;
+
+    // Pin endpoints are fixed for the whole batch (only wires change below).
+    let pins = read_schematic(&sch_path)
+        .map(|(_, tree)| crate::tools::all_pin_endpoints(&tree))
+        .unwrap_or_default();
 
     for w in &wires {
         let x1 = w["x1"].as_f64().unwrap_or(0.0);
@@ -510,6 +562,14 @@ async fn handle_batch_add_wire(
         sch.add_wire(x1, y1, x2, y2);
         for (jx, jy) in &junctions {
             sch.add_junction(*jx, *jy);
+        }
+        // Pins this wire passes over mid-segment also need junction dots.
+        for (px, py) in pins_mid_segment(&pins, x1, y1, x2, y2) {
+            if !sch.junctions.iter().any(|j| {
+                konnect_sexp::geometry::points_coincident(px, py, j.x, j.y, 0.01)
+            }) {
+                sch.add_junction(px, py);
+            }
         }
         added += 1;
     }
@@ -1207,10 +1267,15 @@ async fn handle_add_power_symbol(
     sch.add_symbol(sym);
     sch.overwrite()?;
 
+    // A power pin landing mid-segment on an existing wire needs a junction
+    // dot, or KiCad ERC reports it as not connected.
+    let junctions_added = crate::tools::add_pin_midwire_junctions(&sch_path, &pwr_ref)?;
+
     Ok(CallToolResult::json(&json!({
         "added_power": power_net,
         "reference": pwr_ref,
-        "x": x, "y": y
+        "x": x, "y": y,
+        "junctions_added": junctions_added.iter().map(|(x, y)| json!({"x": x, "y": y})).collect::<Vec<_>>()
     })))
 }
 
@@ -1373,6 +1438,19 @@ async fn handle_connect_to_net(
     sch.add_wire(pin_x, pin_y, label_x, label_y);
     for (jx, jy) in &junctions {
         sch.add_junction(*jx, *jy);
+    }
+    // Pins the stub passes over mid-segment also need junction dots.
+    let pins = read_schematic(&sch_path)
+        .map(|(_, tree)| crate::tools::all_pin_endpoints(&tree))
+        .unwrap_or_default();
+    for (px, py) in pins_mid_segment(&pins, pin_x, pin_y, label_x, label_y) {
+        if !sch
+            .junctions
+            .iter()
+            .any(|j| konnect_sexp::geometry::points_coincident(px, py, j.x, j.y, 0.01))
+        {
+            sch.add_junction(px, py);
+        }
     }
 
     // Add label
@@ -1631,6 +1709,45 @@ mod unit_aware_wiring_tests {
         assert!(
             msg.contains("unit 1"),
             "error should name the instance unit: {msg}"
+        );
+    }
+
+    /// U1 has a single pin at (101.6, 76.2) — on the 1.27 grid so add_wire's
+    /// snapping keeps the new wire exactly through it.
+    fn single_pin_schematic() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pin.kicad_sch");
+        std::fs::write(
+            &path,
+            "(kicad_sch\n\t(version 20260306)\n\t(generator \"eeschema\")\n\t(uuid \"root\")\n\t(lib_symbols\n\t\t(symbol \"Test:P1\"\n\t\t\t(symbol \"P1_1_1\"\n\t\t\t\t(pin passive line (at 0 0 0) (length 2.54)\n\t\t\t\t\t(name \"~\" (effects (font (size 1.27 1.27))))\n\t\t\t\t\t(number \"1\" (effects (font (size 1.27 1.27))))\n\t\t\t\t)\n\t\t\t)\n\t\t)\n\t)\n\t(symbol\n\t\t(lib_id \"Test:P1\")\n\t\t(at 101.6 76.2 0)\n\t\t(unit 1)\n\t\t(uuid \"u1\")\n\t\t(property \"Reference\" \"U1\"\n\t\t\t(at 101.6 71.12 0)\n\t\t)\n\t)\n\t(sheet_instances (path \"/\" (page \"1\")))\n)\n",
+        )
+        .unwrap();
+        (dir, path)
+    }
+
+    /// Drawing a wire across an existing pin mid-segment must auto-insert a
+    /// junction dot — KiCad connects a mid-wire pin only through a junction.
+    #[tokio::test]
+    async fn add_wire_over_pin_inserts_junction() {
+        let (_d, path) = single_pin_schematic();
+        let result = handle_add_wire(
+            &json!({
+                "schematic": path.display().to_string(),
+                "x1": 96.52, "y1": 76.2, "x2": 106.68, "y2": 76.2
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error, "{:?}", result.content);
+        let after = std::fs::read_to_string(&path).unwrap();
+        let tree = konnect_sexp::parse_sexp(&after).unwrap();
+        let juncs = konnect_sexp::schematic::extract_junctions(&tree);
+        assert!(
+            juncs
+                .iter()
+                .any(|&(x, y)| (x - 101.6).abs() < 0.01 && (y - 76.2).abs() < 0.01),
+            "junction expected at the mid-wire pin, got {juncs:?}"
         );
     }
 }

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -512,9 +512,11 @@ async fn handle_add_wire(
     let (_, tree) = read_schematic(&sch_path)?;
     let pins = crate::tools::all_pin_endpoints(&tree);
     for (px, py) in pins_mid_segment(&pins, x1, y1, x2, y2) {
-        if !sch.junctions.iter().any(|j| {
-            konnect_sexp::geometry::points_coincident(px, py, j.x, j.y, 0.01)
-        }) {
+        if !sch
+            .junctions
+            .iter()
+            .any(|j| konnect_sexp::geometry::points_coincident(px, py, j.x, j.y, 0.01))
+        {
             sch.add_junction(px, py);
         }
     }
@@ -565,9 +567,11 @@ async fn handle_batch_add_wire(
         }
         // Pins this wire passes over mid-segment also need junction dots.
         for (px, py) in pins_mid_segment(&pins, x1, y1, x2, y2) {
-            if !sch.junctions.iter().any(|j| {
-                konnect_sexp::geometry::points_coincident(px, py, j.x, j.y, 0.01)
-            }) {
+            if !sch
+                .junctions
+                .iter()
+                .any(|j| konnect_sexp::geometry::points_coincident(px, py, j.x, j.y, 0.01))
+            {
                 sch.add_junction(px, py);
             }
         }

--- a/crates/konnect-sexp/src/schematic.rs
+++ b/crates/konnect-sexp/src/schematic.rs
@@ -89,6 +89,17 @@ pub fn extract_wires(tree: &SexpNode) -> Vec<Wire> {
         .collect()
 }
 
+/// Extract all junction dot positions from a parsed schematic tree.
+pub fn extract_junctions(tree: &SexpNode) -> Vec<(f64, f64)> {
+    tree.find_all("junction")
+        .iter()
+        .filter_map(|node| {
+            let at = node.find("at")?;
+            Some((at.get_f64(1)?, at.get_f64(2)?))
+        })
+        .collect()
+}
+
 // ─── Net label ────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
## Summary

A user reported that a power-symbol/PWR_FLAG pin sitting mid-wire does not connect even with a junction dot (ERC "pin not connected"), requiring a `split_wire_at_point` workaround. Investigation confirmed two bugs (and one misconception):

- Verified with kicad-cli 10.0.4: KiCad connects a mid-wire pin through a junction dot alone — splitting the wire is unnecessary. The "even with a junction" failure was Konnect's own validators.
- **Bug 1:** the union-find `NetGraph` only joined wire *endpoints* and never read junctions, so every connectivity/validation tool reported mid-wire pins as unconnected regardless of junctions.
- **Bug 2:** `find_t_junctions` only handles wire-on-wire T's, so placing a component whose pin lands mid-wire (or drawing a wire across an existing pin) never emitted the junction dot KiCad needs — producing real ERC failures.

## Changes

- `konnect-sexp`: new `extract_junctions`.
- `build_net_graph` takes junctions and unions any label/junction point lying mid-segment on a wire with that wire; all call sites updated.
- `validate_component_connections` accepts pin-mid-wire + junction, still flags the no-junction case (matches KiCad ERC semantics).
- `add_schematic_component` / `add_power_symbol` auto-insert a junction when a placed pin lands mid-wire (reported as `junctions_added`).
- `add_wire` / `batch_add_wire` / `connect_to_net` / `connect_pins` auto-insert a junction for existing pins the new wire passes over.
- Tool descriptions for `split_wire_at_point` / `add_junction` updated to reflect that a junction alone suffices.

## Test plan

- [x] New regression tests: `midwire_pin_connects_with_junction_only`, `add_wire_over_pin_inserts_junction`
- [x] `cargo test -p konnect-core -p konnect-sexp` — 288 passed

Made with [Cursor](https://cursor.com)