### PR TITLE
feat(tools): bound run_drc and list_symbols_in_library results

### DIFF
--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -13,6 +13,29 @@ use std::path::{Path, PathBuf};
 
 // ─── Tool definitions ─────────────────────────────────────────────────────────
 
+/// The pin-item object schema (number/name/type/x/y/angle/length) shared by
+/// `pins`, `units[].pins`, and `power_pins` in the create_symbol schema below.
+/// `type_desc` parameterizes the one wording difference between call sites.
+fn pin_item_schema(type_desc: &str) -> serde_json::Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "number": { "type": "string" },
+            "name": { "type": "string" },
+            "type": {
+                "type": "string",
+                "enum": ["input", "output", "bidirectional", "tri_state", "passive", "free", "unspecified", "power_in", "power_out", "open_collector", "open_emitter", "no_connect"],
+                "description": type_desc
+            },
+            "x": { "type": "number" },
+            "y": { "type": "number" },
+            "angle": { "type": "number", "default": 0 },
+            "length": { "type": "number", "default": 2.54 }
+        },
+        "required": ["number", "name", "type", "x", "y"]
+    })
+}
+
 pub fn tools() -> Vec<ToolDef> {
     vec![
         tool!(
@@ -133,23 +156,7 @@ pub fn tools() -> Vec<ToolDef> {
                     "pins": {
                         "type": "array",
                         "description": "Pin definitions",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "number": { "type": "string" },
-                                "name": { "type": "string" },
-                                "type": {
-                                    "type": "string",
-                                    "enum": ["input", "output", "bidirectional", "tri_state", "passive", "free", "unspecified", "power_in", "power_out", "open_collector", "open_emitter", "no_connect"],
-                                    "description": "Pin electrical type — exactly one of KiCAD's 12 values. Note: NC pins are 'no_connect' (not 'not_connected')."
-                                },
-                                "x": { "type": "number" },
-                                "y": { "type": "number" },
-                                "angle": { "type": "number", "default": 0 },
-                                "length": { "type": "number", "default": 2.54 }
-                            },
-                            "required": ["number", "name", "type", "x", "y"]
-                        }
+                        "items": pin_item_schema("Pin electrical type — exactly one of KiCAD's 12 values. Note: NC pins are 'no_connect' (not 'not_connected').")
                     },
                     "show_pin_names": { "type": "boolean", "description": "Show pin names on the symbol (default true).", "default": true },
                     "show_pin_numbers": { "type": "boolean", "description": "Show pin numbers on the symbol (default true).", "default": true },
@@ -162,23 +169,7 @@ pub fn tools() -> Vec<ToolDef> {
                                 "pins": {
                                     "type": "array",
                                     "description": "Pins for this unit",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "number": { "type": "string" },
-                                            "name": { "type": "string" },
-                                            "type": {
-                                                "type": "string",
-                                                "enum": ["input", "output", "bidirectional", "tri_state", "passive", "free", "unspecified", "power_in", "power_out", "open_collector", "open_emitter", "no_connect"],
-                                                "description": "Pin electrical type — exactly one of KiCAD's 12 values. Note: NC pins are 'no_connect' (not 'not_connected')."
-                                            },
-                                            "x": { "type": "number" },
-                                            "y": { "type": "number" },
-                                            "angle": { "type": "number", "default": 0 },
-                                            "length": { "type": "number", "default": 2.54 }
-                                        },
-                                        "required": ["number", "name", "type", "x", "y"]
-                                    }
+                                    "items": pin_item_schema("Pin electrical type — exactly one of KiCAD's 12 values. Note: NC pins are 'no_connect' (not 'not_connected').")
                                 }
                             },
                             "required": ["pins"]
@@ -187,23 +178,7 @@ pub fn tools() -> Vec<ToolDef> {
                     "power_pins": {
                         "type": "array",
                         "description": "Shared power pins (V+/V-, VCC/GND). Only meaningful with `units`: they become a dedicated final 'power unit' (e.g. Unit C of a dual op-amp, Unit E of a quad gate) placed once, following KiCAD's own 74xx convention. This avoids drawing the power pins on every unit (which would each need wiring to pass ERC). Same shape as `pins`.",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "number": { "type": "string" },
-                                "name": { "type": "string" },
-                                "type": {
-                                    "type": "string",
-                                    "enum": ["input", "output", "bidirectional", "tri_state", "passive", "free", "unspecified", "power_in", "power_out", "open_collector", "open_emitter", "no_connect"],
-                                    "description": "Pin electrical type — exactly one of KiCAD's 12 values (power pins are usually 'power_in'). Note: NC pins are 'no_connect' (not 'not_connected')."
-                                },
-                                "x": { "type": "number" },
-                                "y": { "type": "number" },
-                                "angle": { "type": "number", "default": 0 },
-                                "length": { "type": "number", "default": 2.54 }
-                            },
-                            "required": ["number", "name", "type", "x", "y"]
-                        }
+                        "items": pin_item_schema("Pin electrical type — exactly one of KiCAD's 12 values (power pins are usually 'power_in'). Note: NC pins are 'no_connect' (not 'not_connected').")
                     }
                 },
                 "required": ["library_path", "name", "reference_prefix"]
