### PR TITLE
fix(mcp): advertise protocol version 2025-06-18

### DIFF
--- a/crates/konnect-core/src/mcp/server.rs
+++ b/crates/konnect-core/src/mcp/server.rs
@@ -15,7 +15,7 @@ impl McpServerState {
 
     pub fn build_initialize_result() -> InitializeResult {
         InitializeResult {
-            protocol_version: "2024-11-05".to_string(),
+            protocol_version: "2025-06-18".to_string(),
             capabilities: ServerCapabilities {
                 tools: Some(ToolsCapability {
                     list_changed: Some(true),


### PR DESCRIPTION
## Problem / scope

`McpServerState::build_initialize_result` reported protocol version `2024-11-05` in the `initialize` response, while the HTTP transport docs and every protocol test in the codebase already assumed `2025-06-18`. Clients that gate behavior on the negotiated version (e.g. batch JSON-RPC support, newer capability shapes) were being told the wrong thing.

## Root cause / design

Single stale string literal in `crates/konnect-core/src/mcp/server.rs`. One-line fix: update `protocol_version` to `"2025-06-18"` to match what the rest of the codebase already targets.

## Compatibility

No wire-shape change, only the advertised version string. Clients that pin to `2024-11-05` and refuse to negotiate a newer version could reject the handshake, but nothing in this codebase's transport docs or tests supports that being an intended client population -- this is a truth-in-advertising fix, not a behavior change.

## Tests run

`cargo test --workspace --locked --lib --tests` (17 suites) and `--doc` pass; `cargo clippy --workspace --locked -- -D warnings` and `cargo fmt --all -- --check` clean, as part of the full 8-commit series validation. Clean single-commit cherry-pick onto current `main` (da78ea8), no conflicts, so gates were not re-run for this narrower diff.

## Risk / rollback

Minimal. Single-line revert if a client is discovered that hard-requires the old version string.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>