### PR TITLE
feat(schematic): add conflict-safe transaction layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@ crates/schematic-viewer/target/
 *.dylib
 *.tmp
 *.bak
+.konnect-transaction-*.json
+.konnect-transaction-*.abandoned.json
 dist/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,7 +239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -290,6 +299,15 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -307,6 +325,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +345,16 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -493,6 +531,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +604,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1075,11 +1133,14 @@ name = "konnect-sexp"
 version = "0.2.2"
 dependencies = [
  "anyhow",
+ "dirs",
+ "fs4",
  "nom",
  "pretty_assertions",
  "proptest",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 1.0.69",
  "uuid",
@@ -2060,6 +2121,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2592,6 +2664,12 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 dependencies = [
  "core_maths",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ rusqlite = { version = "0.40", features = ["bundled"] }
 # Error handling
 anyhow = "1"
 thiserror = "1"
+fs4 = "1.1"
+sha2 = "0.10"
 
 # Logging
 tracing = "0.1"

--- a/DEV.md
+++ b/DEV.md
@@ -130,7 +130,31 @@ Konnect/
 - Direct read/write of `.kicad_sch` files
 - Symbol definitions auto-embedded from KiCAD 10's `.kicad_symdir` format
 - Power symbols (VCC, GND) embedded from `power.kicad_symdir`
-- All edits use `write_atomic` (write to .tmp → fsync → rename)
+- Existing-file edits use revision-checked atomic replacement: read the exact
+  source, acquire a cooperative lock, reject any intervening KiCad or Konnect
+  change, write a unique sibling scratch file, fsync, and rename.
+- Cooperative lock files live under `KONNECT_STATE_DIR/locks` when that
+  absolute override is set, otherwise under the platform local-data directory
+  (`konnect/locks`). Reads never create files in the KiCad project.
+- Multi-file schematic changes use project-local
+  `.konnect-transaction-*.json` write-ahead journals. These journals contain
+  complete before/after images and must be treated as sensitive project data.
+
+`konnect_schematic_editor::Schematic` deliberately distinguishes creation from
+replacement:
+
+- `save(new_path)` is create-only and refuses to replace an existing path.
+- `save(loaded_path)` and `overwrite()` replace only when the file still
+  exactly matches the source loaded into the model. KiCad autosave therefore
+  produces a conflict that callers must resolve by reloading and reapplying.
+- Callers that intentionally replace an existing file must use the explicit
+  revision-aware writer/command APIs; they must not delete the destination or
+  weaken `save()` into an unconditional overwrite.
+
+For journal diagnosis and recovery, use `konnect transaction status`,
+`konnect transaction recover`, and the explicit force-gated `konnect
+transaction abandon` escape hatch documented in
+[Troubleshooting](docs/TROUBLESHOOTING.md#transaction-recovery-is-blocked-by-divergent-content).
 
 ### kicad-cli v10 (Subprocess)
 - Verified commands: `sch erc`, `sch export svg/pdf/bom/netlist`, `pcb drc`, `pcb export gerbers/drill/pdf/svg/step/vrml/pos/ipcd356`, `pcb render`

--- a/crates/konnect-core/Cargo.toml
+++ b/crates/konnect-core/Cargo.toml
@@ -24,9 +24,9 @@ base64.workspace = true
 reqwest.workspace = true
 rusqlite.workspace = true
 usvg.workspace = true
+tempfile = "3"
 
 [dev-dependencies]
-tempfile = "3"
 # The pcb_components fallback tests spawn a mock KiCAD NNG endpoint to prove
 # a reachable-but-rejecting KiCAD never triggers the file-editing fallback.
 nng.workspace = true

--- a/crates/konnect-core/src/tools/cli.rs
+++ b/crates/konnect-core/src/tools/cli.rs
@@ -211,7 +211,9 @@ pub async fn run_drc(cli: &str, pcb: &Path, refill_zones: bool) -> Result<Vec<Dr
 pub async fn annotate_schematic(_cli: &str, schematic: &Path) -> Result<()> {
     use std::collections::HashMap;
 
-    let content = tokio::fs::read_to_string(schematic).await?;
+    let read_path = schematic.to_path_buf();
+    let content =
+        tokio::task::spawn_blocking(move || konnect_sexp::read_consistent(&read_path)).await??;
     let mut new_content = content.clone();
     let mut counters: HashMap<String, usize> = HashMap::new();
 
@@ -261,7 +263,11 @@ pub async fn annotate_schematic(_cli: &str, schematic: &Path) -> Result<()> {
     }
 
     if new_content != content {
-        tokio::fs::write(schematic, &new_content).await?;
+        let write_path = schematic.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            konnect_sexp::write_atomic_if_unchanged(&write_path, &content, &new_content)
+        })
+        .await??;
     }
 
     Ok(())

--- a/crates/konnect-core/src/tools/integration.rs
+++ b/crates/konnect-core/src/tools/integration.rs
@@ -17,6 +17,7 @@
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
 use crate::tools::{get_path, require_str, ToolContext, ToolDef};
+use konnect_sexp::writer::{read_consistent, write_atomic_if_unchanged};
 use serde_json::json;
 use std::path::PathBuf;
 
@@ -562,7 +563,8 @@ async fn handle_enrich_datasheets(
     let sch_path = get_path(args, "schematic")?;
     let overwrite = args["overwrite_existing"].as_bool().unwrap_or(false);
 
-    let content = tokio::fs::read_to_string(&sch_path).await?;
+    let read_path = sch_path.clone();
+    let content = tokio::task::spawn_blocking(move || read_consistent(&read_path)).await??;
 
     // Find all LCSC property values in the schematic
     let mut lcsc_ids: Vec<String> = Vec::new();
@@ -648,7 +650,7 @@ async fn handle_enrich_datasheets(
 
     // Write back if anything changed
     if enriched > 0 {
-        konnect_sexp::writer::write_atomic(&sch_path, &new_content)?;
+        write_atomic_if_unchanged(&sch_path, &content, &new_content)?;
     }
 
     Ok(CallToolResult::text(

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -308,10 +308,7 @@ pub fn project_name_for(sch_path: &std::path::Path) -> String {
 /// The root UUID is mandatory: KiCAD's netlister resolves symbol instance
 /// paths against it and silently forms no wire-only nets when it's missing.
 pub fn blank_schematic_template() -> String {
-    format!(
-        "(kicad_sch\n\t(version 20250610)\n\t(generator \"konnect\")\n\t(generator_version \"10.0\")\n\t(uuid \"{}\")\n\t(paper \"A4\")\n\t(lib_symbols\n\t)\n)\n",
-        konnect_sexp::writer::new_uuid()
-    )
+    konnect_sexp::schematic::format_blank_schematic()
 }
 
 /// Root UUID of a loaded schematic, assigning a fresh one when the file

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -20,7 +20,7 @@ use konnect_sexp::{
     },
     writer::{
         apply_edits, find_block_with_leading_whitespace, find_enclosing_direct_child_block,
-        new_uuid, write_atomic, SexpEdit,
+        new_uuid, read_consistent, write_atomic_if_unchanged, SexpEdit,
     },
 };
 use serde_json::json;
@@ -401,10 +401,11 @@ async fn handle_batch_connect_to_net(
     }
 
     if !inserts.is_empty() {
+        let expected = content.clone();
         let close_pos = content.rfind(')').unwrap_or(content.len());
         let edits = vec![SexpEdit::insert(close_pos, inserts)];
         let new_content = apply_edits(content, edits);
-        write_atomic(&sch_path, &new_content)?;
+        write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
     }
 
     Ok(CallToolResult::json(&json!({
@@ -496,6 +497,7 @@ async fn handle_batch_connect_pins(
     };
 
     let (content, tree) = read_schematic(&sch_path)?;
+    let expected = content.clone();
     let instances = extract_symbol_instances(&tree);
     let lib_syms = tree
         .find("lib_symbols")
@@ -533,7 +535,7 @@ async fn handle_batch_connect_pins(
     }
 
     if !resolved.is_empty() {
-        write_atomic(&sch_path, &new_content)?;
+        write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
     }
 
     let mut result = CallToolResult::json(&json!({
@@ -549,7 +551,8 @@ async fn handle_batch_delete(
     _ctx: &crate::tools::ToolContext,
 ) -> anyhow::Result<CallToolResult> {
     let sch_path = get_path(args, "schematic")?;
-    let content = std::fs::read_to_string(&sch_path)?;
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
 
     let mut edits: Vec<SexpEdit> = Vec::new();
     let mut deleted: Vec<String> = Vec::new();
@@ -617,7 +620,7 @@ async fn handle_batch_delete(
     }
 
     let new_content = apply_edits(content, edits);
-    write_atomic(&sch_path, &new_content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
 
     Ok(CallToolResult::json(&json!({
         "deleted_count": deleted.len(),
@@ -670,7 +673,8 @@ async fn handle_bulk_move(
         Err(e) => return Ok(e),
     };
 
-    let content = std::fs::read_to_string(&sch_path)?;
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
     let mut edits: Vec<SexpEdit> = Vec::new();
     let mut moved: Vec<serde_json::Value> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
@@ -733,7 +737,7 @@ async fn handle_bulk_move(
     }
 
     let new_content = apply_edits(content, edits);
-    write_atomic(&sch_path, &new_content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
 
     Ok(CallToolResult::json(&json!({
         "moved_count": moved.len(),
@@ -753,7 +757,8 @@ async fn handle_batch_edit(
         None => return Ok(CallToolResult::error("Missing 'edits' array")),
     };
 
-    let content = std::fs::read_to_string(&sch_path)?;
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
     let mut file_edits: Vec<SexpEdit> = Vec::new();
     let mut changed: Vec<serde_json::Value> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
@@ -809,7 +814,7 @@ async fn handle_batch_edit(
     }
 
     let new_content = apply_edits(content, file_edits);
-    write_atomic(&sch_path, &new_content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
 
     Ok(CallToolResult::json(&json!({
         "updated_count": changed.len(),
@@ -828,7 +833,8 @@ async fn handle_batch_delete_components(
         None => return Ok(CallToolResult::error("Missing 'references' array")),
     };
 
-    let content = std::fs::read_to_string(&sch_path)?;
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
     let mut edits: Vec<SexpEdit> = Vec::new();
     let mut deleted: Vec<String> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
@@ -848,7 +854,7 @@ async fn handle_batch_delete_components(
     }
 
     let new_content = apply_edits(content, edits);
-    write_atomic(&sch_path, &new_content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
 
     Ok(CallToolResult::json(&json!({
         "deleted_count": deleted.len(),
@@ -888,14 +894,15 @@ async fn handle_connect_passthrough(
     let wire_sexp = format_wire(x, y, wire_end_x, wire_end_y);
     let label_sexp = format_net_label(&net_name, wire_end_x, wire_end_y, label_rot);
 
-    let content = std::fs::read_to_string(&sch_path)?;
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
     let close_pos = content.rfind(')').unwrap_or(content.len());
     let edits = vec![SexpEdit::insert(
         close_pos,
         format!("{wire_sexp}{label_sexp}"),
     )];
     let new_content = apply_edits(content, edits);
-    write_atomic(&sch_path, &new_content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
 
     Ok(CallToolResult::json(&json!({
         "net": net_name,
@@ -935,11 +942,12 @@ async fn handle_add_schematic_text(
          (effects (font (size {size} {size})))\n    (uuid \"{uuid}\")\n  )"
     );
 
-    let content = std::fs::read_to_string(&sch_path)?;
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
     let close_pos = content.rfind(')').unwrap_or(content.len());
     let edits = vec![SexpEdit::insert(close_pos, text_sexp)];
     let new_content = apply_edits(content, edits);
-    write_atomic(&sch_path, &new_content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
 
     Ok(CallToolResult::json(&json!({
         "added": text,
@@ -1272,6 +1280,37 @@ mod batch_delete_tests {
         assert!(!after.contains(uuid));
         assert!(after.contains("(uuid \"root\")"));
         assert!(after.contains("keep me"));
+        assert!(after.contains("(sheet_instances"));
+        assert!(konnect_sexp::parse_sexp(&after).is_ok());
+    }
+
+    #[tokio::test]
+    async fn batch_delete_uuid_removes_top_level_text_but_preserves_structure() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("batch-delete-text.kicad_sch");
+        let text_uuid = "22222222-2222-2222-2222-222222222222";
+        std::fs::write(
+            &path,
+            format!(
+                "(kicad_sch\n  (version 20260306)\n  (generator \"eeschema\")\n  (uuid \"root\")\n  (text \"obsolete caption\"\n    (at 5 5 0)\n    (effects (font (size 1.27 1.27)))\n    (uuid \"{text_uuid}\")\n  )\n  (sheet_instances (path \"/\" (page \"1\")))\n)\n"
+            ),
+        )
+        .unwrap();
+
+        let result = handle_batch_delete(
+            &json!({
+                "schematic": path.display().to_string(),
+                "uuids": [text_uuid]
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error);
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(!after.contains("obsolete caption"));
+        assert!(after.contains("(uuid \"root\")"));
         assert!(after.contains("(sheet_instances"));
         assert!(konnect_sexp::parse_sexp(&after).is_ok());
     }

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -12,11 +12,17 @@ use crate::tools::{
 };
 use konnect_schematic_editor as cse;
 use konnect_sexp::{
+    commit_command,
     geometry::snap_point,
+    parse_sexp,
     schematic::{
         extract_lib_pins_for_unit, extract_symbol_instances, pin_endpoint, read_schematic,
     },
-    writer::{apply_edits, new_uuid, write_atomic, SexpEdit},
+    writer::{
+        apply_edits, new_uuid, read_consistent, write_atomic_if_unchanged, write_new_atomic,
+        SexpEdit,
+    },
+    ItemId, SchematicCommand,
 };
 use serde_json::json;
 
@@ -293,7 +299,7 @@ async fn handle_create_schematic(
     let template = crate::tools::blank_schematic_template();
     // Write the template then immediately load/save through cse so the file
     // is normalised to cse's writer output format.
-    write_atomic(&path, &template)?;
+    write_new_atomic(&path, &template)?;
     let sch = cse::Schematic::load(&path)?;
     sch.overwrite()?;
     Ok(CallToolResult::json(
@@ -477,7 +483,8 @@ async fn handle_edit_schematic_component(
         Err(e) => return Ok(e),
     };
 
-    let mut content = std::fs::read_to_string(&sch_path)?;
+    let mut content = read_consistent(&sch_path)?;
+    let expected = content.clone();
     let mut changed = Vec::new();
 
     // Helper: update a property field value in-place within the symbol block
@@ -541,7 +548,14 @@ async fn handle_edit_schematic_component(
     }
 
     if !changed.is_empty() {
-        write_atomic(&sch_path, &content)?;
+        let item_id = symbol_item_id(&expected, &reference)?;
+        let command = SchematicCommand::replace_item_from_document(
+            &expected,
+            &content,
+            item_id,
+            format!("Edit {reference}"),
+        )?;
+        commit_command(&sch_path, &command)?;
     }
 
     let mut result = json!({
@@ -964,7 +978,8 @@ async fn handle_add_component_annotation(
         Err(e) => return Ok(e),
     };
 
-    let content = std::fs::read_to_string(&sch_path)?;
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
 
     // Find the symbol block for this reference
     let (sym_start, sym_end) = match find_symbol_instance_block(&content, &reference) {
@@ -990,13 +1005,30 @@ async fn handle_add_component_annotation(
     );
 
     let new_content = apply_edits(content, vec![SexpEdit::insert(insert_abs, prop_sexp)]);
-    write_atomic(&sch_path, &new_content)?;
+    let item_id = symbol_item_id(&expected, &reference)?;
+    let command = SchematicCommand::replace_item_from_document(
+        &expected,
+        &new_content,
+        item_id,
+        format!("Add {key} property to {reference}"),
+    )?;
+    commit_command(&sch_path, &command)?;
 
     Ok(CallToolResult::json(&json!({
         "reference": reference,
         "added_property": key,
         "value": value
     })))
+}
+
+fn symbol_item_id(content: &str, reference: &str) -> anyhow::Result<ItemId> {
+    let (start, end) = find_symbol_instance_block(content, reference)
+        .ok_or_else(|| anyhow::anyhow!("component '{reference}' not found"))?;
+    let symbol = parse_sexp(&content[start..end])?;
+    let uuid = symbol
+        .find_str("uuid")
+        .ok_or_else(|| anyhow::anyhow!("component '{reference}' has no UUID"))?;
+    Ok(ItemId::new(uuid.to_owned())?)
 }
 
 async fn handle_group_components(
@@ -1021,8 +1053,10 @@ async fn handle_group_components(
         return Ok(CallToolResult::error("No references provided"));
     }
 
-    let mut content = std::fs::read_to_string(&sch_path)?;
+    let mut content = read_consistent(&sch_path)?;
+    let expected = content.clone();
     let mut grouped = Vec::new();
+    let mut item_ids = Vec::new();
 
     for reference in &refs {
         let (sym_start, sym_end) = match find_symbol_instance_block(&content, reference) {
@@ -1041,10 +1075,19 @@ async fn handle_group_components(
         );
 
         content = apply_edits(content, vec![SexpEdit::insert(insert_abs, prop_sexp)]);
+        item_ids.push(symbol_item_id(&expected, reference)?);
         grouped.push(reference.clone());
     }
 
-    write_atomic(&sch_path, &content)?;
+    if !item_ids.is_empty() {
+        let command = SchematicCommand::replace_items_from_document(
+            &expected,
+            &content,
+            item_ids,
+            format!("Group components as {group_name}"),
+        )?;
+        commit_command(&sch_path, &command)?;
+    }
 
     Ok(CallToolResult::json(&json!({
         "group_name": group_name,
@@ -1068,7 +1111,8 @@ async fn handle_replace_component(
     };
     let new_unit = opt_f64(args, "unit").map(|u| u as u32);
 
-    let mut content = std::fs::read_to_string(&sch_path)?;
+    let mut content = read_consistent(&sch_path)?;
+    let expected = content.clone();
 
     // Find the symbol block for this reference
     let (sym_start, sym_end) = match find_symbol_instance_block(&content, &reference) {
@@ -1150,7 +1194,7 @@ async fn handle_replace_component(
     if !super::ensure_lib_symbol_in_schematic(&mut content, &new_lib_id) {
         return Ok(crate::tools::lib_symbol_not_found_error(&new_lib_id));
     }
-    write_atomic(&sch_path, &content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &content)?;
 
     Ok(CallToolResult::json(&json!({
         "reference": reference,

--- a/crates/konnect-core/src/tools/sch_export.rs
+++ b/crates/konnect-core/src/tools/sch_export.rs
@@ -13,7 +13,9 @@ use konnect_sexp::{
         extract_labels, extract_lib_pins, extract_symbol_instances, extract_wires, pin_endpoint,
         read_schematic,
     },
-    writer::{apply_edits, find_block_with_leading_whitespace, write_atomic, SexpEdit},
+    writer::{
+        apply_edits, find_block_with_leading_whitespace, write_atomic_if_unchanged, SexpEdit,
+    },
 };
 use serde_json::json;
 
@@ -423,9 +425,11 @@ async fn handle_fix_connectivity(
         }
     }
 
-    if !dry_run && !file_edits.is_empty() {
+    let applied_count = if dry_run { 0 } else { file_edits.len() };
+    if applied_count > 0 {
+        let expected = content.clone();
         let new_content = apply_edits(content, file_edits);
-        write_atomic(&sch_path, &new_content)?;
+        write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
     }
 
     Ok(CallToolResult::json(&json!({

--- a/crates/konnect-core/src/tools/sch_hierarchy.rs
+++ b/crates/konnect-core/src/tools/sch_hierarchy.rs
@@ -10,10 +10,14 @@
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
 use crate::tools::{
-    ensure_root_uuid, get_path, opt_f64, opt_str, project_name_for, require_f64, require_str,
-    ToolContext, ToolDef,
+    get_path, opt_f64, opt_str, project_name_for, require_f64, require_str, ToolContext, ToolDef,
 };
 use konnect_schematic_editor as cse;
+use konnect_sexp::schematic::{format_hierarchical_sheet, HierarchicalSheetSpec};
+use konnect_sexp::{
+    commit_command, commit_file_transaction, parse_sexp, prepare_command, read_consistent,
+    FileTransition, ItemAnchor, ItemId, SchematicCommand,
+};
 use serde_json::{json, Value};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -260,9 +264,10 @@ fn parent_dir(sch_path: &Path) -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
 }
 
+#[cfg(test)]
 fn create_blank_schematic(path: &Path) -> anyhow::Result<()> {
     let template = crate::tools::blank_schematic_template();
-    konnect_sexp::writer::write_atomic(path, &template)?;
+    konnect_sexp::writer::write_new_atomic(path, &template)?;
     // Round-trip through cse so the file is normalised to its writer's format,
     // matching the existing `create_schematic` tool's behavior.
     let sch = cse::Schematic::load(path)?;
@@ -300,40 +305,80 @@ fn sheet_json(sheet: &cse::Sheet, project_name: &str) -> Value {
     })
 }
 
-/// Insert `sheet` into `parent`. If `patch_existing_symbols` is set, load the
-/// child file and ensure every symbol in it carries an instance path for this
-/// sheet's UUID — needed whenever the child file already has components in it
-/// (a reused file, or a freshly duplicated one).
-fn link_sheet(
-    parent: &mut cse::Schematic,
-    sheet: cse::Sheet,
-    child_path: &Path,
-    project_name: &str,
-    patch_existing_symbols: bool,
-) -> anyhow::Result<usize> {
-    let sheet_uuid = sheet.uuid.clone();
-    let root_uuid = ensure_root_uuid(parent);
-    parent.add_sheet(sheet);
-
-    let mut patched = 0usize;
-    if patch_existing_symbols {
-        let mut child = cse::Schematic::load(child_path)?;
-        // eeschema's path format: "/<root-uuid>/<sheet-symbol-uuid>", no
-        // trailing slash. KiCAD's netlister can't resolve any other shape and
-        // silently drops the symbol from net formation.
-        let hier_path = format!("/{}/{}", root_uuid, sheet_uuid);
-        for sym in child.symbols.iter_mut() {
-            if !sym.has_instance_path(project_name, &hier_path) {
-                let reference = sym.reference().unwrap_or("").to_string();
-                sym.set_instance_path(project_name, &hier_path, &reference, sym.unit);
-                patched += 1;
-            }
-        }
-        if patched > 0 {
-            child.overwrite()?;
-        }
+fn ensure_source_root_uuid(source: &str) -> anyhow::Result<(String, String)> {
+    let tree = parse_sexp(source)?;
+    if let Some(uuid) = tree.find_str("uuid") {
+        return Ok((source.to_owned(), uuid.to_owned()));
     }
-    Ok(patched)
+    let uuid = konnect_sexp::writer::new_uuid();
+    let children = konnect_sexp::writer::find_direct_child_blocks(source, "kicad_sch");
+    let anchor = children
+        .iter()
+        .find_map(|(start, end)| {
+            let node = parse_sexp(&source[*start..*end]).ok()?;
+            (!matches!(
+                node.head(),
+                Some("version" | "generator" | "generator_version")
+            ))
+            .then_some(*start)
+        })
+        .ok_or_else(|| anyhow::anyhow!("parent schematic has no UUID insertion anchor"))?;
+    let line_start = source[..anchor]
+        .rfind('\n')
+        .map_or(anchor, |newline| newline + 1);
+    let indent = &source[line_start..anchor];
+    if !indent.chars().all(char::is_whitespace) {
+        anyhow::bail!("parent schematic metadata is not line-oriented");
+    }
+    let replacement = format!("{indent}(uuid \"{uuid}\")\n");
+    let updated = konnect_sexp::writer::apply_edits(
+        source.to_owned(),
+        vec![konnect_sexp::writer::SexpEdit::insert(
+            line_start,
+            replacement,
+        )],
+    );
+    Ok((updated, uuid))
+}
+
+fn replace_source_root_uuid(source: &str, uuid: &str) -> anyhow::Result<String> {
+    let children = konnect_sexp::writer::find_direct_child_blocks(source, "kicad_sch");
+    let range = children.iter().find_map(|(start, end)| {
+        parse_sexp(&source[*start..*end])
+            .ok()
+            .is_some_and(|node| node.head() == Some("uuid"))
+            .then_some((*start, *end))
+    });
+    if let Some((start, end)) = range {
+        return Ok(konnect_sexp::writer::apply_edits(
+            source.to_owned(),
+            vec![konnect_sexp::writer::SexpEdit::replace(
+                start,
+                end,
+                format!("(uuid \"{uuid}\")"),
+            )],
+        ));
+    }
+    let (with_uuid, generated) = ensure_source_root_uuid(source)?;
+    replace_source_root_uuid(&with_uuid, uuid)
+        .or_else(|_| anyhow::bail!("could not replace newly inserted schematic UUID {generated}"))
+}
+
+fn commit_edited_sheet_item(
+    path: &Path,
+    before: &str,
+    edited: &cse::Schematic,
+    uuid: &str,
+    label: &str,
+) -> anyhow::Result<()> {
+    let command = SchematicCommand::replace_item_from_document(
+        before,
+        &edited.to_source(),
+        ItemId::new(uuid)?,
+        label,
+    )?;
+    commit_command(path, &command)?;
+    Ok(())
 }
 
 // ─── Handlers ───────────────────────────────────────────────────────────────
@@ -359,7 +404,32 @@ async fn handle_add_hierarchical_sheet(
     let dir = parent_dir(&parent_path);
     let child_path = dir.join(&sheet_file);
 
-    let mut parent = cse::Schematic::load(&parent_path)?;
+    let relative = Path::new(&sheet_file);
+    let valid_relative = !relative.is_absolute()
+        && relative
+            .components()
+            .all(|component| matches!(component, std::path::Component::Normal(_)))
+        && relative
+            .extension()
+            .is_some_and(|extension| extension == "kicad_sch");
+    if !valid_relative {
+        return Ok(CallToolResult::error(
+            "sheet_file must be a relative .kicad_sch path without parent traversal",
+        ));
+    }
+    if !child_path.parent().is_some_and(Path::is_dir) {
+        return Ok(CallToolResult::error(
+            "The child sheet directory does not exist",
+        ));
+    }
+    if child_path == parent_path {
+        return Ok(CallToolResult::error(
+            "A hierarchical sheet cannot reference its parent file",
+        ));
+    }
+
+    let parent_before = read_consistent(&parent_path)?;
+    let parent = cse::Schematic::load(&parent_path)?;
 
     if parent.sheets.by_name(&sheet_name).is_some() {
         return Ok(CallToolResult::error(format!(
@@ -369,35 +439,79 @@ async fn handle_add_hierarchical_sheet(
         )));
     }
 
-    let child_existed = child_path.exists();
-    if !child_existed {
-        create_blank_schematic(&child_path)?;
+    let child_existed = child_path.is_file();
+    if child_path.exists() && !child_existed {
+        return Ok(CallToolResult::error(
+            "The child schematic path exists but is not a regular file",
+        ));
     }
-
     let page = next_free_page(&parent, &project_name).to_string();
-    let mut sheet = cse::Sheet::new(
-        sheet_name.as_str(),
-        sheet_file.as_str(),
+    let (parent_base, root_uuid) = ensure_source_root_uuid(&parent_before)?;
+    let root_path = format!("/{root_uuid}");
+    let block = format_hierarchical_sheet(HierarchicalSheetSpec {
+        name: &sheet_name,
+        file: &sheet_file,
         x,
         y,
         width,
         height,
-    );
-    // Sheet page entries live at the parent's own instance path — for a root
-    // sheet that's "/<root-uuid>", matching what eeschema writes.
-    let root_path = format!("/{}", ensure_root_uuid(&mut parent));
-    sheet.set_page(&project_name, &root_path, &page);
+        project_name: &project_name,
+        parent_instance_path: &root_path,
+        page: &page,
+    });
+    let parent_command = SchematicCommand::insert_item(
+        &parent_base,
+        block,
+        ItemAnchor::BeforeFooter,
+        "Add hierarchical sheet",
+    )?
+    .requiring_unchanged_document();
+    let sheet_uuid = parent_command
+        .changes
+        .first()
+        .map(|change| change.id.to_string())
+        .ok_or_else(|| anyhow::anyhow!("sheet insertion produced no item change"))?;
+    let (parent_after, _) = prepare_command(&parent_path, &parent_base, &parent_command)?;
 
-    let patched = link_sheet(
-        &mut parent,
-        sheet,
-        &child_path,
-        &project_name,
-        child_existed,
-    )?;
-    parent.overwrite()?;
+    let child_before = child_path
+        .is_file()
+        .then(|| read_consistent(&child_path))
+        .transpose()?;
+    let mut transitions = vec![FileTransition::replace(
+        &parent_path,
+        parent_before,
+        parent_after,
+    )];
+    let mut patched = 0usize;
+    if let Some(child_before) = child_before {
+        let hierarchy_path = format!("{root_path}/{sheet_uuid}");
+        if let Some(child_command) = SchematicCommand::ensure_symbol_instance_path(
+            &child_before,
+            &project_name,
+            &hierarchy_path,
+            "Link hierarchical child symbols",
+        )? {
+            patched = child_command.changes.len();
+            let (child_after, _) = prepare_command(&child_path, &child_before, &child_command)?;
+            transitions.push(FileTransition::replace(
+                &child_path,
+                child_before,
+                child_after,
+            ));
+        }
+    } else {
+        transitions.push(FileTransition::create(
+            &child_path,
+            konnect_sexp::schematic::format_blank_schematic(),
+        ));
+    }
+    commit_file_transaction(&dir, transitions)?;
 
-    let sheet_ref = parent.sheets.by_name(&sheet_name).expect("just added");
+    let committed = cse::Schematic::load(&parent_path)?;
+    let sheet_ref = committed
+        .sheets
+        .by_name(&sheet_name)
+        .ok_or_else(|| anyhow::anyhow!("committed sheet was not readable"))?;
     Ok(CallToolResult::json(&json!({
         "added": sheet_name,
         "sheet": sheet_json(sheet_ref, &project_name),
@@ -417,6 +531,7 @@ async fn handle_edit_sheet(args: &Value, _ctx: &ToolContext) -> anyhow::Result<C
         .map(str::to_string)
         .unwrap_or_else(|| project_name_for(&sch_path));
 
+    let before = read_consistent(&sch_path)?;
     let mut sch = cse::Schematic::load(&sch_path)?;
     let sheet = match sch.sheets.by_name_mut(&sheet_name) {
         Some(s) => s,
@@ -427,6 +542,7 @@ async fn handle_edit_sheet(args: &Value, _ctx: &ToolContext) -> anyhow::Result<C
             )))
         }
     };
+    let sheet_uuid = sheet.uuid.clone();
 
     let mut changed = Vec::new();
     if let Some(new_name) = opt_str(args, "new_name") {
@@ -453,7 +569,7 @@ async fn handle_edit_sheet(args: &Value, _ctx: &ToolContext) -> anyhow::Result<C
     }
 
     let summary = sheet_json(sheet, &project_name);
-    sch.overwrite()?;
+    commit_edited_sheet_item(&sch_path, &before, &sch, &sheet_uuid, "Edit sheet")?;
     Ok(CallToolResult::json(&json!({
         "edited": sheet_name,
         "changed_fields": changed,
@@ -476,11 +592,13 @@ async fn handle_move_sheet(args: &Value, _ctx: &ToolContext) -> anyhow::Result<C
         Err(e) => return Ok(e),
     };
 
+    let before = read_consistent(&sch_path)?;
     let mut sch = cse::Schematic::load(&sch_path)?;
     match sch.sheets.by_name_mut(&sheet_name) {
         Some(sheet) => {
+            let sheet_uuid = sheet.uuid.clone();
             sheet.move_to(x, y);
-            sch.overwrite()?;
+            commit_edited_sheet_item(&sch_path, &before, &sch, &sheet_uuid, "Move sheet")?;
             Ok(CallToolResult::json(
                 &json!({ "moved": sheet_name, "x": x, "y": y }),
             ))
@@ -499,13 +617,20 @@ async fn handle_delete_sheet(args: &Value, _ctx: &ToolContext) -> anyhow::Result
         Err(e) => return Ok(e),
     };
 
-    let mut sch = cse::Schematic::load(&sch_path)?;
-    match sch.sheets.remove_by_name(&sheet_name) {
+    let before = read_consistent(&sch_path)?;
+    let sch = cse::Schematic::load(&sch_path)?;
+    match sch.sheets.by_name(&sheet_name) {
         Some(removed) => {
-            sch.overwrite()?;
+            let child_file = removed.file().to_owned();
+            let command = SchematicCommand::delete_item(
+                &before,
+                ItemId::new(removed.uuid.clone())?,
+                "Delete sheet",
+            )?;
+            commit_command(&sch_path, &command)?;
             Ok(CallToolResult::json(&json!({
                 "deleted": sheet_name,
-                "child_file_preserved": removed.file(),
+                "child_file_preserved": child_file,
                 "note": "The child schematic file was not deleted. Remaining sheets' page \
                          numbers may now have a gap — call renumber_sheet_pages if needed."
             })))
@@ -538,7 +663,8 @@ async fn handle_duplicate_sheet(
         .map(str::to_string)
         .unwrap_or_else(|| project_name_for(&sch_path));
 
-    let mut parent = cse::Schematic::load(&sch_path)?;
+    let parent_before = read_consistent(&sch_path)?;
+    let parent = cse::Schematic::load(&sch_path)?;
 
     if parent.sheets.by_name(&new_name).is_some() {
         return Ok(CallToolResult::error(format!(
@@ -564,6 +690,20 @@ async fn handle_duplicate_sheet(
     let source_child = dir.join(&src_file);
     let new_child = dir.join(&new_file);
 
+    let relative = Path::new(&new_file);
+    let valid_relative = !relative.is_absolute()
+        && relative
+            .components()
+            .all(|component| matches!(component, std::path::Component::Normal(_)))
+        && relative
+            .extension()
+            .is_some_and(|extension| extension == "kicad_sch");
+    if !valid_relative || !new_child.parent().is_some_and(Path::is_dir) {
+        return Ok(CallToolResult::error(
+            "new_file must be a relative .kicad_sch path in an existing project directory",
+        ));
+    }
+
     if new_child.exists() {
         return Ok(CallToolResult::error(format!(
             "'{}' already exists — pick a different file name, or use add_hierarchical_sheet \
@@ -578,33 +718,65 @@ async fn handle_duplicate_sheet(
         )));
     }
 
-    std::fs::copy(&source_child, &new_child)?;
-
-    // Give the copy its own schematic-level identity so KiCAD doesn't see two
-    // files sharing the same internal UUID.
-    {
-        let mut copied = cse::Schematic::load(&new_child)?;
-        copied.uuid = Some(uuid::Uuid::new_v4().to_string());
-        copied.overwrite()?;
-    }
-
     const DUPLICATE_OFFSET_MM: f64 = 20.0;
     let page = next_free_page(&parent, &project_name).to_string();
-    let mut new_sheet = cse::Sheet::new(
-        new_name.as_str(),
-        new_file.as_str(),
-        src_x + DUPLICATE_OFFSET_MM,
-        src_y + DUPLICATE_OFFSET_MM,
-        src_w,
-        src_h,
-    );
-    let root_path = format!("/{}", ensure_root_uuid(&mut parent));
-    new_sheet.set_page(&project_name, &root_path, &page);
+    let (parent_base, root_uuid) = ensure_source_root_uuid(&parent_before)?;
+    let root_path = format!("/{root_uuid}");
+    let block = format_hierarchical_sheet(HierarchicalSheetSpec {
+        name: &new_name,
+        file: &new_file,
+        x: src_x + DUPLICATE_OFFSET_MM,
+        y: src_y + DUPLICATE_OFFSET_MM,
+        width: src_w,
+        height: src_h,
+        project_name: &project_name,
+        parent_instance_path: &root_path,
+        page: &page,
+    });
+    let parent_command = SchematicCommand::insert_item(
+        &parent_base,
+        block,
+        ItemAnchor::BeforeFooter,
+        "Duplicate hierarchical sheet",
+    )?
+    .requiring_unchanged_document();
+    let sheet_uuid = parent_command
+        .changes
+        .first()
+        .map(|change| change.id.to_string())
+        .ok_or_else(|| anyhow::anyhow!("sheet duplication produced no item change"))?;
+    let (parent_after, _) = prepare_command(&sch_path, &parent_base, &parent_command)?;
 
-    let patched = link_sheet(&mut parent, new_sheet, &new_child, &project_name, true)?;
-    parent.overwrite()?;
+    let source_child_content = read_consistent(&source_child)?;
+    let duplicated_uuid = uuid::Uuid::new_v4().to_string();
+    let duplicated_base = replace_source_root_uuid(&source_child_content, &duplicated_uuid)?;
+    let hierarchy_path = format!("{root_path}/{sheet_uuid}");
+    let (duplicated_after, patched) = if let Some(command) =
+        SchematicCommand::ensure_symbol_instance_path(
+            &duplicated_base,
+            &project_name,
+            &hierarchy_path,
+            "Link duplicated child symbols",
+        )? {
+        let count = command.changes.len();
+        let (after, _) = prepare_command(&new_child, &duplicated_base, &command)?;
+        (after, count)
+    } else {
+        (duplicated_base, 0)
+    };
+    commit_file_transaction(
+        &dir,
+        vec![
+            FileTransition::replace(&sch_path, parent_before, parent_after),
+            FileTransition::create(&new_child, duplicated_after),
+        ],
+    )?;
 
-    let sheet_ref = parent.sheets.by_name(&new_name).expect("just added");
+    let committed = cse::Schematic::load(&sch_path)?;
+    let sheet_ref = committed
+        .sheets
+        .by_name(&new_name)
+        .ok_or_else(|| anyhow::anyhow!("duplicated sheet was not readable"))?;
     Ok(CallToolResult::json(&json!({
         "duplicated_from": source_name,
         "sheet": sheet_json(sheet_ref, &project_name),
@@ -713,24 +885,27 @@ async fn handle_renumber_sheet_pages(
     // Page paths are hierarchical instance paths rooted at the root sheet's
     // UUID ("/<root-uuid>", then "/<root-uuid>/<sheet-uuid>" one level down),
     // matching what eeschema writes.
-    let root_prefix = {
-        let mut root = cse::Schematic::load(&root_path)?;
-        let uuid = ensure_root_uuid(&mut root);
-        root.overwrite()?;
-        format!("/{}", uuid)
-    };
+    let root_before = read_consistent(&root_path)?;
+    let (root_base, root_uuid) = ensure_source_root_uuid(&root_before)?;
+    let root_prefix = format!("/{root_uuid}");
 
     let mut next_page = 2u32; // page 1 is always the root, left untouched
     let mut renumbered = Vec::new();
     let mut visited = HashSet::new();
-    renumber_walk(
+    let mut transitions = Vec::new();
+    collect_renumber_transitions(
         &root_path,
         &root_prefix,
         &project_name,
         &mut next_page,
         &mut renumbered,
         &mut visited,
+        Some((&root_before, &root_base, &root_uuid)),
+        &mut transitions,
     )?;
+    if !transitions.is_empty() {
+        commit_file_transaction(parent_dir(&root_path), transitions)?;
+    }
 
     Ok(CallToolResult::json(&json!({
         "renumbered_count": renumbered.len(),
@@ -738,22 +913,34 @@ async fn handle_renumber_sheet_pages(
     })))
 }
 
-fn renumber_walk(
+#[allow(clippy::too_many_arguments)]
+fn collect_renumber_transitions(
     path: &Path,
     hier_prefix: &str,
     project_name: &str,
     next_page: &mut u32,
     renumbered: &mut Vec<Value>,
     visited: &mut HashSet<PathBuf>,
+    source_override: Option<(&str, &str, &str)>,
+    transitions: &mut Vec<FileTransition>,
 ) -> anyhow::Result<()> {
     let canon = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
     if !visited.insert(canon.clone()) {
         return Ok(()); // cycle guard — already on this DFS path, skip
     }
 
+    let loaded_before = source_override
+        .map(|(before, _, _)| before.to_owned())
+        .unwrap_or(read_consistent(path)?);
+    let command_source = source_override
+        .map(|(_, base, _)| base)
+        .unwrap_or(loaded_before.as_str());
     let mut sch = cse::Schematic::load(path)?;
+    if let Some((_, _, root_uuid)) = source_override {
+        sch.uuid = Some(root_uuid.to_owned());
+    }
     let dir = parent_dir(path);
-    let mut changed = false;
+    let mut changed_ids = Vec::new();
 
     // Snapshot the sheet order first: recursing below needs `sch` unborrowed.
     let sheet_order: Vec<(String, String, String)> = sch
@@ -768,7 +955,7 @@ fn renumber_walk(
         if let Some(sheet) = sch.sheets.by_name_mut(name) {
             if sheet.page(project_name) != Some(page.as_str()) {
                 sheet.set_page(project_name, hier_prefix, &page);
-                changed = true;
+                changed_ids.push(ItemId::new(sheet.uuid.clone())?);
             }
         }
         renumbered.push(json!({ "sheet_name": name, "file": file, "page": page }));
@@ -776,19 +963,32 @@ fn renumber_walk(
         let child_path = dir.join(file);
         if child_path.exists() {
             let child_prefix = format!("{}/{}", hier_prefix, sheet_uuid);
-            renumber_walk(
+            collect_renumber_transitions(
                 &child_path,
                 &child_prefix,
                 project_name,
                 next_page,
                 renumbered,
                 visited,
+                None,
+                transitions,
             )?;
         }
     }
 
-    if changed {
-        sch.overwrite()?;
+    let replacement = if changed_ids.is_empty() {
+        command_source.to_owned()
+    } else {
+        let command = SchematicCommand::replace_items_from_document(
+            command_source,
+            &sch.to_source(),
+            changed_ids,
+            "Renumber hierarchical sheets",
+        )?;
+        prepare_command(path, command_source, &command)?.0
+    };
+    if replacement != loaded_before {
+        transitions.push(FileTransition::replace(path, loaded_before, replacement));
     }
     visited.remove(&canon);
     Ok(())
@@ -811,6 +1011,7 @@ async fn handle_import_sheet_pins(
         )));
     }
 
+    let before = read_consistent(&sch_path)?;
     let mut parent = cse::Schematic::load(&sch_path)?;
     let dir = parent_dir(&sch_path);
 
@@ -850,6 +1051,7 @@ async fn handle_import_sheet_pins(
         .sheets
         .by_name_mut(&sheet_name)
         .expect("looked up above");
+    let sheet_uuid = sheet.uuid.clone();
 
     let edge_x = if side == "right" {
         sheet_x + sheet_w
@@ -880,7 +1082,13 @@ async fn handle_import_sheet_pins(
     }
 
     if !imported.is_empty() {
-        parent.overwrite()?;
+        commit_edited_sheet_item(
+            &sch_path,
+            &before,
+            &parent,
+            &sheet_uuid,
+            "Import sheet pins",
+        )?;
     }
 
     Ok(CallToolResult::json(&json!({
@@ -916,6 +1124,7 @@ async fn handle_add_sheet_pin(args: &Value, _ctx: &ToolContext) -> anyhow::Resul
         Err(e) => return Ok(e),
     };
 
+    let before = read_consistent(&sch_path)?;
     let mut sch = cse::Schematic::load(&sch_path)?;
     let sheet = match sch.sheets.by_name_mut(&sheet_name) {
         Some(s) => s,
@@ -926,6 +1135,7 @@ async fn handle_add_sheet_pin(args: &Value, _ctx: &ToolContext) -> anyhow::Resul
             )))
         }
     };
+    let sheet_uuid = sheet.uuid.clone();
 
     if sheet.pin_by_name(&pin_name).is_some() {
         return Ok(CallToolResult::error(format!(
@@ -940,7 +1150,7 @@ async fn handle_add_sheet_pin(args: &Value, _ctx: &ToolContext) -> anyhow::Resul
         x,
         y,
     ));
-    sch.overwrite()?;
+    commit_edited_sheet_item(&sch_path, &before, &sch, &sheet_uuid, "Add sheet pin")?;
 
     Ok(CallToolResult::json(&json!({
         "added_pin": pin_name,
@@ -967,6 +1177,7 @@ async fn handle_edit_sheet_pin(args: &Value, _ctx: &ToolContext) -> anyhow::Resu
         }
     }
 
+    let before = read_consistent(&sch_path)?;
     let mut sch = cse::Schematic::load(&sch_path)?;
     let sheet = match sch.sheets.by_name_mut(&sheet_name) {
         Some(s) => s,
@@ -977,6 +1188,7 @@ async fn handle_edit_sheet_pin(args: &Value, _ctx: &ToolContext) -> anyhow::Resu
             )))
         }
     };
+    let sheet_uuid = sheet.uuid.clone();
     let pin = match sheet.pin_by_name_mut(&pin_name) {
         Some(p) => p,
         None => {
@@ -1011,7 +1223,7 @@ async fn handle_edit_sheet_pin(args: &Value, _ctx: &ToolContext) -> anyhow::Resu
     let summary = json!({
         "name": pin.name, "pin_type": pin.pin_type, "x": pin.at.x, "y": pin.at.y
     });
-    sch.overwrite()?;
+    commit_edited_sheet_item(&sch_path, &before, &sch, &sheet_uuid, "Edit sheet pin")?;
 
     Ok(CallToolResult::json(&json!({
         "edited_pin": pin_name,
@@ -1035,6 +1247,7 @@ async fn handle_delete_sheet_pin(
         Err(e) => return Ok(e),
     };
 
+    let before = read_consistent(&sch_path)?;
     let mut sch = cse::Schematic::load(&sch_path)?;
     let sheet = match sch.sheets.by_name_mut(&sheet_name) {
         Some(s) => s,
@@ -1045,6 +1258,7 @@ async fn handle_delete_sheet_pin(
             )))
         }
     };
+    let sheet_uuid = sheet.uuid.clone();
 
     if !sheet.remove_pin(&pin_name) {
         return Ok(CallToolResult::error(format!(
@@ -1052,7 +1266,7 @@ async fn handle_delete_sheet_pin(
             pin_name, sheet_name
         )));
     }
-    sch.overwrite()?;
+    commit_edited_sheet_item(&sch_path, &before, &sch, &sheet_uuid, "Delete sheet pin")?;
 
     Ok(CallToolResult::json(&json!({
         "deleted_pin": pin_name,

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -18,7 +18,8 @@ use konnect_sexp::{
     },
     writer::{
         apply_edits, find_balanced_block, find_block_starts, find_block_with_leading_whitespace,
-        find_direct_child_blocks, find_enclosing_block, write_atomic, SexpEdit,
+        find_direct_child_blocks, find_enclosing_block, read_consistent, write_atomic_if_unchanged,
+        SexpEdit,
     },
 };
 use serde_json::json;
@@ -577,7 +578,7 @@ async fn handle_batch_add_wire(
         let (x1, y1) = snap_point(x1, y1, 1.27);
         let (x2, y2) = snap_point(x2, y2, 1.27);
 
-        // T-junction detection for each wire added incrementally
+        // T-junction detection for each wire added incrementally.
         let mut existing_wires = cse_wires_to_sexp(&sch);
         existing_wires.push(konnect_sexp::schematic::Wire {
             x1,
@@ -614,7 +615,8 @@ async fn handle_delete_wire(
     _ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
     let sch_path = get_path(args, "schematic")?;
-    let content = std::fs::read_to_string(&sch_path)?;
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
 
     let delete_range = if let Some(uuid) = opt_str(args, "uuid") {
         let search = format!(r#"(uuid "{uuid}")"#);
@@ -659,7 +661,7 @@ async fn handle_delete_wire(
 
     let edits = vec![SexpEdit::delete(del_start, del_end)];
     let new_content = apply_edits(content, edits);
-    write_atomic(&sch_path, &new_content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
     Ok(CallToolResult::text("Wire deleted."))
 }
 
@@ -675,7 +677,8 @@ async fn handle_batch_delete_wire(
         .filter_map(|v| v.as_str().map(String::from))
         .collect();
 
-    let content = std::fs::read_to_string(&sch_path)?;
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
     let mut errors = Vec::new();
 
     // Collect all delete ranges first, then apply in reverse order
@@ -708,7 +711,7 @@ async fn handle_batch_delete_wire(
         .map(|(s, e)| SexpEdit::delete(s, e))
         .collect();
     let content = apply_edits(content, edits);
-    write_atomic(&sch_path, &content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &content)?;
     Ok(CallToolResult::json(&json!({
         "deleted": deleted,
         "errors": errors
@@ -807,13 +810,14 @@ async fn handle_split_wire_at_point(
         return Ok(delete_result);
     }
 
-    let content = std::fs::read_to_string(&sch_path)?;
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
     let w1 = format_wire(w.x1, w.y1, px, py);
     let w2 = format_wire(px, py, w.x2, w.y2);
     let junc = format_junction(px, py);
     let insert = format!("{w1}{w2}{junc}");
     let new_content = insert_before_close(&content, &insert);
-    write_atomic(&sch_path, &new_content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
 
     Ok(CallToolResult::json(&json!({
         "split_at": { "x": px, "y": py },
@@ -894,7 +898,8 @@ async fn handle_delete_net_label(
         Err(e) => return Ok(e),
     };
 
-    let content = std::fs::read_to_string(&sch_path)?;
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
 
     let labels = find_label_blocks(&content);
     let named: Vec<&LabelBlock> = labels.iter().filter(|l| l.net == net).collect();
@@ -949,7 +954,7 @@ async fn handle_delete_net_label(
     let kind = label.kind;
     let edits = vec![SexpEdit::delete(del_start, del_end)];
     let new_content = apply_edits(content, edits);
-    write_atomic(&sch_path, &new_content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
     Ok(CallToolResult::json(&json!({
         "deleted_label": net,
         "type": kind,
@@ -1037,7 +1042,8 @@ async fn handle_rotate_label(
         Err(e) => return Ok(e),
     };
 
-    let content = std::fs::read_to_string(&sch_path)?;
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
 
     let labels = find_label_blocks(&content);
     let named: Vec<&LabelBlock> = labels.iter().filter(|l| l.net == net).collect();
@@ -1130,7 +1136,7 @@ async fn handle_rotate_label(
     }
 
     let new_content = apply_edits(content, edits);
-    write_atomic(&sch_path, &new_content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
     Ok(CallToolResult::json(&json!({
         "rotated_label": net,
         "type": label.kind,
@@ -1157,7 +1163,8 @@ async fn handle_move_labels_by_offset(
         Err(e) => return Ok(e),
     };
 
-    let content = std::fs::read_to_string(&sch_path)?;
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
     let labels = find_label_blocks(&content);
     let matching: Vec<&LabelBlock> = labels.iter().filter(|l| l.net == net).collect();
     if matching.is_empty() {
@@ -1195,7 +1202,7 @@ async fn handle_move_labels_by_offset(
 
     let moved = edits.len();
     let new_content = apply_edits(content, edits);
-    write_atomic(&sch_path, &new_content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
 
     Ok(CallToolResult::json(
         &json!({ "moved_labels": moved, "net": net }),
@@ -1346,14 +1353,15 @@ async fn handle_delete_no_connect(
         Err(e) => return Ok(e),
     };
 
-    let content = std::fs::read_to_string(&sch_path)?;
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
     let Some((del_start, del_end)) = find_no_connect_block_at(&content, x, y) else {
         return Ok(CallToolResult::error(
             "No-connect not found at that position",
         ));
     };
     let new_content = apply_edits(content, vec![SexpEdit::delete(del_start, del_end)]);
-    write_atomic(&sch_path, &new_content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
     Ok(CallToolResult::text("No-connect deleted."))
 }
 
@@ -1400,7 +1408,8 @@ async fn handle_batch_delete_no_connect(
     // but that handler returns `Ok(CallToolResult::error(..))` when nothing
     // matches, so every failure counted as a success and the tool reported
     // deletions it had not made (#114).
-    let content = std::fs::read_to_string(&sch_path)?;
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
     let mut ranges: Vec<(usize, usize)> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
     for pos in &positions {
@@ -1429,7 +1438,7 @@ async fn handle_batch_delete_no_connect(
         .map(|(s, e)| SexpEdit::delete(s, e))
         .collect();
     let content = apply_edits(content, edits);
-    write_atomic(&sch_path, &content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &content)?;
     Ok(CallToolResult::json(&json!({
         "deleted": deleted,
         "errors": errors
@@ -1586,6 +1595,7 @@ async fn handle_connect_pins(
 
     // Parse the schematic tree
     let (content, tree) = read_schematic(&sch_path)?;
+    let expected = content.clone();
     let instances = extract_symbol_instances(&tree);
     let lib_syms = tree
         .find("lib_symbols")
@@ -1600,7 +1610,7 @@ async fn handle_connect_pins(
     // Route wire(s) between the two pin endpoints
     let new_content = route_between(content, x1, y1, x2, y2);
 
-    write_atomic(&sch_path, &new_content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
 
     Ok(CallToolResult::json(&json!({
         "connected": {
@@ -1667,10 +1677,11 @@ async fn handle_add_schematic_connection(
         Err(e) => return Ok(e),
     };
 
-    let content = std::fs::read_to_string(&sch_path)?;
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
     let content = route_between(content, x1, y1, x2, y2);
 
-    write_atomic(&sch_path, &content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &content)?;
     Ok(CallToolResult::json(&json!({
         "connected": { "from": [x1, y1], "to": [x2, y2] }
     })))

--- a/crates/konnect-core/src/tools/schematic_builder.rs
+++ b/crates/konnect-core/src/tools/schematic_builder.rs
@@ -421,7 +421,11 @@ mod tests {
 
         let error = SchematicBuilder::new().save(&path).unwrap_err();
 
-        assert!(error.to_string().contains("File exists"));
+        assert!(matches!(
+            error.downcast_ref::<konnect_sexp::SexpError>(),
+            Some(konnect_sexp::SexpError::Io(error))
+                if error.kind() == std::io::ErrorKind::AlreadyExists
+        ));
         assert_eq!(std::fs::read_to_string(path).unwrap(), "keep me");
     }
 

--- a/crates/konnect-core/src/tools/schematic_builder.rs
+++ b/crates/konnect-core/src/tools/schematic_builder.rs
@@ -13,13 +13,14 @@
 //!   6. Labels (net_label, global_label, hierarchical_label)
 //!   7. Symbol instances (ALWAYS LAST)
 
-use konnect_sexp::writer::write_atomic;
-use std::path::Path;
+use konnect_sexp::writer::{read_consistent, write_atomic_if_unchanged, write_new_atomic};
+use std::path::{Path, PathBuf};
 use tracing::debug;
 
 /// Structured representation of a .kicad_sch file.
 /// Each section holds raw S-expression strings that are written in order.
 pub struct SchematicBuilder {
+    source_revision: Option<(PathBuf, String)>,
     /// Everything before lib_symbols: version, generator, uuid, paper, title_block
     pub header: String,
     /// Contents inside (lib_symbols ...) — each entry is a complete (symbol "Lib:Name" ...) block
@@ -53,6 +54,7 @@ impl SchematicBuilder {
     pub fn new() -> Self {
         let uuid = konnect_sexp::writer::new_uuid();
         SchematicBuilder {
+            source_revision: None,
             header: format!(
                 "(kicad_sch\n\t(version 20250610)\n\t(generator \"konnect\")\n\t(generator_version \"10.0\")\n\t(uuid \"{}\")\n\t(paper \"A4\")",
                 uuid
@@ -71,13 +73,16 @@ impl SchematicBuilder {
 
     /// Parse an existing .kicad_sch file into structured sections.
     pub fn from_file(path: &Path) -> anyhow::Result<Self> {
-        let content = std::fs::read_to_string(path)?;
-        Self::parse(&content)
+        let content = read_consistent(path)?;
+        let mut builder = Self::parse(&content)?;
+        builder.source_revision = Some((path.to_path_buf(), content));
+        Ok(builder)
     }
 
     /// Parse schematic content into structured sections.
     pub fn parse(content: &str) -> anyhow::Result<Self> {
         let mut builder = SchematicBuilder {
+            source_revision: None,
             header: String::new(),
             lib_symbols: Vec::new(),
             junctions: Vec::new(),
@@ -379,10 +384,17 @@ impl SchematicBuilder {
         out
     }
 
-    /// Write to file atomically (write to .tmp, fsync, rename).
+    /// Save a loaded document with its exact revision precondition, or create a
+    /// new destination without replacing anything already present.
     pub fn save(&self, path: &Path) -> anyhow::Result<()> {
         let content = self.to_string();
-        write_atomic(path, &content)?;
+        if let Some((source_path, expected)) = &self.source_revision {
+            if source_path == path {
+                write_atomic_if_unchanged(path, expected, &content)?;
+                return Ok(());
+            }
+        }
+        write_new_atomic(path, &content)?;
         Ok(())
     }
 }
@@ -399,6 +411,18 @@ mod tests {
         assert!(output.contains("(version 20250610)"));
         assert!(output.contains("(lib_symbols"));
         assert!(output.ends_with(")\n"));
+    }
+
+    #[test]
+    fn new_builder_save_refuses_to_replace_an_existing_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("existing.kicad_sch");
+        std::fs::write(&path, "keep me").unwrap();
+
+        let error = SchematicBuilder::new().save(&path).unwrap_err();
+
+        assert!(error.to_string().contains("File exists"));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "keep me");
     }
 
     #[test]

--- a/crates/konnect-core/src/tools/templates.rs
+++ b/crates/konnect-core/src/tools/templates.rs
@@ -7,7 +7,7 @@
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
 use crate::tools::{get_path, require_str, ToolContext, ToolDef};
-use konnect_sexp::writer::{new_uuid, write_atomic};
+use konnect_sexp::writer::{new_uuid, read_consistent, write_atomic_if_unchanged};
 use serde_json::json;
 use std::path::PathBuf;
 use tracing::{debug, info, warn};
@@ -411,7 +411,8 @@ async fn handle_apply_template(
         }
     };
 
-    let mut content = std::fs::read_to_string(&sch_path)?;
+    let mut content = read_consistent(&sch_path)?;
+    let expected = content.clone();
 
     // Determine starting reference numbers by scanning existing components
     let ref_start = args["ref_start"]
@@ -492,7 +493,7 @@ async fn handle_apply_template(
     }
 
     // Write the updated schematic
-    write_atomic(&sch_path, &content)?;
+    write_atomic_if_unchanged(&sch_path, &expected, &content)?;
 
     info!(
         template_id = %template_id,

--- a/crates/konnect-schematic-editor/src/error.rs
+++ b/crates/konnect-schematic-editor/src/error.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -10,6 +11,9 @@ pub enum Error {
 
     #[error("Missing required field '{0}'")]
     MissingField(&'static str),
+
+    #[error("write conflict: '{0}' changed since it was loaded")]
+    Conflict(PathBuf),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/konnect-schematic-editor/src/schematic/mod.rs
+++ b/crates/konnect-schematic-editor/src/schematic/mod.rs
@@ -6,7 +6,7 @@ pub mod wire;
 
 use std::path::{Path, PathBuf};
 
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::sexp::{atom, parser, qstr, tagged, writer, SexpNode};
 use crate::types::{At, ChangeSet};
 
@@ -67,6 +67,7 @@ impl<'a> LocatedElement<'a> {
 /// ```
 pub struct Schematic {
     filepath: PathBuf,
+    original_source: String,
 
     pub version: Option<u32>,
     pub generator: Option<String>,
@@ -94,21 +95,35 @@ impl Schematic {
 
     pub fn load(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref();
-        let content = std::fs::read_to_string(path).map_err(Error::Io)?;
+        let content = konnect_sexp::read_consistent(path).map_err(map_sexp_error)?;
         let root = parser::parse(&content)?;
-        Self::from_sexp(root, path.to_path_buf())
+        Self::from_sexp(root, path.to_path_buf(), content)
     }
 
-    /// Save to a new file path using atomic write (write to .tmp → fsync → rename).
-    /// This is safe with the Tauri schematic viewer's file-watcher.
+    /// Save to a new file path atomically, refusing to replace an existing file.
+    /// Saving to the loaded path instead performs a revision-checked commit.
     pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
+        let path = path.as_ref();
         let text = writer::write(&self.to_sexp());
-        atomic_write(path.as_ref(), &text)
+        if path == self.filepath {
+            atomic_write_revision(path, &self.original_source, &text)
+        } else {
+            atomic_create(path, &text)
+        }
     }
 
     /// Save back to the original file (atomic write).
     pub fn overwrite(&self) -> Result<()> {
         self.save(&self.filepath)
+    }
+
+    /// Serialize the current in-memory schematic without writing it.
+    ///
+    /// This is intended for revision-aware callers that prepare UUID-targeted
+    /// commands from an edited candidate and commit through `konnect-sexp`.
+    #[must_use]
+    pub fn to_source(&self) -> String {
+        writer::write(&self.to_sexp())
     }
 
     pub fn filepath(&self) -> &Path {
@@ -335,7 +350,7 @@ impl Schematic {
 
     // ---- internal -----------------------------------------------------------
 
-    fn from_sexp(root: SexpNode, filepath: PathBuf) -> Result<Self> {
+    fn from_sexp(root: SexpNode, filepath: PathBuf, original_source: String) -> Result<Self> {
         let mut version = None;
         let mut generator = None;
         let mut generator_version = None;
@@ -416,6 +431,7 @@ impl Schematic {
 
         Ok(Schematic {
             filepath,
+            original_source,
             version,
             generator,
             generator_version,
@@ -536,16 +552,19 @@ fn dist(ax: f64, ay: f64, bx: f64, by: f64) -> f64 {
     (dx * dx + dy * dy).sqrt()
 }
 
-/// Write content to file atomically: write to .tmp → fsync → rename.
-/// This ensures the schematic viewer's file-watcher sees a complete file.
-fn atomic_write(path: &Path, content: &str) -> crate::error::Result<()> {
-    use std::io::Write;
-    let tmp_path = path.with_extension("kicad_sch.tmp");
-    let mut f = std::fs::File::create(&tmp_path).map_err(crate::error::Error::Io)?;
-    f.write_all(content.as_bytes())
-        .map_err(crate::error::Error::Io)?;
-    f.sync_all().map_err(crate::error::Error::Io)?;
-    drop(f);
-    std::fs::rename(&tmp_path, path).map_err(crate::error::Error::Io)?;
-    Ok(())
+/// Create a save-as target atomically without replacing another document.
+fn atomic_create(path: &Path, content: &str) -> crate::error::Result<()> {
+    konnect_sexp::writer::write_new_atomic(path, content).map_err(map_sexp_error)
+}
+
+fn atomic_write_revision(path: &Path, expected: &str, content: &str) -> crate::error::Result<()> {
+    konnect_sexp::writer::write_atomic_if_unchanged(path, expected, content).map_err(map_sexp_error)
+}
+
+fn map_sexp_error(error: konnect_sexp::SexpError) -> crate::error::Error {
+    match error {
+        konnect_sexp::SexpError::Io(error) => crate::error::Error::Io(error),
+        konnect_sexp::SexpError::Conflict { path } => crate::error::Error::Conflict(path),
+        error => crate::error::Error::Io(std::io::Error::other(error)),
+    }
 }

--- a/crates/konnect-schematic-editor/src/schematic/mod.rs
+++ b/crates/konnect-schematic-editor/src/schematic/mod.rs
@@ -5,6 +5,7 @@ pub mod symbol;
 pub mod wire;
 
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use crate::error::Result;
 use crate::sexp::{atom, parser, qstr, tagged, writer, SexpNode};
@@ -67,7 +68,7 @@ impl<'a> LocatedElement<'a> {
 /// ```
 pub struct Schematic {
     filepath: PathBuf,
-    original_source: String,
+    original_source: Mutex<String>,
 
     pub version: Option<u32>,
     pub generator: Option<String>,
@@ -106,7 +107,14 @@ impl Schematic {
         let path = path.as_ref();
         let text = writer::write(&self.to_sexp());
         if path == self.filepath {
-            atomic_write_revision(path, &self.original_source, &text)
+            let mut original_source = self.original_source.lock().map_err(|_| {
+                crate::error::Error::Io(std::io::Error::other(
+                    "schematic revision state is unavailable after a panic",
+                ))
+            })?;
+            atomic_write_revision(path, &original_source, &text)?;
+            *original_source = text;
+            Ok(())
         } else {
             atomic_create(path, &text)
         }
@@ -431,7 +439,7 @@ impl Schematic {
 
         Ok(Schematic {
             filepath,
-            original_source,
+            original_source: Mutex::new(original_source),
             version,
             generator,
             generator_version,

--- a/crates/konnect-schematic-editor/tests/integration.rs
+++ b/crates/konnect-schematic-editor/tests/integration.rs
@@ -1,6 +1,6 @@
 use konnect_schematic_editor::{
     sexp::{parser, writer},
-    Schematic,
+    Error, Schematic,
 };
 
 // ---- S-expression parser round-trip ----------------------------------------
@@ -324,6 +324,46 @@ fn add_label_and_save() {
 
     let sch2 = Schematic::load(tmp.path()).unwrap();
     assert!(sch2.labels.value_contains("GND").len() > 0);
+}
+
+#[test]
+fn overwrite_rejects_a_stale_loaded_revision() {
+    let tmp = fresh_minimal_file();
+    let mut schematic = Schematic::load(tmp.path()).unwrap();
+    let external_revision = minimal_sch().replace("10k", "22k");
+    std::fs::write(tmp.path(), &external_revision).unwrap();
+    schematic
+        .symbols
+        .by_reference_mut("R1")
+        .unwrap()
+        .set_value_str("4.7k");
+
+    let error = schematic.overwrite().unwrap_err();
+
+    assert!(matches!(error, Error::Conflict(_)));
+    assert_eq!(
+        std::fs::read_to_string(tmp.path()).unwrap(),
+        external_revision
+    );
+}
+
+#[test]
+fn save_as_refuses_to_replace_an_existing_document() {
+    let source = fresh_minimal_file();
+    let destination = tempfile::Builder::new()
+        .suffix(".kicad_sch")
+        .tempfile()
+        .expect("create destination");
+    std::fs::write(destination.path(), "keep this document").unwrap();
+    let schematic = Schematic::load(source.path()).unwrap();
+
+    let error = schematic.save(destination.path()).unwrap_err();
+
+    assert!(matches!(error, Error::Io(_)));
+    assert_eq!(
+        std::fs::read_to_string(destination.path()).unwrap(),
+        "keep this document"
+    );
 }
 
 #[test]

--- a/crates/konnect-schematic-editor/tests/integration.rs
+++ b/crates/konnect-schematic-editor/tests/integration.rs
@@ -348,6 +348,61 @@ fn overwrite_rejects_a_stale_loaded_revision() {
 }
 
 #[test]
+fn repeated_overwrites_advance_the_owned_revision_baseline() {
+    let tmp = fresh_minimal_file();
+    let mut schematic = Schematic::load(tmp.path()).unwrap();
+    schematic
+        .symbols
+        .by_reference_mut("R1")
+        .unwrap()
+        .set_value_str("4.7k");
+    schematic.overwrite().unwrap();
+
+    schematic
+        .symbols
+        .by_reference_mut("R1")
+        .unwrap()
+        .set_value_str("1k");
+    schematic.overwrite().unwrap();
+
+    let reloaded = Schematic::load(tmp.path()).unwrap();
+    assert_eq!(
+        reloaded.symbols.by_reference("R1").unwrap().value_str(),
+        Some("1k")
+    );
+}
+
+#[test]
+fn overwrite_still_rejects_an_external_change_after_a_successful_save() {
+    let tmp = fresh_minimal_file();
+    let mut schematic = Schematic::load(tmp.path()).unwrap();
+    schematic
+        .symbols
+        .by_reference_mut("R1")
+        .unwrap()
+        .set_value_str("4.7k");
+    schematic.overwrite().unwrap();
+
+    let external_revision = std::fs::read_to_string(tmp.path())
+        .unwrap()
+        .replace("4.7k", "22k");
+    std::fs::write(tmp.path(), &external_revision).unwrap();
+    schematic
+        .symbols
+        .by_reference_mut("R1")
+        .unwrap()
+        .set_value_str("1k");
+
+    let error = schematic.overwrite().unwrap_err();
+
+    assert!(matches!(error, Error::Conflict(_)));
+    assert_eq!(
+        std::fs::read_to_string(tmp.path()).unwrap(),
+        external_revision
+    );
+}
+
+#[test]
 fn save_as_refuses_to_replace_an_existing_document() {
     let source = fresh_minimal_file();
     let destination = tempfile::Builder::new()

--- a/crates/konnect-sexp/Cargo.toml
+++ b/crates/konnect-sexp/Cargo.toml
@@ -13,8 +13,11 @@ anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
+tempfile = "3"
+dirs.workspace = true
+fs4.workspace = true
+sha2.workspace = true
 
 [dev-dependencies]
 pretty_assertions = "1"
 proptest = "1"
-tempfile = "3"

--- a/crates/konnect-sexp/src/command.rs
+++ b/crates/konnect-sexp/src/command.rs
@@ -1,0 +1,1432 @@
+//! Revision-aware, UUID-targeted schematic edit commands.
+//!
+//! Commands preserve KiCad formatting by replacing only complete top-level
+//! item blocks. Each changed item carries its exact previous block as a
+//! precondition. Consequently, a command prepared against an older document
+//! can be safely rebased when only unrelated items changed, while concurrent
+//! changes to the same item fail explicitly.
+
+use crate::writer::{apply_edits, find_direct_child_blocks, transact_atomic, SexpEdit};
+use crate::{parse_sexp, SexpError, SexpNode};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+const SCHEMATIC_ROOT: &str = "kicad_sch";
+
+/// Stable content identity used to detect whether a command was rebased.
+///
+/// Correctness does not depend on hash uniqueness: item preconditions compare
+/// exact source blocks before every commit. The byte length is included to make
+/// accidental collisions still less likely and useful in diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DocumentRevision {
+    hash: u64,
+    bytes: u64,
+}
+
+impl DocumentRevision {
+    /// Compute a deterministic revision token for `source`.
+    #[must_use]
+    pub fn of(source: &str) -> Self {
+        // FNV-1a is deliberately implemented locally: this token is an
+        // identity hint, not a security boundary, and exact strings remain the
+        // transaction precondition.
+        let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+        for byte in source.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+        Self {
+            hash,
+            bytes: source.len() as u64,
+        }
+    }
+
+    /// Deterministic hash component of this revision.
+    #[must_use]
+    pub fn hash(self) -> u64 {
+        self.hash
+    }
+
+    /// UTF-8 byte length of the document revision.
+    #[must_use]
+    pub fn bytes(self) -> u64 {
+        self.bytes
+    }
+}
+
+impl fmt::Display for DocumentRevision {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{:016x}/{}", self.hash, self.bytes)
+    }
+}
+
+/// UUID of a top-level KiCad schematic item.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ItemId(String);
+
+impl ItemId {
+    /// Construct a non-empty item identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SexpError::InvalidValue`] for an empty or whitespace-only ID.
+    pub fn new(value: impl Into<String>) -> Result<Self, SexpError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(SexpError::InvalidValue(
+                "schematic item UUID cannot be empty".to_owned(),
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    /// Borrow the UUID text.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ItemId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// Stable insertion location for a newly-created or restored item.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum ItemAnchor {
+    /// Insert immediately before another UUID-owned top-level item.
+    Before(ItemId),
+    /// Insert before KiCad's trailing instance tables, preserving the
+    /// conventional top-level item ordering.
+    BeforeFooter,
+    /// Insert after all existing top-level children, before the root closing
+    /// parenthesis.
+    EndOfDocument,
+}
+
+/// One exact top-level item transition within an atomic command.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ItemChange {
+    /// UUID of the affected item.
+    pub id: ItemId,
+    /// Exact block required before applying; `None` requires the item to be
+    /// absent and represents insertion.
+    pub before: Option<String>,
+    /// Replacement block; `None` represents deletion.
+    pub after: Option<String>,
+    /// Location used when `before` is `None`.
+    pub anchor: ItemAnchor,
+}
+
+/// An atomic, invertible group of schematic item changes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SchematicCommand {
+    /// Human-readable operation name for history and conflict UI.
+    pub label: String,
+    /// Document revision on which this command was prepared.
+    pub base_revision: DocumentRevision,
+    /// Refuse to rebase this command over any intervening document change.
+    ///
+    /// Most UUID-owned edits should leave this disabled so disjoint changes
+    /// can merge safely. Enable it when validation depends on document-wide
+    /// invariants such as a unique hierarchical-sheet name or page number.
+    #[serde(default)]
+    pub require_unchanged_document: bool,
+    /// UUID-targeted changes committed as one durable replacement.
+    pub changes: Vec<ItemChange>,
+}
+
+impl SchematicCommand {
+    /// Prepare a command that replaces one existing item block.
+    ///
+    /// # Errors
+    ///
+    /// Fails when the target is absent, the replacement is malformed, or its
+    /// UUID does not match `id`.
+    pub fn replace_item(
+        source: &str,
+        id: ItemId,
+        replacement: impl Into<String>,
+        label: impl Into<String>,
+    ) -> Result<Self, SexpError> {
+        let items = document_items(source)?;
+        let current = require_item(&items, &id)?.source.to_owned();
+        let replacement = replacement.into();
+        require_block_id(&replacement, &id)?;
+        Ok(Self {
+            label: label.into(),
+            base_revision: DocumentRevision::of(source),
+            require_unchanged_document: false,
+            changes: vec![ItemChange {
+                id,
+                before: Some(current),
+                after: Some(replacement),
+                anchor: ItemAnchor::EndOfDocument,
+            }],
+        })
+    }
+
+    /// Prepare a replacement by taking the target block from a fully edited
+    /// document while retaining `source` as the exact item precondition.
+    ///
+    /// This bridges existing format-preserving editors that currently produce
+    /// a complete candidate document into the UUID-targeted transaction model.
+    pub fn replace_item_from_document(
+        source: &str,
+        edited_source: &str,
+        id: ItemId,
+        label: impl Into<String>,
+    ) -> Result<Self, SexpError> {
+        let edited_items = document_items(edited_source)?;
+        let replacement = require_item(&edited_items, &id)?.source.to_owned();
+        Self::replace_item(source, id, replacement, label)
+    }
+
+    /// Prepare one atomic replacement command for several UUID-owned items by
+    /// comparing their blocks in `source` and `edited_source`.
+    pub fn replace_items_from_document(
+        source: &str,
+        edited_source: &str,
+        ids: impl IntoIterator<Item = ItemId>,
+        label: impl Into<String>,
+    ) -> Result<Self, SexpError> {
+        let current_items = document_items(source)?;
+        let edited_items = document_items(edited_source)?;
+        let changes = ids
+            .into_iter()
+            .map(|id| {
+                let before = require_item(&current_items, &id)?.source.to_owned();
+                let after = require_item(&edited_items, &id)?.source.to_owned();
+                Ok(ItemChange {
+                    id,
+                    before: Some(before),
+                    after: Some(after),
+                    anchor: ItemAnchor::EndOfDocument,
+                })
+            })
+            .collect::<Result<Vec<_>, SexpError>>()?;
+        Self::from_changes(source, label, changes)
+    }
+
+    /// Prepare an exact update of an existing `(property "Name" "Value")`
+    /// field on one top-level item.
+    ///
+    /// The surrounding item remains byte-for-byte unchanged, including its
+    /// indentation and unknown child nodes.
+    pub fn set_property(
+        source: &str,
+        id: ItemId,
+        property_name: &str,
+        value: &str,
+        label: impl Into<String>,
+    ) -> Result<Self, SexpError> {
+        let items = document_items(source)?;
+        let item = require_item(&items, &id)?;
+        let node = parse_sexp(item.source)?;
+        let parent = node
+            .head()
+            .ok_or_else(|| SexpError::MissingNode(format!("item {id} type")))?;
+        let property_range = find_direct_child_blocks(item.source, parent)
+            .into_iter()
+            .find(|(start, end)| {
+                parse_sexp(&item.source[*start..*end])
+                    .ok()
+                    .is_some_and(|property| {
+                        property.head() == Some("property")
+                            && property.get(1).and_then(SexpNode::as_str) == Some(property_name)
+                    })
+            })
+            .ok_or_else(|| {
+                SexpError::MissingNode(format!("property {property_name} on item {id}"))
+            })?;
+        let property = &item.source[property_range.0..property_range.1];
+        let strings = quoted_string_contents(property);
+        let value_range = strings.get(1).ok_or_else(|| {
+            SexpError::InvalidValue(format!(
+                "property {property_name} on item {id} has no quoted value"
+            ))
+        })?;
+        let replacement = apply_edits(
+            item.source.to_owned(),
+            vec![SexpEdit::replace(
+                property_range.0 + value_range.0,
+                property_range.0 + value_range.1,
+                escape_quoted(value),
+            )],
+        );
+        Self::replace_item(source, id, replacement, label)
+    }
+
+    /// Ensure every placed symbol carries one hierarchical instance path.
+    ///
+    /// Existing symbol blocks are changed individually, preserving all other
+    /// top-level items byte-for-byte. Returns `None` when every symbol already
+    /// has the requested project/path pair.
+    ///
+    /// # Errors
+    ///
+    /// Fails when a placed symbol lacks a UUID, has malformed instance data,
+    /// or the generated replacements fail command validation.
+    pub fn ensure_symbol_instance_path(
+        source: &str,
+        project_name: &str,
+        path: &str,
+        label: impl Into<String>,
+    ) -> Result<Option<Self>, SexpError> {
+        let items = document_items(source)?;
+        let mut changes = Vec::new();
+        for item in items
+            .iter()
+            .filter(|item| item.kind.as_deref() == Some("symbol"))
+        {
+            let node = parse_sexp(item.source)?;
+            if node.find("lib_id").is_none() || symbol_has_instance_path(&node, project_name, path)
+            {
+                continue;
+            }
+            let id = item.id.clone().ok_or_else(|| {
+                SexpError::MissingNode("placed symbol UUID for instance patch".to_owned())
+            })?;
+            let reference = symbol_property(&node, "Reference").unwrap_or_default();
+            let unit = node
+                .find("unit")
+                .and_then(|unit| unit.get(1))
+                .and_then(SexpNode::as_str)
+                .and_then(|unit| unit.parse::<u32>().ok())
+                .unwrap_or(1);
+            let replacement =
+                insert_symbol_instance_path(item.source, project_name, path, reference, unit)?;
+            changes.push(ItemChange {
+                id,
+                before: Some(item.source.to_owned()),
+                after: Some(replacement),
+                anchor: ItemAnchor::EndOfDocument,
+            });
+        }
+        if changes.is_empty() {
+            return Ok(None);
+        }
+        Self::from_changes(source, label, changes).map(Some)
+    }
+
+    /// Insert one nested pin into a hierarchical sheet as a sheet-item
+    /// replacement command.
+    ///
+    /// # Errors
+    ///
+    /// Fails when the sheet is absent, `pin` is malformed, or another direct
+    /// pin on the sheet already has the same name.
+    pub fn insert_sheet_pin(
+        source: &str,
+        sheet_id: ItemId,
+        pin: &str,
+        label: impl Into<String>,
+    ) -> Result<Self, SexpError> {
+        let items = document_items(source)?;
+        let sheet = require_item(&items, &sheet_id)?;
+        let sheet_node = parse_sexp(sheet.source)?;
+        if sheet_node.head() != Some("sheet") {
+            return Err(SexpError::InvalidValue(format!(
+                "schematic item {sheet_id} is not a sheet"
+            )));
+        }
+        let pin = pin.trim();
+        let pin_node = parse_sexp(pin)?;
+        if pin_node.head() != Some("pin") {
+            return Err(SexpError::InvalidValue(
+                "hierarchical sheet child must be a pin".to_owned(),
+            ));
+        }
+        let pin_name = pin_node
+            .get(1)
+            .and_then(SexpNode::as_str)
+            .ok_or_else(|| SexpError::MissingNode("hierarchical pin name".to_owned()))?;
+        if sheet_node
+            .find_all("pin")
+            .iter()
+            .any(|existing| existing.get(1).and_then(SexpNode::as_str) == Some(pin_name))
+        {
+            return Err(SexpError::InvalidValue(format!(
+                "sheet already has a pin named {pin_name}"
+            )));
+        }
+        let direct = find_direct_child_blocks(sheet.source, "sheet");
+        let anchor = direct
+            .iter()
+            .find_map(|(start, end)| {
+                parse_sexp(&sheet.source[*start..*end])
+                    .ok()
+                    .is_some_and(|node| node.head() == Some("instances"))
+                    .then_some(*start)
+            })
+            .unwrap_or(closing_line_start(sheet.source)?);
+        let line_start = sheet.source[..anchor]
+            .rfind('\n')
+            .map_or(anchor, |newline| newline + 1);
+        let indent = if sheet.source[line_start..anchor]
+            .chars()
+            .all(char::is_whitespace)
+        {
+            line_indent(sheet.source, anchor)
+        } else {
+            "\t".to_owned()
+        };
+        let formatted = pin
+            .lines()
+            .map(|line| format!("{indent}{line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let prefix = if sheet.source[..line_start].ends_with('\n') || line_start == 0 {
+            ""
+        } else {
+            "\n"
+        };
+        let replacement = apply_edits(
+            sheet.source.to_owned(),
+            vec![SexpEdit::insert(
+                line_start,
+                format!("{prefix}{formatted}\n"),
+            )],
+        );
+        Self::replace_item(source, sheet_id, replacement, label)
+    }
+
+    /// Prepare a command that deletes one existing item.
+    ///
+    /// The following UUID-owned item is captured as an insertion anchor so an
+    /// inverse undo restores the original top-level order.
+    pub fn delete_item(
+        source: &str,
+        id: ItemId,
+        label: impl Into<String>,
+    ) -> Result<Self, SexpError> {
+        Self::delete_items(source, [id], label)
+    }
+
+    /// Prepare one atomic deletion for several existing items.
+    ///
+    /// Changes are stored in reverse document order and anchor to the next
+    /// surviving UUID. This lets the inverse restore adjacent deleted items in
+    /// their exact original order without depending on another deleted item.
+    pub fn delete_items(
+        source: &str,
+        ids: impl IntoIterator<Item = ItemId>,
+        label: impl Into<String>,
+    ) -> Result<Self, SexpError> {
+        let items = document_items(source)?;
+        let ids = ids.into_iter().collect::<Vec<_>>();
+        let selected = ids
+            .iter()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
+        if selected.is_empty() {
+            return Err(SexpError::InvalidValue(
+                "delete command needs at least one item UUID".to_owned(),
+            ));
+        }
+        if selected.len() != ids.len() {
+            return Err(SexpError::InvalidValue(
+                "delete command contains a duplicate item UUID".to_owned(),
+            ));
+        }
+        for id in &selected {
+            require_item(&items, id)?;
+        }
+        let changes = items
+            .iter()
+            .enumerate()
+            .rev()
+            .filter_map(|(index, item)| {
+                let id = item.id.as_ref()?;
+                selected.contains(id).then(|| {
+                    let anchor = items[index + 1..]
+                        .iter()
+                        .filter_map(|candidate| candidate.id.as_ref())
+                        .find(|candidate| !selected.contains(*candidate))
+                        .cloned()
+                        .map(ItemAnchor::Before)
+                        .unwrap_or_else(|| {
+                            if items[index + 1..].iter().any(|candidate| {
+                                matches!(
+                                    candidate.kind.as_deref(),
+                                    Some("sheet_instances" | "symbol_instances" | "embedded_fonts")
+                                )
+                            }) {
+                                ItemAnchor::BeforeFooter
+                            } else {
+                                ItemAnchor::EndOfDocument
+                            }
+                        });
+                    ItemChange {
+                        id: id.clone(),
+                        before: Some(item.source.to_owned()),
+                        after: None,
+                        anchor,
+                    }
+                })
+            })
+            .collect();
+        Self::from_changes(source, label, changes)
+    }
+
+    /// Prepare a command that inserts a new UUID-owned top-level item.
+    pub fn insert_item(
+        source: &str,
+        item: impl Into<String>,
+        anchor: ItemAnchor,
+        label: impl Into<String>,
+    ) -> Result<Self, SexpError> {
+        // Inserted formatters commonly include a leading newline/indent for
+        // direct textual insertion. Item preconditions, however, are always
+        // captured from the opening `(` through the matching `)`. Store that
+        // same canonical span so the generated inverse matches exactly.
+        let item = item.into().trim().to_owned();
+        let id = block_id(&item)?
+            .ok_or_else(|| SexpError::MissingNode("inserted schematic item UUID".to_owned()))?;
+        if document_items(source)?
+            .iter()
+            .any(|existing| existing.id.as_ref() == Some(&id))
+        {
+            return Err(SexpError::InvalidValue(format!(
+                "schematic item {id} already exists"
+            )));
+        }
+        Ok(Self {
+            label: label.into(),
+            base_revision: DocumentRevision::of(source),
+            require_unchanged_document: false,
+            changes: vec![ItemChange {
+                id,
+                before: None,
+                after: Some(item),
+                anchor,
+            }],
+        })
+    }
+
+    /// Build an atomic multi-item command from validated transitions.
+    ///
+    /// # Errors
+    ///
+    /// Fails for an empty command, duplicate target UUIDs, no-op transitions,
+    /// or blocks whose direct UUID differs from the change ID.
+    pub fn from_changes(
+        source: &str,
+        label: impl Into<String>,
+        changes: Vec<ItemChange>,
+    ) -> Result<Self, SexpError> {
+        validate_changes(&changes)?;
+        let command = Self {
+            label: label.into(),
+            base_revision: DocumentRevision::of(source),
+            require_unchanged_document: false,
+            changes,
+        };
+        command.validate_against(source)?;
+        Ok(command)
+    }
+
+    /// Require the complete document revision to remain unchanged at commit.
+    ///
+    /// Use this only when the operation depends on a document-wide invariant;
+    /// normal item edits should retain their safe disjoint-rebase behavior.
+    #[must_use]
+    pub fn requiring_unchanged_document(mut self) -> Self {
+        self.require_unchanged_document = true;
+        self
+    }
+
+    fn validate_against(&self, source: &str) -> Result<(), SexpError> {
+        validate_changes(&self.changes)?;
+        let items = document_items(source)?;
+        for change in &self.changes {
+            let current = items
+                .iter()
+                .find(|item| item.id.as_ref() == Some(&change.id));
+            match (&change.before, current) {
+                (Some(expected), Some(item)) if expected == item.source => {}
+                (None, None) => {}
+                (Some(_), None) => return Err(missing_item(&change.id)),
+                (None, Some(_)) => {
+                    return Err(SexpError::InvalidValue(format!(
+                        "schematic item {} already exists",
+                        change.id
+                    )))
+                }
+                (Some(_), Some(_)) => {
+                    return Err(SexpError::InvalidValue(format!(
+                        "schematic item {} does not match its prepared revision",
+                        change.id
+                    )))
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Result of a committed command, including the command used for safe undo.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransactionOutcome {
+    /// Revision actually read while holding the transaction lock.
+    pub previous_revision: DocumentRevision,
+    /// Revision produced by the command.
+    pub revision: DocumentRevision,
+    /// True when unrelated document content changed after command preparation.
+    pub rebased: bool,
+    /// Exact inverse transaction. Committing it performs conflict-safe undo.
+    pub inverse: SchematicCommand,
+}
+
+/// Commit a command under the shared document transaction lock.
+///
+/// Exact per-item preconditions allow safe rebasing over unrelated changes.
+/// Any changed, inserted, or deleted target produces
+/// [`SexpError::ItemConflict`] and leaves the document untouched.
+///
+/// # Errors
+///
+/// Returns an item conflict for a stale target, an invalid-value error for a
+/// malformed command, or an I/O/write conflict from the atomic writer.
+pub fn commit_command(
+    path: impl AsRef<Path>,
+    command: &SchematicCommand,
+) -> Result<TransactionOutcome, SexpError> {
+    let path = path.as_ref().to_path_buf();
+    validate_changes(&command.changes)?;
+    transact_atomic(&path, |current| prepare_command(&path, current, command))
+}
+
+/// Evaluate a command against `current` without writing it.
+///
+/// This exposes the same precondition and inverse-command logic used by
+/// [`commit_command`] for callers that need to include the resulting document
+/// in a durable multi-file transaction.
+///
+/// # Errors
+///
+/// Returns a document or item conflict when the command preconditions do not
+/// match `current`, or an invalid-value error for a malformed command.
+pub fn prepare_command(
+    path: &Path,
+    current: &str,
+    command: &SchematicCommand,
+) -> Result<(String, TransactionOutcome), SexpError> {
+    let previous_revision = DocumentRevision::of(current);
+    if command.require_unchanged_document && previous_revision != command.base_revision {
+        return Err(SexpError::Conflict {
+            path: path.to_path_buf(),
+        });
+    }
+    let items = document_items(current)?;
+    let mut edits = Vec::with_capacity(command.changes.len());
+
+    for change in &command.changes {
+        let found = items
+            .iter()
+            .find(|item| item.id.as_ref() == Some(&change.id));
+        match (&change.before, found) {
+            (Some(expected), Some(item)) if item.source == expected => {
+                let (start, end) = if change.after.is_none() {
+                    deletion_span(current, item.start, item.end)
+                } else {
+                    (item.start, item.end)
+                };
+                edits.push(SexpEdit::replace(
+                    start,
+                    end,
+                    change.after.as_deref().unwrap_or_default(),
+                ));
+            }
+            (None, None) => {
+                let replacement = change.after.as_deref().ok_or_else(|| {
+                    SexpError::InvalidValue(format!(
+                        "item {} cannot be absent before and after a command",
+                        change.id
+                    ))
+                })?;
+                let (offset, prefix, suffix) = insertion_point(current, &items, &change.anchor)?;
+                edits.push(SexpEdit::insert(
+                    offset,
+                    format!("{prefix}{replacement}{suffix}"),
+                ));
+            }
+            (Some(_), None) => {
+                return Err(item_conflict(path, &change.id, "target item was deleted"))
+            }
+            (None, Some(_)) => {
+                return Err(item_conflict(path, &change.id, "target UUID was inserted"))
+            }
+            (Some(_), Some(_)) => {
+                return Err(item_conflict(path, &change.id, "target item was modified"))
+            }
+        }
+    }
+
+    let next = apply_edits(current.to_owned(), edits);
+    let revision = DocumentRevision::of(&next);
+    let inverse = SchematicCommand {
+        label: inverse_label(&command.label),
+        base_revision: revision,
+        require_unchanged_document: false,
+        changes: command
+            .changes
+            .iter()
+            .map(|change| ItemChange {
+                id: change.id.clone(),
+                before: change.after.clone(),
+                after: change.before.clone(),
+                anchor: change.anchor.clone(),
+            })
+            .collect(),
+    };
+    let outcome = TransactionOutcome {
+        previous_revision,
+        revision,
+        rebased: previous_revision != command.base_revision,
+        inverse,
+    };
+    Ok((next, outcome))
+}
+
+#[derive(Debug)]
+struct DocumentItem<'a> {
+    id: Option<ItemId>,
+    kind: Option<String>,
+    start: usize,
+    end: usize,
+    source: &'a str,
+}
+
+fn document_items(source: &str) -> Result<Vec<DocumentItem<'_>>, SexpError> {
+    let ranges = find_direct_child_blocks(source, SCHEMATIC_ROOT);
+    if ranges.is_empty() {
+        return Err(SexpError::MissingNode(SCHEMATIC_ROOT.to_owned()));
+    }
+    ranges
+        .into_iter()
+        .map(|(start, end)| {
+            let block = &source[start..end];
+            let node = parse_sexp(block)?;
+            Ok(DocumentItem {
+                id: node
+                    .find("uuid")
+                    .and_then(|uuid| uuid.get(1))
+                    .and_then(SexpNode::as_str)
+                    .map(|uuid| ItemId::new(uuid.to_owned()))
+                    .transpose()?,
+                kind: node.head().map(ToOwned::to_owned),
+                start,
+                end,
+                source: block,
+            })
+        })
+        .collect()
+}
+
+fn block_id(block: &str) -> Result<Option<ItemId>, SexpError> {
+    let node = parse_sexp(block)?;
+    node.find("uuid")
+        .and_then(|uuid| uuid.get(1))
+        .and_then(SexpNode::as_str)
+        .map(|uuid| ItemId::new(uuid.to_owned()))
+        .transpose()
+}
+
+fn require_block_id(block: &str, expected: &ItemId) -> Result<(), SexpError> {
+    match block_id(block)? {
+        Some(actual) if &actual == expected => Ok(()),
+        Some(actual) => Err(SexpError::InvalidValue(format!(
+            "replacement UUID {actual} does not match target {expected}"
+        ))),
+        None => Err(SexpError::MissingNode(format!(
+            "replacement UUID for {expected}"
+        ))),
+    }
+}
+
+fn require_item<'a>(
+    items: &'a [DocumentItem<'a>],
+    id: &ItemId,
+) -> Result<&'a DocumentItem<'a>, SexpError> {
+    items
+        .iter()
+        .find(|item| item.id.as_ref() == Some(id))
+        .ok_or_else(|| missing_item(id))
+}
+
+fn validate_changes(changes: &[ItemChange]) -> Result<(), SexpError> {
+    if changes.is_empty() {
+        return Err(SexpError::InvalidValue(
+            "schematic command must contain at least one item change".to_owned(),
+        ));
+    }
+    let mut ids = std::collections::HashSet::with_capacity(changes.len());
+    for change in changes {
+        if !ids.insert(&change.id) {
+            return Err(SexpError::InvalidValue(format!(
+                "duplicate schematic command target {}",
+                change.id
+            )));
+        }
+        if change.before == change.after {
+            return Err(SexpError::InvalidValue(format!(
+                "schematic item {} has no effective change",
+                change.id
+            )));
+        }
+        if let Some(before) = &change.before {
+            require_block_id(before, &change.id)?;
+        }
+        if let Some(after) = &change.after {
+            require_block_id(after, &change.id)?;
+        }
+    }
+    Ok(())
+}
+
+fn insertion_point(
+    source: &str,
+    items: &[DocumentItem<'_>],
+    anchor: &ItemAnchor,
+) -> Result<(usize, String, String), SexpError> {
+    match anchor {
+        ItemAnchor::Before(id) => {
+            let item = require_item(items, id)?;
+            let indent = line_indent(source, item.start);
+            Ok((item.start, String::new(), format!("\n{indent}")))
+        }
+        ItemAnchor::BeforeFooter => {
+            if let Some(item) = items.iter().find(|item| {
+                matches!(
+                    item.kind.as_deref(),
+                    Some("sheet_instances" | "symbol_instances" | "embedded_fonts")
+                )
+            }) {
+                let indent = line_indent(source, item.start);
+                Ok((item.start, String::new(), format!("\n{indent}")))
+            } else {
+                insertion_point(source, items, &ItemAnchor::EndOfDocument)
+            }
+        }
+        ItemAnchor::EndOfDocument => {
+            let root_start = crate::writer::find_block_starts(source, SCHEMATIC_ROOT)
+                .into_iter()
+                .next()
+                .ok_or_else(|| SexpError::MissingNode(SCHEMATIC_ROOT.to_owned()))?;
+            let (_, root_end) = crate::writer::find_balanced_block(source, root_start)
+                .ok_or_else(|| SexpError::MissingNode(SCHEMATIC_ROOT.to_owned()))?;
+            let item_indent = items
+                .iter()
+                .find(|item| item.id.is_some())
+                .map_or_else(|| "\t".to_owned(), |item| line_indent(source, item.start));
+            let closing = root_end - 1;
+            let closing_line = source[..closing]
+                .rfind('\n')
+                .map_or(0, |newline| newline + 1);
+            Ok((closing_line, item_indent, "\n".to_owned()))
+        }
+    }
+}
+
+fn deletion_span(source: &str, item_start: usize, item_end: usize) -> (usize, usize) {
+    let line_start = source[..item_start]
+        .rfind('\n')
+        .map_or(0, |newline| newline + 1);
+    let line_end = source[item_end..]
+        .find('\n')
+        .map(|newline| item_end + newline + 1)
+        .unwrap_or(item_end);
+    let before_is_indent = source[line_start..item_start]
+        .chars()
+        .all(char::is_whitespace);
+    let after_content_end = line_end.saturating_sub(usize::from(line_end > item_end));
+    let after_is_indent = source[item_end..after_content_end]
+        .chars()
+        .all(char::is_whitespace);
+    if before_is_indent && after_is_indent {
+        (line_start, line_end)
+    } else {
+        (item_start, item_end)
+    }
+}
+
+fn inverse_label(label: &str) -> String {
+    label
+        .strip_prefix("Undo ")
+        .map_or_else(|| format!("Undo {label}"), ToOwned::to_owned)
+}
+
+fn quoted_string_contents(source: &str) -> Vec<(usize, usize)> {
+    let bytes = source.as_bytes();
+    let mut ranges = Vec::new();
+    let mut start = None;
+    let mut escaped = false;
+    for (index, byte) in bytes.iter().copied().enumerate() {
+        if let Some(content_start) = start {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                ranges.push((content_start, index));
+                start = None;
+            }
+        } else if byte == b'"' {
+            start = Some(index + 1);
+        }
+    }
+    ranges
+}
+
+fn escape_quoted(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\t', "\\t")
+}
+
+fn line_indent(source: &str, offset: usize) -> String {
+    let line_start = source[..offset].rfind('\n').map_or(0, |index| index + 1);
+    source[line_start..offset]
+        .chars()
+        .take_while(|character| character.is_whitespace())
+        .collect()
+}
+
+fn missing_item(id: &ItemId) -> SexpError {
+    SexpError::MissingNode(format!("schematic item {id}"))
+}
+
+fn item_conflict(path: &Path, id: &ItemId, reason: &str) -> SexpError {
+    SexpError::ItemConflict {
+        path: PathBuf::from(path),
+        item: id.to_string(),
+        reason: reason.to_owned(),
+    }
+}
+
+fn symbol_has_instance_path(node: &SexpNode, project_name: &str, path: &str) -> bool {
+    node.find("instances").is_some_and(|instances| {
+        instances.find_all("project").iter().any(|project| {
+            project.get(1).and_then(SexpNode::as_str) == Some(project_name)
+                && project.find_all("path").iter().any(|instance_path| {
+                    instance_path.get(1).and_then(SexpNode::as_str) == Some(path)
+                })
+        })
+    })
+}
+
+fn symbol_property<'a>(node: &'a SexpNode, name: &str) -> Option<&'a str> {
+    node.find_all("property")
+        .into_iter()
+        .find(|property| property.get(1).and_then(SexpNode::as_str) == Some(name))
+        .and_then(|property| property.get(2))
+        .and_then(SexpNode::as_str)
+}
+
+fn insert_symbol_instance_path(
+    symbol: &str,
+    project_name: &str,
+    path: &str,
+    reference: &str,
+    unit: u32,
+) -> Result<String, SexpError> {
+    let direct = find_direct_child_blocks(symbol, "symbol");
+    let instances = direct.iter().find_map(|(start, end)| {
+        parse_sexp(&symbol[*start..*end])
+            .ok()
+            .filter(|node| node.head() == Some("instances"))
+            .map(|_| (*start, *end))
+    });
+    let project_name_escaped = escape_quoted(project_name);
+    let path_escaped = escape_quoted(path);
+    let reference_escaped = escape_quoted(reference);
+
+    if let Some((instances_start, instances_end)) = instances {
+        let instances_source = &symbol[instances_start..instances_end];
+        let projects = find_direct_child_blocks(instances_source, "instances");
+        if let Some((project_start, project_end)) = projects.iter().find_map(|(start, end)| {
+            let node = parse_sexp(&instances_source[*start..*end]).ok()?;
+            (node.head() == Some("project")
+                && node.get(1).and_then(SexpNode::as_str) == Some(project_name))
+            .then_some((*start, *end))
+        }) {
+            let project_source = &instances_source[project_start..project_end];
+            let closing = closing_line_start(project_source)?;
+            let closing_indent = closing_indent(project_source, closing)?;
+            let unit_indent = indentation_unit(closing_indent);
+            let path_indent = format!("{closing_indent}{unit_indent}");
+            let field_indent = format!("{path_indent}{unit_indent}");
+            let prefix = insertion_prefix(project_source, closing);
+            let insertion = format!(
+                "{prefix}{path_indent}(path \"{path_escaped}\"\n{field_indent}(reference \"{reference_escaped}\")\n{field_indent}(unit {unit})\n{path_indent})\n"
+            );
+            return Ok(apply_edits(
+                symbol.to_owned(),
+                vec![SexpEdit::insert(
+                    instances_start + project_start + closing,
+                    insertion,
+                )],
+            ));
+        }
+
+        let closing = closing_line_start(instances_source)?;
+        let closing_indent = closing_indent(instances_source, closing)?;
+        let unit_indent = indentation_unit(closing_indent);
+        let project_indent = format!("{closing_indent}{unit_indent}");
+        let path_indent = format!("{project_indent}{unit_indent}");
+        let field_indent = format!("{path_indent}{unit_indent}");
+        let prefix = insertion_prefix(instances_source, closing);
+        let insertion = format!(
+            "{prefix}{project_indent}(project \"{project_name_escaped}\"\n{path_indent}(path \"{path_escaped}\"\n{field_indent}(reference \"{reference_escaped}\")\n{field_indent}(unit {unit})\n{path_indent})\n{project_indent})\n"
+        );
+        return Ok(apply_edits(
+            symbol.to_owned(),
+            vec![SexpEdit::insert(instances_start + closing, insertion)],
+        ));
+    }
+
+    let closing = closing_line_start(symbol)?;
+    let closing_indent = closing_indent(symbol, closing)?;
+    let unit_indent = indentation_unit(closing_indent);
+    let instances_indent = direct
+        .first()
+        .map(|(start, _)| line_indent(symbol, *start))
+        .unwrap_or_else(|| format!("{closing_indent}{unit_indent}"));
+    let project_indent = format!("{instances_indent}{unit_indent}");
+    let path_indent = format!("{project_indent}{unit_indent}");
+    let field_indent = format!("{path_indent}{unit_indent}");
+    let prefix = insertion_prefix(symbol, closing);
+    let insertion = format!(
+        "{prefix}{instances_indent}(instances\n{project_indent}(project \"{project_name_escaped}\"\n{path_indent}(path \"{path_escaped}\"\n{field_indent}(reference \"{reference_escaped}\")\n{field_indent}(unit {unit})\n{path_indent})\n{project_indent})\n{instances_indent})\n"
+    );
+    Ok(apply_edits(
+        symbol.to_owned(),
+        vec![SexpEdit::insert(closing, insertion)],
+    ))
+}
+
+fn closing_line_start(source: &str) -> Result<usize, SexpError> {
+    let closing = source.rfind(')').ok_or_else(|| {
+        SexpError::InvalidValue("S-expression block has no closing parenthesis".to_owned())
+    })?;
+    let line_start = source[..closing].rfind('\n').map_or(0, |line| line + 1);
+    if source[line_start..closing].chars().all(char::is_whitespace) {
+        Ok(line_start)
+    } else {
+        Ok(closing)
+    }
+}
+
+fn closing_indent(source: &str, line_start: usize) -> Result<&str, SexpError> {
+    let closing = source[line_start..]
+        .find(')')
+        .map(|offset| line_start + offset)
+        .ok_or_else(|| {
+            SexpError::InvalidValue("S-expression block has no closing parenthesis".to_owned())
+        })?;
+    let indent = &source[line_start..closing];
+    if !indent.chars().all(char::is_whitespace) {
+        return Err(SexpError::InvalidValue(
+            "S-expression closing parenthesis is not on its own line".to_owned(),
+        ));
+    }
+    Ok(indent)
+}
+
+fn insertion_prefix(source: &str, offset: usize) -> &'static str {
+    if source[..offset].ends_with('\n') {
+        ""
+    } else {
+        "\n"
+    }
+}
+
+fn indentation_unit(indent: &str) -> &'static str {
+    if indent.is_empty() || indent.contains('\t') {
+        "\t"
+    } else {
+        "  "
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SOURCE: &str = r#"(kicad_sch
+  (version 20250101)
+  (wire (pts (xy 0 0) (xy 10 0)) (uuid "wire-a"))
+  (junction (at 10 0) (uuid "junction-b"))
+  (sheet_instances (path "/" (page "1")))
+)"#;
+
+    fn replace_coordinate(source: &str, id: &str, old: &str, new: &str) -> SchematicCommand {
+        let id = ItemId::new(id).expect("fixture ID is valid");
+        let items = document_items(source).expect("fixture parses");
+        let before = require_item(&items, &id)
+            .expect("fixture item exists")
+            .source;
+        let after = before.replace(old, new);
+        SchematicCommand::replace_item(source, id, after, "Move item")
+            .expect("replacement is valid")
+    }
+
+    #[test]
+    fn document_revision_is_deterministic_and_content_sensitive() {
+        assert_eq!(DocumentRevision::of(SOURCE), DocumentRevision::of(SOURCE));
+        assert_ne!(
+            DocumentRevision::of(SOURCE),
+            DocumentRevision::of(&SOURCE.replace("10 0", "20 0"))
+        );
+    }
+
+    #[test]
+    fn disjoint_stale_commands_rebase_safely() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("design.kicad_sch");
+        std::fs::write(&path, SOURCE).expect("write fixture");
+        let wire = replace_coordinate(SOURCE, "wire-a", "10 0", "20 0");
+        let junction = replace_coordinate(SOURCE, "junction-b", "10 0", "30 0");
+
+        let first = commit_command(&path, &wire).expect("first command commits");
+        let second = commit_command(&path, &junction).expect("disjoint command rebases");
+
+        assert!(!first.rebased);
+        assert!(second.rebased);
+        let result = std::fs::read_to_string(path).expect("read result");
+        assert!(result.contains("(xy 20 0)"));
+        assert!(result.contains("(at 30 0)"));
+    }
+
+    #[test]
+    fn strict_command_refuses_an_unrelated_document_change() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("design.kicad_sch");
+        std::fs::write(&path, SOURCE).expect("write fixture");
+        let strict_insert = SchematicCommand::insert_item(
+            SOURCE,
+            r#"(label "STRICT" (at 5 5 0) (uuid "strict-label"))"#,
+            ItemAnchor::BeforeFooter,
+            "Add document-wide unique item",
+        )
+        .expect("insert prepares")
+        .requiring_unchanged_document();
+        let unrelated = replace_coordinate(SOURCE, "wire-a", "10 0", "20 0");
+
+        commit_command(&path, &unrelated).expect("unrelated command commits");
+        let error = commit_command(&path, &strict_insert).expect_err("strict command conflicts");
+
+        assert!(matches!(error, SexpError::Conflict { .. }));
+        let result = std::fs::read_to_string(path).expect("read result");
+        assert!(result.contains("(xy 20 0)"));
+        assert!(!result.contains("strict-label"));
+    }
+
+    #[test]
+    fn same_item_stale_command_reports_item_conflict() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("design.kicad_sch");
+        std::fs::write(&path, SOURCE).expect("write fixture");
+        let first = replace_coordinate(SOURCE, "wire-a", "10 0", "20 0");
+        let second = replace_coordinate(SOURCE, "wire-a", "10 0", "30 0");
+
+        commit_command(&path, &first).expect("first command commits");
+        let error = commit_command(&path, &second).expect_err("same item must conflict");
+
+        assert!(matches!(error, SexpError::ItemConflict { .. }));
+        assert!(std::fs::read_to_string(path)
+            .expect("read result")
+            .contains("(xy 20 0)"));
+    }
+
+    #[test]
+    fn inverse_command_undoes_without_reverting_unrelated_change() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("design.kicad_sch");
+        std::fs::write(&path, SOURCE).expect("write fixture");
+        let wire = replace_coordinate(SOURCE, "wire-a", "10 0", "20 0");
+        let junction = replace_coordinate(SOURCE, "junction-b", "10 0", "30 0");
+
+        let wire_outcome = commit_command(&path, &wire).expect("wire command commits");
+        commit_command(&path, &junction).expect("junction command rebases");
+        let undo = commit_command(&path, &wire_outcome.inverse).expect("inverse rebases");
+
+        assert!(undo.rebased);
+        let result = std::fs::read_to_string(path).expect("read result");
+        assert!(result.contains("(xy 10 0)"));
+        assert!(result.contains("(at 30 0)"));
+    }
+
+    #[test]
+    fn delete_and_inverse_restore_original_order() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("design.kicad_sch");
+        std::fs::write(&path, SOURCE).expect("write fixture");
+        let command = SchematicCommand::delete_item(
+            SOURCE,
+            ItemId::new("wire-a").expect("valid ID"),
+            "Delete wire",
+        )
+        .expect("delete prepares");
+
+        let outcome = commit_command(&path, &command).expect("delete commits");
+        assert!(!std::fs::read_to_string(&path)
+            .expect("read deleted result")
+            .contains("wire-a"));
+        commit_command(&path, &outcome.inverse).expect("undo delete commits");
+
+        let result = std::fs::read_to_string(path).expect("read restored result");
+        assert_eq!(result, SOURCE);
+        assert!(
+            result.find("wire-a").expect("wire restored")
+                < result.find("junction-b").expect("junction remains")
+        );
+    }
+
+    #[test]
+    fn multi_delete_inverse_restores_adjacent_items_before_footer_in_order() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("design.kicad_sch");
+        std::fs::write(&path, SOURCE).expect("write fixture");
+        let command = SchematicCommand::delete_items(
+            SOURCE,
+            [
+                ItemId::new("wire-a").expect("valid ID"),
+                ItemId::new("junction-b").expect("valid ID"),
+            ],
+            "Delete items",
+        )
+        .expect("multi-delete prepares");
+
+        let outcome = commit_command(&path, &command).expect("multi-delete commits");
+        let deleted = std::fs::read_to_string(&path).expect("read deleted result");
+        assert!(!deleted.contains("wire-a"));
+        assert!(!deleted.contains("junction-b"));
+
+        commit_command(&path, &outcome.inverse).expect("undo multi-delete commits");
+        let restored = std::fs::read_to_string(path).expect("read restored result");
+        assert_eq!(restored, SOURCE);
+        let wire = restored.find("wire-a").expect("wire restored");
+        let junction = restored.find("junction-b").expect("junction restored");
+        let footer = restored.find("sheet_instances").expect("footer remains");
+        assert!(wire < junction && junction < footer);
+    }
+
+    #[test]
+    fn insert_and_inverse_remove_only_inserted_item() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("design.kicad_sch");
+        std::fs::write(&path, SOURCE).expect("write fixture");
+        let inserted = r#"(label "NEW" (at 5 5 0) (uuid "label-c"))"#;
+        let command = SchematicCommand::insert_item(
+            SOURCE,
+            inserted,
+            ItemAnchor::Before(ItemId::new("junction-b").expect("valid ID")),
+            "Add label",
+        )
+        .expect("insert prepares");
+
+        let outcome = commit_command(&path, &command).expect("insert commits");
+        let inserted_source = std::fs::read_to_string(&path).expect("read inserted result");
+        assert!(
+            inserted_source.find("label-c").expect("label inserted")
+                < inserted_source
+                    .find("junction-b")
+                    .expect("junction remains")
+        );
+
+        commit_command(&path, &outcome.inverse).expect("undo insert commits");
+        assert!(!std::fs::read_to_string(path)
+            .expect("read undo result")
+            .contains("label-c"));
+    }
+
+    #[test]
+    fn indented_formatter_insertion_has_an_exact_inverse() {
+        let path = tempfile::NamedTempFile::new().expect("temporary file");
+        std::fs::write(path.path(), SOURCE).expect("write fixture");
+        let command = SchematicCommand::insert_item(
+            SOURCE,
+            "\n  (label \"FORMATTED\" (at 5 5 0) (uuid \"formatted-label\"))\n",
+            ItemAnchor::BeforeFooter,
+            "Add formatted label",
+        )
+        .expect("insert prepares");
+
+        let outcome = commit_command(path.path(), &command).expect("insert commits");
+        commit_command(path.path(), &outcome.inverse).expect("inverse matches inserted block");
+
+        assert_eq!(std::fs::read_to_string(path.path()).unwrap(), SOURCE);
+    }
+
+    #[test]
+    fn end_insertion_uses_sibling_indentation_and_preserves_root_closing_indent() {
+        let command = SchematicCommand::insert_item(
+            SOURCE,
+            r#"(label "END" (at 5 5 0) (uuid "label-end"))"#,
+            ItemAnchor::EndOfDocument,
+            "Add ending label",
+        )
+        .expect("insert prepares");
+        let path = tempfile::NamedTempFile::new().expect("temporary file");
+        std::fs::write(path.path(), SOURCE).expect("write fixture");
+
+        commit_command(path.path(), &command).expect("insert commits");
+
+        let result = std::fs::read_to_string(path.path()).expect("read result");
+        assert!(result.contains("\n  (label \"END\""));
+        assert!(result.ends_with("\n)"));
+        parse_sexp(&result).expect("result remains valid S-expression");
+    }
+
+    #[test]
+    fn property_command_preserves_item_format_and_escapes_value() {
+        let source = r#"(kicad_sch
+	(symbol
+		(lib_id "Device:R")
+		(property "Reference" "R1" (at 1 2 0))
+		(property "Value" "10k" (at 1 3 0))
+		(uuid "symbol-a"))
+)"#;
+        let command = SchematicCommand::set_property(
+            source,
+            ItemId::new("symbol-a").expect("valid ID"),
+            "Value",
+            "4.7k \"precision\"",
+            "Edit value",
+        )
+        .expect("property command prepares");
+        let path = tempfile::NamedTempFile::new().expect("temporary file");
+        std::fs::write(path.path(), source).expect("write fixture");
+
+        let outcome = commit_command(path.path(), &command).expect("property edit commits");
+        let edited = std::fs::read_to_string(path.path()).expect("read edited source");
+        assert!(edited.contains(r#"(property "Value" "4.7k \"precision\"" (at 1 3 0))"#));
+        assert!(edited.contains("\t\t(lib_id \"Device:R\")"));
+
+        commit_command(path.path(), &outcome.inverse).expect("property undo commits");
+        assert_eq!(
+            std::fs::read_to_string(path.path()).expect("read restored source"),
+            source
+        );
+    }
+
+    #[test]
+    fn symbol_instance_patch_is_targeted_parseable_and_idempotent() {
+        let source = r#"(kicad_sch
+	(symbol
+		(lib_id "Device:R")
+		(at 10 20 0)
+		(unit 1)
+		(property "Reference" "R1" (at 10 20 0))
+		(uuid "symbol-a")
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 30 40 0)
+		(unit 2)
+		(property "Reference" "C1" (at 30 40 0))
+		(uuid "symbol-b")
+		(instances
+			(project "other"
+				(path "/other" (reference "C1") (unit 2))
+			)
+		)
+	)
+	(sheet_instances (path "/" (page "1")))
+)"#;
+        let command = SchematicCommand::ensure_symbol_instance_path(
+            source,
+            "demo",
+            "/root/sheet",
+            "Link child symbols",
+        )
+        .expect("patch prepares")
+        .expect("symbols need patching");
+
+        assert_eq!(command.changes.len(), 2);
+        let path = Path::new("child.kicad_sch");
+        let (patched, _) = prepare_command(path, source, &command).expect("patch applies");
+        parse_sexp(&patched).expect("patched schematic parses");
+        assert_eq!(patched.matches("(project \"demo\"").count(), 2);
+        assert_eq!(patched.matches("(path \"/root/sheet\"").count(), 2);
+        assert!(patched.contains("(reference \"R1\")"));
+        assert!(patched.contains("(reference \"C1\")"));
+        assert!(patched.contains("(unit 2)"));
+        assert!(patched.contains("(project \"other\""));
+        assert!(SchematicCommand::ensure_symbol_instance_path(
+            &patched,
+            "demo",
+            "/root/sheet",
+            "Link child symbols",
+        )
+        .expect("idempotence check succeeds")
+        .is_none());
+    }
+
+    #[test]
+    fn nested_sheet_pin_insert_and_inverse_restore_exact_source() {
+        let source = r#"(kicad_sch
+	(uuid "root")
+	(sheet
+		(at 10 20)
+		(size 80 50)
+		(uuid "sheet-a")
+		(instances (project "demo" (path "/root" (page "2"))))
+	)
+)"#;
+        let pin = crate::schematic::format_sheet_pin(
+            "ENABLE",
+            crate::schematic::SheetPinType::Input,
+            90.0,
+            25.4,
+            180.0,
+        );
+        let command = SchematicCommand::insert_sheet_pin(
+            source,
+            ItemId::new("sheet-a").unwrap(),
+            &pin,
+            "Add sheet pin",
+        )
+        .expect("pin command prepares");
+        let file = tempfile::NamedTempFile::new().expect("temporary file");
+        std::fs::write(file.path(), source).expect("write fixture");
+
+        let outcome = commit_command(file.path(), &command).expect("pin commits");
+        let edited = std::fs::read_to_string(file.path()).unwrap();
+        parse_sexp(&edited).expect("edited source parses");
+        assert!(edited.contains("(pin \"ENABLE\" input"));
+        assert!(edited.find("(pin \"ENABLE\"").unwrap() < edited.find("(instances").unwrap());
+        commit_command(file.path(), &outcome.inverse).expect("pin inverse commits");
+        assert_eq!(std::fs::read_to_string(file.path()).unwrap(), source);
+    }
+
+    #[test]
+    fn before_footer_anchor_keeps_items_ahead_of_instance_tables() {
+        let inserted = r#"(label "NEW" (at 5 5 0) (uuid "label-footer"))"#;
+        let command =
+            SchematicCommand::insert_item(SOURCE, inserted, ItemAnchor::BeforeFooter, "Add label")
+                .expect("insert prepares");
+        let path = tempfile::NamedTempFile::new().expect("temporary file");
+        std::fs::write(path.path(), SOURCE).expect("write fixture");
+
+        commit_command(path.path(), &command).expect("insert commits");
+
+        let result = std::fs::read_to_string(path.path()).expect("read result");
+        assert!(
+            result.find("label-footer").expect("label inserted")
+                < result
+                    .find("sheet_instances")
+                    .expect("footer remains present")
+        );
+    }
+}

--- a/crates/konnect-sexp/src/error.rs
+++ b/crates/konnect-sexp/src/error.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -13,4 +14,29 @@ pub enum SexpError {
 
     #[error("Invalid value: {0}")]
     InvalidValue(String),
+
+    /// The document no longer matches the revision the caller edited.
+    ///
+    /// Callers must reload and reapply their operation instead of overwriting
+    /// the newer document.
+    #[error("write conflict: {path} changed since it was read")]
+    Conflict { path: PathBuf },
+
+    /// A revision-aware command found that one of its target items no longer
+    /// matches the exact item revision on which the command was prepared.
+    #[error("item conflict in {path}: {item}: {reason}")]
+    ItemConflict {
+        path: PathBuf,
+        item: String,
+        reason: String,
+    },
+
+    /// A durable multi-file transaction found content that matches neither
+    /// the recorded before image nor the intended replacement.
+    #[error("transaction conflict in {journal}: {path}: {reason}")]
+    TransactionConflict {
+        path: PathBuf,
+        journal: PathBuf,
+        reason: String,
+    },
 }

--- a/crates/konnect-sexp/src/lib.rs
+++ b/crates/konnect-sexp/src/lib.rs
@@ -1,10 +1,25 @@
+pub mod command;
 pub mod error;
 pub mod geometry;
 pub mod parser;
 pub mod schematic;
+pub mod transaction;
 pub mod writer;
 
+pub use command::{
+    commit_command, prepare_command, DocumentRevision, ItemAnchor, ItemChange, ItemId,
+    SchematicCommand, TransactionOutcome,
+};
 pub use error::SexpError;
 pub use geometry::{transform_pin, PinTransform};
 pub use parser::{parse_sexp, SexpNode};
-pub use writer::{apply_edits, write_atomic, SexpEdit};
+pub use transaction::{
+    abandon_file_transaction, commit_file_transaction, inspect_file_transactions,
+    recover_file_transaction, recover_file_transactions, AbandonedTransaction, FileTransition,
+    RecoveryOutcome, TransactionCommit, TransactionStatus, TransactionTargetState,
+    TransactionTargetStatus,
+};
+pub use writer::{
+    apply_edits, read_consistent, transact_atomic, write_atomic, write_atomic_if_unchanged,
+    write_new_atomic, SexpEdit,
+};

--- a/crates/konnect-sexp/src/schematic.rs
+++ b/crates/konnect-sexp/src/schematic.rs
@@ -4,13 +4,23 @@
 
 use crate::geometry::{transform_pin, PinTransform};
 use crate::parser::{parse_sexp, SexpNode};
+use crate::writer::read_consistent;
 use crate::SexpError;
 use std::path::Path;
 
 // ─── Schematic file I/O ───────────────────────────────────────────────────────
 
+/// Create a minimal standalone schematic with a fresh root UUID.
+#[must_use]
+pub fn format_blank_schematic() -> String {
+    format!(
+        "(kicad_sch\n\t(version 20250610)\n\t(generator \"konnect\")\n\t(generator_version \"10.0\")\n\t(uuid \"{}\")\n\t(paper \"A4\")\n\t(lib_symbols\n\t)\n)\n",
+        crate::writer::new_uuid()
+    )
+}
+
 pub fn read_schematic(path: &Path) -> Result<(String, SexpNode), SexpError> {
-    let content = std::fs::read_to_string(path)?;
+    let content = read_consistent(path)?;
     let tree = parse_sexp(&content)?;
     Ok((content, tree))
 }
@@ -52,7 +62,16 @@ pub struct Wire {
 /// Extract all wires from a parsed schematic tree.
 /// Handles both KiCAD 8/9 format `(start)(end)` and KiCAD 10 format `(pts (xy)(xy))`.
 pub fn extract_wires(tree: &SexpNode) -> Vec<Wire> {
-    tree.find_all("wire")
+    extract_schematic_lines(tree, "wire")
+}
+
+/// Extract all bus segments using the same point representation as wires.
+pub fn extract_buses(tree: &SexpNode) -> Vec<Wire> {
+    extract_schematic_lines(tree, "bus")
+}
+
+fn extract_schematic_lines(tree: &SexpNode, kind: &str) -> Vec<Wire> {
+    tree.find_all(kind)
         .iter()
         .filter_map(|node| {
             // Try KiCAD 10 format first: (pts (xy X Y) (xy X Y))
@@ -420,10 +439,17 @@ pub fn find_t_junctions(wires: &[Wire], tol: f64) -> Vec<(f64, f64)> {
 // ─── S-expression formatters for new elements ─────────────────────────────────
 
 pub fn format_wire(x1: f64, y1: f64, x2: f64, y2: f64) -> String {
+    format_schematic_line("wire", x1, y1, x2, y2)
+}
+
+pub fn format_bus(x1: f64, y1: f64, x2: f64, y2: f64) -> String {
+    format_schematic_line("bus", x1, y1, x2, y2)
+}
+
+fn format_schematic_line(kind: &str, x1: f64, y1: f64, x2: f64, y2: f64) -> String {
     let uuid = crate::writer::new_uuid();
     format!(
-        "(wire\n\t\t(pts\n\t\t\t(xy {} {}) (xy {} {})\n\t\t)\n\t\t(stroke\n\t\t\t(width 0)\n\t\t\t(type default)\n\t\t)\n\t\t(uuid \"{}\")\n\t)",
-        x1, y1, x2, y2, uuid
+        "({kind}\n\t\t(pts\n\t\t\t(xy {x1} {y1}) (xy {x2} {y2})\n\t\t)\n\t\t(stroke\n\t\t\t(width 0)\n\t\t\t(type default)\n\t\t)\n\t\t(uuid \"{uuid}\")\n\t)"
     )
 }
 
@@ -434,8 +460,159 @@ pub fn format_junction(x: f64, y: f64) -> String {
     )
 }
 
+pub fn format_no_connect(x: f64, y: f64) -> String {
+    let uuid = crate::writer::new_uuid();
+    format!("\n  (no_connect\n    (at {x} {y})\n    (uuid \"{uuid}\")\n  )")
+}
+
+/// Orientation of a graphical wire-to-bus entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BusEntryDirection {
+    DownRight,
+    DownLeft,
+    UpRight,
+    UpLeft,
+}
+
+impl BusEntryDirection {
+    #[must_use]
+    pub const fn size(self) -> (f64, f64) {
+        match self {
+            Self::DownRight => (2.54, 2.54),
+            Self::DownLeft => (-2.54, 2.54),
+            Self::UpRight => (2.54, -2.54),
+            Self::UpLeft => (-2.54, -2.54),
+        }
+    }
+
+    #[must_use]
+    pub const fn rotated_clockwise(self) -> Self {
+        match self {
+            Self::DownRight => Self::DownLeft,
+            Self::DownLeft => Self::UpLeft,
+            Self::UpLeft => Self::UpRight,
+            Self::UpRight => Self::DownRight,
+        }
+    }
+}
+
+pub fn format_bus_entry(x: f64, y: f64, direction: BusEntryDirection) -> String {
+    let uuid = crate::writer::new_uuid();
+    let (width, height) = direction.size();
+    format!(
+        "\n  (bus_entry\n    (at {x} {y})\n    (size {width} {height})\n    (stroke\n      (width 0)\n      (type default)\n    )\n    (uuid \"{uuid}\")\n  )"
+    )
+}
+
+/// Data required for one parent-side hierarchical sheet reference.
+#[derive(Debug, Clone, Copy)]
+pub struct HierarchicalSheetSpec<'a> {
+    pub name: &'a str,
+    pub file: &'a str,
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    pub project_name: &'a str,
+    pub parent_instance_path: &'a str,
+    pub page: &'a str,
+}
+
+pub fn format_hierarchical_sheet(spec: HierarchicalSheetSpec<'_>) -> String {
+    let uuid = crate::writer::new_uuid();
+    let name = escape_quoted_text(spec.name);
+    let file = escape_quoted_text(spec.file);
+    let project_name = escape_quoted_text(spec.project_name);
+    let parent_instance_path = escape_quoted_text(spec.parent_instance_path);
+    let page = escape_quoted_text(spec.page);
+    let name_y = spec.y - 0.635;
+    let file_y = spec.y + spec.height + 0.635;
+    format!(
+        r#"
+  (sheet
+    (at {x} {y})
+    (size {width} {height})
+    (fields_autoplaced yes)
+    (stroke (width 0.1524) (type solid))
+    (fill (color 0 0 0 0.0))
+    (uuid "{uuid}")
+    (property "Sheetname" "{name}"
+      (at {x} {name_y} 0)
+      (effects (font (size 1.27 1.27)) (justify left bottom))
+    )
+    (property "Sheetfile" "{file}"
+      (at {x} {file_y} 0)
+      (effects (font (size 1.27 1.27)) (justify left top))
+    )
+    (instances
+      (project "{project_name}"
+        (path "{parent_instance_path}" (page "{page}"))
+      )
+    )
+  )"#,
+        x = spec.x,
+        y = spec.y,
+        width = spec.width,
+        height = spec.height,
+    )
+}
+
+/// Electrical direction of a hierarchical-sheet pin.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SheetPinType {
+    Input,
+    Output,
+    Bidirectional,
+    TriState,
+    Passive,
+}
+
+impl SheetPinType {
+    #[must_use]
+    pub const fn keyword(self) -> &'static str {
+        match self {
+            Self::Input => "input",
+            Self::Output => "output",
+            Self::Bidirectional => "bidirectional",
+            Self::TriState => "tri_state",
+            Self::Passive => "passive",
+        }
+    }
+
+    #[must_use]
+    pub const fn next(self) -> Self {
+        match self {
+            Self::Input => Self::Output,
+            Self::Output => Self::Bidirectional,
+            Self::Bidirectional => Self::TriState,
+            Self::TriState => Self::Passive,
+            Self::Passive => Self::Input,
+        }
+    }
+}
+
+pub fn format_sheet_pin(
+    name: &str,
+    pin_type: SheetPinType,
+    x: f64,
+    y: f64,
+    rotation: f64,
+) -> String {
+    let name = escape_quoted_text(name);
+    let uuid = crate::writer::new_uuid();
+    format!(
+        "(pin \"{name}\" {}\n\t(at {x} {y} {rotation})\n\t(uuid \"{uuid}\")\n)",
+        pin_type.keyword()
+    )
+}
+
+fn escape_quoted_text(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
 pub fn format_net_label(net: &str, x: f64, y: f64, rotation: f64) -> String {
     let uuid = crate::writer::new_uuid();
+    let net = escape_quoted_text(net);
     // The tag must be `label`: KiCAD has no `net_label` in its schematic
     // format and refuses to load a file containing one ("Failed to load
     // schematic"), so emitting that made the whole schematic unopenable.
@@ -598,6 +775,86 @@ mod pin_endpoint_tests {
 mod label_tag_tests {
     use super::*;
 
+    #[test]
+    fn format_no_connect_emits_a_parseable_uuid_item() {
+        let sexp = format_no_connect(12.7, 25.4);
+        let tree = parse_sexp(&format!("(kicad_sch{sexp}\n)")).unwrap();
+        let item = tree.find("no_connect").expect("no-connect item");
+        assert_eq!(parse_at(item), Some((12.7, 25.4, 0.0)));
+        assert!(item.find("uuid").is_some());
+    }
+
+    #[test]
+    fn format_bus_entry_uses_typed_direction_and_parseable_geometry() {
+        let sexp = format_bus_entry(10.16, 20.32, BusEntryDirection::UpLeft);
+        let tree = parse_sexp(&format!("(kicad_sch{sexp}\n)")).unwrap();
+        let entry = tree.find("bus_entry").expect("bus entry");
+        assert_eq!(parse_at(entry), Some((10.16, 20.32, 0.0)));
+        let size = entry.find("size").expect("entry size");
+        assert_eq!(size.get_f64(1), Some(-2.54));
+        assert_eq!(size.get_f64(2), Some(-2.54));
+        assert!(entry.find("uuid").is_some());
+    }
+
+    #[test]
+    fn format_bus_emits_a_parseable_uuid_line() {
+        let sexp = format_bus(1.27, 2.54, 25.4, 2.54);
+        let tree = parse_sexp(&format!("(kicad_sch\n\t{sexp}\n)")).unwrap();
+        let bus = tree.find("bus").expect("bus line");
+        assert!(bus.find("pts").is_some());
+        assert!(bus.find("uuid").is_some());
+    }
+
+    #[test]
+    fn format_hierarchical_sheet_positions_fields_and_escapes_metadata() {
+        let sexp = format_hierarchical_sheet(HierarchicalSheetSpec {
+            name: "Power \\\"A\\\"",
+            file: "power_a.kicad_sch",
+            x: 25.4,
+            y: 50.8,
+            width: 76.2,
+            height: 50.8,
+            project_name: "Pack",
+            parent_instance_path: "/root-uuid",
+            page: "2",
+        });
+        let tree = parse_sexp(&format!("(kicad_sch{sexp}\n)")).unwrap();
+        let sheet = tree.find("sheet").expect("sheet");
+        assert_eq!(parse_at(sheet), Some((25.4, 50.8, 0.0)));
+        assert_eq!(sheet.find_all("property").len(), 2);
+        assert!(sheet
+            .find_all("property")
+            .iter()
+            .all(|property| property.find("at").is_some()));
+        assert_eq!(
+            sheet.find_all("property")[0]
+                .get(2)
+                .and_then(SexpNode::as_str),
+            Some("Power \\\"A\\\"")
+        );
+        assert_eq!(
+            sheet
+                .find("instances")
+                .and_then(|instances| instances.find("project"))
+                .and_then(|project| project.find("path"))
+                .and_then(|path| path.find("page"))
+                .and_then(|page| page.get(1))
+                .and_then(SexpNode::as_str),
+            Some("2")
+        );
+    }
+
+    #[test]
+    fn format_sheet_pin_uses_a_typed_direction_and_escapes_its_name() {
+        let source = format_sheet_pin("DATA \"A\"", SheetPinType::Bidirectional, 10.0, 20.0, 180.0);
+        let pin = parse_sexp(&source).expect("sheet pin parses");
+        assert_eq!(pin.head(), Some("pin"));
+        assert_eq!(pin.get(1).and_then(SexpNode::as_str), Some("DATA \"A\""));
+        assert_eq!(pin.get(2).and_then(SexpNode::as_str), Some("bidirectional"));
+        assert_eq!(parse_at(&pin), Some((10.0, 20.0, 180.0)));
+        assert!(pin.find("uuid").is_some());
+    }
+
     /// KiCAD's schematic format has no `net_label` tag — a file containing one
     /// fails to load outright ("Failed to load schematic" from kicad-cli 10.0.3,
     /// verified against a file identical but for this tag). The plain net label
@@ -627,6 +884,13 @@ mod label_tag_tests {
         assert_eq!(labels[0].y, 50.8);
         assert_eq!(labels[0].rotation, 90.0);
         assert!(labels[0].uuid.is_some());
+    }
+
+    #[test]
+    fn format_net_label_escapes_user_text() {
+        let sch = format!("(kicad_sch{}\n)", format_net_label("A\\\"B", 1.0, 2.0, 0.0));
+        let tree = parse_sexp(&sch).expect("escaped label parses");
+        assert_eq!(extract_labels(&tree)[0].net, "A\\\"B");
     }
 
     #[test]

--- a/crates/konnect-sexp/src/transaction.rs
+++ b/crates/konnect-sexp/src/transaction.rs
@@ -795,16 +795,12 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[test]
-    fn transaction_journal_round_trips_a_non_unicode_target_path() {
+    fn non_unicode_journal_fixture(root: &Path) -> (Journal, PathBuf) {
         use std::os::unix::ffi::OsStringExt;
 
-        let directory = tempfile::tempdir().expect("temporary directory");
-        let root = directory.path().canonicalize().unwrap();
         let relative = PathBuf::from(std::ffi::OsString::from_vec(
             b"sheet-\xff.kicad_sch".to_vec(),
         ));
-        let target = root.join(&relative);
         let journal = Journal {
             version: JOURNAL_VERSION,
             id: "non-unicode-fixture".to_owned(),
@@ -814,11 +810,35 @@ mod tests {
                 replacement: "created".to_owned(),
             }],
         };
+        (journal, root.join(relative))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn transaction_journal_codec_round_trips_a_non_unicode_target_path() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let root = directory.path().canonicalize().unwrap();
+        let (journal, _) = non_unicode_journal_fixture(&root);
         let path = journal_path(&root, &journal.id);
         persist_journal(&path, &journal).expect("journal serializes");
 
         let decoded = read_validated_journal(&root, &path).expect("journal deserializes");
-        assert_eq!(decoded.entries[0].path, relative);
+        assert_eq!(decoded.entries[0].path, journal.entries[0].path);
+        remove_journal(&path).unwrap();
+    }
+
+    // Linux filesystems accept arbitrary non-NUL filename bytes. macOS APIs
+    // reject ill-formed UTF-8 with EILSEQ, so only the codec/identity contract
+    // is portable there rather than creation of such a path.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn transaction_recovers_a_non_unicode_target_path_on_linux() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let root = directory.path().canonicalize().unwrap();
+        let (journal, target) = non_unicode_journal_fixture(&root);
+        let path = journal_path(&root, &journal.id);
+        persist_journal(&path, &journal).expect("journal serializes");
+
         recover_file_transaction(&root, &journal.id).expect("non-Unicode recovery commits");
 
         assert_eq!(std::fs::read_to_string(target).unwrap(), "created");

--- a/crates/konnect-sexp/src/transaction.rs
+++ b/crates/konnect-sexp/src/transaction.rs
@@ -1,0 +1,1218 @@
+//! Durable, exact-precondition transactions spanning several project files.
+//!
+//! A write-ahead journal is persisted before the first target is changed. On
+//! restart, recovery rolls the transaction forward only while every target
+//! still equals either its recorded before image or intended replacement.
+//! Divergent content is never overwritten and leaves the journal available for
+//! explicit resolution.
+
+use crate::writer::{
+    open_document_lock, read_string_unlocked, sync_parent_directory, write_atomic_unlocked,
+    write_new_atomic_unlocked,
+};
+use crate::SexpError;
+use fs4::FileExt;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+const JOURNAL_VERSION: u32 = 1;
+const JOURNAL_PREFIX: &str = ".konnect-transaction-";
+const JOURNAL_SUFFIX: &str = ".json";
+
+/// One exact file transition in a durable project transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileTransition {
+    path: PathBuf,
+    expected: Option<String>,
+    replacement: String,
+}
+
+impl FileTransition {
+    /// Replace an existing file only when it still equals `expected`.
+    #[must_use]
+    pub fn replace(
+        path: impl Into<PathBuf>,
+        expected: impl Into<String>,
+        replacement: impl Into<String>,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            expected: Some(expected.into()),
+            replacement: replacement.into(),
+        }
+    }
+
+    /// Create a new file without replacing an existing path.
+    #[must_use]
+    pub fn create(path: impl Into<PathBuf>, replacement: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            expected: None,
+            replacement: replacement.into(),
+        }
+    }
+
+    /// Target path of this transition.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// Result of a successfully committed multi-file transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransactionCommit {
+    /// Stable identifier used by the write-ahead journal.
+    pub id: String,
+    /// Number of files committed.
+    pub files: usize,
+}
+
+/// Result of rolling one persisted transaction forward.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoveryOutcome {
+    /// Stable transaction identifier.
+    pub id: String,
+    /// Files that were still at their before image and were completed.
+    pub completed_files: usize,
+}
+
+/// Current relationship between a transaction target and its journal images.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransactionTargetState {
+    /// The target still matches its recorded before image and can be completed.
+    Pending,
+    /// The target already matches its intended replacement.
+    Applied,
+    /// The target matches neither image and will never be overwritten automatically.
+    Divergent,
+}
+
+/// Redacted status for one target in a persisted transaction journal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransactionTargetStatus {
+    /// Path relative to the inspected project directory.
+    pub path: PathBuf,
+    /// Content relationship without exposing either stored schematic image.
+    pub state: TransactionTargetState,
+}
+
+/// Redacted status for one persisted transaction journal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransactionStatus {
+    /// Stable transaction identifier.
+    pub id: String,
+    /// Active journal path.
+    pub journal: PathBuf,
+    /// Per-target states without journal contents.
+    pub targets: Vec<TransactionTargetStatus>,
+}
+
+/// Result of explicitly abandoning a journal that cannot be recovered safely.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AbandonedTransaction {
+    /// Stable transaction identifier supplied by the caller.
+    pub id: String,
+    /// Former active journal path.
+    pub journal: PathBuf,
+    /// Inactive evidence file retained beside the project.
+    pub abandoned_journal: PathBuf,
+    /// Whether the journal parsed and passed containment validation.
+    pub was_valid: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Journal {
+    version: u32,
+    id: String,
+    entries: Vec<JournalEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct JournalEntry {
+    /// Path relative to the canonical journal directory.
+    #[serde(with = "journal_path_serde")]
+    path: PathBuf,
+    expected: Option<String>,
+    replacement: String,
+}
+
+mod journal_path_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::path::{Path, PathBuf};
+
+    #[derive(Serialize, Deserialize)]
+    struct EncodedPath {
+        encoding: String,
+        hex: String,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StoredPath {
+        Unicode(String),
+        Encoded(EncodedPath),
+    }
+
+    pub fn serialize<S>(path: &Path, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if let Some(path) = path.to_str() {
+            return serializer.serialize_str(path);
+        }
+
+        let (encoding, bytes) = native_bytes(path);
+        EncodedPath {
+            encoding: encoding.to_owned(),
+            hex: encode_hex(&bytes),
+        }
+        .serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match StoredPath::deserialize(deserializer)? {
+            StoredPath::Unicode(path) => Ok(PathBuf::from(path)),
+            StoredPath::Encoded(path) => {
+                let bytes = decode_hex(&path.hex).map_err(serde::de::Error::custom)?;
+                path_from_native_bytes(&path.encoding, bytes).map_err(serde::de::Error::custom)
+            }
+        }
+    }
+
+    fn encode_hex(bytes: &[u8]) -> String {
+        const DIGITS: &[u8; 16] = b"0123456789abcdef";
+        let mut encoded = String::with_capacity(bytes.len() * 2);
+        for byte in bytes {
+            encoded.push(char::from(DIGITS[usize::from(byte >> 4)]));
+            encoded.push(char::from(DIGITS[usize::from(byte & 0x0f)]));
+        }
+        encoded
+    }
+
+    fn decode_hex(encoded: &str) -> Result<Vec<u8>, &'static str> {
+        if !encoded.len().is_multiple_of(2) {
+            return Err("encoded transaction path has an odd number of hex digits");
+        }
+        encoded
+            .as_bytes()
+            .chunks_exact(2)
+            .map(|pair| {
+                let high = hex_digit(pair[0])?;
+                let low = hex_digit(pair[1])?;
+                Ok((high << 4) | low)
+            })
+            .collect()
+    }
+
+    fn hex_digit(byte: u8) -> Result<u8, &'static str> {
+        match byte {
+            b'0'..=b'9' => Ok(byte - b'0'),
+            b'a'..=b'f' => Ok(byte - b'a' + 10),
+            b'A'..=b'F' => Ok(byte - b'A' + 10),
+            _ => Err("encoded transaction path contains a non-hex digit"),
+        }
+    }
+
+    #[cfg(unix)]
+    fn native_bytes(path: &Path) -> (&'static str, Vec<u8>) {
+        use std::os::unix::ffi::OsStrExt;
+        ("unix-bytes-v1", path.as_os_str().as_bytes().to_vec())
+    }
+
+    #[cfg(unix)]
+    fn path_from_native_bytes(encoding: &str, bytes: Vec<u8>) -> Result<PathBuf, String> {
+        use std::os::unix::ffi::OsStringExt;
+        if encoding != "unix-bytes-v1" {
+            return Err(format!(
+                "transaction path encoding '{encoding}' is not supported on this platform"
+            ));
+        }
+        Ok(std::ffi::OsString::from_vec(bytes).into())
+    }
+
+    #[cfg(windows)]
+    fn native_bytes(path: &Path) -> (&'static str, Vec<u8>) {
+        use std::os::windows::ffi::OsStrExt;
+        let bytes = path
+            .as_os_str()
+            .encode_wide()
+            .flat_map(u16::to_le_bytes)
+            .collect();
+        ("windows-wide-le-v1", bytes)
+    }
+
+    #[cfg(windows)]
+    fn path_from_native_bytes(encoding: &str, bytes: Vec<u8>) -> Result<PathBuf, String> {
+        use std::os::windows::ffi::OsStringExt;
+        if encoding != "windows-wide-le-v1" || !bytes.len().is_multiple_of(2) {
+            return Err(format!(
+                "transaction path encoding '{encoding}' is not supported on this platform"
+            ));
+        }
+        let units: Vec<u16> = bytes
+            .chunks_exact(2)
+            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+            .collect();
+        Ok(std::ffi::OsString::from_wide(&units).into())
+    }
+}
+
+/// Commit exact file transitions under one durable write-ahead journal.
+///
+/// Target paths must live inside `journal_directory`. Existing project-local
+/// transaction journals are recovered before a new transaction starts.
+/// Locks are acquired in stable path order to prevent cooperating writers from
+/// deadlocking.
+///
+/// # Errors
+///
+/// Returns a conflict when a target does not match its expected content, a
+/// transaction conflict when recovery encounters divergent content, or an I/O
+/// error when journal or target durability cannot be established.
+pub fn commit_file_transaction(
+    journal_directory: impl AsRef<Path>,
+    transitions: Vec<FileTransition>,
+) -> Result<TransactionCommit, SexpError> {
+    let root = canonical_directory(journal_directory.as_ref())?;
+    recover_file_transactions(&root)?;
+    let entries = normalize_transitions(&root, transitions)?;
+    let id = uuid::Uuid::new_v4().to_string();
+    let journal = Journal {
+        version: JOURNAL_VERSION,
+        id: id.clone(),
+        entries,
+    };
+    let journal_path = journal_path(&root, &id);
+    let _locks = lock_entries(&root, &journal.entries)?;
+    verify_before_images(&root, &journal_path, &journal.entries)?;
+    persist_journal(&journal_path, &journal)?;
+
+    for entry in &journal.entries {
+        apply_entry(&root, entry)?;
+    }
+    verify_after_images(&root, &journal_path, &journal.entries)?;
+    remove_journal(&journal_path)?;
+
+    Ok(TransactionCommit {
+        id,
+        files: journal.entries.len(),
+    })
+}
+
+/// Recover all project-local write-ahead journals in stable filename order.
+///
+/// Recovery is idempotent. Files already at their replacement are left alone;
+/// files still at their before image are completed. Any other content is
+/// preserved and reported as a transaction conflict.
+///
+/// # Errors
+///
+/// Returns a transaction conflict for divergent content, an invalid-value
+/// error for malformed or unsupported journals, or an I/O error.
+pub fn recover_file_transactions(
+    journal_directory: impl AsRef<Path>,
+) -> Result<Vec<RecoveryOutcome>, SexpError> {
+    let root = canonical_directory(journal_directory.as_ref())?;
+    let journals = active_journal_paths(&root)?;
+
+    let mut outcomes = Vec::with_capacity(journals.len());
+    for path in journals {
+        outcomes.push(recover_journal(&root, &path)?);
+    }
+    Ok(outcomes)
+}
+
+/// Inspect every active transaction journal without exposing stored file images.
+///
+/// Target files are locked while each status is sampled. Malformed, unsupported,
+/// or path-unsafe journals return an error rather than being trusted.
+///
+/// # Errors
+///
+/// Returns an invalid-value error for an invalid journal, a transaction error
+/// for unsafe target paths, or an I/O error while reading or locking files.
+pub fn inspect_file_transactions(
+    journal_directory: impl AsRef<Path>,
+) -> Result<Vec<TransactionStatus>, SexpError> {
+    let root = canonical_directory(journal_directory.as_ref())?;
+    let mut journals = active_journal_paths(&root)?;
+    let mut statuses = Vec::with_capacity(journals.len());
+    for path in journals.drain(..) {
+        let journal = read_validated_journal(&root, &path)?;
+        let _locks = lock_entries(&root, &journal.entries)?;
+        statuses.push(inspect_journal(&root, &path, &journal)?);
+    }
+    Ok(statuses)
+}
+
+/// Recover one active transaction selected by its exact journal identifier.
+///
+/// # Errors
+///
+/// Returns an invalid-value error for an unsafe identifier or missing journal,
+/// and otherwise the same errors as [`recover_file_transactions`].
+pub fn recover_file_transaction(
+    journal_directory: impl AsRef<Path>,
+    id: &str,
+) -> Result<RecoveryOutcome, SexpError> {
+    let root = canonical_directory(journal_directory.as_ref())?;
+    validate_transaction_id(id)?;
+    let path = journal_path(&root, id);
+    if !path.is_file() {
+        return Err(SexpError::InvalidValue(format!(
+            "transaction journal '{id}' was not found in {}",
+            root.display()
+        )));
+    }
+    recover_journal(&root, &path)
+}
+
+/// Make one unrecoverable journal inactive without modifying any target file.
+///
+/// Valid journals may be abandoned only when at least one target is divergent;
+/// safely recoverable journals must use [`recover_file_transaction`] instead.
+/// Invalid journals can also be abandoned because their target paths are never
+/// trusted or opened. The journal is retained beside the project with an
+/// `.abandoned.json` suffix for explicit later inspection or deletion.
+///
+/// # Errors
+///
+/// Returns an invalid-value error for an unsafe identifier, missing journal,
+/// safely recoverable journal, or an existing abandoned evidence file.
+pub fn abandon_file_transaction(
+    journal_directory: impl AsRef<Path>,
+    id: &str,
+) -> Result<AbandonedTransaction, SexpError> {
+    let root = canonical_directory(journal_directory.as_ref())?;
+    validate_transaction_id(id)?;
+    let path = journal_path(&root, id);
+    if !path.is_file() {
+        return Err(SexpError::InvalidValue(format!(
+            "transaction journal '{id}' was not found in {}",
+            root.display()
+        )));
+    }
+
+    let mut held_locks = None;
+    let was_valid = match read_validated_journal(&root, &path) {
+        Ok(journal) => {
+            held_locks = Some(lock_entries(&root, &journal.entries)?);
+            let status = inspect_journal(&root, &path, &journal)?;
+            if status
+                .targets
+                .iter()
+                .all(|target| target.state != TransactionTargetState::Divergent)
+            {
+                return Err(SexpError::InvalidValue(format!(
+                    "transaction '{id}' is safely recoverable; run transaction recover instead"
+                )));
+            }
+            true
+        }
+        Err(SexpError::Io(error)) => return Err(SexpError::Io(error)),
+        Err(_) => false,
+    };
+
+    let abandoned_journal = abandoned_journal_path(&root, id);
+    if abandoned_journal.exists() {
+        return Err(SexpError::InvalidValue(format!(
+            "abandoned journal already exists: {}",
+            abandoned_journal.display()
+        )));
+    }
+    std::fs::rename(&path, &abandoned_journal)?;
+    sync_parent_directory(&root)?;
+    drop(held_locks);
+    Ok(AbandonedTransaction {
+        id: id.to_owned(),
+        journal: path,
+        abandoned_journal,
+        was_valid,
+    })
+}
+
+fn recover_journal(root: &Path, journal_path: &Path) -> Result<RecoveryOutcome, SexpError> {
+    let journal = read_validated_journal(root, journal_path)?;
+    let _locks = lock_entries(root, &journal.entries)?;
+    let mut pending = Vec::new();
+    for entry in &journal.entries {
+        let path = root.join(&entry.path);
+        match current_content(&path)? {
+            Some(current) if current == entry.replacement => {}
+            current if current == entry.expected => pending.push(entry),
+            _ => {
+                return Err(transaction_conflict(
+                    journal_path,
+                    &path,
+                    "content matches neither the before image nor replacement",
+                ))
+            }
+        }
+    }
+    for entry in &pending {
+        apply_entry(root, entry)?;
+    }
+    verify_after_images(root, journal_path, &journal.entries)?;
+    remove_journal(journal_path)?;
+    Ok(RecoveryOutcome {
+        id: journal.id,
+        completed_files: pending.len(),
+    })
+}
+
+fn active_journal_paths(root: &Path) -> Result<Vec<PathBuf>, SexpError> {
+    let mut journals = Vec::new();
+    for entry in std::fs::read_dir(root)? {
+        let path = entry?.path();
+        if is_journal_path(&path) {
+            journals.push(path);
+        }
+    }
+    journals.sort();
+    Ok(journals)
+}
+
+fn read_validated_journal(root: &Path, path: &Path) -> Result<Journal, SexpError> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_file() {
+        return Err(SexpError::InvalidValue(format!(
+            "transaction journal must be a regular file, not a symlink or directory: {}",
+            path.display()
+        )));
+    }
+    let source = std::fs::read_to_string(path)?;
+    let journal: Journal = serde_json::from_str(&source).map_err(|error| {
+        SexpError::InvalidValue(format!(
+            "invalid transaction journal {}: {error}",
+            path.display()
+        ))
+    })?;
+    validate_transaction_id(&journal.id)?;
+    if journal_path(root, &journal.id) != path {
+        return Err(SexpError::InvalidValue(format!(
+            "transaction journal ID does not match its filename: {}",
+            path.display()
+        )));
+    }
+    if journal.version != JOURNAL_VERSION {
+        return Err(SexpError::InvalidValue(format!(
+            "unsupported transaction journal version {} in {}",
+            journal.version,
+            path.display()
+        )));
+    }
+    validate_journal_entries(root, &journal.entries)?;
+    Ok(journal)
+}
+
+fn inspect_journal(
+    root: &Path,
+    path: &Path,
+    journal: &Journal,
+) -> Result<TransactionStatus, SexpError> {
+    let mut targets = Vec::with_capacity(journal.entries.len());
+    for entry in &journal.entries {
+        let current = current_content(&root.join(&entry.path))?;
+        let state = if current.as_deref() == Some(entry.replacement.as_str()) {
+            TransactionTargetState::Applied
+        } else if current == entry.expected {
+            TransactionTargetState::Pending
+        } else {
+            TransactionTargetState::Divergent
+        };
+        targets.push(TransactionTargetStatus {
+            path: entry.path.clone(),
+            state,
+        });
+    }
+    Ok(TransactionStatus {
+        id: journal.id.clone(),
+        journal: path.to_path_buf(),
+        targets,
+    })
+}
+
+fn normalize_transitions(
+    root: &Path,
+    transitions: Vec<FileTransition>,
+) -> Result<Vec<JournalEntry>, SexpError> {
+    if transitions.is_empty() {
+        return Err(SexpError::InvalidValue(
+            "file transaction needs at least one transition".to_owned(),
+        ));
+    }
+    let mut seen = HashSet::with_capacity(transitions.len());
+    let mut entries = Vec::with_capacity(transitions.len());
+    for transition in transitions {
+        let relative = normalize_target(root, &transition.path)?;
+        if !seen.insert(relative.clone()) {
+            return Err(SexpError::InvalidValue(format!(
+                "duplicate transaction target {}",
+                transition.path.display()
+            )));
+        }
+        if transition.expected.as_ref() == Some(&transition.replacement) {
+            return Err(SexpError::InvalidValue(format!(
+                "transaction target {} is unchanged",
+                transition.path.display()
+            )));
+        }
+        entries.push(JournalEntry {
+            path: relative,
+            expected: transition.expected,
+            replacement: transition.replacement,
+        });
+    }
+    entries.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(entries)
+}
+
+fn validate_journal_entries(root: &Path, entries: &[JournalEntry]) -> Result<(), SexpError> {
+    if entries.is_empty() {
+        return Err(SexpError::InvalidValue(
+            "transaction journal has no entries".to_owned(),
+        ));
+    }
+    let mut seen = HashSet::with_capacity(entries.len());
+    for entry in entries {
+        let normalized = normalize_target(root, &root.join(&entry.path))?;
+        if normalized != entry.path || !seen.insert(normalized) {
+            return Err(SexpError::InvalidValue(
+                "transaction journal contains an unsafe or duplicate path".to_owned(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn canonical_directory(path: &Path) -> Result<PathBuf, SexpError> {
+    let canonical = path.canonicalize()?;
+    if !canonical.is_dir() {
+        return Err(SexpError::InvalidValue(format!(
+            "transaction journal root is not a directory: {}",
+            path.display()
+        )));
+    }
+    Ok(canonical)
+}
+
+fn normalize_target(root: &Path, path: &Path) -> Result<PathBuf, SexpError> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    };
+    let file_name = absolute.file_name().ok_or_else(|| {
+        SexpError::InvalidValue(format!(
+            "transaction target has no filename: {}",
+            path.display()
+        ))
+    })?;
+    let parent = absolute.parent().ok_or_else(|| {
+        SexpError::InvalidValue(format!(
+            "transaction target has no parent: {}",
+            path.display()
+        ))
+    })?;
+    let canonical_parent = parent.canonicalize()?;
+    if !canonical_parent.starts_with(root) {
+        return Err(SexpError::InvalidValue(format!(
+            "transaction target escapes journal root: {}",
+            path.display()
+        )));
+    }
+    canonical_parent
+        .join(file_name)
+        .strip_prefix(root)
+        .map(Path::to_path_buf)
+        .map_err(|_| {
+            SexpError::InvalidValue(format!(
+                "transaction target escapes journal root: {}",
+                path.display()
+            ))
+        })
+}
+
+fn lock_entries(root: &Path, entries: &[JournalEntry]) -> Result<Vec<std::fs::File>, SexpError> {
+    let mut locks = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let lock = open_document_lock(&root.join(&entry.path))?;
+        <std::fs::File as FileExt>::lock(&lock)?;
+        locks.push(lock);
+    }
+    Ok(locks)
+}
+
+fn verify_before_images(
+    root: &Path,
+    journal: &Path,
+    entries: &[JournalEntry],
+) -> Result<(), SexpError> {
+    for entry in entries {
+        let path = root.join(&entry.path);
+        if current_content(&path)? != entry.expected {
+            return Err(transaction_conflict(
+                journal,
+                &path,
+                "content changed before the transaction committed",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn verify_after_images(
+    root: &Path,
+    journal: &Path,
+    entries: &[JournalEntry],
+) -> Result<(), SexpError> {
+    for entry in entries {
+        let path = root.join(&entry.path);
+        if current_content(&path)?.as_deref() != Some(entry.replacement.as_str()) {
+            return Err(transaction_conflict(
+                journal,
+                &path,
+                "replacement did not remain durable",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn apply_entry(root: &Path, entry: &JournalEntry) -> Result<(), SexpError> {
+    let path = root.join(&entry.path);
+    if entry.expected.is_some() {
+        write_atomic_unlocked(&path, &entry.replacement)
+    } else {
+        write_new_atomic_unlocked(&path, &entry.replacement)
+    }
+}
+
+fn current_content(path: &Path) -> Result<Option<String>, SexpError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(SexpError::InvalidValue(format!(
+                "transaction target must not be a symlink: {}",
+                path.display()
+            )))
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    }
+    match read_string_unlocked(path) {
+        Ok(content) => Ok(Some(content)),
+        Err(SexpError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn persist_journal(path: &Path, journal: &Journal) -> Result<(), SexpError> {
+    let source = serde_json::to_string(journal).map_err(|error| {
+        SexpError::InvalidValue(format!("could not serialize journal: {error}"))
+    })?;
+    write_new_atomic_unlocked(path, &source)
+}
+
+fn remove_journal(path: &Path) -> Result<(), SexpError> {
+    std::fs::remove_file(path)?;
+    sync_parent_directory(path.parent().unwrap_or_else(|| Path::new(".")))
+}
+
+fn journal_path(root: &Path, id: &str) -> PathBuf {
+    root.join(format!("{JOURNAL_PREFIX}{id}{JOURNAL_SUFFIX}"))
+}
+
+fn abandoned_journal_path(root: &Path, id: &str) -> PathBuf {
+    root.join(format!("{JOURNAL_PREFIX}{id}.abandoned{JOURNAL_SUFFIX}"))
+}
+
+fn validate_transaction_id(id: &str) -> Result<(), SexpError> {
+    if id.is_empty()
+        || id.len() > 128
+        || !id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(SexpError::InvalidValue(
+            "transaction ID must contain only ASCII letters, digits, '-' or '_'".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn is_journal_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| {
+            name.strip_prefix(JOURNAL_PREFIX)
+                .and_then(|name| name.strip_suffix(JOURNAL_SUFFIX))
+        })
+        .is_some_and(|id| !id.ends_with(".abandoned") && validate_transaction_id(id).is_ok())
+}
+
+fn transaction_conflict(journal: &Path, path: &Path, reason: &str) -> SexpError {
+    SexpError::TransactionConflict {
+        path: path.to_path_buf(),
+        journal: journal.to_path_buf(),
+        reason: reason.to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schematic::{format_hierarchical_sheet, HierarchicalSheetSpec};
+    use crate::{prepare_command, ItemAnchor, SchematicCommand};
+
+    #[test]
+    fn transaction_replaces_and_creates_files_together() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let parent = directory.path().join("root.kicad_sch");
+        let child = directory.path().join("child.kicad_sch");
+        std::fs::write(&parent, "parent before").expect("write parent");
+
+        let outcome = commit_file_transaction(
+            directory.path(),
+            vec![
+                FileTransition::replace(&parent, "parent before", "parent after"),
+                FileTransition::create(&child, "child after"),
+            ],
+        )
+        .expect("transaction commits");
+
+        assert_eq!(outcome.files, 2);
+        assert_eq!(std::fs::read_to_string(parent).unwrap(), "parent after");
+        assert_eq!(std::fs::read_to_string(child).unwrap(), "child after");
+        assert!(recover_file_transactions(directory.path())
+            .unwrap()
+            .is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn transaction_journal_round_trips_a_non_unicode_target_path() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let root = directory.path().canonicalize().unwrap();
+        let relative = PathBuf::from(std::ffi::OsString::from_vec(
+            b"sheet-\xff.kicad_sch".to_vec(),
+        ));
+        let target = root.join(&relative);
+        let journal = Journal {
+            version: JOURNAL_VERSION,
+            id: "non-unicode-fixture".to_owned(),
+            entries: vec![JournalEntry {
+                path: relative.clone(),
+                expected: None,
+                replacement: "created".to_owned(),
+            }],
+        };
+        let path = journal_path(&root, &journal.id);
+        persist_journal(&path, &journal).expect("journal serializes");
+
+        let decoded = read_validated_journal(&root, &path).expect("journal deserializes");
+        assert_eq!(decoded.entries[0].path, relative);
+        recover_file_transaction(&root, &journal.id).expect("non-Unicode recovery commits");
+
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "created");
+        assert!(recover_file_transactions(directory.path())
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn stale_precondition_changes_nothing_and_leaves_no_journal() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let parent = directory.path().join("root.kicad_sch");
+        let child = directory.path().join("child.kicad_sch");
+        std::fs::write(&parent, "external edit").expect("write parent");
+
+        let error = commit_file_transaction(
+            directory.path(),
+            vec![
+                FileTransition::replace(&parent, "old parent", "new parent"),
+                FileTransition::create(&child, "new child"),
+            ],
+        )
+        .expect_err("stale transaction conflicts");
+
+        assert!(matches!(error, SexpError::TransactionConflict { .. }));
+        assert_eq!(std::fs::read_to_string(parent).unwrap(), "external edit");
+        assert!(!child.exists());
+        assert!(recover_file_transactions(directory.path())
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn recovery_finishes_a_partially_applied_transaction() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let root = directory.path().canonicalize().unwrap();
+        let parent = root.join("root.kicad_sch");
+        let child = root.join("child.kicad_sch");
+        std::fs::write(&parent, "parent after").expect("simulate first write");
+        let journal = Journal {
+            version: JOURNAL_VERSION,
+            id: "crash-fixture".to_owned(),
+            entries: vec![
+                JournalEntry {
+                    path: PathBuf::from("root.kicad_sch"),
+                    expected: Some("parent before".to_owned()),
+                    replacement: "parent after".to_owned(),
+                },
+                JournalEntry {
+                    path: PathBuf::from("child.kicad_sch"),
+                    expected: None,
+                    replacement: "child after".to_owned(),
+                },
+            ],
+        };
+        let journal_path = journal_path(&root, &journal.id);
+        persist_journal(&journal_path, &journal).expect("persist crash journal");
+
+        let outcomes = recover_file_transactions(&root).expect("recovery succeeds");
+
+        assert_eq!(outcomes[0].completed_files, 1);
+        assert_eq!(std::fs::read_to_string(parent).unwrap(), "parent after");
+        assert_eq!(std::fs::read_to_string(child).unwrap(), "child after");
+        assert!(!journal_path.exists());
+    }
+
+    #[test]
+    fn recovery_preserves_divergent_content_and_journal() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let root = directory.path().canonicalize().unwrap();
+        let parent = root.join("root.kicad_sch");
+        std::fs::write(&parent, "external edit").expect("write divergence");
+        let journal = Journal {
+            version: JOURNAL_VERSION,
+            id: "conflict-fixture".to_owned(),
+            entries: vec![JournalEntry {
+                path: PathBuf::from("root.kicad_sch"),
+                expected: Some("parent before".to_owned()),
+                replacement: "parent after".to_owned(),
+            }],
+        };
+        let journal_path = journal_path(&root, &journal.id);
+        persist_journal(&journal_path, &journal).expect("persist crash journal");
+
+        let error = recover_file_transactions(&root).expect_err("divergence conflicts");
+
+        assert!(matches!(error, SexpError::TransactionConflict { .. }));
+        assert_eq!(std::fs::read_to_string(parent).unwrap(), "external edit");
+        assert!(journal_path.exists());
+    }
+
+    #[test]
+    fn inspection_reports_redacted_target_states() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let root = directory.path().canonicalize().unwrap();
+        std::fs::write(root.join("pending.kicad_sch"), "before").unwrap();
+        std::fs::write(root.join("applied.kicad_sch"), "after").unwrap();
+        std::fs::write(root.join("divergent.kicad_sch"), "external").unwrap();
+        let journal = Journal {
+            version: JOURNAL_VERSION,
+            id: "inspection-fixture".to_owned(),
+            entries: vec![
+                JournalEntry {
+                    path: PathBuf::from("pending.kicad_sch"),
+                    expected: Some("before".to_owned()),
+                    replacement: "after".to_owned(),
+                },
+                JournalEntry {
+                    path: PathBuf::from("applied.kicad_sch"),
+                    expected: Some("before".to_owned()),
+                    replacement: "after".to_owned(),
+                },
+                JournalEntry {
+                    path: PathBuf::from("divergent.kicad_sch"),
+                    expected: Some("before".to_owned()),
+                    replacement: "after".to_owned(),
+                },
+            ],
+        };
+        persist_journal(&journal_path(&root, &journal.id), &journal).unwrap();
+
+        let statuses = inspect_file_transactions(&root).unwrap();
+
+        assert_eq!(statuses.len(), 1);
+        let states: Vec<_> = statuses[0]
+            .targets
+            .iter()
+            .map(|target| target.state)
+            .collect();
+        assert_eq!(
+            states,
+            [
+                TransactionTargetState::Pending,
+                TransactionTargetState::Applied,
+                TransactionTargetState::Divergent,
+            ]
+        );
+    }
+
+    #[test]
+    fn targeted_recovery_only_recovers_the_selected_journal() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let root = directory.path().canonicalize().unwrap();
+        for id in ["first", "second"] {
+            let target = format!("{id}.kicad_sch");
+            std::fs::write(root.join(&target), "before").unwrap();
+            let journal = Journal {
+                version: JOURNAL_VERSION,
+                id: id.to_owned(),
+                entries: vec![JournalEntry {
+                    path: PathBuf::from(&target),
+                    expected: Some("before".to_owned()),
+                    replacement: "after".to_owned(),
+                }],
+            };
+            persist_journal(&journal_path(&root, id), &journal).unwrap();
+        }
+
+        recover_file_transaction(&root, "first").unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(root.join("first.kicad_sch")).unwrap(),
+            "after"
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.join("second.kicad_sch")).unwrap(),
+            "before"
+        );
+        assert!(!journal_path(&root, "first").exists());
+        assert!(journal_path(&root, "second").exists());
+    }
+
+    #[test]
+    fn abandon_unwedges_a_divergent_transaction_without_touching_targets() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let root = directory.path().canonicalize().unwrap();
+        let target = root.join("root.kicad_sch");
+        std::fs::write(&target, "external edit").unwrap();
+        let journal = Journal {
+            version: JOURNAL_VERSION,
+            id: "abandon-fixture".to_owned(),
+            entries: vec![JournalEntry {
+                path: PathBuf::from("root.kicad_sch"),
+                expected: Some("before".to_owned()),
+                replacement: "after".to_owned(),
+            }],
+        };
+        persist_journal(&journal_path(&root, &journal.id), &journal).unwrap();
+
+        let outcome = abandon_file_transaction(&root, &journal.id).unwrap();
+
+        assert!(outcome.was_valid);
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "external edit");
+        assert!(!outcome.journal.exists());
+        assert!(outcome.abandoned_journal.exists());
+        assert!(recover_file_transactions(&root).unwrap().is_empty());
+    }
+
+    #[test]
+    fn abandon_refuses_a_safely_recoverable_transaction() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let root = directory.path().canonicalize().unwrap();
+        std::fs::write(root.join("root.kicad_sch"), "before").unwrap();
+        let journal = Journal {
+            version: JOURNAL_VERSION,
+            id: "recoverable-fixture".to_owned(),
+            entries: vec![JournalEntry {
+                path: PathBuf::from("root.kicad_sch"),
+                expected: Some("before".to_owned()),
+                replacement: "after".to_owned(),
+            }],
+        };
+        let path = journal_path(&root, &journal.id);
+        persist_journal(&path, &journal).unwrap();
+
+        let error = abandon_file_transaction(&root, &journal.id).unwrap_err();
+
+        assert!(matches!(error, SexpError::InvalidValue(_)));
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn forceful_abandonment_can_quarantine_a_malformed_journal() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let root = directory.path().canonicalize().unwrap();
+        let path = journal_path(&root, "malformed-fixture");
+        std::fs::write(&path, "not json").unwrap();
+
+        let outcome = abandon_file_transaction(&root, "malformed-fixture").unwrap();
+
+        assert!(!outcome.was_valid);
+        assert!(!path.exists());
+        assert!(outcome.abandoned_journal.exists());
+        assert!(recover_file_transactions(&root).unwrap().is_empty());
+    }
+
+    #[test]
+    fn transaction_rejects_targets_outside_the_journal_root() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let outside = tempfile::tempdir().expect("outside directory");
+        let target = outside.path().join("outside.kicad_sch");
+
+        let error = commit_file_transaction(
+            directory.path(),
+            vec![FileTransition::create(target, "content")],
+        )
+        .expect_err("outside target rejected");
+
+        assert!(matches!(error, SexpError::InvalidValue(_)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn recovery_rejects_a_symlink_target_without_touching_its_destination() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let root = directory.path().canonicalize().unwrap();
+        let outside = tempfile::NamedTempFile::new().expect("outside file");
+        std::fs::write(outside.path(), "outside before").unwrap();
+        symlink(outside.path(), root.join("linked.kicad_sch")).unwrap();
+        let journal = Journal {
+            version: JOURNAL_VERSION,
+            id: "symlink-target".to_owned(),
+            entries: vec![JournalEntry {
+                path: PathBuf::from("linked.kicad_sch"),
+                expected: Some("outside before".to_owned()),
+                replacement: "outside after".to_owned(),
+            }],
+        };
+        let path = journal_path(&root, &journal.id);
+        persist_journal(&path, &journal).unwrap();
+
+        let error = recover_file_transaction(&root, &journal.id).unwrap_err();
+
+        assert!(matches!(error, SexpError::InvalidValue(_)));
+        assert_eq!(
+            std::fs::read_to_string(outside.path()).unwrap(),
+            "outside before"
+        );
+        assert!(path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_journal_is_not_followed_and_can_be_quarantined() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let root = directory.path().canonicalize().unwrap();
+        let outside = tempfile::NamedTempFile::new().expect("outside journal");
+        std::fs::write(outside.path(), "private outside content").unwrap();
+        let path = journal_path(&root, "symlink-journal");
+        symlink(outside.path(), &path).unwrap();
+
+        let error = inspect_file_transactions(&root).unwrap_err();
+        assert!(matches!(error, SexpError::InvalidValue(_)));
+
+        let outcome = abandon_file_transaction(&root, "symlink-journal").unwrap();
+        assert!(!outcome.was_valid);
+        assert_eq!(
+            std::fs::read_to_string(outside.path()).unwrap(),
+            "private outside content"
+        );
+        assert!(outcome.abandoned_journal.is_symlink());
+    }
+
+    #[test]
+    fn hierarchy_link_and_inverse_restore_both_files_exactly() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let parent = directory.path().join("root.kicad_sch");
+        let child = directory.path().join("child.kicad_sch");
+        let parent_before = r#"(kicad_sch
+	(version 20250101)
+	(uuid "root-uuid")
+	(sheet_instances (path "/" (page "1")))
+)"#;
+        let child_before = r#"(kicad_sch
+	(version 20250101)
+	(uuid "child-root")
+	(symbol
+		(lib_id "Device:R")
+		(at 10 20 0)
+		(unit 1)
+		(property "Reference" "R1" (at 10 20 0))
+		(uuid "child-symbol")
+	)
+)"#;
+        std::fs::write(&parent, parent_before).expect("write parent");
+        std::fs::write(&child, child_before).expect("write child");
+        let sheet_block = format_hierarchical_sheet(HierarchicalSheetSpec {
+            name: "Child",
+            file: "child.kicad_sch",
+            x: 20.0,
+            y: 30.0,
+            width: 80.0,
+            height: 50.0,
+            project_name: "demo",
+            parent_instance_path: "/root-uuid",
+            page: "2",
+        });
+        let parent_command = SchematicCommand::insert_item(
+            parent_before,
+            sheet_block,
+            ItemAnchor::BeforeFooter,
+            "Link child",
+        )
+        .expect("parent command prepares")
+        .requiring_unchanged_document();
+        let sheet_id = parent_command.changes[0].id.to_string();
+        let child_command = SchematicCommand::ensure_symbol_instance_path(
+            child_before,
+            "demo",
+            &format!("/root-uuid/{sheet_id}"),
+            "Link child symbols",
+        )
+        .expect("child command prepares")
+        .expect("child needs patching");
+        let (parent_after, parent_outcome) =
+            prepare_command(&parent, parent_before, &parent_command).expect("parent applies");
+        let (child_after, child_outcome) =
+            prepare_command(&child, child_before, &child_command).expect("child applies");
+
+        commit_file_transaction(
+            directory.path(),
+            vec![
+                FileTransition::replace(&parent, parent_before, &parent_after),
+                FileTransition::replace(&child, child_before, &child_after),
+            ],
+        )
+        .expect("link transaction commits");
+
+        let (parent_restored, _) = prepare_command(
+            &parent,
+            &std::fs::read_to_string(&parent).unwrap(),
+            &parent_outcome.inverse,
+        )
+        .expect("parent inverse applies");
+        let (child_restored, _) = prepare_command(
+            &child,
+            &std::fs::read_to_string(&child).unwrap(),
+            &child_outcome.inverse,
+        )
+        .expect("child inverse applies");
+        commit_file_transaction(
+            directory.path(),
+            vec![
+                FileTransition::replace(&parent, &parent_after, parent_restored),
+                FileTransition::replace(&child, &child_after, child_restored),
+            ],
+        )
+        .expect("inverse transaction commits");
+
+        assert_eq!(std::fs::read_to_string(parent).unwrap(), parent_before);
+        assert_eq!(std::fs::read_to_string(child).unwrap(), child_before);
+    }
+}

--- a/crates/konnect-sexp/src/writer.rs
+++ b/crates/konnect-sexp/src/writer.rs
@@ -22,6 +22,7 @@
 use crate::SexpError;
 use fs4::FileExt;
 use sha2::{Digest, Sha256};
+use std::ffi::OsStr;
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -197,12 +198,37 @@ pub(crate) fn read_string_unlocked(path: &Path) -> Result<String, SexpError> {
 
 pub(crate) fn open_document_lock(path: &Path) -> Result<std::fs::File, SexpError> {
     let lock_path = document_lock_path(path)?;
-    Ok(OpenOptions::new()
+    open_lock_file(&lock_path)
+}
+
+fn open_lock_file(lock_path: &Path) -> Result<std::fs::File, SexpError> {
+    reject_non_file_lock_path(lock_path)?;
+    let lock = OpenOptions::new()
         .create(true)
         .read(true)
         .write(true)
         .truncate(false)
-        .open(lock_path)?)
+        .open(lock_path)?;
+    reject_non_file_lock_path(lock_path)?;
+    if !lock.metadata()?.is_file() {
+        return Err(SexpError::InvalidValue(format!(
+            "document lock is not a regular file: {}",
+            lock_path.display()
+        )));
+    }
+    Ok(lock)
+}
+
+fn reject_non_file_lock_path(path: &Path) -> Result<(), SexpError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if !metadata.file_type().is_file() => Err(SexpError::InvalidValue(format!(
+            "document lock must be a regular file, not a symlink or directory: {}",
+            path.display()
+        ))),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
 }
 
 fn document_lock_path(path: &Path) -> Result<PathBuf, SexpError> {
@@ -237,18 +263,46 @@ fn document_lock_path_in(state_root: &Path, path: &Path) -> Result<PathBuf, Sexp
 
     let lock_directory = state_root.join("locks");
     std::fs::create_dir_all(&lock_directory)?;
+    let lock_directory_metadata = std::fs::symlink_metadata(&lock_directory)?;
+    if !lock_directory_metadata.file_type().is_dir() {
+        return Err(SexpError::InvalidValue(format!(
+            "Konnect lock state must be a real directory, not a symlink or file: {}",
+            lock_directory.display()
+        )));
+    }
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&lock_directory, std::fs::Permissions::from_mode(0o700))?;
+        let directory = std::fs::File::open(&lock_directory)?;
+        if !directory.metadata()?.is_dir() {
+            return Err(SexpError::InvalidValue(format!(
+                "Konnect lock state is not a directory: {}",
+                lock_directory.display()
+            )));
+        }
+        directory.set_permissions(std::fs::Permissions::from_mode(0o700))?;
     }
 
     let mut hasher = Sha256::new();
     hasher.update(b"konnect-document-lock-v1\0");
-    hasher.update(canonical_parent.as_os_str().as_encoded_bytes());
+    hash_native_os_str(&mut hasher, canonical_parent.as_os_str());
     hasher.update([0]);
-    hasher.update(file_name.as_encoded_bytes());
+    hash_native_os_str(&mut hasher, file_name);
     Ok(lock_directory.join(format!("{:x}.lock", hasher.finalize())))
+}
+
+#[cfg(unix)]
+fn hash_native_os_str(hasher: &mut Sha256, value: &OsStr) {
+    use std::os::unix::ffi::OsStrExt;
+    hasher.update(value.as_bytes());
+}
+
+#[cfg(windows)]
+fn hash_native_os_str(hasher: &mut Sha256, value: &OsStr) {
+    use std::os::windows::ffi::OsStrExt;
+    for unit in value.encode_wide() {
+        hasher.update(unit.to_le_bytes());
+    }
 }
 
 /// Atomically create a new file without replacing an existing destination.
@@ -790,6 +844,41 @@ mod atomic_write_tests {
             Some("lock")
         );
         assert!(!path.exists(), "lock identity must not create the target");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn document_lock_refuses_a_symlink_without_touching_its_target() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let victim = directory.path().join("victim");
+        let lock = directory.path().join("planted.lock");
+        std::fs::write(&victim, "unchanged").unwrap();
+        symlink(&victim, &lock).unwrap();
+
+        assert!(open_lock_file(&lock).is_err());
+        assert_eq!(std::fs::read_to_string(victim).unwrap(), "unchanged");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn document_lock_refuses_a_symlinked_lock_directory() {
+        use std::os::unix::fs::symlink;
+
+        let state = tempfile::tempdir().unwrap();
+        let redirected = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        symlink(redirected.path(), state.path().join("locks")).unwrap();
+
+        let error = document_lock_path_in(state.path(), &project.path().join("design.kicad_sch"))
+            .unwrap_err();
+
+        assert!(error.to_string().contains("real directory"));
+        assert!(std::fs::read_dir(redirected.path())
+            .unwrap()
+            .next()
+            .is_none());
     }
 
     /// The precondition for the collision, stated without threads.

--- a/crates/konnect-sexp/src/writer.rs
+++ b/crates/konnect-sexp/src/writer.rs
@@ -8,19 +8,22 @@
 //! # Usage Pattern (all handlers must follow this)
 //!
 //! ```rust,ignore
-//! let content = std::fs::read_to_string(&path)?;
+//! let content = read_consistent(&path)?;
 //! let mut edits = Vec::new();
 //! edits.push(SexpEdit::insert_before_closing(parent_close_offset, new_sexp));
 //! edits.push(SexpEdit::replace_span(start, end, new_value));
 //! let new_content = apply_edits(content, edits);
-//! write_atomic(&path, &new_content)?;
+//! write_atomic_if_unchanged(&path, &content, &new_content)?;
 //! ```
 //!
 //! Edits **must** be applied in **reverse byte-offset order** so that earlier
 //! offsets are not invalidated by later insertions.
 
 use crate::SexpError;
-use std::io::Write;
+use fs4::FileExt;
+use sha2::{Digest, Sha256};
+use std::fs::OpenOptions;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 // ─── Edit Types ───────────────────────────────────────────────────────────────
@@ -100,10 +103,20 @@ pub fn apply_edits(mut content: String, mut edits: Vec<SexpEdit>) -> String {
 /// can itself fail on a locked or read-only directory, and a write already
 /// failing is the wrong moment to start reporting a second error.
 pub fn write_atomic(path: &Path, content: &str) -> Result<(), SexpError> {
+    let lock = open_document_lock(path)?;
+    <std::fs::File as FileExt>::lock(&lock)?;
+    write_atomic_unlocked(path, content)
+}
+
+pub(crate) fn write_atomic_unlocked(path: &Path, content: &str) -> Result<(), SexpError> {
     let (tmp_path, mut file) = create_scratch_file(path)?;
 
     // Remove the scratch file unless the rename below succeeds.
     let mut cleanup = ScratchGuard(Some(tmp_path.clone()));
+
+    if let Ok(metadata) = std::fs::metadata(path) {
+        file.set_permissions(metadata.permissions())?;
+    }
 
     file.write_all(content.as_bytes())?;
     file.flush()?;
@@ -112,6 +125,157 @@ pub fn write_atomic(path: &Path, content: &str) -> Result<(), SexpError> {
 
     std::fs::rename(&tmp_path, path)?;
     cleanup.disarm();
+    sync_parent_directory(path.parent().unwrap_or_else(|| Path::new(".")))?;
+    Ok(())
+}
+
+/// Atomically replace `path` only when it still contains `expected`.
+///
+/// A stable sibling lock serializes participating writers. The exact source
+/// comparison also catches changes made by applications that do not honor the
+/// advisory lock, including KiCad itself.
+pub fn write_atomic_if_unchanged(
+    path: &Path,
+    expected: &str,
+    content: &str,
+) -> Result<(), SexpError> {
+    let lock = open_document_lock(path)?;
+    <std::fs::File as FileExt>::lock(&lock)?;
+
+    let current = read_string_unlocked(path)?;
+    if current != expected {
+        return Err(SexpError::Conflict {
+            path: path.to_path_buf(),
+        });
+    }
+
+    write_atomic_unlocked(path, content)?;
+    if std::fs::read_to_string(path)? != content {
+        return Err(SexpError::Conflict {
+            path: path.to_path_buf(),
+        });
+    }
+    Ok(())
+}
+
+/// Apply a read/modify/write transaction while holding the document lock.
+pub fn transact_atomic<T>(
+    path: &Path,
+    update: impl FnOnce(&str) -> Result<(String, T), SexpError>,
+) -> Result<T, SexpError> {
+    let lock = open_document_lock(path)?;
+    <std::fs::File as FileExt>::lock(&lock)?;
+    let current = read_string_unlocked(path)?;
+    let (next, result) = update(&current)?;
+
+    if next != current {
+        write_atomic_unlocked(path, &next)?;
+        if std::fs::read_to_string(path)? != next {
+            return Err(SexpError::Conflict {
+                path: path.to_path_buf(),
+            });
+        }
+    }
+
+    Ok(result)
+}
+
+/// Read a complete document while participating in the document lock.
+pub fn read_consistent(path: &Path) -> Result<String, SexpError> {
+    let lock = open_document_lock(path)?;
+    <std::fs::File as FileExt>::lock_shared(&lock)?;
+    read_string_unlocked(path)
+}
+
+pub(crate) fn read_string_unlocked(path: &Path) -> Result<String, SexpError> {
+    let mut file = std::fs::File::open(path)?;
+    let size = file.metadata()?.len().min(usize::MAX as u64) as usize;
+    let mut content = String::with_capacity(size);
+    file.read_to_string(&mut content)?;
+    Ok(content)
+}
+
+pub(crate) fn open_document_lock(path: &Path) -> Result<std::fs::File, SexpError> {
+    let lock_path = document_lock_path(path)?;
+    Ok(OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(lock_path)?)
+}
+
+fn document_lock_path(path: &Path) -> Result<PathBuf, SexpError> {
+    let state_root = match std::env::var_os("KONNECT_STATE_DIR") {
+        Some(value) if !value.is_empty() => {
+            let root = PathBuf::from(value);
+            if !root.is_absolute() {
+                return Err(SexpError::InvalidValue(
+                    "KONNECT_STATE_DIR must be an absolute path".to_owned(),
+                ));
+            }
+            root
+        }
+        _ => dirs::data_local_dir()
+            .map(|root| root.join("konnect"))
+            .ok_or_else(|| {
+                SexpError::InvalidValue(
+                    "no platform local-data directory is available; set KONNECT_STATE_DIR to an absolute path"
+                        .to_owned(),
+                )
+            })?,
+    };
+    document_lock_path_in(&state_root, path)
+}
+
+fn document_lock_path_in(state_root: &Path, path: &Path) -> Result<PathBuf, SexpError> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let canonical_parent = parent.canonicalize()?;
+    let file_name = path.file_name().ok_or_else(|| {
+        SexpError::InvalidValue(format!("document path has no filename: {}", path.display()))
+    })?;
+
+    let lock_directory = state_root.join("locks");
+    std::fs::create_dir_all(&lock_directory)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&lock_directory, std::fs::Permissions::from_mode(0o700))?;
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"konnect-document-lock-v1\0");
+    hasher.update(canonical_parent.as_os_str().as_encoded_bytes());
+    hasher.update([0]);
+    hasher.update(file_name.as_encoded_bytes());
+    Ok(lock_directory.join(format!("{:x}.lock", hasher.finalize())))
+}
+
+/// Atomically create a new file without replacing an existing destination.
+pub fn write_new_atomic(path: &Path, content: &str) -> Result<(), SexpError> {
+    let lock = open_document_lock(path)?;
+    <std::fs::File as FileExt>::lock(&lock)?;
+    write_new_atomic_unlocked(path, content)
+}
+
+pub(crate) fn write_new_atomic_unlocked(path: &Path, content: &str) -> Result<(), SexpError> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut temporary = tempfile::Builder::new()
+        .prefix(".konnect-")
+        .tempfile_in(parent)?;
+    temporary.write_all(content.as_bytes())?;
+    temporary.flush()?;
+    temporary.as_file().sync_all()?;
+    temporary
+        .persist_noclobber(path)
+        .map_err(|error| SexpError::Io(error.error))?;
+    sync_parent_directory(parent)?;
+    Ok(())
+}
+
+pub(crate) fn sync_parent_directory(_parent: &Path) -> Result<(), SexpError> {
+    #[cfg(unix)]
+    std::fs::File::open(_parent)?.sync_all()?;
     Ok(())
 }
 
@@ -577,6 +741,57 @@ mod block_start_tests {
 mod atomic_write_tests {
     use super::*;
 
+    #[test]
+    fn reading_a_document_never_creates_a_project_sidecar() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("design.kicad_sch");
+        std::fs::write(&path, "(kicad_sch)").unwrap();
+
+        assert_eq!(read_consistent(&path).unwrap(), "(kicad_sch)");
+
+        let names: Vec<_> = std::fs::read_dir(directory.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        assert_eq!(names, [std::ffi::OsString::from("design.kicad_sch")]);
+    }
+
+    #[test]
+    fn lock_identity_is_stable_and_separates_equal_filenames() {
+        let state = tempfile::tempdir().unwrap();
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        let first_path = first.path().join("design.kicad_sch");
+        let second_path = second.path().join("design.kicad_sch");
+
+        let first_lock = document_lock_path_in(state.path(), &first_path).unwrap();
+        assert_eq!(
+            first_lock,
+            document_lock_path_in(state.path(), &first_path).unwrap()
+        );
+        assert_ne!(
+            first_lock,
+            document_lock_path_in(state.path(), &second_path).unwrap()
+        );
+        assert_eq!(first_lock.parent().unwrap(), state.path().join("locks"));
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn lock_identity_accepts_a_non_unicode_new_filename() {
+        let state = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let path = project.path().join(non_unicode_name());
+
+        let lock = document_lock_path_in(state.path(), &path).unwrap();
+
+        assert_eq!(
+            lock.extension().and_then(|value| value.to_str()),
+            Some("lock")
+        );
+        assert!(!path.exists(), "lock identity must not create the target");
+    }
+
     /// The precondition for the collision, stated without threads.
     ///
     /// This is what `with_extension` did, and why every file in a project
@@ -835,5 +1050,109 @@ mod atomic_write_tests {
         assert_eq!(std::fs::read_to_string(&pcb).unwrap(), pcb_content);
         assert_eq!(std::fs::read_to_string(&sch).unwrap(), sch_content);
         assert!(!leftover_scratch_files(dir.path()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_replaces_a_symlink_without_touching_its_target() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("target");
+        let path = directory.path().join("board.kicad_pcb");
+        std::fs::write(&target, "keep me").unwrap();
+        symlink(&target, &path).unwrap();
+
+        write_atomic(&path, "new board").unwrap();
+
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "keep me");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new board");
+        assert!(!std::fs::symlink_metadata(&path)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+    }
+
+    #[test]
+    fn atomic_create_never_overwrites_an_existing_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("project.kicad_pro");
+        std::fs::write(&path, "user project").unwrap();
+
+        let error = write_new_atomic(&path, "replacement").unwrap_err();
+
+        assert!(matches!(error, SexpError::Io(_)));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "user project");
+    }
+
+    #[test]
+    fn conditional_write_rejects_a_stale_revision() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("design.kicad_sch");
+        std::fs::write(&path, "newer").unwrap();
+
+        let error = write_atomic_if_unchanged(&path, "older", "my edit").unwrap_err();
+
+        assert!(matches!(error, SexpError::Conflict { .. }));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "newer");
+    }
+
+    #[test]
+    fn conditional_write_commits_a_matching_revision() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("design.kicad_sch");
+        std::fs::write(&path, "expected").unwrap();
+
+        write_atomic_if_unchanged(&path, "expected", "edited").unwrap();
+
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "edited");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn conditional_write_preserves_existing_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("design.kicad_sch");
+        std::fs::write(&path, "expected").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
+
+        write_atomic_if_unchanged(&path, "expected", "edited").unwrap();
+
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o640
+        );
+    }
+
+    #[test]
+    fn concurrent_conditional_writes_have_exactly_one_winner() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("design.kicad_sch");
+        std::fs::write(&path, "expected").unwrap();
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+
+        let handles = ["first", "second"].map(|content| {
+            let path = path.clone();
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                write_atomic_if_unchanged(&path, "expected", content)
+            })
+        });
+        barrier.wait();
+        let results = handles.map(|handle| handle.join().unwrap());
+
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(result, Err(SexpError::Conflict { .. })))
+                .count(),
+            1
+        );
+        let final_content = std::fs::read_to_string(path).unwrap();
+        assert!(final_content == "first" || final_content == "second");
     }
 }

--- a/crates/konnect-sexp/src/writer.rs
+++ b/crates/konnect-sexp/src/writer.rs
@@ -283,24 +283,31 @@ fn document_lock_path_in(state_root: &Path, path: &Path) -> Result<PathBuf, Sexp
         directory.set_permissions(std::fs::Permissions::from_mode(0o700))?;
     }
 
+    Ok(lock_directory.join(document_lock_name(canonical_parent.as_os_str(), file_name)))
+}
+
+fn document_lock_name(canonical_parent: &OsStr, file_name: &OsStr) -> String {
     let mut hasher = Sha256::new();
     hasher.update(b"konnect-document-lock-v1\0");
-    hash_native_os_str(&mut hasher, canonical_parent.as_os_str());
-    hasher.update([0]);
+    hash_native_os_str(&mut hasher, canonical_parent);
     hash_native_os_str(&mut hasher, file_name);
-    Ok(lock_directory.join(format!("{:x}.lock", hasher.finalize())))
+    format!("{:x}.lock", hasher.finalize())
 }
 
 #[cfg(unix)]
 fn hash_native_os_str(hasher: &mut Sha256, value: &OsStr) {
     use std::os::unix::ffi::OsStrExt;
-    hasher.update(value.as_bytes());
+    let bytes = value.as_bytes();
+    hasher.update((bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
 }
 
 #[cfg(windows)]
 fn hash_native_os_str(hasher: &mut Sha256, value: &OsStr) {
     use std::os::windows::ffi::OsStrExt;
-    for unit in value.encode_wide() {
+    let units: Vec<_> = value.encode_wide().collect();
+    hasher.update(((units.len() as u64) * 2).to_le_bytes());
+    for unit in units {
         hasher.update(unit.to_le_bytes());
     }
 }
@@ -828,6 +835,24 @@ mod atomic_write_tests {
             document_lock_path_in(state.path(), &second_path).unwrap()
         );
         assert_eq!(first_lock.parent().unwrap(), state.path().join("locks"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn lock_identity_length_prefixes_windows_native_components() {
+        use std::os::windows::ffi::OsStringExt;
+
+        // Without component lengths these pairs both encode as
+        // 61 00 00 62 00 63 00 when separated by one zero byte.
+        let first_parent = std::ffi::OsString::from_wide(&[0x0061]);
+        let first_name = std::ffi::OsString::from_wide(&[0x0062, 0x0063]);
+        let second_parent = std::ffi::OsString::from_wide(&[0x0061, 0x6200]);
+        let second_name = std::ffi::OsString::from_wide(&[0x0063]);
+
+        assert_ne!(
+            document_lock_name(&first_parent, &first_name),
+            document_lock_name(&second_parent, &second_name)
+        );
     }
 
     #[cfg(any(unix, windows))]

--- a/crates/konnect/src/main.rs
+++ b/crates/konnect/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod install;
 mod manifest;
+mod transaction_cli;
 mod transport;
 
 use anyhow::Result;
@@ -24,6 +25,7 @@ async fn main() -> Result<()> {
             let name = args.get(2).map(String::as_str).unwrap_or("");
             return install::print_skill_content(name);
         }
+        Some("transaction") => return transaction_cli::run(&args[2..]),
         Some("--version") | Some("-V") => {
             println!("konnect {}", env!("CARGO_PKG_VERSION"));
             return Ok(());
@@ -123,6 +125,9 @@ fn print_help() {
     println!("  konnect uninstall        Remove all installed files");
     println!("  konnect status           Show install state");
     println!("  konnect skill <name>     Print skill content (for hooks)");
+    println!("  konnect transaction status <project-dir>");
+    println!("  konnect transaction recover <project-dir>");
+    println!("  konnect transaction abandon <project-dir> <id> --force");
     println!("  konnect --config <path>  Start server with config file");
     println!("  konnect --version        Print version");
     println!("  konnect --help           This message");

--- a/crates/konnect/src/transaction_cli.rs
+++ b/crates/konnect/src/transaction_cli.rs
@@ -1,0 +1,113 @@
+use anyhow::{bail, Context, Result};
+use konnect_sexp::{
+    abandon_file_transaction, inspect_file_transactions, recover_file_transactions,
+    TransactionTargetState,
+};
+use std::path::Path;
+
+pub fn run(args: &[String]) -> Result<()> {
+    match args.first().map(String::as_str) {
+        Some("status") => status(exact_project_path(args, "status")?),
+        Some("recover") => recover(exact_project_path(args, "recover")?),
+        Some("abandon") => abandon(args),
+        Some(command) => {
+            bail!("unknown transaction command '{command}'; expected status, recover, or abandon")
+        }
+        None => bail!("transaction command required; expected status, recover, or abandon"),
+    }
+}
+
+fn exact_project_path<'a>(args: &'a [String], command: &str) -> Result<&'a Path> {
+    if args.len() != 2 {
+        bail!("usage: konnect transaction {command} <project-dir>");
+    }
+    Ok(Path::new(&args[1]))
+}
+
+fn status(project: &Path) -> Result<()> {
+    let statuses = inspect_file_transactions(project)
+        .with_context(|| format!("failed to inspect transactions in {}", project.display()))?;
+    if statuses.is_empty() {
+        println!("No active transaction journals.");
+        return Ok(());
+    }
+
+    for status in statuses {
+        println!("Transaction {} ({})", status.id, status.journal.display());
+        for target in status.targets {
+            let state = match target.state {
+                TransactionTargetState::Pending => "pending",
+                TransactionTargetState::Applied => "applied",
+                TransactionTargetState::Divergent => "divergent",
+            };
+            println!("  {state:9} {}", target.path.display());
+        }
+    }
+    println!("Journal contents are redacted because they contain complete schematic images.");
+    Ok(())
+}
+
+fn recover(project: &Path) -> Result<()> {
+    let outcomes = recover_file_transactions(project)
+        .with_context(|| format!("failed to recover transactions in {}", project.display()))?;
+    if outcomes.is_empty() {
+        println!("No active transaction journals.");
+    } else {
+        for outcome in outcomes {
+            println!(
+                "Recovered transaction {} (completed {} file(s)).",
+                outcome.id, outcome.completed_files
+            );
+        }
+    }
+    Ok(())
+}
+
+fn abandon(args: &[String]) -> Result<()> {
+    if args.len() != 4 || args[3] != "--force" {
+        bail!("usage: konnect transaction abandon <project-dir> <transaction-id> --force");
+    }
+    let project = Path::new(&args[1]);
+    let outcome = abandon_file_transaction(project, &args[2]).with_context(|| {
+        format!(
+            "failed to abandon transaction '{}' in {}",
+            args[2],
+            project.display()
+        )
+    })?;
+    println!(
+        "Abandoned transaction {} without modifying target files.",
+        outcome.id
+    );
+    println!(
+        "Evidence retained at {}.",
+        outcome.abandoned_journal.display()
+    );
+    println!("Warning: the abandoned journal contains complete before/after schematic images.");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_project_path_rejects_extra_arguments() {
+        let args = vec![
+            "status".to_owned(),
+            "project".to_owned(),
+            "extra".to_owned(),
+        ];
+        assert!(exact_project_path(&args, "status").is_err());
+    }
+
+    #[test]
+    fn abandon_requires_force() {
+        let args = vec![
+            "abandon".to_owned(),
+            "project".to_owned(),
+            "transaction".to_owned(),
+        ];
+        assert!(abandon(&args).is_err());
+    }
+}

--- a/crates/konnect/tests/transaction_cli.rs
+++ b/crates/konnect/tests/transaction_cli.rs
@@ -1,0 +1,58 @@
+use std::process::Command;
+
+fn konnect() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_konnect"))
+}
+
+#[test]
+fn transaction_help_is_advertised() {
+    let output = konnect().arg("--help").output().unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("transaction status <project-dir>"));
+    assert!(stdout.contains("transaction recover <project-dir>"));
+    assert!(stdout.contains("transaction abandon <project-dir> <id> --force"));
+}
+
+#[test]
+fn malformed_journal_requires_force_and_can_be_abandoned() {
+    let project = tempfile::tempdir().unwrap();
+    let active = project
+        .path()
+        .join(".konnect-transaction-malformed-fixture.json");
+    std::fs::write(&active, "not json").unwrap();
+
+    let refused = konnect()
+        .args([
+            "transaction",
+            "abandon",
+            project.path().to_str().unwrap(),
+            "malformed-fixture",
+        ])
+        .output()
+        .unwrap();
+    assert!(!refused.status.success());
+    assert!(active.exists());
+
+    let abandoned = konnect()
+        .args([
+            "transaction",
+            "abandon",
+            project.path().to_str().unwrap(),
+            "malformed-fixture",
+            "--force",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(abandoned.status.success(), "{abandoned:?}");
+    assert!(!active.exists());
+    assert!(project
+        .path()
+        .join(".konnect-transaction-malformed-fixture.abandoned.json")
+        .exists());
+    let stdout = String::from_utf8(abandoned.stdout).unwrap();
+    assert!(stdout.contains("without modifying target files"));
+    assert!(stdout.contains("complete before/after schematic images"));
+}

--- a/crates/schematic-viewer/Cargo.lock
+++ b/crates/schematic-viewer/Cargo.lock
@@ -542,11 +542,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -557,7 +578,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -813,6 +834,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1668,9 +1699,13 @@ name = "konnect-sexp"
 version = "0.2.2"
 dependencies = [
  "anyhow",
+ "dirs 5.0.1",
+ "fs4",
  "nom",
  "serde",
  "serde_json",
+ "sha2",
+ "tempfile",
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -2469,6 +2504,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -3148,7 +3194,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -3198,7 +3244,7 @@ checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -3673,7 +3719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -4289,6 +4335,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -4327,6 +4382,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4388,6 +4458,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4406,6 +4482,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4421,6 +4503,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4454,6 +4542,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4469,6 +4563,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4490,6 +4590,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4505,6 +4611,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4656,7 +4768,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -53,6 +53,51 @@ Common install paths are auto-detected (including the Windows registry). If
 your install is somewhere unusual, set the path in the plugin settings dialog
 or in `konnect-settings.json` (`kicad_cli`).
 
+## Transaction recovery is blocked by divergent content
+
+Multi-file schematic changes persist a `.konnect-transaction-<id>.json`
+write-ahead journal in the project before changing any target. On restart,
+Konnect safely completes files that still match either the recorded before
+image or intended replacement. It never overwrites a file changed by KiCad or
+another process after the journal was written.
+
+Inspect active journals without printing their contents:
+
+```text
+konnect transaction status <project-dir>
+```
+
+Each target is reported as `pending`, `applied`, or `divergent`. Retry safe
+recovery with:
+
+```text
+konnect transaction recover <project-dir>
+```
+
+If a target is divergent, first inspect the schematic in KiCad and preserve
+the version you want. To unblock future transactions without changing any
+schematic file, explicitly abandon the journal:
+
+```text
+konnect transaction abandon <project-dir> <transaction-id> --force
+```
+
+Abandonment renames the journal to
+`.konnect-transaction-<id>.abandoned.json`; it does not restore, replace, or
+delete a target. The abandoned file is retained as recovery evidence and is
+ignored by future transactions. Delete it only after you have made any backup
+you need.
+
+Active and abandoned journals contain complete before/after images of every
+affected schematic. Treat them as sensitive, do not attach them to bug reports
+without reviewing their contents, and do not commit them. Both forms are
+ignored by the repository `.gitignore`.
+
+Cooperative document locks are stored outside the project under the platform
+local-data directory. Set `KONNECT_STATE_DIR` to an absolute directory to
+override that location. A relative override is rejected rather than falling
+back to project-local sidecars.
+
 ## Tools don't appear after `load_toolset`
 
 After a successful `load_toolset` call the server sends a


### PR DESCRIPTION
## Summary

This is PR 1 of the replacement roadmap for #85. It reconstructs only the schematic command/transaction foundation on the latest `upstream/main`; the three maintenance tools and Schematic Studio viewer feature/source are intentionally excluded. The existing standalone viewer lockfile is regenerated only so its current path dependency on `konnect-sexp` remains buildable with `--locked`.

## Maintainer-blocker mapping

- [x] Split the original 22k-line contribution into an independently reviewable foundation PR
- [x] Reconciled by hand with current `sch_components.rs`, `sch_wiring.rs`, `sch_analysis.rs`, `library.rs`, and `sch_batch.rs`
- [x] Preserved #35 multi-unit validation, replacement, pin extraction, wiring, and flattened library inheritance
- [x] Preserved #104 pin-mid-wire/junction semantics and current analysis call sites
- [x] Preserved #111 batch placement/connect behavior and junction deduplication
- [x] Added UUID-targeted commands, exact revision preconditions, inverses, and atomic multi-file transactions
- [x] Replaced `fs2` completely with `fs4`
- [x] Moved cooperative locks out of projects to `KONNECT_STATE_DIR/locks` or the platform local-data `konnect/locks`
- [x] Lock identities use canonical parents plus length-prefixed native filename data and support new/non-Unicode targets
- [x] Rejects symlinked lock artifacts/state directories and keeps project files untouched
- [x] Added redacted `transaction status`, safe `transaction recover`, and force-gated `transaction abandon`
- [x] Validates journal version, ID/filename agreement, containment, duplicates, malformed paths/content, and symlinks
- [x] Active/abandoned journals are ignored and documented as sensitive full before/after images
- [x] `Schematic::save(new_path)` is create-only; loaded-path saves and `overwrite()` are revision-checked
- [x] Existing schematic mutation callers were migrated without weakening replacement semantics
- [x] No maintenance tools, viewer feature/source, screenshots, registry count, or tool-directory changes

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --locked`
- [x] `cargo test --workspace --locked --lib --tests`
- [x] `cargo test --workspace --locked --doc`
- [x] `cargo clippy --workspace --locked -- -D warnings`
- [x] Standalone viewer `cargo check` and `cargo test` with its own lockfile
- [x] Repository metadata validation
- [x] Linux PCM assembly/structure validation
- [x] Conflict-marker search
- [x] `git diff --check`
- [x] Focused concurrency, stale revision, create-only save, permission, symlink, non-Unicode path, external lock-state, malformed/divergent journal, abandonment, and crash-recovery tests
- [x] Regression coverage for #35, #104, and #111
- [x] [Exact-head manual real-KiCad E2E dispatch](https://github.com/perara/Konnect/actions/runs/30704632401) on `a2d89fd` (all steps green)

## Follow-up sequence

After this merges:

1. `feat/schematic-maintenance-tools` — only the three MCP maintenance tools
2. `feat/schematic-studio-vello` — only the feature-gated Vello studio/viewer work

Each successor will branch from `main` only after its dependency merges.