@@ -229,7 +204,8 @@ pub fn tools() -> Vec<ToolDef> {
             json!({
                 "type": "object",
                 "properties": {
-                    "library_path": { "type": "string", "description": "Path to .kicad_sym library file" }
+                    "library_path": { "type": "string", "description": "Path to .kicad_sym library file" },
+                    "limit": { "type": "integer", "description": "Maximum number of symbols to return", "default": 100 }
                 },
                 "required": ["library_path"]
             }),
@@ -685,7 +661,7 @@ async fn handle_create_footprint(
     write_atomic(&output, &content)?;
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "success": true,
             "footprint": name,
             "output": output.to_str().unwrap_or(""),
@@ -817,7 +793,7 @@ async fn handle_edit_footprint_pad(
     write_atomic(&path, &new_content)?;
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "success": true,
             "pad": pad_number
         }))
@@ -1206,7 +1182,7 @@ async fn handle_register_footprint_library(
     .await?;
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "success": true,
             "nickname": nickname,
             "scope": scope,
@@ -1251,7 +1227,7 @@ async fn handle_list_footprint_libraries(
     }
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "count": all_libs.len(),
             "libraries": all_libs
         }))
@@ -1289,7 +1265,7 @@ async fn handle_register_symbol_library(
     .await?;
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "success": true,
             "nickname": nickname,
             "scope": scope,
@@ -1336,7 +1312,7 @@ async fn handle_list_symbol_libraries(
     }
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "count": all_libs.len(),
             "libraries": all_libs
         }))
@@ -1684,7 +1660,7 @@ async fn handle_create_symbol(
     write_atomic(&lib_path, &new_content)?;
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "success": true,
             "symbol": name,
             "library": lib_path.to_str().unwrap_or(""),
@@ -1740,7 +1716,7 @@ async fn handle_delete_symbol(
     write_atomic(&lib_path, &new_content)?;
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "success": true,
             "deleted": symbol_name
         }))
@@ -1891,12 +1867,15 @@ async fn handle_list_symbols_in_library(
     let content = tokio::fs::read_to_string(&lib_path).await?;
 
     let symbols = top_level_symbol_names(&content)?;
+    let limit = args["limit"].as_u64().unwrap_or(100) as usize;
+    let truncated = symbols.len() > limit;
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "library": lib_path.to_str().unwrap_or(""),
             "count": symbols.len(),
-            "symbols": symbols
+            "truncated": truncated,
+            "symbols": symbols.into_iter().take(limit).collect::<Vec<_>>()
         }))
         .unwrap(),
     ))
@@ -1952,7 +1931,7 @@ async fn handle_search_symbols(
     }
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "query": query,
             "count": results.len(),
             "results": results
