### PR TITLE
docs(skills): fix phantom tool references in kicad-* skills

### DIFF
--- a/crates/konnect/assets/skills/kicad-library/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-library/SKILL.md
@@ -226,7 +226,7 @@ Dimension format: `LxW` in mm (body dimensions, not pad-to-pad).
 
 ### Add LCSC Number to Existing Components
 
-1. Load `sch_query` toolset
+1. Load `sch_analysis` toolset
 2. Find components missing LCSC field
 3. Search JLCPCB parts for matching part numbers
 4. Update component fields with LCSC numbers

--- a/crates/konnect/assets/skills/kicad-manufacture/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-manufacture/SKILL.md
@@ -26,9 +26,9 @@ load_toolset('verification')     # get_drc_violations, validate_for_manufacturin
 Load additional toolsets as needed:
 
 ```
-load_toolset('sch_query')        # inspect nets, verify footprints assigned
-load_toolset('jlcpcb')           # search_jlcpcb_parts, suggest_jlcpcb_alternatives, estimate_cost
-load_toolset('3d')               # export_3d for visual verification
+load_toolset('sch_analysis')     # inspect nets, verify footprints assigned
+load_toolset('integration')      # search_jlcpcb_parts, suggest_jlcpcb_alternatives, estimate_cost
+load_toolset('pcb_export')       # export_3d for visual verification
 ```
 
 Always call `get_active_toolsets()` first to see what is already loaded.

--- a/crates/konnect/assets/skills/kicad-pcb/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-pcb/SKILL.md
@@ -36,13 +36,13 @@ load_toolset('pcb_components')   # place, move, rotate, align footprints
 load_toolset('pcb_routing')      # traces, vias, differential pairs
 ```
 
+Zones (`pcb_board`: add_zone; `pcb_routing`: add_copper_pour), component/net queries (`pcb_components`: find_component, get_component_list; `pcb_board`: get_board_info), and bulk placement (`pcb_components`: place_component_array, align_components, duplicate_component) are already covered by the toolsets loaded above.
+
 Load additional toolsets as needed:
 
 ```
-load_toolset('pcb_zones')        # copper pours, keepouts, zone fills
-load_toolset('pcb_query')        # find components, nets, DRC results
-load_toolset('pcb_batch')        # bulk operations
-load_toolset('pcb_design_rules') # netclasses, clearances, track widths
+load_toolset('config')           # design rule storage: add_design_rule, list_design_rules
+load_toolset('verification')     # run_drc, set_design_rules, get_design_rules, check_clearance
 ```
 
 Always call `get_active_toolsets()` first to see what is already loaded.
@@ -83,10 +83,8 @@ Do NOT add copper pours before routing is complete — they interfere with inter
 | `place_component`         | Position a single footprint at x,y          |
 | `move_component`          | Relocate an existing footprint              |
 | `rotate_component`        | Rotate footprint (0/90/180/270)             |
-| `flip_component`          | Move to opposite board side (F.Cu <-> B.Cu) |
 | `align_components`        | Align multiple components (top/bottom/left/right/center) |
 | `place_component_array`   | Grid placement for repeated elements        |
-| `distribute_components`   | Equal spacing between components            |
 
 ### Placement Tips
 
@@ -168,7 +166,7 @@ Common netclass configurations:
 
 ## Copper Pour
 
-Load `pcb_zones` toolset for zone operations.
+Zone tools live in the `pcb_board` toolset.
 
 ### add_zone
 

--- a/crates/konnect/assets/skills/kicad-review/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-review/SKILL.md
@@ -27,8 +27,8 @@ load_toolset('design_review')    # audit_decoupling, audit_connections, audit_po
 Optional (for deeper analysis):
 
 ```
-load_toolset('sch_query')        # get net info, trace connections, inspect components
-load_toolset('pcb_query')        # check routing, zone fills, stackup
+load_toolset('sch_analysis')     # get net info, trace connections, inspect components
+load_toolset('pcb_routing')      # query_traces, get_nets_list
 ```
 
 Always call `get_active_toolsets()` first to see what is already loaded.
@@ -150,17 +150,6 @@ Checks:
 - Power sequencing considered for multi-rail designs
 - Power flags present (avoids ERC false positives)
 
-### ESD Protection Audit
-
-```
-audit_esd_protection()
-```
-
-Checks:
-- External connectors have ESD protection (TVS diodes, clamps)
-- USB, Ethernet, antenna ports have proper protection
-- Current limiting on exposed signal lines
-
 ### Manufacturing Audit
 
 ```
@@ -195,8 +184,7 @@ Equivalent to running:
 6. audit_decoupling
 7. audit_connections
 8. audit_power_rails
