### PR TITLE
feat(router): opt-in auto-load of unloaded toolsets (default off)

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -233,6 +233,7 @@ The server does NOT expose all 187 tools (193 total with the 6 meta-tools) in `t
 - **On demand**: the LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose a toolset's tools in subsequent `tools/list` responses. `unload_toolset(name)` prunes them when the task shifts.
 - **`tools/list_changed` notification**: sent on every load/unload so MCP clients refresh their local tool cache.
 - **Error recovery**: if the LLM calls an unloaded tool, `handler.rs` returns an actionable error naming the toolset that owns it (so the LLM can load it and retry in one hop — no extra `list_toolboxes` round-trip).
+- **`auto_load_toolsets` (config key, default `false`)**: when set, a miss in `dispatch_tool` loads the owning toolset and executes the call in the same hop instead of returning `toolset_not_loaded` -- fewer round trips, at the cost of toolsets accumulating monotonically for the rest of the session (`unload_toolset` still prunes, but a tool call reloads its toolset right back). Off by default because the router's whole point is keeping `tools/list` small; turn it on only if your client would rather eat the context growth than handle one recoverable error per miss. Set via `konnect.toml`/`settings.json` (`auto_load_toolsets = true`) or the equivalent `ServerConfig` field when embedding.
 
 The router is defined in `crates/konnect-core/src/router/mod.rs`.
 

--- a/crates/konnect-core/src/mcp/handler.rs
+++ b/crates/konnect-core/src/mcp/handler.rs
@@ -225,8 +225,19 @@ impl McpHandler {
             return (result, status, None);
         }
 
-        // Loaded domain tool?
-        if let Some(tool_def) = self.ctx.router.get_tool(name).await {
+        // Loaded domain tool? If not and auto-load is enabled (opt-in, off by
+        // default -- see `ServerConfig::auto_load_toolsets`), load its toolset
+        // and retry in the same call instead of erroring.
+        let mut tool_def = self.ctx.router.get_tool(name).await;
+        if tool_def.is_none() && self.ctx.config.auto_load_toolsets {
+            if let Some(toolset) = self.ctx.router.find_toolset_for_tool(name) {
+                self.ctx.router.load(toolset).await;
+                self.notify_tools_list_changed().await;
+                tool_def = self.ctx.router.get_tool(name).await;
+            }
+        }
+
+        if let Some(tool_def) = tool_def {
             return match (tool_def.handler)(args, self.ctx.clone()).await {
                 Ok(result) => {
                     let status = if result.is_error {

--- a/crates/konnect-core/src/router/meta_tools.rs
+++ b/crates/konnect-core/src/router/meta_tools.rs
@@ -62,7 +62,8 @@ pub fn meta_tool_descriptions() -> Vec<McpToolDescription> {
         McpToolDescription {
             name: "unload_toolset".to_string(),
             description: "Unload a toolset to remove its tools from the active session. \
-                 Use this to keep the tool list manageable when switching tasks."
+                 Use this to keep the tool list manageable when switching tasks. \
+                 With auto_load_toolsets enabled, tools reload on use."
                 .to_string(),
             input_schema: json!({
                 "type": "object",

--- a/crates/konnect-core/src/router/meta_tools.rs
+++ b/crates/konnect-core/src/router/meta_tools.rs
@@ -1,7 +1,7 @@
 //! The 6 always-visible meta-tools.
 //!
 //! Discovery / routing:
-//!   list_toolboxes()          — show all 17 toolsets with descriptions and load state
+//!   list_toolboxes()          — show all 18 toolsets with descriptions and load state
 //!   load_toolset(name)        — activate a toolset, expose its tools in tools/list
 //!   unload_toolset(name)      — deactivate a toolset, remove its tools from tools/list
 //!   get_active_toolsets()     — list currently loaded toolsets
@@ -14,6 +14,7 @@
 //! baseline context stays small. The LLM reads `list_toolboxes` and calls
 //! `load_toolset(name)` to expose the tools it actually needs for the task.
 
+use crate::mcp::error::ToolErrorKind;
 use crate::mcp::protocol::{CallToolResult, McpToolDescription};
 use crate::tools::ToolContext;
 use serde_json::{json, Value};
@@ -41,14 +42,18 @@ pub fn meta_tool_descriptions() -> Vec<McpToolDescription> {
             description:
                 "Load a toolset by name so its tools appear in tools/list and can be called. \
                  Returns the list of tools that were added. Use list_toolboxes() first to \
-                 see valid names."
+                 see valid names. Pass an array to load several toolsets in one call -- \
+                 cheaper, one tools/list refresh."
                     .to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "name": {
-                        "type": "string",
-                        "description": "Toolset name (e.g. 'sch_components', 'pcb_routing')"
+                        "anyOf": [
+                            {"type": "string"},
+                            {"type": "array", "items": {"type": "string"}}
+                        ],
+                        "description": "Toolset name (e.g. 'sch_components', 'pcb_routing'), or an array of names"
                     }
                 },
                 "required": ["name"]
@@ -167,27 +172,86 @@ async fn handle_list_toolboxes(ctx: &std::sync::Arc<ToolContext>) -> CallToolRes
 }
 
 async fn handle_load_toolset(args: &Value, ctx: &std::sync::Arc<ToolContext>) -> CallToolResult {
-    let name = match args["name"].as_str() {
-        Some(n) => n,
-        None => return CallToolResult::error("Missing required argument: name"),
-    };
+    match &args["name"] {
+        // Legacy single-name form: result shape is byte-identical to the
+        // pre-batch behavior (`loaded` is a string, `tools` echoes descriptions).
+        Value::String(name) => match ctx.router.load(name).await {
+            Some(tools) => {
+                let tool_list: Vec<Value> = tools
+                    .iter()
+                    .map(|t| json!({ "name": t.name, "description": t.description }))
+                    .collect();
+                CallToolResult::json(&json!({
+                    "loaded": name,
+                    "tools_added": tools.len(),
+                    "tools": tool_list
+                }))
+            }
+            None => CallToolResult::error(format!(
+                "Unknown toolset '{}'. Call list_toolboxes() to see valid names.",
+                name
+            )),
+        },
+        // New array form: one load, one tools/list_changed notification.
+        Value::Array(arr) => {
+            let mut names: Vec<String> =
+                match arr.iter().map(|v| v.as_str().map(str::to_string)).collect() {
+                    Some(names) => names,
+                    None => return CallToolResult::error("name array must contain only strings"),
+                };
+            // Duplicate names in one call would double-count tools_added.
+            let mut seen = std::collections::HashSet::new();
+            names.retain(|n| seen.insert(n.clone()));
 
-    match ctx.router.load(name).await {
-        Some(tools) => {
-            let tool_list: Vec<Value> = tools
-                .iter()
-                .map(|t| json!({ "name": t.name, "description": t.description }))
-                .collect();
+            let mut loaded = Vec::new();
+            let mut tools_added = 0usize;
+            let mut tool_list: Vec<Value> = Vec::new();
+            let mut errors = Vec::new();
+
+            for name in &names {
+                match ctx.router.load(name).await {
+                    Some(tools) => {
+                        loaded.push(name.clone());
+                        tools_added += tools.len();
+                        tool_list.extend(
+                            tools
+                                .iter()
+                                .map(|t| json!({ "name": t.name, "description": t.description })),
+                        );
+                    }
+                    None => errors.push(format!(
+                        "Unknown toolset '{}'. Call list_toolboxes() to see valid names.",
+                        name
+                    )),
+                }
+            }
+
+            // Nothing loaded at all -- a typed error so the observer keeps a kind,
+            // rather than a JSON body with a manually-set is_error flag.
+            if loaded.is_empty() {
+                let kind = ToolErrorKind::InvalidArgument {
+                    field: "name".to_string(),
+                    reason: names.join(", "),
+                };
+                return CallToolResult::error_kind(
+                    kind,
+                    format!(
+                        "No toolsets loaded -- all names were unknown: {}. Call list_toolboxes() to see valid names.",
+                        names.join(", ")
+                    ),
+                );
+            }
+
+            // Partial success (some names unknown, some loaded) is not an error --
+            // the caller gets what loaded plus an errors array for the rest.
             CallToolResult::json(&json!({
-                "loaded": name,
-                "tools_added": tools.len(),
-                "tools": tool_list
+                "loaded": loaded,
+                "tools_added": tools_added,
+                "tools": tool_list,
+                "errors": errors,
             }))
         }
-        None => CallToolResult::error(format!(
-            "Unknown toolset '{}'. Call list_toolboxes() to see valid names.",
-            name
-        )),
+        _ => CallToolResult::error("Missing required argument: name (string or array of strings)"),
     }
 }
 

--- a/crates/konnect-core/src/tools/integration.rs
+++ b/crates/konnect-core/src/tools/integration.rs
@@ -933,6 +933,7 @@ mod jlcpcb_cache_tests {
                 ipc_address: String::new(),
                 project_dir: None,
                 jlcpcb_db_path: None,
+                auto_load_toolsets: false,
             },
             Arc::new(ToolRouter::new()),
         )

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -2816,6 +2816,7 @@ mod tests {
                 ipc_address: String::new(),
                 project_dir: None,
                 jlcpcb_db_path: None,
+                auto_load_toolsets: false,
             },
             Arc::new(ToolRouter::new()),
         )

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -170,6 +170,9 @@ pub struct ServerConfig {
     pub ipc_address: String,
     pub project_dir: Option<std::path::PathBuf>,
     pub jlcpcb_db_path: Option<std::path::PathBuf>,
+    /// Auto-load a tool's toolset on call instead of returning
+    /// `toolset_not_loaded`. Off by default (see `konnect::Config::auto_load_toolsets`).
+    pub auto_load_toolsets: bool,
 }
 
 #[cfg(test)]

--- a/crates/konnect-core/src/tools/pcb_board.rs
+++ b/crates/konnect-core/src/tools/pcb_board.rs
@@ -878,6 +878,7 @@ mod svg_logo_tests {
                 ipc_address: String::new(),
                 project_dir: None,
                 jlcpcb_db_path: None,
+                auto_load_toolsets: false,
             },
             Arc::new(ToolRouter::new()),
         )

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -1883,6 +1883,7 @@ mod tests {
                 ipc_address: String::new(),
                 project_dir: None,
                 jlcpcb_db_path: None,
+                auto_load_toolsets: false,
             },
             std::sync::Arc::new(crate::router::ToolRouter::new()),
         )
@@ -2199,6 +2200,7 @@ mod tests {
                 ipc_address: spawn_rejecting_kicad(),
                 project_dir: None,
                 jlcpcb_db_path: None,
+                auto_load_toolsets: false,
             },
             std::sync::Arc::new(crate::router::ToolRouter::new()),
         );

--- a/crates/konnect-core/src/tools/pcb_export.rs
+++ b/crates/konnect-core/src/tools/pcb_export.rs
@@ -698,6 +698,7 @@ mod new_export_format_tests {
                 ipc_address: String::new(),
                 project_dir: None,
                 jlcpcb_db_path: None,
+                auto_load_toolsets: false,
             },
             Arc::new(ToolRouter::new()),
         )

--- a/crates/konnect-core/src/tools/project.rs
+++ b/crates/konnect-core/src/tools/project.rs
@@ -408,6 +408,7 @@ mod tests {
                 ipc_address: String::new(),
                 project_dir: None,
                 jlcpcb_db_path: None,
+                auto_load_toolsets: false,
             },
             Arc::new(ToolRouter::new()),
         )

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -1247,6 +1247,7 @@ mod batch_delete_tests {
                 ipc_address: String::new(),
                 project_dir: None,
                 jlcpcb_db_path: None,
+                auto_load_toolsets: false,
             },
             Arc::new(ToolRouter::new()),
         )
@@ -1331,6 +1332,7 @@ mod batch_place_and_connect_tests {
                 ipc_address: String::new(),
                 project_dir: None,
                 jlcpcb_db_path: None,
+                auto_load_toolsets: false,
             },
             Arc::new(ToolRouter::new()),
         )
@@ -1514,6 +1516,7 @@ mod midwire_pin_tests {
                 ipc_address: String::new(),
                 project_dir: None,
                 jlcpcb_db_path: None,
+                auto_load_toolsets: false,
             },
             Arc::new(ToolRouter::new()),
         )

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -1221,6 +1221,7 @@ mod tests {
                 ipc_address: String::new(),
                 project_dir: None,
                 jlcpcb_db_path: None,
+                auto_load_toolsets: false,
             },
             Arc::new(ToolRouter::new()),
         )

--- a/crates/konnect-core/src/tools/sch_hierarchy.rs
+++ b/crates/konnect-core/src/tools/sch_hierarchy.rs
@@ -1367,6 +1367,7 @@ mod tests {
             ipc_address: String::new(),
             project_dir: None,
             jlcpcb_db_path: None,
+            auto_load_toolsets: false,
         };
         ToolContext::new(config, Arc::new(crate::router::ToolRouter::new()))
     }

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -1702,6 +1702,7 @@ mod unit_aware_wiring_tests {
                 ipc_address: String::new(),
                 project_dir: None,
                 jlcpcb_db_path: None,
+                auto_load_toolsets: false,
             },
             Arc::new(ToolRouter::new()),
         )
@@ -1842,6 +1843,7 @@ mod label_tests {
                 ipc_address: String::new(),
                 project_dir: None,
                 jlcpcb_db_path: None,
+                auto_load_toolsets: false,
             },
             Arc::new(ToolRouter::new()),
         )
@@ -2132,6 +2134,7 @@ mod wire_delete_tests {
                 ipc_address: String::new(),
                 project_dir: None,
                 jlcpcb_db_path: None,
+                auto_load_toolsets: false,
             },
             Arc::new(ToolRouter::new()),
         )
@@ -2275,6 +2278,7 @@ mod power_symbol_tests {
                 ipc_address: String::new(),
                 project_dir: None,
                 jlcpcb_db_path: None,
+                auto_load_toolsets: false,
             },
             Arc::new(ToolRouter::new()),
         )
@@ -2361,6 +2365,7 @@ mod no_connect_delete_tests {
                 ipc_address: String::new(),
                 project_dir: None,
                 jlcpcb_db_path: None,
+                auto_load_toolsets: false,
             },
             Arc::new(ToolRouter::new()),
         )

--- a/crates/konnect-core/tests/integration_test.rs
+++ b/crates/konnect-core/tests/integration_test.rs
@@ -224,6 +224,7 @@ async fn observability_meta_tools_surface_recorded_calls() {
             ipc_address: String::new(),
             project_dir: None,
             jlcpcb_db_path: None,
+            auto_load_toolsets: false,
         },
         router,
         observer.clone(),

--- a/crates/konnect/assets/skills/konnect/SKILL.md
+++ b/crates/konnect/assets/skills/konnect/SKILL.md
@@ -81,6 +81,8 @@ get_active_toolsets     → See what's currently loaded
 unload_toolset("name")  → Remove a toolset when done
 ```
 