@@ -1988,7 +1967,7 @@ async fn handle_list_library_footprints(
     footprints.sort();
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "library": library_path_str,
             "count": footprints.len(),
             "footprints": footprints
@@ -2034,7 +2013,7 @@ async fn handle_get_footprint_info(
     let has_3d = content.contains("(model ");
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "name": fp_name,
             "description": description,
             "pad_count": pad_count,
@@ -2088,7 +2067,7 @@ async fn handle_search_footprints(
     }
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "query": args["query"].as_str().unwrap_or(""),
             "count": results.len(),
             "results": results
@@ -2182,7 +2161,7 @@ async fn handle_get_symbol_info(
     }
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "lib_id": lib_id,
             "name": sym_name,
             "library": lib_nick,

--- a/crates/konnect-core/src/tools/verification.rs
+++ b/crates/konnect-core/src/tools/verification.rs
@@ -36,6 +36,11 @@ pub fn tools() -> Vec<ToolDef> {
                         "type": "array",
                         "description": "Specific DRC test IDs to run (empty = all tests)",
                         "items": { "type": "string" }
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum number of violations to return",
+                        "default": 50
                     }
                 },
                 "required": ["board"]
@@ -180,6 +185,7 @@ async fn handle_run_drc(
     let board = get_path(args, "board")?;
     let severity_filter = args["severity"].as_str().unwrap_or("warning");
     let min_rank = severity_rank(severity_filter);
+    let limit = args["limit"].as_u64().unwrap_or(50) as usize;
 
     let refill = args["refill_zones"].as_bool().unwrap_or(false);
     let violations = cli::run_drc(&ctx.config.kicad_cli, &board, refill).await?;
@@ -197,15 +203,19 @@ async fn handle_run_drc(
 
     let errors = filtered.iter().filter(|v| v.severity == "error").count();
     let warnings = filtered.iter().filter(|v| v.severity == "warning").count();
+    let shown = filtered.len().min(limit);
+    let truncated = filtered.len() > limit;
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "total_violations": violations.len(),
             "filtered_count": filtered.len(),
             "errors": errors,
             "warnings": warnings,
             "severity_filter": severity_filter,
-            "violations": filtered.iter().map(|v| json!({
+            "shown": shown,
+            "truncated": truncated,
+            "violations": filtered.iter().take(limit).map(|v| json!({
                 "severity": v.severity,
                 "description": v.description,
                 "pos": v.pos.as_ref().map(|p| json!({ "x": p.x, "y": p.y }))
@@ -316,7 +326,7 @@ async fn handle_set_design_rules(
     }
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "success": true,
             "changed": changed
         }))
@@ -332,7 +342,7 @@ async fn handle_get_design_rules(
     let content = tokio::fs::read_to_string(&board).await?;
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "board": board.to_str().unwrap_or(""),
             "rules": {
                 "min_clearance": read_constraint(&content, "min_clearance"),
@@ -419,7 +429,7 @@ async fn handle_check_kicad_ui(
 
     if !running {
         return Ok(CallToolResult::text(
-            serde_json::to_string_pretty(&json!({
+            serde_json::to_string(&json!({
                 "running": false,
                 "ipc_responsive": false
             }))
@@ -438,7 +448,7 @@ async fn handle_check_kicad_ui(
     .unwrap_or(false);
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "running": true,
             "ipc_responsive": ipc_ok
         }))
@@ -481,7 +491,7 @@ async fn handle_launch_kicad_ui(
 
                     if ok {
                         return Ok(CallToolResult::text(
-                            serde_json::to_string_pretty(&json!({
+                            serde_json::to_string(&json!({
                                 "launched": true,
                                 "ipc_ready": true
                             }))
@@ -490,7 +500,7 @@ async fn handle_launch_kicad_ui(
                     }
                     if std::time::Instant::now() >= deadline {
                         return Ok(CallToolResult::text(
-                            serde_json::to_string_pretty(&json!({
+                            serde_json::to_string(&json!({
                                 "launched": true,
                                 "ipc_ready": false,
                                 "note": "KiCAD launched but IPC not yet responsive within timeout"
@@ -502,7 +512,7 @@ async fn handle_launch_kicad_ui(
             }
 
             Ok(CallToolResult::text(
-                serde_json::to_string_pretty(&json!({
+                serde_json::to_string(&json!({
                     "launched": true,
                     "ipc_ready": null
                 }))
@@ -559,7 +569,7 @@ async fn handle_copy_routing_pattern(
 
     if new_tracks.is_empty() {
         return Ok(CallToolResult::text(
-            serde_json::to_string_pretty(&json!({
+            serde_json::to_string(&json!({
                 "copied": 0,
                 "note": "No routing elements found in the specified source region"
             }))
@@ -583,7 +593,7 @@ async fn handle_copy_routing_pattern(
     write_atomic(&board, &new_content)?;
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "copied": new_tracks.len(),
             "dx": dx,
             "dy": dy
@@ -800,7 +810,7 @@ async fn handle_set_layer_constraints(
     }
 
     Ok(CallToolResult::text(
-        serde_json::to_string_pretty(&json!({
+        serde_json::to_string(&json!({
             "success": true,
             "layer": layer,
             "changed": changed


### PR DESCRIPTION
## Problem / scope

Two tools returned unbounded result sets that blow up on real-world inputs: `run_drc` returns every DRC violation (real boards routinely emit hundreds), and `list_symbols_in_library` returns every symbol name (stock KiCAD libraries hold 800+). Both dumped their full result into LLM context on every call, unlike their sibling `search_symbols`, which already had a `limit` pattern.

## Root cause / design

- `run_drc` gains a `limit` param (default 50) plus `shown`/`truncated` fields in the response so a caller knows a result was cut and can ask for more or narrow the filter.
- `list_symbols_in_library` gains the same `limit` pattern (default 100) as its sibling `search_symbols`, with a `truncated` flag.
- While in `library.rs`, also factored `create_symbol`'s pin-item schema (pasted three times across `pins`, `units[].pins`, and `power_pins`, with wording that had already drifted between the three copies) into one `pin_item_schema(type_desc)` helper. Schema output is unchanged.
- Also converts the remaining `to_string_pretty` call sites in `library.rs` and `verification.rs` to compact `to_string` -- these two files weren't touched by the separate compact-JSON PR (#106) since that commit didn't reach them, and it was natural to finish the conversion while already editing the same response-building code in this commit.

## Compatibility

Additive: `limit` is optional with sane defaults matching existing sibling tools, so unbounded-result callers just start getting truncated (labeled) results instead of a context-exploding dump. `create_symbol`'s public schema shape is unchanged (only the Rust-side schema construction was deduplicated). The `to_string_pretty` -> `to_string` conversions only affect whitespace, not JSON structure (see #106 for the same argument at wire-format scope).

## Tests run

`cargo test --workspace --locked --lib --tests` (17 suites) and `--doc` pass; `cargo clippy --workspace --locked -- -D warnings` and `cargo fmt --all -- --check` clean, as part of the full 8-commit series validation. Clean single-commit cherry-pick onto current `main` (da78ea8), no conflicts, so gates were not re-run for this narrower diff.

## Risk / rollback

Low. A caller depending on getting literally every violation/symbol in one call without ever passing `limit` now gets at most 50/100 by default -- the `truncated` flag makes that visible rather than a silent cutoff, and raising `limit` restores the old behavior. Single-commit revert available.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>