### PR TITLE
feat(router): load_toolset accepts an array of toolset names

### DIFF
--- a/crates/konnect-core/src/router/meta_tools.rs
+++ b/crates/konnect-core/src/router/meta_tools.rs
@@ -1,7 +1,7 @@
 //! The 6 always-visible meta-tools.
 //!
 //! Discovery / routing:
-//!   list_toolboxes()          — show all 17 toolsets with descriptions and load state
+//!   list_toolboxes()          — show all 18 toolsets with descriptions and load state
 //!   load_toolset(name)        — activate a toolset, expose its tools in tools/list
 //!   unload_toolset(name)      — deactivate a toolset, remove its tools from tools/list
 //!   get_active_toolsets()     — list currently loaded toolsets
@@ -14,6 +14,7 @@
 //! baseline context stays small. The LLM reads `list_toolboxes` and calls
 //! `load_toolset(name)` to expose the tools it actually needs for the task.
 
+use crate::mcp::error::ToolErrorKind;
 use crate::mcp::protocol::{CallToolResult, McpToolDescription};
 use crate::tools::ToolContext;
 use serde_json::{json, Value};
@@ -41,14 +42,18 @@ pub fn meta_tool_descriptions() -> Vec<McpToolDescription> {
             description:
                 "Load a toolset by name so its tools appear in tools/list and can be called. \
                  Returns the list of tools that were added. Use list_toolboxes() first to \
-                 see valid names."
+                 see valid names. Pass an array to load several toolsets in one call -- \
+                 cheaper, one tools/list refresh."
                     .to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "name": {
-                        "type": "string",
-                        "description": "Toolset name (e.g. 'sch_components', 'pcb_routing')"
+                        "anyOf": [
+                            {"type": "string"},
+                            {"type": "array", "items": {"type": "string"}}
+                        ],
+                        "description": "Toolset name (e.g. 'sch_components', 'pcb_routing'), or an array of names"
                     }
                 },
                 "required": ["name"]