-9. audit_esd_protection
-10. audit_manufacturing
+9. audit_manufacturing
 
 ---
 

--- a/crates/konnect/assets/skills/kicad-schematic/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-schematic/SKILL.md
@@ -26,9 +26,9 @@ load_toolset('sch_wiring')       # wires, net labels, power symbols, connections
 Load additional toolsets as needed:
 
 ```
-load_toolset('sch_library')      # search_symbols, get_symbol_info, list_libraries
+load_toolset('library')          # search_symbols, get_symbol_info, list_symbol_libraries
 load_toolset('sch_batch')        # batch operations for 3+ items
-load_toolset('sch_query')        # find components, get pin info, inspect nets
+load_toolset('sch_analysis')     # find components, get pin info, inspect nets
 ```
 
 Always call `get_active_toolsets()` first to see what is already loaded.
@@ -42,7 +42,7 @@ Always call `get_active_toolsets()` first to see what is already loaded.
 1. Search the library first: use `search_symbols` to find the correct lib_id
 2. Get pin info: use `get_symbol_info` to see pin names, numbers, and positions
 3. Place on the 1.27mm grid (KiCAD default schematic grid)
-4. Verify placement with `get_schematic_components`
+4. Verify placement with `list_schematic_components`
 
 ### Common Library IDs
 
@@ -143,7 +143,7 @@ Load `sch_batch` toolset when placing 3 or more components or making bulk connec
 
 ### batch_place_components
 
-Place multiple components in one call. Provide an array of placements with lib_id, position, and reference.
+Place multiple components in one call. Provide `schematic` and a `components` array of `{lib_id, x, y, rotation?, reference?, value?, unit?}` objects. Pass `reference` explicitly for each component -- it is not auto-assigned.
 
 ### batch_connect_to_net
 


### PR DESCRIPTION
## Problem / scope

The five kicad-* bundled skills (kicad-library, kicad-manufacture, kicad-pcb, kicad-review, kicad-schematic) referenced toolsets and tools that do not exist in the registry: `sch_library`, `sch_query`, `pcb_zones`, `pcb_query`, `pcb_batch`, `pcb_design_rules`, `jlcpcb`, `3d`, `get_schematic_components`, `flip_component`, `distribute_components`, `audit_esd_protection`. Every session that followed a skill's instructions to `load_toolset` one of these, or call one of these tools, burned a guaranteed unknown-tool round trip before it could self-correct.

## Root cause / design

Each phantom name is mapped to its real registry equivalent:

- `sch_library` -> `library`, `sch_query` -> `sch_analysis` (used across kicad-library, kicad-manufacture, kicad-review, kicad-schematic)
- `pcb_zones` -> zone tools actually live in `pcb_board`; `pcb_query` -> `pcb_routing` (for routing/net queries) or removed where the info is already covered by toolsets already loaded in the same workflow step
- `pcb_batch` / `pcb_design_rules` -> replaced with the toolsets that actually own bulk-placement and design-rule tools (`config` for rule storage, `verification` for `run_drc`/`set_design_rules`/etc; bulk placement is already covered by `pcb_components` tools mentioned earlier in the same file)
- `jlcpcb` -> `integration`, `3d` -> `pcb_export` (owns `export_3d`)
- `get_schematic_components` -> `list_schematic_components`
- `flip_component`, `distribute_components`, `audit_esd_protection` -> removed; no such tools exist, and kicad-review's numbered `run_design_review` step list is renumbered accordingly

Also updates kicad-schematic/SKILL.md's `batch_place_components` description to match that tool's real argument shape (`schematic` + `components: [{lib_id, x, y, rotation?, reference?, value?, unit?}]`, references not auto-assigned). **Dependency note**: `batch_place_components` itself doesn't exist on `main` yet -- it lands in the companion `pr-sch-batch-tools` PR. This PR only fixes the *description* of that tool to match its real (soon-to-land) shape rather than the placeholder wording that was there before; merge order between the two PRs doesn't matter for this file (worst case the description is simply ahead of the code by a few hours), but both should land close together so the skill doesn't describe a real tool with stale wording in the interim.

## Compatibility

Documentation only, zero code changes. No compatibility impact.

## Tests run

No code changed; nothing to run beyond the standard `cargo fmt --all -- --check` / `cargo clippy --workspace --locked -- -D warnings` / `cargo test --workspace --locked --lib --tests` / `--doc` gates, all of which were verified clean as part of the full 8-commit series and are unaffected by markdown-only changes. Diffed the resulting five files byte-for-byte against the originally verified change before pushing.

## Risk / rollback

None -- markdown-only. Single-commit revert available.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>