### PR TITLE
fix(build): resolve protoc from PATH before deriving includes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,12 @@ Thanks for your interest! Bug reports, feature requests, and pull requests are w
 ## Development setup
 
 ```bash
-# protoc is required for protobuf code generation (kicad-ipc crate)
-# Windows: choco install protoc   /   macOS: brew install protobuf   /   Linux: apt install protobuf-compiler
+# protoc is required for protobuf code generation (konnect-ipc crate). The build also
+# needs protobuf's well-known .proto files, which some distributions package separately.
+# Windows: choco install protoc   (shim installs may also need PROTOC_INCLUDE — see DEV.md)
+# macOS:   brew install protobuf
+# Debian:  sudo apt install protobuf-compiler libprotobuf-dev
+# Fedora:  sudo dnf install protobuf-compiler protobuf-devel
 
 cargo check --workspace
 cargo test --workspace --lib --tests

--- a/DEV.md
+++ b/DEV.md
@@ -244,10 +244,18 @@ The router is defined in `crates/konnect-core/src/router/mod.rs`.
   version IS the MSRV: bump it deliberately, in its own commit, after running the full
   local gate on the new version.
 - `protoc` binary (for protobuf code generation in konnect-ipc crate)
-  - Set `PROTOC` environment variable, or leave it unset and `konnect-ipc/build.rs`
-    falls back to `protoc` found on PATH
-  - Well-known-type includes are derived from `<PROTOC>/../../include` (i.e. a standard
-    protoc release layout with `bin/protoc` next to `include/`) when that directory exists
+  - Set `PROTOC` to the binary, or leave it unset and `konnect-ipc/build.rs` resolves
+    `protoc` from PATH
+  - Well-known-type includes (`google/protobuf/any.proto`) are derived from
+    `<protoc>/../../include` after the binary is resolved to an absolute path. This
+    covers both the upstream release layout (`bin/protoc` beside `include/`) and system
+    packages (`/usr/bin/protoc` → `/usr/include`). Set `PROTOC_INCLUDE` to override when
+    the binary and its protos live in unrelated prefixes — notably Chocolatey and scoop,
+    whose shared shim directory is not the package prefix.
+  - Some distributions ship the well-known `.proto` files separately from the compiler.
+    Debian/Ubuntu need `protobuf-compiler` **and** `libprotobuf-dev`; Fedora needs
+    `protobuf-compiler` and `protobuf-devel`. Missing them fails the build with
+    `google/protobuf/any.proto: File not found`.
   - Download: https://github.com/protocolbuffers/protobuf/releases
 - For schematic-viewer (built separately from the workspace — see Quick Start):
   - Rust toolchain on PATH (Windows: `set PATH=%PATH%;%USERPROFILE%\.cargo\bin` if `cargo`

--- a/crates/konnect-ipc/build.rs
+++ b/crates/konnect-ipc/build.rs
@@ -1,3 +1,81 @@
+use std::path::{Path, PathBuf};
+
+/// Resolve `protoc` to an absolute path.
+///
+/// A bare command name — what the unset-`PROTOC` fallback yields — has no
+/// grandparent, so the include derived from it below silently comes out empty.
+/// Resolving against `PATH` first is what makes "just have protoc on PATH"
+/// work.
+fn resolve_protoc(raw: &str) -> Option<PathBuf> {
+    let path = Path::new(raw);
+
+    // Already a path, not a command name. Relative ones are made absolute so
+    // there is something to walk up from.
+    if path.components().count() > 1 {
+        return if path.is_absolute() {
+            Some(path.to_path_buf())
+        } else {
+            std::fs::canonicalize(path).ok()
+        };
+    }
+
+    // Search PATH as a shell would; entries hold `protoc.exe` on Windows.
+    let candidates: Vec<String> = if cfg!(windows) {
+        vec![format!("{raw}.exe"), raw.to_string()]
+    } else {
+        vec![raw.to_string()]
+    };
+
+    std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths)
+            .flat_map(|dir| candidates.iter().map(move |name| dir.join(name)))
+            .find(|candidate| is_executable(candidate))
+    })
+}
+
+/// Whether a `PATH` candidate is something the OS would actually run.
+///
+/// A bare `is_file()` would match a non-executable `protoc` in an earlier
+/// entry, deriving the include from that directory while prost-build runs the
+/// real compiler from a later one.
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::metadata(path)
+        .map(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    // No executable bit on Windows; the `.exe` candidate already narrows it.
+    path.is_file()
+}
+
+/// Locate the directory holding protobuf's well-known types
+/// (`google/protobuf/any.proto` and friends).
+///
+/// `PROTOC_INCLUDE` wins when set — prost-build's own escape hatch, and the
+/// only answer when protoc and its protos sit in unrelated prefixes. Otherwise
+/// `<protoc>/../../include`, covering both the upstream release layout
+/// (`bin/protoc` beside `include/`) and system packages (`/usr/bin/protoc` →
+/// `/usr/include`).
+fn protoc_include_dir() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("PROTOC_INCLUDE") {
+        let dir = PathBuf::from(dir);
+        if dir.is_dir() {
+            return Some(dir);
+        }
+    }
+
+    let raw = std::env::var("PROTOC").unwrap_or_else(|_| "protoc".to_string());
+    let protoc = resolve_protoc(&raw)?;
+
+    let include = protoc.parent()?.parent()?.join("include");
+    include.is_dir().then_some(include)
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // nng-sys's Windows IPC listener references IsValidSecurityDescriptor
     // (advapi32) but doesn't always emit the link directive itself — without
@@ -6,6 +84,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }
+
+    // Any rerun-if-* directive replaces Cargo's default of watching every
+    // package file, so the protos must be listed or edits to them would build
+    // against stale generated code. The directory form is recursive, so it
+    // also covers imports missing from the list below.
+    println!("cargo:rerun-if-changed=proto");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Either variable moves the include dir out from under the generated code.
+    // PATH feeds it too when PROTOC is unset, but watching PATH rebuilds on
+    // unrelated shell changes — swapping protoc installs without touching a
+    // variable needs `cargo clean -p konnect-ipc`.
+    println!("cargo:rerun-if-env-changed=PROTOC");
+    println!("cargo:rerun-if-env-changed=PROTOC_INCLUDE");
 
     let protos = &[
         "proto/common/envelope.proto",
@@ -20,19 +112,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "proto/board/board_types.proto",
     ];
 
-    // Include paths: our proto dir + protoc's well-known types
-    // The PROTOC env var points to the protoc binary; its sibling ../include/ has google protos
-    let protoc_path = std::env::var("PROTOC").unwrap_or_else(|_| "protoc".to_string());
-    let protoc_dir = std::path::Path::new(&protoc_path)
-        .parent()
-        .and_then(|p| p.parent())
-        .map(|p| p.join("include"))
-        .unwrap_or_default();
-
-    let mut includes: Vec<&str> = vec!["proto/"];
-    let protoc_include = protoc_dir.to_str().unwrap_or("");
-    if !protoc_include.is_empty() && std::path::Path::new(protoc_include).exists() {
-        includes.push(protoc_include);
+    let mut includes: Vec<PathBuf> = vec![PathBuf::from("proto/")];
+    if let Some(dir) = protoc_include_dir() {
+        includes.push(dir);
     }
 
     prost_build::Config::new().compile_protos(protos, &includes)?;


### PR DESCRIPTION
## Problem

Building with `PROTOC` unset — the setup both `DEV.md` and `CONTRIBUTING.md`
document — fails with `google/protobuf/any.proto: File not found`.

## Root cause and design

The fallback derived the well-known-types include from the bare string
`"protoc"`. `Path::new("protoc").parent()` is `Some("")` and *its* `.parent()`
is `None`, so the include was silently dropped and only an absolute `PROTOC`
ever worked.

`build.rs` now resolves a bare command name against `PATH` (with `.exe` on
Windows, skipping non-executable matches) before walking up to
`<protoc>/../../include` — covering both the upstream release layout and system
packages where `/usr/bin/protoc` pairs with `/usr/include` — and gives
`PROTOC_INCLUDE` precedence for installs that split the binary from the protos.

`PROTOC`, `PROTOC_INCLUDE`, `proto/`, and `build.rs` are all declared as re-run
triggers: emitting any `rerun-if-*` directive drops Cargo's default of watching
every package file, so the protos must be listed or editing one would compile
against stale generated code.

## Compatibility and risk

No public API, schema, or generated-code change. An absolute `PROTOC` behaves
exactly as before. Build-script only, so a bad resolution fails loudly rather
than producing a wrong artifact; rollback is reverting the one commit.

## Tests

`--lib --tests` (476) and `--doc` (3) pass; `clippy -D warnings` and
`fmt --check` clean. `konnect-ipc` verified with `PROTOC` unset, absolute, and
via `PROTOC_INCLUDE`, and touching a `.proto` confirmed to retrigger codegen.
`schematic-viewer` is outside the workspace and was not touched.

## Docs

`DEV.md` and `CONTRIBUTING.md` now name the separately packaged well-known
protos (Debian `libprotobuf-dev`, Fedora `protobuf-devel`), the error their
absence produces, and the Chocolatey/scoop shim case that still needs
`PROTOC_INCLUDE`. Also fixes a stale `kicad-ipc` reference.