+`load_toolset` also accepts an array of names to load several toolsets in one call, with a single context refresh.
+
 ### Available Toolsets
 
 | Category | Toolsets |

--- a/crates/konnect/src/config.rs
+++ b/crates/konnect/src/config.rs
@@ -36,6 +36,13 @@ pub struct Config {
     /// Log level (error, warn, info, debug, trace)
     #[serde(default = "default_log_level")]
     pub log_level: String,
+
+    /// Auto-load a tool's toolset on call instead of returning
+    /// `toolset_not_loaded`. Off by default: toolsets accumulate monotonically
+    /// once loaded, so auto-load trades one recoverable error for permanent
+    /// context growth -- opt in only if that trade is worth it for your client.
+    #[serde(default)]
+    pub auto_load_toolsets: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -142,6 +149,7 @@ impl Default for Config {
             http_address: default_http_address(),
             jlcpcb_db_path: None,
             log_level: default_log_level(),
+            auto_load_toolsets: false,
         }
     }
 }

--- a/crates/konnect/src/ffi.rs
+++ b/crates/konnect/src/ffi.rs
@@ -48,6 +48,7 @@ pub unsafe extern "C" fn kicad_plugin_init(config_path: *const c_char) -> c_int 
             ipc_address: config.ipc_address.clone(),
             project_dir: config.project_dir.clone(),
             jlcpcb_db_path: config.jlcpcb_db_path.clone(),