@@ -167,27 +172,86 @@ async fn handle_list_toolboxes(ctx: &std::sync::Arc<ToolContext>) -> CallToolRes
 }
 
 async fn handle_load_toolset(args: &Value, ctx: &std::sync::Arc<ToolContext>) -> CallToolResult {
-    let name = match args["name"].as_str() {
-        Some(n) => n,
-        None => return CallToolResult::error("Missing required argument: name"),
-    };
+    match &args["name"] {
+        // Legacy single-name form: result shape is byte-identical to the
+        // pre-batch behavior (`loaded` is a string, `tools` echoes descriptions).
+        Value::String(name) => match ctx.router.load(name).await {
+            Some(tools) => {
+                let tool_list: Vec<Value> = tools
+                    .iter()
+                    .map(|t| json!({ "name": t.name, "description": t.description }))
+                    .collect();
+                CallToolResult::json(&json!({
+                    "loaded": name,
+                    "tools_added": tools.len(),
+                    "tools": tool_list
+                }))
+            }
+            None => CallToolResult::error(format!(
+                "Unknown toolset '{}'. Call list_toolboxes() to see valid names.",
+                name
+            )),
+        },
+        // New array form: one load, one tools/list_changed notification.
+        Value::Array(arr) => {
+            let mut names: Vec<String> =
+                match arr.iter().map(|v| v.as_str().map(str::to_string)).collect() {
+                    Some(names) => names,
+                    None => return CallToolResult::error("name array must contain only strings"),
+                };
+            // Duplicate names in one call would double-count tools_added.
+            let mut seen = std::collections::HashSet::new();
+            names.retain(|n| seen.insert(n.clone()));
 
-    match ctx.router.load(name).await {
-        Some(tools) => {
-            let tool_list: Vec<Value> = tools
-                .iter()
-                .map(|t| json!({ "name": t.name, "description": t.description }))
-                .collect();
+            let mut loaded = Vec::new();
+            let mut tools_added = 0usize;
+            let mut tool_list: Vec<Value> = Vec::new();
+            let mut errors = Vec::new();
+
+            for name in &names {
+                match ctx.router.load(name).await {
+                    Some(tools) => {
+                        loaded.push(name.clone());
+                        tools_added += tools.len();
+                        tool_list.extend(
+                            tools
+                                .iter()
+                                .map(|t| json!({ "name": t.name, "description": t.description })),
+                        );
+                    }
+                    None => errors.push(format!(
+                        "Unknown toolset '{}'. Call list_toolboxes() to see valid names.",
+                        name
+                    )),
+                }
+            }
+
+            // Nothing loaded at all -- a typed error so the observer keeps a kind,
+            // rather than a JSON body with a manually-set is_error flag.
+            if loaded.is_empty() {
+                let kind = ToolErrorKind::InvalidArgument {
+                    field: "name".to_string(),
+                    reason: names.join(", "),
+                };
+                return CallToolResult::error_kind(
+                    kind,
+                    format!(
+                        "No toolsets loaded -- all names were unknown: {}. Call list_toolboxes() to see valid names.",
+                        names.join(", ")
+                    ),
+                );
+            }
+
+            // Partial success (some names unknown, some loaded) is not an error --
+            // the caller gets what loaded plus an errors array for the rest.
             CallToolResult::json(&json!({
-                "loaded": name,
-                "tools_added": tools.len(),
-                "tools": tool_list
+                "loaded": loaded,
+                "tools_added": tools_added,
+                "tools": tool_list,
+                "errors": errors,
             }))
         }
-        None => CallToolResult::error(format!(
-            "Unknown toolset '{}'. Call list_toolboxes() to see valid names.",
-            name
-        )),
+        _ => CallToolResult::error("Missing required argument: name (string or array of strings)"),
     }
 }
 

--- a/crates/konnect/assets/skills/konnect/SKILL.md
+++ b/crates/konnect/assets/skills/konnect/SKILL.md
@@ -81,6 +81,8 @@ get_active_toolsets     → See what's currently loaded
 unload_toolset("name")  → Remove a toolset when done
 ```
 
+`load_toolset` also accepts an array of names to load several toolsets in one call, with a single context refresh.
+
 ### Available Toolsets
 
 | Category | Toolsets |

--- a/crates/konnect/tests/protocol_stdio.rs
+++ b/crates/konnect/tests/protocol_stdio.rs
@@ -267,3 +267,83 @@ fn unload_toolset_emits_list_changed_over_stdio() {
         "expected notifications/tools/list_changed after unload_toolset; saw: {lines:#?}"
     );
 }
+
+/// `load_toolset` accepts an array of names in one call: all listed toolsets
+/// load, tools_added sums across them, and only one list_changed notification
+/// fires for the whole batch.
+#[test]
+fn load_toolset_batch_form_loads_all_and_notifies_once() {
+    let mut p = McpProcess::spawn();
+    let lines = p.call_tool_then_fence(
+        "load_toolset",
+        json!({"name": ["sch_components", "sch_wiring"]}),
+    );
+    let r = lines
+        .iter()
+        .find(|v| v.get("result").is_some())
+        .expect("expected a tools/call result")["result"]
+        .clone();
+    let body = McpProcess::tool_body(&r);
+    assert_eq!(body["tools_added"].as_u64(), Some(36));
+    // tools items are {name, description} objects, matching the legacy
+    // single-name result shape -- not bare name strings.
+    let tools = body["tools"].as_array().expect("tools array");
+    assert!(!tools.is_empty());
+    for t in tools {
+        assert!(t.get("name").and_then(Value::as_str).is_some(), "{t:#?}");
+        assert!(
+            t.get("description").and_then(Value::as_str).is_some(),
+            "{t:#?}"
+        );
+    }
+
+    let notification_count = lines
+        .iter()
+        .filter(|v| {
+            v.get("method").and_then(Value::as_str) == Some("notifications/tools/list_changed")
+                && v.get("id").is_none()
+        })
+        .count();
+    assert_eq!(
+        notification_count, 1,
+        "expected exactly one list_changed notification for the batch; saw: {lines:#?}"
+    );
+
+    // Mixed valid/invalid names: partial failure is not isError, but the
+    // errors array names the unknown toolset and loaded lists only the real one.
+    let lines = p.call_tool_then_fence(
+        "load_toolset",
+        json!({"name": ["templates", "bogus_toolset"]}),
+    );
+    let r = lines
+        .iter()
+        .find(|v| v.get("result").is_some())
+        .expect("expected a tools/call result")["result"]
+        .clone();
+    assert_ne!(r["isError"].as_bool(), Some(true), "{r:#?}");
+    let body = McpProcess::tool_body(&r);
+    assert_eq!(body["loaded"], json!(["templates"]));
+    let errors = body["errors"].as_array().expect("errors array");
+    assert_eq!(errors.len(), 1);
+    assert!(
+        errors[0].as_str().unwrap().contains("list_toolboxes"),
+        "{errors:#?}"
+    );
+}
+
+/// All names in one `load_toolset` call unknown -> a typed `invalid_argument`
+/// error (not a JSON body with a hand-set `isError`), so the observer keeps a
+/// real `error_kind` column instead of degrading to `handler_error`.
+#[test]
+fn load_toolset_batch_total_failure_is_typed_error() {
+    let mut p = McpProcess::spawn();
+    let r = p.call_tool("load_toolset", json!({"name": ["bogus_one", "bogus_two"]}));
+    assert_eq!(r["isError"], json!(true));
+    let body = McpProcess::tool_body(&r);
+    assert_eq!(body["error"]["kind"], "invalid_argument");
+    assert_eq!(body["error"]["field"], "name");
+    assert!(
+        body["message"].as_str().unwrap().contains("list_toolboxes"),
+        "{body:#?}"
+    );
+}

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -11,7 +11,7 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 
 - **18 toolsets** organized into 10 categories
 - **187 registered tools** + **6 always-visible meta-tools** = **193 total**
-- **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop.
+- **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
 ## Meta-tools (always visible)


### PR DESCRIPTION
## Problem / scope

Loading toolsets one at a time fired one `tools/list_changed` notification per call, forcing clients to re-fetch the entire cumulative tool list each time. Measured on a scripted stdio session loading 7 toolsets sequentially: 220,334 bytes (~55K tokens) of `tools/list` traffic; batching the same 7 loads into one call drops that to 53,707 bytes (~13.4K tokens) -- a 4.1x reduction. This measurement comes from batching alone; it doesn't depend on auto-load.

## Root cause / design

`load_toolset`'s `name` argument now also accepts an array, so a client can load several toolsets in one call with a single `tools/list_changed` notification instead of N. Duplicate names are deduped so `tools_added` reflects reality.

**Result shape**, called out explicitly per @mixelpixx's review since tool schemas are public API:
- Single-name (string) input produces a result byte-identical to before this PR: `loaded` is the string, `tools` is `[{name, description}]`.
- Array input is new documented surface: `loaded` is the array of names that loaded, `tools` is the union of every loaded toolset's `{name, description}` entries (same per-item shape as the string form, not bare name strings), and `errors` lists any unknown names -- each carrying the `Call list_toolboxes() to see valid names` recovery hint.
- Partial success (some names load, some are unknown) is not an error.
- Total failure (every name unknown) returns `CallToolResult::error_kind(ToolErrorKind::InvalidArgument { field: "name", .. })` rather than a JSON body with a hand-set `is_error` flag, so `extract_error_kind` still populates the observer's typed column instead of degrading to `handler_error`.

This PR carries no auto-load behavior. An unloaded tool still returns the original `toolset_not_loaded` error naming the owning toolset, unchanged from `main` before this branch -- `dispatch_tool` in `handler.rs` is untouched.

## Compatibility

Additive and backward compatible: `load_toolset(name)` with a single string is unchanged input *and* output. Passing an array is new. `unload_toolset` is untouched (its description text is back to the pre-PR wording -- the auto-reload sentence didn't belong here).

## Tests run

`load_toolset_batch_form_loads_all_and_notifies_once` (batch load + single notification + tools-item shape) and a new `load_toolset_batch_total_failure_is_typed_error` test (asserts the typed `invalid_argument` kind and the `list_toolboxes` hint in the message) in `crates/konnect/tests/protocol_stdio.rs`. `structured_errors_guide_recovery` is back to asserting `toolset_not_loaded` for an unloaded tool, since that behavior is unchanged. `cargo test --workspace --locked --lib --tests` (19 suites on current `main`) and `--doc` pass; `cargo clippy --workspace --locked -- -D warnings` and `cargo fmt --all -- --check` are clean.

## Risk / rollback

Low. Two-commit revert available (feat + docs). The only behavioral change from current `main` is additive (array input); every existing single-name call path is untouched.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>