### PR TITLE
feat(pcb): cap get_board_2d_view render size

### DIFF
--- a/crates/konnect-core/src/tools/cli.rs
+++ b/crates/konnect-core/src/tools/cli.rs
@@ -566,13 +566,26 @@ pub async fn render_schematic_svg(cli: &str, schematic: &Path, output: &Path) ->
     export_schematic_svg(cli, schematic, output_dir).await
 }
 
-/// KiCAD 10: `pcb render --output <path> [--layers <layer>]... <input>`
-pub async fn render_pcb_png(cli: &str, pcb: &Path, output: &Path, layers: &[&str]) -> Result<()> {
+/// KiCAD 10: `pcb render --output <path> [--layers <layer>]... --width <w> --height <h> <input>`
+pub async fn render_pcb_png(
+    cli: &str,
+    pcb: &Path,
+    output: &Path,
+    layers: &[&str],
+    width: u32,
+    height: u32,
+) -> Result<()> {
+    let width_str = width.to_string();
+    let height_str = height.to_string();
     let mut args = vec!["pcb", "render", "--output", output.to_str().unwrap()];
     for layer in layers {
         args.push("--layers");
         args.push(layer);
     }
+    args.push("--width");
+    args.push(&width_str);
+    args.push("--height");
+    args.push(&height_str);
     args.push(pcb.to_str().unwrap());
     run_cli(cli, &args, LONG_TIMEOUT).await?;
     Ok(())

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -1050,7 +1050,9 @@ pub fn tools() -> Vec<ToolDef> {
                         "type": "array",
                         "description": "Layers to include (empty = default copper + silkscreen)",
                         "items": { "type": "string" }
-                    }
+                    },
+                    "width":  { "type": "integer", "default": 800, "description": "Render width in pixels, clamped to 100-4000 (kept small since the image lands in LLM context, raise it when detail matters)" },
+                    "height": { "type": "integer", "default": 600, "description": "Render height in pixels, clamped to 100-4000" }
                 },
                 "required": ["board"]
             }),
@@ -1713,9 +1715,20 @@ async fn handle_get_board_2d_view(
             ]
         });
 
+    let width = args["width"].as_u64().unwrap_or(800).clamp(100, 4000) as u32;
+    let height = args["height"].as_u64().unwrap_or(600).clamp(100, 4000) as u32;
+
     let tmp = board_path.with_extension("render.png");
     let layer_refs: Vec<&str> = layers.iter().map(String::as_str).collect();
-    super::cli::render_pcb_png(&ctx.config.kicad_cli, &board_path, &tmp, &layer_refs).await?;
+    super::cli::render_pcb_png(
+        &ctx.config.kicad_cli,
+        &board_path,
+        &tmp,
+        &layer_refs,
+        width,
+        height,
+    )
+    .await?;
     let bytes = tokio::fs::read(&tmp).await?;
     let _ = tokio::fs::remove_file(&tmp).await;
 


### PR DESCRIPTION
## Problem / scope

`get_board_2d_view` invoked `kicad-cli pcb render` with no size flags, so KiCAD's default render (1600x900 or larger) landed in the LLM's context as a base64-encoded PNG on every call -- an expensive default for a tool that's typically used for a quick visual sanity check, not pixel-perfect inspection.

## Root cause / design

`render_pcb_png` in `crates/konnect-core/src/tools/cli.rs` never passed `--width`/`--height` to `kicad-cli`. Added both parameters to the function signature and threaded them through from two new optional tool-schema fields (`width`, `height`), each defaulting to 800x600 and clamped server-side to 100-4000 px so a caller can't request a pathologically large or a degenerate render.

## Compatibility

Additive, backward compatible: existing callers that omit `width`/`height` now get an 800x600 render instead of KiCAD's larger default -- a smaller image, not a behavior break. Callers that want the old higher-detail render can pass explicit `width`/`height` up to 4000px.

## Tests run

`cargo test --workspace --locked --lib --tests` (17 suites) and `--doc` pass; `cargo clippy --workspace --locked -- -D warnings` and `cargo fmt --all -- --check` clean, as part of the full 8-commit series validation. Clean single-commit cherry-pick onto current `main` (da78ea8), no conflicts, so gates were not re-run for this narrower diff.

## Risk / rollback

Low. Worst case a caller relying on the old undocumented large default gets a smaller image by default and needs to pass explicit `width`/`height` -- a one-line caller-side fix. Single-commit revert available.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>