+            auto_load_toolsets: config.auto_load_toolsets,
         };
         match McpHandler::new(server_config).await {
             Ok(handler) => match config.transport {

--- a/crates/konnect/src/main.rs
+++ b/crates/konnect/src/main.rs
@@ -83,6 +83,7 @@ async fn main() -> Result<()> {
         ipc_address: config.ipc_address.clone(),
         project_dir: config.project_dir.clone(),
         jlcpcb_db_path: config.jlcpcb_db_path.clone(),
+        auto_load_toolsets: config.auto_load_toolsets,
     };
     let handler = McpHandler::new(server_config).await?;
 

--- a/crates/konnect/tests/protocol_stdio.rs
+++ b/crates/konnect/tests/protocol_stdio.rs
@@ -17,7 +17,18 @@ struct McpProcess {
 
 impl McpProcess {
     fn spawn() -> Self {
-        let mut child = Command::new(env!("CARGO_BIN_EXE_konnect"))
+        Self::spawn_in_dir(None)
+    }
+
+    /// Spawn with the process working directory set to `dir`, so
+    /// `Config::load()`'s first search path (`konnect.toml` in cwd) picks up
+    /// a test config file placed there.
+    fn spawn_in_dir(dir: Option<&std::path::Path>) -> Self {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_konnect"));
+        if let Some(dir) = dir {
+            command.current_dir(dir);
+        }
+        let mut child = command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -345,5 +356,45 @@ fn load_toolset_batch_total_failure_is_typed_error() {
     assert!(
         body["message"].as_str().unwrap().contains("list_toolboxes"),
         "{body:#?}"
+    );
+}
+
+/// With `auto_load_toolsets = true` in `konnect.toml` (picked up from the
+/// server process's cwd), calling a tool from an unloaded toolset auto-loads
+/// it and executes in the same call instead of returning `toolset_not_loaded`.
+/// Default-off behavior (no config file) is covered by
+/// `structured_errors_guide_recovery`.
+#[test]
+fn auto_load_toolsets_config_loads_and_executes_on_miss() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("konnect.toml"),
+        "auto_load_toolsets = true\n",
+    )
+    .unwrap();
+    let mut p = McpProcess::spawn_in_dir(Some(tmp.path()));
+
+    // route_trace is in pcb_routing, not loaded at startup. With auto-load on,
+    // the toolset loads, a list_changed notification fires, and the call
+    // reaches the handler's own missing-argument check (net_name) instead of
+    // failing with toolset_not_loaded.
+    let lines = p.call_tool_then_fence("route_trace", json!({}));
+    let r = lines
+        .iter()
+        .find(|v| v.get("result").is_some())
+        .expect("expected a tools/call result")["result"]
+        .clone();
+    assert_eq!(r["isError"], json!(true));
+    let body = McpProcess::tool_body(&r);
+    assert_eq!(body["error"]["kind"], "invalid_argument");
+    assert_eq!(body["error"]["field"], "net_name");
+
+    let saw_notification = lines.iter().any(|v| {
+        v.get("method").and_then(Value::as_str) == Some("notifications/tools/list_changed")
+            && v.get("id").is_none()
+    });
+    assert!(
+        saw_notification,
+        "expected notifications/tools/list_changed after auto-load; saw: {lines:#?}"
     );
 }

--- a/crates/konnect/tests/protocol_stdio.rs
+++ b/crates/konnect/tests/protocol_stdio.rs
@@ -267,3 +267,83 @@ fn unload_toolset_emits_list_changed_over_stdio() {
         "expected notifications/tools/list_changed after unload_toolset; saw: {lines:#?}"
     );
 }
+
+/// `load_toolset` accepts an array of names in one call: all listed toolsets
+/// load, tools_added sums across them, and only one list_changed notification
+/// fires for the whole batch.
+#[test]
+fn load_toolset_batch_form_loads_all_and_notifies_once() {
+    let mut p = McpProcess::spawn();
+    let lines = p.call_tool_then_fence(
+        "load_toolset",
+        json!({"name": ["sch_components", "sch_wiring"]}),
+    );
+    let r = lines
+        .iter()
+        .find(|v| v.get("result").is_some())
+        .expect("expected a tools/call result")["result"]
+        .clone();
+    let body = McpProcess::tool_body(&r);
+    assert_eq!(body["tools_added"].as_u64(), Some(36));
+    // tools items are {name, description} objects, matching the legacy
+    // single-name result shape -- not bare name strings.
+    let tools = body["tools"].as_array().expect("tools array");
+    assert!(!tools.is_empty());
+    for t in tools {
+        assert!(t.get("name").and_then(Value::as_str).is_some(), "{t:#?}");
+        assert!(
+            t.get("description").and_then(Value::as_str).is_some(),
+            "{t:#?}"
+        );
+    }
+
+    let notification_count = lines
+        .iter()
+        .filter(|v| {
+            v.get("method").and_then(Value::as_str) == Some("notifications/tools/list_changed")
+                && v.get("id").is_none()
+        })
+        .count();
+    assert_eq!(
+        notification_count, 1,
+        "expected exactly one list_changed notification for the batch; saw: {lines:#?}"
+    );
+
+    // Mixed valid/invalid names: partial failure is not isError, but the
+    // errors array names the unknown toolset and loaded lists only the real one.
+    let lines = p.call_tool_then_fence(
+        "load_toolset",
+        json!({"name": ["templates", "bogus_toolset"]}),
+    );
+    let r = lines
+        .iter()
+        .find(|v| v.get("result").is_some())
+        .expect("expected a tools/call result")["result"]
+        .clone();
+    assert_ne!(r["isError"].as_bool(), Some(true), "{r:#?}");
+    let body = McpProcess::tool_body(&r);
+    assert_eq!(body["loaded"], json!(["templates"]));
+    let errors = body["errors"].as_array().expect("errors array");
+    assert_eq!(errors.len(), 1);
+    assert!(
+        errors[0].as_str().unwrap().contains("list_toolboxes"),
+        "{errors:#?}"
+    );
+}
+
+/// All names in one `load_toolset` call unknown -> a typed `invalid_argument`
+/// error (not a JSON body with a hand-set `isError`), so the observer keeps a
+/// real `error_kind` column instead of degrading to `handler_error`.
+#[test]
+fn load_toolset_batch_total_failure_is_typed_error() {
+    let mut p = McpProcess::spawn();
+    let r = p.call_tool("load_toolset", json!({"name": ["bogus_one", "bogus_two"]}));
+    assert_eq!(r["isError"], json!(true));
+    let body = McpProcess::tool_body(&r);
+    assert_eq!(body["error"]["kind"], "invalid_argument");
+    assert_eq!(body["error"]["field"], "name");
+    assert!(
+        body["message"].as_str().unwrap().contains("list_toolboxes"),
+        "{body:#?}"
+    );
+}

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -11,7 +11,7 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 
 - **18 toolsets** organized into 10 categories
 - **187 registered tools** + **6 always-visible meta-tools** = **193 total**
-- **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop.
+- **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
 ## Meta-tools (always visible)


### PR DESCRIPTION
**Depends on #110** -- this branch is stacked on `pr-router-batch-autoload` (the reworked batch-only PR) and includes its commits. Please review/merge #110 first; this PR's diff against `main` will shrink to just the commit below once #110 lands.

## Problem / scope

@mixelpixx's review of #110 objected to unconditional auto-load: toolsets accumulate monotonically, so any tool the model calls permanently costs ~19 tool descriptions on every later `tools/list` for the rest of the session, and `unload_toolset` becomes advisory rather than a real prune. This resubmits auto-load as an opt-in, defaulting off, per that feedback.

## Root cause / design

- New `auto_load_toolsets` field (default `false`) on both `konnect::Config` (TOML/JSON key `auto_load_toolsets`) and `konnect_core::tools::ServerConfig`, wired through both construction sites (`main.rs`, `ffi.rs`).
- `dispatch_tool`'s miss branch in `handler.rs` is the only behavioral fork: with the flag off (default), an unloaded-tool call returns the original `toolset_not_loaded` error naming the owner toolset, unchanged from `main` today. With it on, the owning toolset loads, `tools/list_changed` fires, and the call executes in the same hop.
- `unload_toolset`'s description gains one sentence noting that with `auto_load_toolsets` on, tools reload on use -- the same tradeoff the maintainer flagged, now opt-in and documented rather than a silent default.
- DEV.md documents the config key, its default, and the round-trip-vs-context-growth tradeoff explicitly so it's a caller's informed choice.

## Compatibility

Off by default: zero behavior change for any existing deployment that doesn't set the config key. No schema changes -- `load_toolset`'s result shape is exactly what #110 ships (unaffected by this PR).

## Tests run

Extended the `McpProcess` stdio test harness with `spawn_in_dir`, which sets the child process's working directory to a tempdir so `Config::load()`'s first search path (`konnect.toml` in cwd) picks up a test config. New test `auto_load_toolsets_config_loads_and_executes_on_miss` writes `auto_load_toolsets = true` to that file, calls an unloaded tool (`route_trace` with `{}`), and asserts it auto-loads, executes through to the tool's own `invalid_argument` check (field `net_name`), and fires `notifications/tools/list_changed`. Default-off behavior is already covered by `structured_errors_guide_recovery` in #110 (unchanged). `cargo test --workspace --locked --lib --tests` (19 suites) and `--doc` pass; `cargo clippy --workspace --locked -- -D warnings` and `cargo fmt --all -- --check` are clean.

## Risk / rollback

Low -- default-off, single behavioral fork gated by one config bool. Single-commit revert available on top of #110.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>