### PR TITLE
fix(library): resolve symbols through sym-lib-table

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -54,7 +54,7 @@ Konnect/
 │   │       │   ├── registry.rs      # Static toolset metadata + tools_for() dispatcher
 │   │       │   └── meta_tools.rs    # 6 always-visible meta-tools
 │   │       └── tools/
-│   │           ├── mod.rs            # ToolDef, ToolContext, tool! macro, helpers, kicad_config_dir(), resolve_lib_symbol()
+│   │           ├── mod.rs            # ToolDef, ToolContext, tool! macro, helpers, kicad_config_dir()
 │   │           ├── cli.rs            # kicad-cli v10 subprocess wrapper (verified against actual binary)
 │   │           ├── svg_import.rs     # SVG parsing + Bezier flattening for import_svg_logo (usvg-backed)
 │   │           ├── project.rs        # 6 tools (incl. open_schematic_viewer)

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -838,6 +838,73 @@ fn global_sym_lib_table() -> PathBuf {
     super::kicad_config_dir().join("sym-lib-table")
 }
 
+/// Symbol libraries resolved as KiCad does: project `sym-lib-table` (shadowing
+/// same-nickname global entries), then global, then the conventional
+/// `<nickname>.kicad_symdir` / `.kicad_sym` layout. Same order as
+/// [`resolve_footprint_path`]; the last step covers a missing global table.
+///
+/// Both the flattened tables and the install dirs are memoised: placing one
+/// component asks for candidates at least twice, and the default global table
+/// is a `(type "Table")` indirection to ~200 bundled entries, each of which
+/// re-probes the install roots when `${KICAD*_DIR}` is unset.
+pub(crate) struct KiCadSymbolSource {
+    project_dir: Option<PathBuf>,
+    tables: std::sync::OnceLock<Vec<serde_json::Value>>,
+    install_dirs: std::sync::OnceLock<Vec<PathBuf>>,
+}
+
+impl KiCadSymbolSource {
+    pub(crate) fn new(project_dir: Option<PathBuf>) -> Self {
+        Self {
+            project_dir,
+            tables: std::sync::OnceLock::new(),
+            install_dirs: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// For a `.kicad_sch` or `.kicad_pcb` — `sym-lib-table` sits beside it.
+    pub(crate) fn for_file(file: &Path) -> Self {
+        Self::new(file.parent().map(Path::to_path_buf))
+    }
+
+    /// Project entries first so they shadow same-nickname global ones.
+    fn tables(&self) -> &[serde_json::Value] {
+        self.tables.get_or_init(|| {
+            let mut libs = Vec::new();
+            if let Some(dir) = &self.project_dir {
+                libs.extend(read_flat_lib_table(&dir.join("sym-lib-table")));
+            }
+            libs.extend(read_flat_lib_table(&global_sym_lib_table()));
+            libs
+        })
+    }
+}
+
+impl konnect_schematic_editor::library::SymbolLibrarySource for KiCadSymbolSource {
+    fn candidates(&self, nickname: &str) -> Vec<PathBuf> {
+        let mut out = Vec::new();
+
+        for lib in self
+            .tables()
+            .iter()
+            .filter(|l| l["nickname"].as_str() == Some(nickname))
+        {
+            if let Some(path) = lib["path"].as_str() {
+                out.push(PathBuf::from(path));
+            }
+        }
+
+        let install_dirs = self
+            .install_dirs
+            .get_or_init(|| super::find_kicad_library_dirs("symbols"));
+        for base in install_dirs {
+            out.push(base.join(format!("{}.kicad_symdir", nickname)));
+            out.push(base.join(format!("{}.kicad_sym", nickname)));
+        }
+        out
+    }
+}
+
 /// Parse a lib-table S-expression and return list of (nickname, uri, type) tuples.
 ///
 /// Indentation-agnostic: KiCad's own writers emit tab-indented, CRLF-terminated
@@ -1075,8 +1142,8 @@ pub(crate) fn footprint_lib_nickname_for_dir(dir: &Path) -> Option<String> {
 /// registers. The `.pretty` fallback covers a stock install whose global
 /// table is missing or unreadable.
 ///
-/// (`resolve_symbol_lib_path` still searches global-first for symbols; that
-/// asymmetry is pre-existing and noted on that function.)
+/// Symbols resolve the same way and in the same order, via
+/// [`KiCadSymbolSource`] and `resolve_symbol_lib_path`.
 pub(crate) fn resolve_footprint_path(
     reference: &str,
     project_dir: Option<&Path>,
@@ -1185,26 +1252,18 @@ async fn handle_register_footprint_library(
     let nickname = require_str(args, "nickname").map_err(|e| anyhow::anyhow!("{:?}", e))?;
     let scope = args["scope"].as_str().unwrap_or("project");
 
-    let table_path = if scope == "global" {
-        global_fp_lib_table()
-    } else if let Some(proj) = args["project"].as_str() {
-        PathBuf::from(proj)
-            .parent()
-            .unwrap_or(Path::new("."))
-            .join("fp-lib-table")
-    } else {
-        return Ok(CallToolResult::error(
-            "For project scope, provide 'project' path to .kicad_pro file",
-        ));
+    let (table_path, uri) = match lib_table_target(
+        scope,
+        args["project"].as_str(),
+        &lib_path,
+        global_fp_lib_table(),
+        "fp-lib-table",
+    ) {
+        Ok(target) => target,
+        Err(e) => return Ok(e),
     };
 
-    register_in_lib_table(
-        &table_path,
-        nickname,
-        lib_path.to_str().unwrap_or(""),
-        "KiCad",
-    )
-    .await?;
+    register_in_lib_table(&table_path, nickname, &uri, "KiCad").await?;
 
     Ok(CallToolResult::text(
         serde_json::to_string(&json!({
@@ -1260,6 +1319,56 @@ async fn handle_list_footprint_libraries(
     ))
 }
 
+/// A lib-table URI for `lib_path`: `${KIPRJMOD}/…` when it lives inside the
+/// project, so the project survives being moved or cloned. Anything outside
+/// keeps its absolute path.
+fn project_relative_uri(lib_path: &Path, table_dir: &Path) -> String {
+    let absolute_uri = || lib_path.to_string_lossy().into_owned();
+    // Both must canonicalise: `strip_prefix("")` succeeds and returns the whole
+    // path, which would emit a `${KIPRJMOD}//abs/path` that resolves nowhere.
+    let (Ok(lib), Ok(dir)) = (
+        std::fs::canonicalize(lib_path),
+        std::fs::canonicalize(table_dir),
+    ) else {
+        return absolute_uri();
+    };
+    match lib.strip_prefix(dir) {
+        // Forward slashes: KiCad writes URIs this way on Windows too.
+        Ok(rel) => format!("${{KIPRJMOD}}/{}", rel.to_string_lossy().replace('\\', "/")),
+        Err(_) => absolute_uri(),
+    }
+}
+
+/// Which lib-table a `register_*` call writes to, and the URI it records.
+///
+/// Shared by the symbol and footprint registrars so the two cannot drift: both
+/// need the same `${KIPRJMOD}` portability and the same empty-parent guard.
+fn lib_table_target(
+    scope: &str,
+    project: Option<&str>,
+    lib_path: &Path,
+    global_table: PathBuf,
+    table_filename: &str,
+) -> Result<(PathBuf, String), CallToolResult> {
+    if scope == "global" {
+        return Ok((global_table, lib_path.to_string_lossy().into_owned()));
+    }
+    let Some(proj) = project else {
+        return Err(CallToolResult::error(
+            "For project scope, provide 'project' path to .kicad_pro file",
+        ));
+    };
+    // `Path::new("board.kicad_pro").parent()` is Some("") — an empty path, not
+    // None — so the `.` default needs an explicit emptiness check.
+    let table_dir = PathBuf::from(proj)
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or(Path::new("."))
+        .to_path_buf();
+    let uri = project_relative_uri(lib_path, &table_dir);
+    Ok((table_dir.join(table_filename), uri))
+}
+
 async fn handle_register_symbol_library(
     args: &serde_json::Value,
     _ctx: &ToolContext,
@@ -1268,33 +1377,26 @@ async fn handle_register_symbol_library(
     let nickname = require_str(args, "nickname").map_err(|e| anyhow::anyhow!("{:?}", e))?;
     let scope = args["scope"].as_str().unwrap_or("project");
 
-    let table_path = if scope == "global" {
-        global_sym_lib_table()
-    } else if let Some(proj) = args["project"].as_str() {
-        PathBuf::from(proj)
-            .parent()
-            .unwrap_or(Path::new("."))
-            .join("sym-lib-table")
-    } else {
-        return Ok(CallToolResult::error(
-            "For project scope, provide 'project' path to .kicad_pro file",
-        ));
+    let (table_path, uri) = match lib_table_target(
+        scope,
+        args["project"].as_str(),
+        &lib_path,
+        global_sym_lib_table(),
+        "sym-lib-table",
+    ) {
+        Ok(target) => target,
+        Err(e) => return Ok(e),
     };
 
-    register_in_lib_table(
-        &table_path,
-        nickname,
-        lib_path.to_str().unwrap_or(""),
-        "KiCad",
-    )
-    .await?;
+    register_in_lib_table(&table_path, nickname, &uri, "KiCad").await?;
 
     Ok(CallToolResult::text(
         serde_json::to_string(&json!({
             "success": true,
             "nickname": nickname,
             "scope": scope,
-            "table": table_path.to_str().unwrap_or("")
+            "table": table_path.to_str().unwrap_or(""),
+            "uri": uri
         }))
         .unwrap(),
     ))
@@ -2377,33 +2479,21 @@ fn top_level_symbol_names(content: &str) -> anyhow::Result<Vec<String>> {
     Ok(names)
 }
 
-/// Resolve a symbol library nickname to an on-disk `.kicad_sym` path.
-///
-/// Checks the **global** sym-lib-table first, then the **project** table at
-/// `project_dir/sym-lib-table` (if a project dir is supplied). Returns the first
-/// entry whose nickname matches and whose URI resolved to a path at all. Both
-/// tables are read with `read_flat_lib_table`, so nested `(type "Table")`
-/// references are followed and `${KICAD*_DIR}` URIs are expanded.
-///
-/// The returned path is *not* guaranteed to exist: `expand_lib_uri` checks
-/// existence only for `${KICAD*_DIR}` expansions, and takes a plain URI as
-/// written. A stale global entry therefore still shadows a working project one
-/// with the same nickname, and the caller's read is what discovers it.
-async fn resolve_symbol_lib_path(nick: &str, project_dir: Option<&Path>) -> Option<PathBuf> {
-    let mut tables = vec![global_sym_lib_table()];
-    if let Some(pd) = project_dir {
-        tables.push(pd.join("sym-lib-table"));
-    }
-    for table in tables {
-        for lib in read_flat_lib_table(&table) {
-            if lib["nickname"].as_str() == Some(nick) {
-                if let Some(path) = lib["path"].as_str() {
-                    return Some(PathBuf::from(path));
-                }
-            }
-        }
-    }
-    None
+/// The `.kicad_sym` file defining `nick:sym_name`, found exactly the way symbol
+/// placement finds it — via [`KiCadSymbolSource`], so a lookup here and a
+/// placement of the same lib_id can never disagree.
+fn resolve_symbol_lib_path(
+    nick: &str,
+    sym_name: &str,
+    project_dir: Option<&Path>,
+) -> Option<PathBuf> {
+    use konnect_schematic_editor::library::SymbolLibrarySource;
+    KiCadSymbolSource::new(project_dir.map(Path::to_path_buf))
+        .candidates(nick)
+        .iter()
+        .find_map(|candidate| {
+            konnect_schematic_editor::library::symbol_file_in(candidate, sym_name)
+        })
 }
 
 /// Recursively collect every descendant `SexpNode::List` whose head matches
@@ -2726,12 +2816,13 @@ async fn handle_get_symbol_info(
         .map(PathBuf::from)
         .or_else(|| ctx.config.project_dir.clone());
 
-    let lib_path = match resolve_symbol_lib_path(lib_nick, project_dir.as_deref()).await {
+    let lib_path = match resolve_symbol_lib_path(lib_nick, sym_name, project_dir.as_deref()) {
         Some(p) => p,
         None => {
             return Ok(CallToolResult::error(format!(
-                "Library '{}' not found in global or project sym-lib-table, or its uri uses an unresolved env var",
-                lib_nick
+                "Symbol '{}' not found: no library '{}' in the project or global \
+                 sym-lib-table, nor in the installed KiCad symbol libraries",
+                lib_id, lib_nick
             )));
         }
     };
@@ -4417,6 +4508,170 @@ mod tests {
         assert!(
             rc.contains("(name \"IN\" (effects (font (size 1.27 1.27))))"),
             "rectangle pin names keep the default 1.27 font:\n{rc}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod symbol_source_tests {
+    use super::*;
+    use konnect_schematic_editor::library::SymbolLibrarySource;
+
+    /// The bug this fixes: a library registered in the project table was
+    /// invisible to placement, which only scanned the KiCad install dirs.
+    #[test]
+    fn project_table_entry_is_offered_before_the_install_dirs() {
+        let proj = tempfile::tempdir().unwrap();
+        let lib = proj.path().join("lib");
+        std::fs::create_dir_all(&lib).unwrap();
+        let file = lib.join("vendor-parts.kicad_sym");
+        std::fs::write(&file, "(kicad_symbol_lib)\n").unwrap();
+
+        std::fs::write(
+            proj.path().join("sym-lib-table"),
+            format!(
+                "(sym_lib_table\n  (version 7)\n  (lib (name \"MyParts\") (type \"KiCad\") (uri \"{}\") (options \"\") (descr \"\"))\n)\n",
+                file.display()
+            ),
+        )
+        .unwrap();
+
+        let src = KiCadSymbolSource::new(Some(proj.path().to_path_buf()));
+        let candidates = src.candidates("MyParts");
+
+        assert_eq!(
+            candidates.first(),
+            Some(&file),
+            "the project table entry must be tried first, got {candidates:?}"
+        );
+    }
+
+    /// `${KIPRJMOD}` resolves against the table's own directory, not the env.
+    #[test]
+    fn kiprjmod_uri_resolves_against_the_project_dir() {
+        let proj = tempfile::tempdir().unwrap();
+        let lib = proj.path().join("lib");
+        std::fs::create_dir_all(&lib).unwrap();
+        let file = lib.join("parts.kicad_sym");
+        std::fs::write(&file, "(kicad_symbol_lib)\n").unwrap();
+
+        std::fs::write(
+            proj.path().join("sym-lib-table"),
+            "(sym_lib_table\n  (version 7)\n  (lib (name \"Proj\") (type \"KiCad\") (uri \"${KIPRJMOD}/lib/parts.kicad_sym\") (options \"\") (descr \"\"))\n)\n",
+        )
+        .unwrap();
+
+        let src = KiCadSymbolSource::new(Some(proj.path().to_path_buf()));
+        assert!(
+            src.candidates("Proj").contains(&file),
+            "${{KIPRJMOD}} must expand to the project dir"
+        );
+    }
+
+    /// A stock install keeps working with no table entry at all. Points
+    /// KICAD10_SYMBOL_DIR at a tempdir rather than asserting against whatever
+    /// KiCad is installed — CI has none, so the fallback would have no
+    /// directory to derive from and the assertion would be vacuous at best.
+    #[test]
+    fn unregistered_nickname_falls_back_to_the_conventional_layout() {
+        let _env = crate::tools::KICAD_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let install = tempfile::tempdir().unwrap();
+        std::env::set_var("KICAD10_SYMBOL_DIR", install.path());
+
+        let src = KiCadSymbolSource::new(None);
+        let candidates = src.candidates("Device");
+        assert!(
+            candidates.contains(&install.path().join("Device.kicad_symdir")),
+            "expected the symdir fallback, got {candidates:?}"
+        );
+        assert!(
+            candidates.contains(&install.path().join("Device.kicad_sym")),
+            "expected the single-file fallback, got {candidates:?}"
+        );
+    }
+
+    #[test]
+    fn project_scoped_registration_writes_a_portable_uri() {
+        let proj = tempfile::tempdir().unwrap();
+        let lib = proj.path().join("lib");
+        std::fs::create_dir_all(&lib).unwrap();
+        let file = lib.join("parts.kicad_sym");
+        std::fs::write(&file, "(kicad_symbol_lib)\n").unwrap();
+
+        assert_eq!(
+            project_relative_uri(&file, proj.path()),
+            "${KIPRJMOD}/lib/parts.kicad_sym"
+        );
+    }
+
+    /// `Path::new("board.kicad_pro").parent()` is `Some("")`, and
+    /// `strip_prefix("")` returns the whole path — which would emit
+    /// `${KIPRJMOD}//abs/path`, resolving nowhere on read.
+    #[test]
+    fn an_empty_table_dir_does_not_produce_a_rooted_kiprjmod_uri() {
+        let other = tempfile::tempdir().unwrap();
+        let file = other.path().join("parts.kicad_sym");
+        std::fs::write(&file, "(kicad_symbol_lib)\n").unwrap();
+
+        let uri = project_relative_uri(&file, Path::new(""));
+        assert!(
+            !uri.contains("KIPRJMOD"),
+            "empty project dir must fall back to an absolute uri: {uri}"
+        );
+        assert_eq!(uri, file.to_string_lossy());
+    }
+
+    /// Both registrars share one target helper, so footprints get the same
+    /// portable URI and the same empty-parent guard as symbols.
+    #[test]
+    fn both_registrars_agree_on_the_project_table_target() {
+        let proj = tempfile::tempdir().unwrap();
+        let lib = proj.path().join("lib");
+        std::fs::create_dir_all(&lib).unwrap();
+        let sym = lib.join("parts.kicad_sym");
+        std::fs::write(&sym, "(kicad_symbol_lib)\n").unwrap();
+        let fp = lib.join("parts.pretty");
+        std::fs::create_dir_all(&fp).unwrap();
+
+        let proj_file = proj.path().join("board.kicad_pro");
+        let proj_arg = proj_file.to_str();
+
+        let (sym_table, sym_uri) = lib_table_target(
+            "project",
+            proj_arg,
+            &sym,
+            global_sym_lib_table(),
+            "sym-lib-table",
+        )
+        .expect("symbol target");
+        let (fp_table, fp_uri) = lib_table_target(
+            "project",
+            proj_arg,
+            &fp,
+            global_fp_lib_table(),
+            "fp-lib-table",
+        )
+        .expect("footprint target");
+
+        assert_eq!(sym_uri, "${KIPRJMOD}/lib/parts.kicad_sym");
+        assert_eq!(fp_uri, "${KIPRJMOD}/lib/parts.pretty");
+        assert_eq!(sym_table, proj.path().join("sym-lib-table"));
+        assert_eq!(fp_table, proj.path().join("fp-lib-table"));
+    }
+
+    #[test]
+    fn a_library_outside_the_project_keeps_its_absolute_uri() {
+        let proj = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let file = other.path().join("shared.kicad_sym");
+        std::fs::write(&file, "(kicad_symbol_lib)\n").unwrap();
+
+        let uri = project_relative_uri(&file, proj.path());
+        assert!(
+            !uri.contains("KIPRJMOD"),
+            "nothing portable to say about an out-of-project library: {uri}"
         );
     }
 }

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -838,6 +838,32 @@ fn global_sym_lib_table() -> PathBuf {
     super::kicad_config_dir().join("sym-lib-table")
 }
 
+/// Directory of the nearest ancestor of `file` that holds a `.kicad_pro`,
+/// falling back to the file's own directory when it belongs to no project — a
+/// loose schematic keeps resolving against the tables beside it.
+///
+/// The project file is found by scanning for the extension rather than by name:
+/// a sheet's filename says nothing about what the project is called.
+fn project_root_for(file: &Path) -> Option<PathBuf> {
+    let start = file.parent()?;
+    start
+        .ancestors()
+        .find(|dir| holds_kicad_pro(dir))
+        .map(Path::to_path_buf)
+        .or_else(|| Some(start.to_path_buf()))
+}
+
+/// Whether `dir` contains a `.kicad_pro`. An unreadable directory holds none.
+fn holds_kicad_pro(dir: &Path) -> bool {
+    std::fs::read_dir(dir).is_ok_and(|entries| {
+        entries.flatten().any(|e| {
+            e.path()
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("kicad_pro"))
+        })
+    })
+}
+
 /// Symbol libraries resolved as KiCad does: project `sym-lib-table` (shadowing
 /// same-nickname global entries), then global, then the conventional
 /// `<nickname>.kicad_symdir` / `.kicad_sym` layout. Same order as
@@ -862,9 +888,13 @@ impl KiCadSymbolSource {
         }
     }
 
-    /// For a `.kicad_sch` or `.kicad_pcb` — `sym-lib-table` sits beside it.
+    /// For a `.kicad_sch` or `.kicad_pcb` — `sym-lib-table` sits at the project
+    /// root, which is the nearest ancestor holding a `.kicad_pro`. A
+    /// hierarchical sheet under `<proj>/sheets/` therefore still resolves
+    /// against `<proj>/sym-lib-table`: KiCad anchors `KIPRJMOD` at the project,
+    /// not at the sheet.
     pub(crate) fn for_file(file: &Path) -> Self {
-        Self::new(file.parent().map(Path::to_path_buf))
+        Self::new(project_root_for(file))
     }
 
     /// Project entries first so they shadow same-nickname global ones.
@@ -4589,6 +4619,67 @@ mod symbol_source_tests {
         assert!(
             candidates.contains(&install.path().join("Device.kicad_sym")),
             "expected the single-file fallback, got {candidates:?}"
+        );
+    }
+
+    /// Reported on #136: a sheet under `<proj>/sheets/` saw no project library,
+    /// because the table was looked for beside the sheet rather than at the
+    /// project root. `add_hierarchical_sheet` accepts such a `sheet_file`, so
+    /// this is reachable through Konnect alone.
+    #[test]
+    fn a_sheet_in_a_subdirectory_resolves_against_the_project_table() {
+        let proj = tempfile::tempdir().unwrap();
+        let file = proj.path().join("parts.kicad_sym");
+        std::fs::write(&file, "(kicad_symbol_lib)\n").unwrap();
+        std::fs::write(proj.path().join("board.kicad_pro"), "{}\n").unwrap();
+        std::fs::write(
+            proj.path().join("sym-lib-table"),
+            "(sym_lib_table\n  (version 7)\n  (lib (name \"MyLib\") (type \"KiCad\") (uri \"${KIPRJMOD}/parts.kicad_sym\") (options \"\") (descr \"\"))\n)\n",
+        )
+        .unwrap();
+
+        let sheets = proj.path().join("sheets");
+        std::fs::create_dir_all(&sheets).unwrap();
+        let child = sheets.join("child.kicad_sch");
+        std::fs::write(&child, "(kicad_sch)\n").unwrap();
+
+        let candidates = KiCadSymbolSource::for_file(&child).candidates("MyLib");
+        assert!(
+            candidates.contains(&file),
+            "a sub-sheet must see the project table at the root, got {candidates:?}"
+        );
+    }
+
+    /// The fallback the walk must not break: a schematic belonging to no
+    /// project still resolves against the tables sitting beside it.
+    #[test]
+    fn a_schematic_with_no_project_falls_back_to_its_own_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("parts.kicad_sym");
+        std::fs::write(&file, "(kicad_symbol_lib)\n").unwrap();
+        std::fs::write(
+            dir.path().join("sym-lib-table"),
+            "(sym_lib_table\n  (version 7)\n  (lib (name \"Loose\") (type \"KiCad\") (uri \"${KIPRJMOD}/parts.kicad_sym\") (options \"\") (descr \"\"))\n)\n",
+        )
+        .unwrap();
+        let sch = dir.path().join("loose.kicad_sch");
+        std::fs::write(&sch, "(kicad_sch)\n").unwrap();
+
+        let candidates = KiCadSymbolSource::for_file(&sch).candidates("Loose");
+        assert!(
+            candidates.contains(&file),
+            "a projectless schematic must still use the table beside it, got {candidates:?}"
+        );
+    }
+
+    /// `Path::new("board.kicad_sch").parent()` is `Some("")`, not `None`. The
+    /// walk must leave that as-is so a bare relative path keeps resolving
+    /// against the working directory.
+    #[test]
+    fn a_bare_relative_schematic_keeps_an_empty_project_dir() {
+        assert_eq!(
+            project_root_for(Path::new("board.kicad_sch")),
+            Some(PathBuf::new())
         );
     }
 

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -971,6 +971,33 @@ fn parse_lib_table(content: &str) -> Vec<serde_json::Value> {
 /// `${KICAD10_FOOTPRINT_DIR}/Resistor_SMD.pretty`. An exported environment
 /// variable wins; otherwise the variable's kind is inferred from its name and
 /// the known install locations are searched.
+/// User path variables from `kicad_common.json` (Preferences → Configure
+/// Paths).
+///
+/// These are KiCad's own variables, not process environment variables — KiCad
+/// stores them in its config and substitutes them itself when reading a
+/// lib-table, so `std::env::var` never finds them. A table written against one
+/// is perfectly normal and is the recommended way to keep a table portable
+/// across machines.
+fn kicad_user_path_vars() -> std::collections::HashMap<String, String> {
+    let Ok(text) = std::fs::read_to_string(super::kicad_config_dir().join("kicad_common.json"))
+    else {
+        return std::collections::HashMap::new();
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return std::collections::HashMap::new();
+    };
+    json.get("environment")
+        .and_then(|e| e.get("vars"))
+        .and_then(|v| v.as_object())
+        .map(|m| {
+            m.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn expand_lib_uri(uri: &str, kiprjmod: Option<&Path>) -> Option<PathBuf> {
     let Some(rest) = uri.strip_prefix("${") else {
         return (!uri.is_empty()).then(|| PathBuf::from(uri));
@@ -993,6 +1020,19 @@ fn expand_lib_uri(uri: &str, kiprjmod: Option<&Path>) -> Option<PathBuf> {
     // var_os, not var: `var` treats a non-Unicode value as absent, which would
     // send a perfectly good ${KICAD*_DIR} down the install-root guess path.
     if let Some(base) = std::env::var_os(var) {
+        let p = PathBuf::from(base).join(tail);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+
+    // User path variables (Preferences → Configure Paths) are stored in
+    // kicad_common.json and are NOT process environment variables, so the
+    // var_os lookup above can never see them. They are the normal way to write
+    // a portable lib-table — `${MY_PARTS}/house.kicad_sym` — and without this
+    // every such entry resolved to None and the library was invisible.
+    // Credit to @JYPochez (#172) for finding this.
+    if let Some(base) = kicad_user_path_vars().get(var) {
         let p = PathBuf::from(base).join(tail);
         if p.exists() {
             return Some(p);
@@ -1349,23 +1389,54 @@ async fn handle_list_footprint_libraries(
     ))
 }
 
+/// A lib-table path written the way KiCad writes one: forward slashes on every
+/// platform, and without the Windows verbatim prefix.
+///
+/// `canonicalize` on Windows returns `\\?\C:\…`. That prefix is an OS-level
+/// escape for the 260-character limit, not part of the path — KiCad neither
+/// writes nor expects it, and a table carrying one is not portable. Backslashes
+/// are normalised for the same reason: a URI written on Windows has to still
+/// resolve when the project is opened on Linux or macOS.
+/// Credit to @anyn99 (#163), whose PR carried this and the lexical fallback
+/// below.
+fn portable_uri(path: &Path) -> String {
+    let raw = path.to_string_lossy();
+    let stripped = raw.strip_prefix(r"\\?\").unwrap_or(&raw);
+    stripped.replace('\\', "/")
+}
+
 /// A lib-table URI for `lib_path`: `${KIPRJMOD}/…` when it lives inside the
 /// project, so the project survives being moved or cloned. Anything outside
 /// keeps its absolute path.
 fn project_relative_uri(lib_path: &Path, table_dir: &Path) -> String {
-    let absolute_uri = || lib_path.to_string_lossy().into_owned();
-    // Both must canonicalise: `strip_prefix("")` succeeds and returns the whole
-    // path, which would emit a `${KIPRJMOD}//abs/path` that resolves nowhere.
-    let (Ok(lib), Ok(dir)) = (
+    // An empty table dir must never reach `strip_prefix`: it succeeds and
+    // returns the whole path, which would emit a `${KIPRJMOD}//abs/path` that
+    // resolves nowhere on read.
+    if table_dir.as_os_str().is_empty() {
+        return portable_uri(lib_path);
+    }
+
+    let relative = |rel: &Path| format!("${{KIPRJMOD}}/{}", portable_uri(rel));
+
+    // Canonicalising both sides is the accurate comparison — it resolves
+    // symlinks, `..` and case differences — but it only works for paths that
+    // already exist. Registering a library before creating it is normal, so a
+    // failure here falls through to a lexical compare rather than giving up on
+    // portability.
+    if let (Ok(lib), Ok(dir)) = (
         std::fs::canonicalize(lib_path),
         std::fs::canonicalize(table_dir),
-    ) else {
-        return absolute_uri();
-    };
-    match lib.strip_prefix(dir) {
-        // Forward slashes: KiCad writes URIs this way on Windows too.
-        Ok(rel) => format!("${{KIPRJMOD}}/{}", rel.to_string_lossy().replace('\\', "/")),
-        Err(_) => absolute_uri(),
+    ) {
+        if let Ok(rel) = lib.strip_prefix(&dir) {
+            return relative(rel);
+        }
+        // Canonicalised and genuinely outside the project.
+        return portable_uri(&lib);
+    }
+
+    match lib_path.strip_prefix(table_dir) {
+        Ok(rel) => relative(rel),
+        Err(_) => portable_uri(lib_path),
     }
 }
 
@@ -1381,7 +1452,7 @@ fn lib_table_target(
     table_filename: &str,
 ) -> Result<(PathBuf, String), CallToolResult> {
     if scope == "global" {
-        return Ok((global_table, lib_path.to_string_lossy().into_owned()));
+        return Ok((global_table, portable_uri(lib_path)));
     }
     let Some(proj) = project else {
         return Err(CallToolResult::error(
@@ -4711,7 +4782,60 @@ mod symbol_source_tests {
             !uri.contains("KIPRJMOD"),
             "empty project dir must fall back to an absolute uri: {uri}"
         );
-        assert_eq!(uri, file.to_string_lossy());
+        assert_eq!(uri, portable_uri(&file));
+    }
+
+    /// A library outside the project keeps an absolute URI, but still written
+    /// with forward slashes — a backslash URI does not survive the project
+    /// being opened on Linux or macOS.
+    #[test]
+    fn a_library_outside_the_project_stays_absolute_with_forward_slashes() {
+        let proj = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let file = other.path().join("parts.kicad_sym");
+        std::fs::write(&file, "(kicad_symbol_lib)\n").unwrap();
+
+        let uri = project_relative_uri(&file, proj.path());
+        assert!(!uri.contains("KIPRJMOD"), "outside the project: {uri}");
+        assert!(!uri.contains('\\'), "uri must be slash-separated: {uri}");
+    }
+
+    /// Global scope is never relativized, and never carries the Windows
+    /// verbatim prefix or backslashes.
+    #[test]
+    fn global_scope_writes_a_plain_forward_slash_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("parts.kicad_sym");
+        std::fs::write(&file, "(kicad_symbol_lib)\n").unwrap();
+
+        let (table, uri) = lib_table_target(
+            "global",
+            None,
+            &file,
+            PathBuf::from("/cfg/sym-lib-table"),
+            "sym-lib-table",
+        )
+        .expect("global scope needs no project");
+
+        assert_eq!(table, PathBuf::from("/cfg/sym-lib-table"));
+        assert!(!uri.contains("KIPRJMOD"), "global is never relative: {uri}");
+        assert!(!uri.starts_with(r"\\?\"), "verbatim prefix leaked: {uri}");
+        assert!(!uri.contains('\\'), "uri must be slash-separated: {uri}");
+    }
+
+    /// Registering a library before it exists on disk is normal — the file is
+    /// often created by the very next call. `canonicalize` fails for a path
+    /// that is not there yet, so without a lexical fallback the URI silently
+    /// came out absolute and the project stopped being portable.
+    #[test]
+    fn a_library_not_yet_on_disk_still_gets_a_portable_uri() {
+        let proj = tempfile::tempdir().unwrap();
+        let file = proj.path().join("lib").join("not-created-yet.kicad_sym");
+
+        assert_eq!(
+            project_relative_uri(&file, proj.path()),
+            "${KIPRJMOD}/lib/not-created-yet.kicad_sym"
+        );
     }
 
     /// Both registrars share one target helper, so footprints get the same

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -175,6 +175,12 @@ pub struct ServerConfig {
     pub auto_load_toolsets: bool,
 }
 
+/// Serialises tests that set `KICAD*_DIR`. Those are process-wide and read at
+/// call time by `find_kicad_library_dirs`, so two such tests running
+/// concurrently see each other's directories.
+#[cfg(test)]
+pub(crate) static KICAD_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[cfg(test)]
 mod query_cache_tests {
     use super::*;
@@ -625,117 +631,33 @@ fn kicad_config_base() -> std::path::PathBuf {
     }
 }
 
-// ─── KiCAD symbol library resolution ────────────────────────────────────────
-
-/// Resolve a lib_id like "Device:R" to the full symbol S-expression definition.
-/// KiCAD 10 stores symbols in .kicad_symdir directories, one .kicad_sym file per symbol.
-/// Returns the symbol block with the lib_id prefix (e.g. "Device:R") as the symbol name.
-pub fn resolve_lib_symbol(lib_id: &str) -> Option<String> {
-    let parts: Vec<&str> = lib_id.splitn(2, ':').collect();
-    if parts.len() != 2 {
-        tracing::warn!(
-            "[BETA] Cannot resolve lib_id '{}' — expected 'Library:Symbol' format",
-            lib_id
-        );
-        return None;
-    }
-    let (library_name, symbol_name) = (parts[0], parts[1]);
-
-    let sym_dirs = find_kicad_symbol_dirs();
-
-    for base_dir in &sym_dirs {
-        // KiCAD 10: Library.kicad_symdir/SymbolName.kicad_sym
-        let symdir_path = base_dir.join(format!("{}.kicad_symdir", library_name));
-        let sym_file = symdir_path.join(format!("{}.kicad_sym", symbol_name));
-
-        if sym_file.exists() {
-            tracing::debug!("[BETA] Found symbol file: {}", sym_file.display());
-            match std::fs::read_to_string(&sym_file) {
-                Ok(content) => {
-                    if let Some(sym_block) = extract_symbol_block(&content, symbol_name) {
-                        let renamed = sym_block.replacen(
-                            &format!("(symbol \"{}\"", symbol_name),
-                            &format!("(symbol \"{}:{}\"", library_name, symbol_name),
-                            1,
-                        );
-                        return Some(renamed);
-                    }
-                }
-                Err(e) => tracing::warn!("[BETA] Failed to read {}: {}", sym_file.display(), e),
-            }
-        }
-
-        // Fallback: KiCAD 8/9 format — Library.kicad_sym (single file)
-        let legacy_path = base_dir.join(format!("{}.kicad_sym", library_name));
-        if legacy_path.exists() {
-            match std::fs::read_to_string(&legacy_path) {
-                Ok(content) => {
-                    if let Some(sym_block) = extract_symbol_block(&content, symbol_name) {
-                        let renamed = sym_block.replacen(
-                            &format!("(symbol \"{}\"", symbol_name),
-                            &format!("(symbol \"{}:{}\"", library_name, symbol_name),
-                            1,
-                        );
-                        return Some(renamed);
-                    }
-                }
-                Err(e) => tracing::warn!("[BETA] Failed to read {}: {}", legacy_path.display(), e),
-            }
-        }
-    }
-
-    tracing::warn!(
-        "[BETA] Symbol '{}' not found in any library directory",
-        lib_id
-    );
-    None
-}
-
-/// Extract a top-level (symbol "NAME" ...) block from a .kicad_sym file.
-fn extract_symbol_block(content: &str, symbol_name: &str) -> Option<String> {
-    let pattern = format!("(symbol \"{}\"", symbol_name);
-    let start = content.find(&pattern)?;
-    let mut depth = 0i32;
-    let mut end = start;
-    for (i, ch) in content[start..].char_indices() {
-        match ch {
-            '(' => depth += 1,
-            ')' => {
-                depth -= 1;
-                if depth == 0 {
-                    end = start + i + 1;
-                    break;
-                }
-            }
-            _ => {}
-        }
-    }
-    if end > start {
-        Some(content[start..end].to_string())
-    } else {
-        None
-    }
-}
+// ─── lib_symbols embedding ──────────────────────────────────────────────────
 
 /// Structured "this lib_id doesn't exist" error, with did-you-mean hints —
 /// silently accepting an unresolvable lib_id writes a netlist-invisible
 /// component with an empty pin list (#34).
-pub fn lib_symbol_not_found_error(lib_id: &str) -> CallToolResult {
+pub fn lib_symbol_not_found_error(
+    lib_id: &str,
+    src: &dyn konnect_schematic_editor::library::SymbolLibrarySource,
+) -> CallToolResult {
     let library = lib_id.split(':').next().unwrap_or(lib_id);
-    let mut msg = if !konnect_schematic_editor::library::library_exists(library) {
+    let mut msg = if !konnect_schematic_editor::library::library_exists(library, src) {
+        // Naming only KICAD10_SYMBOL_DIR misleads when the library *is*
+        // registered — the tables are the primary source.
         format!(
-            "Library '{}' not found in the installed KiCAD symbol libraries \
-             (lib_id '{}'). Check the library name, the KiCAD install, or \
-             KICAD10_SYMBOL_DIR.",
-            library, lib_id
+            "Library '{}' not found in the project or global sym-lib-table, nor as \
+             '{}.kicad_symdir'/'{}.kicad_sym' in the installed KiCad symbol \
+             libraries (lib_id '{}'). Register it with register_symbol_library, \
+             or set KICAD10_SYMBOL_DIR for a non-standard install.",
+            library, library, library, lib_id
         )
     } else {
         format!(
-            "Library symbol '{}' not found in the installed KiCAD libraries.",
-            lib_id
+            "Library symbol '{}' not found in library '{}'.",
+            lib_id, library
         )
     };
-    let suggestions = konnect_schematic_editor::library::suggest_symbols(lib_id, 3);
+    let suggestions = konnect_schematic_editor::library::suggest_symbols(lib_id, 3, src);
     if !suggestions.is_empty() {
         msg.push_str(&format!(
             " Did you mean: {}? (KiCAD 10 renamed several older symbol names)",
@@ -751,19 +673,20 @@ pub fn lib_symbol_not_found_error(lib_id: &str) -> CallToolResult {
 /// Returns `false` when `lib_id` cannot be resolved — callers must surface
 /// that as an error rather than writing a definition-less instance (#34).
 #[must_use]
-pub fn ensure_lib_symbol_in_schematic(content: &mut String, lib_id: &str) -> bool {
+pub fn ensure_lib_symbol_in_schematic(
+    content: &mut String,
+    lib_id: &str,
+    src: &dyn konnect_schematic_editor::library::SymbolLibrarySource,
+) -> bool {
     // Check if already present
     let lib_id_check = format!("(symbol \"{}\"", lib_id);
     if content.contains(&lib_id_check) {
         return true;
     }
 
-    // Resolve the symbol from KiCAD libraries. Prefer the flattened resolver:
-    // derived symbols ((extends "Parent")) must be embedded with the parent's
-    // units copied in, not as a stub kicad-cli can't netlist (#35). Fall back
-    // to the local raw resolver for parity with the pre-flattening behavior.
-    let sym_def = match konnect_schematic_editor::library::resolve_lib_symbol_flattened(lib_id)
-        .or_else(|| resolve_lib_symbol(lib_id))
+    // Flattened: a derived symbol must be embedded with its parent's units
+    // copied in, not as a stub kicad-cli can't netlist (#35).
+    let sym_def = match konnect_schematic_editor::library::resolve_lib_symbol_flattened(lib_id, src)
     {
         Some(s) => s,
         None => return false,
@@ -922,9 +845,4 @@ fn kicad_env_suffix(kind: &str) -> Option<&'static str> {
         "3dmodels" => Some("3DMODEL_DIR"),
         _ => None,
     }
-}
-
-/// Find directories where KiCAD symbol libraries are stored.
-fn find_kicad_symbol_dirs() -> Vec<std::path::PathBuf> {
-    find_kicad_library_dirs("symbols")
 }

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -438,6 +438,8 @@ async fn handle_batch_place_components(
     let mut sch = cse::Schematic::load(&sch_path)?;
     let root_uuid = crate::tools::ensure_root_uuid(&mut sch);
     let project_name = project_name_for(&sch_path);
+    // Built once: the lib-table parse is memoised across the whole batch.
+    let src = crate::tools::library::KiCadSymbolSource::for_file(&sch_path);
 
     let mut placed: Vec<serde_json::Value> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
@@ -467,6 +469,7 @@ async fn handle_batch_place_components(
             reference,
             value,
             unit,
+            &src,
         ) {
             Ok(v) => placed.push(v),
             Err(e) => errors.push(error_text(&e)),

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -350,6 +350,7 @@ async fn handle_add_schematic_component(
         ref_str,
         value,
         unit,
+        &crate::tools::library::KiCadSymbolSource::for_file(&sch_path),
     ) {
         Ok(v) => v,
         Err(e) => return Ok(e),
@@ -386,20 +387,21 @@ pub(crate) fn place_one_component(
     reference: &str,
     value: Option<&str>,
     unit: u32,
+    src: &dyn cse::library::SymbolLibrarySource,
 ) -> Result<serde_json::Value, CallToolResult> {
     // Snap to 1.27mm grid
     let (x, y) = snap_point(x, y, 1.27);
     let val_str = value.unwrap_or(lib_id.split(':').next_back().unwrap_or("?"));
 
     // Embed the library symbol definition
-    if !cse::library::ensure_lib_symbol(sch, lib_id) {
-        return Err(crate::tools::lib_symbol_not_found_error(lib_id));
+    if !cse::library::ensure_lib_symbol(sch, lib_id, src) {
+        return Err(crate::tools::lib_symbol_not_found_error(lib_id, src));
     }
 
     // Validate the unit against the resolved symbol BEFORE writing anything:
     // eeschema silently renders an out-of-range unit as unit 1 and the
     // netlister mis-assigns its pins (#35).
-    let unit_count = cse::library::symbol_unit_count(lib_id).unwrap_or(1);
+    let unit_count = cse::library::symbol_unit_count(lib_id, src).unwrap_or(1);
     if unit < 1 || unit > unit_count {
         return Err(CallToolResult::error(format!(
             "Invalid unit {} for '{}': the symbol has {} unit(s) (valid: 1..={}).",
@@ -1157,8 +1159,9 @@ async fn handle_replace_component(
 
     // Optional unit change, validated against the NEW symbol's unit count
     // (#35). Applied before the embed so all edits land in one write.
+    let src = crate::tools::library::KiCadSymbolSource::for_file(&sch_path);
     if let Some(unit) = new_unit {
-        let unit_count = cse::library::symbol_unit_count(&new_lib_id).unwrap_or(1);
+        let unit_count = cse::library::symbol_unit_count(&new_lib_id, &src).unwrap_or(1);
         if unit < 1 || unit > unit_count {
             return Ok(CallToolResult::error(format!(
                 "Invalid unit {} for '{}': the symbol has {} unit(s) (valid: 1..={}).",
@@ -1191,8 +1194,8 @@ async fn handle_replace_component(
     // Ensure the new library symbol definition is present. Bail BEFORE writing:
     // a replace that can't embed its definition would leave the component
     // netlist-invisible (#34).
-    if !super::ensure_lib_symbol_in_schematic(&mut content, &new_lib_id) {
-        return Ok(crate::tools::lib_symbol_not_found_error(&new_lib_id));
+    if !super::ensure_lib_symbol_in_schematic(&mut content, &new_lib_id, &src) {
+        return Ok(crate::tools::lib_symbol_not_found_error(&new_lib_id, &src));
     }
     write_atomic_if_unchanged(&sch_path, &expected, &content)?;
 
@@ -1227,12 +1230,20 @@ mod tests {
         )
     }
 
-    /// Serializes tests that set KICAD10_SYMBOL_DIR (process-wide env).
-    static SYMBOL_DIR_ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    /// Serializes tests that set KICAD10_SYMBOL_DIR (process-wide env), shared
+    /// with every other module that does so.
+    use crate::tools::KICAD_ENV_LOCK as SYMBOL_DIR_ENV;
+
+    /// Only the stub carries this, so asserting on it proves a placement
+    /// resolved the fixture and not a KiCad library installed on the machine.
+    const STUB_MARKER: &str = "stub://device";
 
     /// A stub symbol library so component adds resolve without an installed
-    /// KiCAD (CI has none): Device:R and Device:C_Polarized in the KiCAD 10
-    /// symdir layout. Returns (tempdir guard, env lock).
+    /// KiCad (CI has none): Device:R and Device:C_Polarized in the KiCad 10
+    /// symdir layout, plus a `sym-lib-table` registering them.
+    ///
+    /// The returned tempdir doubles as the project directory — put the test's
+    /// schematic in it, so the project table is the one consulted.
     fn stub_symbol_dir() -> (tempfile::TempDir, std::sync::MutexGuard<'static, ()>) {
         let guard = SYMBOL_DIR_ENV.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().unwrap();
@@ -1240,7 +1251,7 @@ mod tests {
         std::fs::create_dir_all(&symdir).unwrap();
         let symbol = |name: &str| {
             format!(
-                "(kicad_symbol_lib\n\t(version 20241209)\n\t(generator \"test\")\n\t(symbol \"{name}\"\n\t\t(property \"Reference\" \"R\" (at 0 0 0))\n\t\t(property \"Value\" \"{name}\" (at 0 0 0))\n\t\t(symbol \"{name}_0_1\"\n\t\t\t(pin passive line (at 0 3.81 270) (length 1.27)\n\t\t\t\t(name \"~\" (effects (font (size 1.27 1.27))))\n\t\t\t\t(number \"1\" (effects (font (size 1.27 1.27))))\n\t\t\t)\n\t\t\t(pin passive line (at 0 -3.81 90) (length 1.27)\n\t\t\t\t(name \"~\" (effects (font (size 1.27 1.27))))\n\t\t\t\t(number \"2\" (effects (font (size 1.27 1.27))))\n\t\t\t)\n\t\t)\n\t)\n)\n"
+                "(kicad_symbol_lib\n\t(version 20241209)\n\t(generator \"test\")\n\t(symbol \"{name}\"\n\t\t(property \"Reference\" \"R\" (at 0 0 0))\n\t\t(property \"Value\" \"{name}\" (at 0 0 0))\n\t\t(property \"Datasheet\" \"{STUB_MARKER}\" (at 0 0 0))\n\t\t(symbol \"{name}_0_1\"\n\t\t\t(pin passive line (at 0 3.81 270) (length 1.27)\n\t\t\t\t(name \"~\" (effects (font (size 1.27 1.27))))\n\t\t\t\t(number \"1\" (effects (font (size 1.27 1.27))))\n\t\t\t)\n\t\t\t(pin passive line (at 0 -3.81 90) (length 1.27)\n\t\t\t\t(name \"~\" (effects (font (size 1.27 1.27))))\n\t\t\t\t(number \"2\" (effects (font (size 1.27 1.27))))\n\t\t\t)\n\t\t)\n\t)\n)\n"
             )
         };
         std::fs::write(symdir.join("R.kicad_sym"), symbol("R")).unwrap();
@@ -1271,6 +1282,18 @@ mod tests {
             "(kicad_symbol_lib\n\t(version 20241209)\n\t(generator \"test\")\n\t(symbol \"OPAMP_DERIVED\"\n\t\t(extends \"OPAMP_DUAL\")\n\t\t(property \"Reference\" \"U\" (at 0 0 0))\n\t\t(property \"Value\" \"OPAMP_DERIVED\" (at 0 0 0))\n\t)\n)\n",
         )
         .unwrap();
+        // A project sym-lib-table, checked before the global one, is what
+        // makes this hermetic: KICAD10_SYMBOL_DIR alone is not enough, because
+        // the global table's own `Device` entry resolves to whatever KiCad the
+        // developer has installed and would shadow the stub.
+        std::fs::write(
+            dir.path().join("sym-lib-table"),
+            format!(
+                "(sym_lib_table\n  (version 7)\n  (lib (name \"Device\") (type \"KiCad\") (uri \"{}\") (options \"\") (descr \"\"))\n)\n",
+                symdir.display()
+            ),
+        )
+        .unwrap();
         std::env::set_var("KICAD10_SYMBOL_DIR", dir.path());
         (dir, guard)
     }
@@ -1295,8 +1318,7 @@ mod tests {
 
     #[tokio::test]
     async fn add_component_writes_eeschema_style_instance_path() {
-        let (_symdir, _env) = stub_symbol_dir();
-        let dir = tempfile::tempdir().unwrap();
+        let (dir, _env) = stub_symbol_dir();
         let path = dir.path().join("amp.kicad_sch");
         let ctx = test_ctx();
 
@@ -1316,6 +1338,15 @@ mod tests {
         .unwrap();
         assert!(!result.is_error);
 
+        // Guards the fixture itself: the project sym-lib-table must win over
+        // any real Device library the developer has installed, or these tests
+        // silently stop exercising the stub they set up.
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            raw.contains(STUB_MARKER),
+            "Device:R must resolve from the stub, not an installed KiCad library"
+        );
+
         let sch = cse::Schematic::load(&path).unwrap();
         let root_uuid = sch.uuid.clone().expect("root uuid present");
         let sym = sch.symbols.by_reference("R1").unwrap();
@@ -1329,8 +1360,7 @@ mod tests {
 
     #[tokio::test]
     async fn add_component_writes_requested_unit() {
-        let (_symdir, _env) = stub_symbol_dir();
-        let dir = tempfile::tempdir().unwrap();
+        let (dir, _env) = stub_symbol_dir();
         let path = dir.path().join("multi.kicad_sch");
         let ctx = test_ctx();
 
@@ -1370,8 +1400,7 @@ mod tests {
 
     #[tokio::test]
     async fn add_component_rejects_out_of_range_unit() {
-        let (_symdir, _env) = stub_symbol_dir();
-        let dir = tempfile::tempdir().unwrap();
+        let (dir, _env) = stub_symbol_dir();
         let path = dir.path().join("units.kicad_sch");
         let ctx = test_ctx();
 
@@ -1428,8 +1457,7 @@ mod tests {
     async fn pin_locations_are_unit_aware() {
         // The #35 repro: an LM2904-style dual op-amp placed as unit 1 and as
         // unit 2 must report DISJOINT pin sets, not all units superimposed.
-        let (_symdir, _env) = stub_symbol_dir();
-        let dir = tempfile::tempdir().unwrap();
+        let (dir, _env) = stub_symbol_dir();
         let path = dir.path().join("dual.kicad_sch");
         let ctx = test_ctx();
 
@@ -1560,8 +1588,7 @@ mod tests {
 
     #[tokio::test]
     async fn replace_component_sets_validated_unit() {
-        let (_symdir, _env) = stub_symbol_dir();
-        let dir = tempfile::tempdir().unwrap();
+        let (dir, _env) = stub_symbol_dir();
         let path = dir.path().join("swap.kicad_sch");
         let ctx = test_ctx();
 
@@ -1626,8 +1653,7 @@ mod tests {
 
     #[tokio::test]
     async fn add_component_repairs_legacy_file_without_root_uuid() {
-        let (_symdir, _env) = stub_symbol_dir();
-        let dir = tempfile::tempdir().unwrap();
+        let (dir, _env) = stub_symbol_dir();
         let path = dir.path().join("legacy.kicad_sch");
         // File shape produced by Konnect before root UUIDs were written.
         std::fs::write(
@@ -1658,8 +1684,7 @@ mod tests {
 
     #[tokio::test]
     async fn add_component_with_nonexistent_lib_id_errors_with_suggestion() {
-        let (_symdir, _env) = stub_symbol_dir();
-        let dir = tempfile::tempdir().unwrap();
+        let (dir, _env) = stub_symbol_dir();
         let path = dir.path().join("ghost.kicad_sch");
         let ctx = test_ctx();
 
@@ -1694,8 +1719,7 @@ mod tests {
 
     #[tokio::test]
     async fn add_component_with_unknown_library_says_so() {
-        let (_symdir, _env) = stub_symbol_dir();
-        let dir = tempfile::tempdir().unwrap();
+        let (dir, _env) = stub_symbol_dir();
         let path = dir.path().join("nolib.kicad_sch");
         let ctx = test_ctx();
 

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -1265,8 +1265,9 @@ async fn handle_add_power_symbol(
 
     // Embed the power symbol definition in lib_symbols
     let lib_id = format!("power:{}", power_net);
-    if !cse::library::ensure_lib_symbol(&mut sch, &lib_id) {
-        return Ok(crate::tools::lib_symbol_not_found_error(&lib_id));
+    let src = crate::tools::library::KiCadSymbolSource::for_file(&sch_path);
+    if !cse::library::ensure_lib_symbol(&mut sch, &lib_id, &src) {
+        return Ok(crate::tools::lib_symbol_not_found_error(&lib_id, &src));
     }
 
     // Build the Symbol struct

--- a/crates/konnect-schematic-editor/src/library.rs
+++ b/crates/konnect-schematic-editor/src/library.rs
@@ -1,99 +1,92 @@
-//! Library symbol resolution — loads symbol definitions from KiCAD's installed libraries.
+//! Library symbol resolution — loads symbol definitions from KiCad libraries.
 //!
-//! KiCAD 10 stores symbols in `.kicad_symdir` directories:
-//! ```text
-//! C:\KiCad\10.0\share\kicad\symbols\Device.kicad_symdir\R.kicad_sym
-//! C:\KiCad\10.0\share\kicad\symbols\power.kicad_symdir\VCC.kicad_sym
-//! ```
-//!
-//! This module resolves a `lib_id` like `"Device:R"` to the full symbol S-expression
-//! definition, and can inject it into a Schematic's `lib_symbols` section.
+//! Resolves a `lib_id` like `"Device:R"` to its full symbol S-expression and
+//! can inject it into a Schematic's `lib_symbols` section. *Where* a library
+//! lives is supplied by a [`SymbolLibrarySource`]; this module reads whatever
+//! paths it is given, in either the KiCad 10 symdir layout
+//! (`Device.kicad_symdir/R.kicad_sym`) or a single-file `Device.kicad_sym`.
 
 use crate::sexp::{parser, SexpNode};
 use crate::Schematic;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+/// Locates the on-disk libraries that may define a library nickname.
+///
+/// Keeps KiCad-config knowledge (install paths, `sym-lib-table`) in
+/// konnect-core, which already owns it for footprints.
+pub trait SymbolLibrarySource {
+    /// Candidate locations for `nickname`, highest priority first: either a
+    /// `.kicad_symdir` directory or a `.kicad_sym` file. Full paths, since a
+    /// table may map a nickname to any filename. Missing entries are skipped
+    /// by callers.
+    fn candidates(&self, nickname: &str) -> Vec<PathBuf>;
+}
+
+impl<F> SymbolLibrarySource for F
+where
+    F: Fn(&str) -> Vec<PathBuf>,
+{
+    fn candidates(&self, nickname: &str) -> Vec<PathBuf> {
+        self(nickname)
+    }
+}
+
+/// The `.kicad_sym` file that would define `symbol_name` at `candidate`.
+/// A symdir holds one file per symbol; a single-file library holds them all.
+pub fn symbol_file_in(candidate: &Path, symbol_name: &str) -> Option<PathBuf> {
+    if candidate.is_dir() {
+        let file = candidate.join(format!("{}.kicad_sym", symbol_name));
+        return file.is_file().then_some(file);
+    }
+    candidate.is_file().then(|| candidate.to_path_buf())
+}
+
+/// Prefix a symbol block's name with its library, as an embedded `lib_symbols`
+/// entry must be. Unit sub-symbols (`Name_0_1`) stay unprefixed — eeschema
+/// refuses to load a schematic whose units carry the prefix.
+fn prefix_symbol_block(block: &str, library_name: &str, symbol_name: &str) -> String {
+    let mut renamed = block.replacen(
+        &format!("(symbol \"{}\"", symbol_name),
+        &format!("(symbol \"{}:{}\"", library_name, symbol_name),
+        1,
+    );
+    // `(extends "Parent")` names a sibling; qualify it into a lib_id.
+    if let Some(ext_pos) = renamed.find("(extends \"") {
+        let after = &renamed[ext_pos + 10..];
+        if let Some(end) = after.find('"') {
+            let parent = after[..end].to_string();
+            renamed = renamed.replace(
+                &format!("(extends \"{}\")", parent),
+                &format!("(extends \"{}:{}\")", library_name, parent),
+            );
+        }
+    }
+    renamed
+}
 
 /// Resolve a lib_id (e.g. "Device:R") to the full symbol S-expression string.
 /// The returned string is the raw content of the `(symbol "R" ...)` block,
 /// with the name prefixed as `"Device:R"`.
-pub fn resolve_lib_symbol(lib_id: &str) -> Option<String> {
-    let parts: Vec<&str> = lib_id.splitn(2, ':').collect();
-    if parts.len() != 2 {
-        return None;
-    }
-    let (library_name, symbol_name) = (parts[0], parts[1]);
+pub fn resolve_lib_symbol(lib_id: &str, src: &dyn SymbolLibrarySource) -> Option<String> {
+    let (library_name, symbol_name) = lib_id.split_once(':')?;
 
-    for base_dir in find_symbol_dirs() {
-        // KiCAD 10: Library.kicad_symdir/SymbolName.kicad_sym
-        let symdir = base_dir.join(format!("{}.kicad_symdir", library_name));
-        let sym_file = symdir.join(format!("{}.kicad_sym", symbol_name));
-
-        if sym_file.exists() {
-            if let Ok(content) = std::fs::read_to_string(&sym_file) {
-                if let Some(block) = extract_symbol_block(&content, symbol_name) {
-                    // Rename symbol to include library prefix
-                    let mut renamed = block.replacen(
-                        &format!("(symbol \"{}\"", symbol_name),
-                        &format!("(symbol \"{}:{}\"", library_name, symbol_name),
-                        1,
-                    );
-                    // Also fix (extends "ParentName") to use prefixed name
-                    if let Some(ext_pos) = renamed.find("(extends \"") {
-                        let after = &renamed[ext_pos + 10..];
-                        if let Some(end) = after.find('"') {
-                            let parent = after[..end].to_string();
-                            renamed = renamed.replace(
-                                &format!("(extends \"{}\")", parent),
-                                &format!("(extends \"{}:{}\")", library_name, parent),
-                            );
-                        }
-                    }
-                    // Unit sub-symbols ("Name_0_1", "Name_1_1") must stay
-                    // UNPREFIXED: eeschema names only the outer symbol with
-                    // the library prefix and refuses to load a schematic
-                    // whose units carry it ("Failed to load schematic" —
-                    // verified against kicad-cli 10.0 and the KiCAD demo
-                    // corpus, which embeds units without the prefix).
-                    return Some(renamed);
-                }
-            }
-        }
-
-        // Fallback: KiCAD 8/9 format — single Library.kicad_sym file
-        let legacy = base_dir.join(format!("{}.kicad_sym", library_name));
-        if legacy.exists() {
-            if let Ok(content) = std::fs::read_to_string(&legacy) {
-                if let Some(block) = extract_symbol_block(&content, symbol_name) {
-                    let mut renamed = block.replacen(
-                        &format!("(symbol \"{}\"", symbol_name),
-                        &format!("(symbol \"{}:{}\"", library_name, symbol_name),
-                        1,
-                    );
-                    if let Some(ext_pos) = renamed.find("(extends \"") {
-                        let after = &renamed[ext_pos + 10..];
-                        if let Some(end) = after.find('"') {
-                            let parent = after[..end].to_string();
-                            renamed = renamed.replace(
-                                &format!("(extends \"{}\")", parent),
-                                &format!("(extends \"{}:{}\")", library_name, parent),
-                            );
-                        }
-                    }
-                    // Unit sub-symbols stay UNPREFIXED here too — same rule
-                    // as the symdir branch above (eeschema refuses prefixed
-                    // unit names; hit in CI where KiCAD ships single-file
-                    // libraries and this legacy branch handles the embed).
-                    return Some(renamed);
-                }
-            }
+    for candidate in src.candidates(library_name) {
+        let Some(file) = symbol_file_in(&candidate, symbol_name) else {
+            continue;
+        };
+        let Ok(content) = std::fs::read_to_string(&file) else {
+            continue;
+        };
+        if let Some(block) = extract_symbol_block(&content, symbol_name) {
+            return Some(prefix_symbol_block(&block, library_name, symbol_name));
         }
     }
     None
 }
 
 /// Resolve a lib_id to a parsed SexpNode tree.
-pub fn resolve_lib_symbol_node(lib_id: &str) -> Option<SexpNode> {
-    let raw = resolve_lib_symbol(lib_id)?;
+pub fn resolve_lib_symbol_node(lib_id: &str, src: &dyn SymbolLibrarySource) -> Option<SexpNode> {
+    let raw = resolve_lib_symbol(lib_id, src)?;
     parser::parse(&raw).ok()
 }
 
@@ -110,8 +103,11 @@ pub fn resolve_lib_symbol_node(lib_id: &str) -> Option<SexpNode> {
 /// kicad-cli cannot resolve — the netlist gets a pinless libpart — and one
 /// eeschema never writes. A missing/broken parent stops the walk gracefully,
 /// returning the partially flattened child.
-pub fn resolve_lib_symbol_flattened_node(lib_id: &str) -> Option<SexpNode> {
-    let mut node = resolve_lib_symbol_node(lib_id)?;
+pub fn resolve_lib_symbol_flattened_node(
+    lib_id: &str,
+    src: &dyn SymbolLibrarySource,
+) -> Option<SexpNode> {
+    let mut node = resolve_lib_symbol_node(lib_id, src)?;
     let child_base = lib_id.split_once(':')?.1.to_string();
 
     let mut parent_id = node.get_value("extends").map(str::to_string);
@@ -128,7 +124,7 @@ pub fn resolve_lib_symbol_flattened_node(lib_id: &str) -> Option<SexpNode> {
         if !visited.insert(pid.clone()) {
             break; // cyclic extends: stop, keep what we have
         }
-        let Some(parent) = resolve_lib_symbol_node(&pid) else {
+        let Some(parent) = resolve_lib_symbol_node(&pid, src) else {
             break; // broken library (dangling parent): keep what we have
         };
         let parent_base = pid
@@ -143,8 +139,8 @@ pub fn resolve_lib_symbol_flattened_node(lib_id: &str) -> Option<SexpNode> {
 
 /// Serialized form of [`resolve_lib_symbol_flattened_node`], for callers that
 /// splice raw text into a schematic's `lib_symbols` section.
-pub fn resolve_lib_symbol_flattened(lib_id: &str) -> Option<String> {
-    resolve_lib_symbol_flattened_node(lib_id).map(|n| crate::sexp::writer::write(&n))
+pub fn resolve_lib_symbol_flattened(lib_id: &str, src: &dyn SymbolLibrarySource) -> Option<String> {
+    resolve_lib_symbol_flattened_node(lib_id, src).map(|n| crate::sexp::writer::write(&n))
 }
 
 /// Copy one parent level into a derived symbol: unit sub-symbols renamed to
@@ -243,7 +239,11 @@ fn unit_suffix_of<'a>(name: &'a str, base: &str) -> Option<&'a str> {
 /// without an embedded definition is invisible to KiCAD's netlister and
 /// yields empty pin lists downstream (#34).
 #[must_use]
-pub fn ensure_lib_symbol(schematic: &mut Schematic, lib_id: &str) -> bool {
+pub fn ensure_lib_symbol(
+    schematic: &mut Schematic,
+    lib_id: &str,
+    src: &dyn SymbolLibrarySource,
+) -> bool {
     // Check if already present
     let check_name = format!("\"{}\"", lib_id);
     let already_present = schematic.raw_other.iter().any(|node| {
@@ -259,7 +259,7 @@ pub fn ensure_lib_symbol(schematic: &mut Schematic, lib_id: &str) -> bool {
     }
 
     // Resolve and embed the symbol, flattening any extends chain.
-    let sym_node = match resolve_lib_symbol_flattened_node(lib_id) {
+    let sym_node = match resolve_lib_symbol_flattened_node(lib_id, src) {
         Some(n) => n,
         None => return false,
     };
@@ -293,11 +293,11 @@ pub fn ensure_lib_symbol(schematic: &mut Schematic, lib_id: &str) -> bool {
 /// own (#35). The count is the maximum `N >= 1` over `Name_N_M` sub-symbol
 /// names; symbols with only a `_0_1` body (or none) count as 1. Returns
 /// `None` when `lib_id` cannot be resolved at all.
-pub fn symbol_unit_count(lib_id: &str) -> Option<u32> {
+pub fn symbol_unit_count(lib_id: &str, src: &dyn SymbolLibrarySource) -> Option<u32> {
     let mut current = lib_id.to_string();
     let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
     while visited.insert(current.clone()) {
-        let node = resolve_lib_symbol_node(&current)?;
+        let node = resolve_lib_symbol_node(&current, src)?;
         let max_unit = node
             .find_all("symbol")
             .iter()
@@ -317,20 +317,19 @@ pub fn symbol_unit_count(lib_id: &str) -> Option<u32> {
     Some(1) // cyclic extends: treat as single-unit rather than erroring
 }
 
-/// Whether `library_name` (e.g. "Device") exists in any installed symbol dir,
-/// in either the KiCAD 10 symdir layout or the legacy single-file one.
-pub fn library_exists(library_name: &str) -> bool {
-    find_symbol_dirs().iter().any(|base| {
-        base.join(format!("{}.kicad_symdir", library_name)).is_dir()
-            || base.join(format!("{}.kicad_sym", library_name)).is_file()
-    })
+/// Whether any library `src` offers for `library_name` is actually on disk,
+/// in either the KiCad 10 symdir layout or the single-file one.
+pub fn library_exists(library_name: &str, src: &dyn SymbolLibrarySource) -> bool {
+    src.candidates(library_name)
+        .iter()
+        .any(|p| p.is_dir() || p.is_file())
 }
 
 /// Symbol names similar to the one in `lib_id`, for did-you-mean hints when a
 /// lib_id doesn't resolve (#34: LLM callers habitually reach for KiCAD ≤9
 /// names like `Device:CP` that KiCAD 10 renamed). Returns full `Library:Name`
 /// ids, closest first, at most `limit`.
-pub fn suggest_symbols(lib_id: &str, limit: usize) -> Vec<String> {
+pub fn suggest_symbols(lib_id: &str, limit: usize, src: &dyn SymbolLibrarySource) -> Vec<String> {
     let parts: Vec<&str> = lib_id.splitn(2, ':').collect();
     if parts.len() != 2 {
         return Vec::new();
@@ -339,9 +338,10 @@ pub fn suggest_symbols(lib_id: &str, limit: usize) -> Vec<String> {
     let wanted = symbol_name.to_lowercase();
 
     let mut candidates: Vec<String> = Vec::new();
-    for base in find_symbol_dirs() {
-        let symdir = base.join(format!("{}.kicad_symdir", library_name));
-        if let Ok(entries) = std::fs::read_dir(&symdir) {
+    for base in src.candidates(library_name) {
+        // symdir layout: one .kicad_sym per symbol, so the file stems are the
+        // symbol names.
+        if let Ok(entries) = std::fs::read_dir(&base) {
             for entry in entries.flatten() {
                 let path = entry.path();
                 if path.extension().and_then(|e| e.to_str()) == Some("kicad_sym") {
@@ -351,9 +351,8 @@ pub fn suggest_symbols(lib_id: &str, limit: usize) -> Vec<String> {
                 }
             }
         }
-        // Legacy single-file library: scan top-level (symbol "NAME" entries.
-        let legacy = base.join(format!("{}.kicad_sym", library_name));
-        if let Ok(content) = std::fs::read_to_string(&legacy) {
+        // Single-file library: scan top-level (symbol "NAME" entries.
+        if let Ok(content) = std::fs::read_to_string(&base) {
             let mut from = 0usize;
             while let Some(rel) = content[from..].find("(symbol \"") {
                 let start = from + rel + 9;
@@ -473,68 +472,6 @@ fn extract_symbol_block(content: &str, symbol_name: &str) -> Option<String> {
     }
 }
 
-/// Find directories where KiCAD symbol libraries are stored.
-pub fn find_symbol_dirs() -> Vec<PathBuf> {
-    let mut dirs = Vec::new();
-
-    if let Ok(dir) = std::env::var("KICAD10_SYMBOL_DIR") {
-        let p = PathBuf::from(&dir);
-        if p.is_dir() {
-            dirs.push(p);
-        }
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        let candidates = [
-            r"C:\KiCad\10.0\share\kicad\symbols",
-            r"C:\Program Files\KiCad\10.0\share\kicad\symbols",
-            r"C:\KiCad\9.0\share\kicad\symbols",
-            r"C:\Program Files\KiCad\9.0\share\kicad\symbols",
-        ];
-        for c in &candidates {
-            let p = PathBuf::from(c);
-            if p.is_dir() && !dirs.contains(&p) {
-                dirs.push(p);
-            }
-        }
-    }
-
-    #[cfg(target_os = "macos")]
-    {
-        // KiCad on macOS ships its libraries inside the app bundle.
-        let mut candidates = vec![
-            PathBuf::from("/Applications/KiCad/KiCad.app/Contents/SharedSupport/symbols"),
-            PathBuf::from("/usr/local/share/kicad/symbols"),
-        ];
-        if let Ok(home) = std::env::var("HOME") {
-            // Per-user install (KiCad.app dragged into ~/Applications)
-            candidates.push(
-                PathBuf::from(home)
-                    .join("Applications/KiCad/KiCad.app/Contents/SharedSupport/symbols"),
-            );
-        }
-        for p in candidates {
-            if p.is_dir() && !dirs.contains(&p) {
-                dirs.push(p);
-            }
-        }
-    }
-
-    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
-    {
-        let candidates = ["/usr/share/kicad/symbols", "/usr/local/share/kicad/symbols"];
-        for c in &candidates {
-            let p = PathBuf::from(c);
-            if p.is_dir() && !dirs.contains(&p) {
-                dirs.push(p);
-            }
-        }
-    }
-
-    dirs
-}
-
 #[cfg(test)]
 mod suggestion_tests {
     use super::*;
@@ -606,7 +543,10 @@ mod suggestion_tests {
             "(kicad_symbol_lib\n\t(version 20241209)\n\t(generator \"test\")\n\t(symbol \"NE5532\"\n\t\t(extends \"LM2904\")\n\t\t(property \"Reference\" \"U\" (at 0 0 0))\n\t\t(property \"Value\" \"NE5532\" (at 0 0 0))\n\t)\n)\n",
         )
         .unwrap();
-        std::env::set_var("KICAD10_SYMBOL_DIR", libdir.path());
+        // Explicit source, not KICAD10_SYMBOL_DIR: env vars are process-wide
+        // and force the test to be serialised.
+        let root = libdir.path().to_path_buf();
+        let src = move |nick: &str| vec![root.join(format!("{}.kicad_symdir", nick))];
 
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("flat.kicad_sch");
@@ -616,7 +556,7 @@ mod suggestion_tests {
         )
         .unwrap();
         let mut sch = Schematic::load(&path).unwrap();
-        assert!(ensure_lib_symbol(&mut sch, "Amp:NE5532"));
+        assert!(ensure_lib_symbol(&mut sch, "Amp:NE5532", &src));
         sch.overwrite().unwrap();
         let out = std::fs::read_to_string(&path).unwrap();
 
@@ -660,9 +600,58 @@ mod suggestion_tests {
         .unwrap();
         let mut sch = Schematic::load(&path).unwrap();
         // No library named like this exists anywhere.
+        let empty = |_: &str| Vec::<PathBuf>::new();
         assert!(!ensure_lib_symbol(
             &mut sch,
-            "Definitely_Not_A_Library_xyzzy:Nope"
+            "Definitely_Not_A_Library_xyzzy:Nope",
+            &empty
         ));
+    }
+
+    /// A project library is one `.kicad_sym` file under a nickname that need
+    /// not match the filename. The old directory scan could not express that.
+    #[test]
+    fn resolves_a_single_file_library_whose_name_differs_from_its_nickname() {
+        let libdir = tempfile::tempdir().unwrap();
+        let file = libdir.path().join("vendor-parts.kicad_sym");
+        std::fs::write(
+            &file,
+            "(kicad_symbol_lib\n\t(version 20241209)\n\t(generator \"test\")\n\t(symbol \"CH347T\"\n\t\t(property \"Reference\" \"U\" (at 0 0 0))\n\t\t(property \"Value\" \"CH347T\" (at 0 0 0))\n\t\t(symbol \"CH347T_1_1\"\n\t\t\t(pin bidirectional line (at 7.62 0 180) (length 2.54)\n\t\t\t\t(name \"TMS\" (effects (font (size 1.27 1.27))))\n\t\t\t\t(number \"5\" (effects (font (size 1.27 1.27))))\n\t\t\t)\n\t\t)\n\t)\n)\n",
+        )
+        .unwrap();
+
+        // What a project sym-lib-table entry resolves to.
+        let target = file.clone();
+        let src = move |nick: &str| {
+            if nick == "MyParts" {
+                vec![target.clone()]
+            } else {
+                Vec::new()
+            }
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("proj.kicad_sch");
+        std::fs::write(
+            &path,
+            "(kicad_sch\n\t(version 20250610)\n\t(generator \"test\")\n\t(lib_symbols\n\t)\n)\n",
+        )
+        .unwrap();
+        let mut sch = Schematic::load(&path).unwrap();
+
+        assert!(ensure_lib_symbol(&mut sch, "MyParts:CH347T", &src));
+        assert_eq!(symbol_unit_count("MyParts:CH347T", &src), Some(1));
+        assert!(library_exists("MyParts", &src));
+
+        sch.overwrite().unwrap();
+        let out = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            out.contains("(symbol \"MyParts:CH347T\""),
+            "symbol embedded under its lib_id:\n{out}"
+        );
+        assert!(
+            out.contains("(number \"5\""),
+            "pins must come with it — a definition-less instance netlists empty (#34):\n{out}"
+        );
     }
 }


### PR DESCRIPTION
Fixes #105.

## Problem

Symbol placement never read a lib table — `resolve_lib_symbol` scanned the KiCad install
dirs for `<nickname>.kicad_sym`. A library registered with `register_symbol_library` was
therefore invisible to `add_schematic_component`: registration reported success, then
placement failed blaming `KICAD10_SYMBOL_DIR`. **No custom symbol could be placed at
all** — the normal case for a project carrying its own parts.

Footprints already resolved correctly (project `fp-lib-table` → global → conventional
layout, following nested `(type "Table")` entries and expanding `${KIPRJMOD}`). Symbols
now use that same machinery.

## Changes

`konnect-schematic-editor` gains a `SymbolLibrarySource` trait and stops probing the
environment; `konnect-core` implements it as `KiCadSymbolSource`. The trait sits in the
lower crate because the dependency runs that way — interface where it is consumed, impl
where the KiCad-config knowledge already lives. Candidates are full paths rather than
directories searched by convention, so a nickname may map to any filename:
`(name "MyParts") (uri ".../vendor.kicad_sym")` is valid KiCad and was previously
unresolvable in principle, not just in practice.

Two further defects share the root cause:

- **Three drifted copies of install-path probing.** The one on the placement path knew
  only `KICAD10_SYMBOL_DIR`, `/usr/share` and `/usr/local/share`, so on flatpak, snap or
  `/opt` it resolved *no* symbol — `Device:R` included — while footprints and
  `get_symbol_info` worked on the same machine. `find_symbol_dirs`, konnect-core's
  duplicate `resolve_lib_symbol` and `find_kicad_symbol_dirs` are deleted; everything
  routes through `find_kicad_library_dirs`.
- **`resolve_symbol_lib_path` searched global before project**, resolving a shared
  nickname to the wrong file. It is now a thin wrapper over `KiCadSymbolSource`, so
  `get_symbol_info` and placement cannot disagree, and it gains the install-dir fallback
  it lacked — which also fixes symdir libraries, previously a `read_to_string` on a
  directory.

`lib_table_target()` is shared by both registrars: project scope writes `${KIPRJMOD}/…`
as KiCad does, and both carry the empty-parent guard —
`Path::new("board.kicad_pro").parent()` is `Some("")`, not `None`, which produced a
corrupt `${KIPRJMOD}//abs/path`. The not-found error now names the tables searched
instead of blaming `KICAD10_SYMBOL_DIR`.

## Review notes

- Follows the plan in #105 (thread the project dir through the editor-crate resolvers,
  try the table before the stock scan, consolidate the two drifted copies) with one
  deliberate deviation: `resolve_symbol_lib_path`'s **global-then-project** order is
  flipped to **project-then-global**, matching KiCad and `resolve_footprint_path`.
  Global-first meant a project entry could not shadow a same-nickname global one, which
  is the case @ncolomer hit in step 3 of the repro.
- Not covered: passing an absolute path as the library half of a lib_id
  (`"/abs/MyLib.kicad_sym:Part"`, step 5 of that repro). That was diagnostic rather than a
  request — lib_ids stay `Nickname:Symbol`, as in KiCad.
- **Beyond the title:** footprint registration now writes `${KIPRJMOD}` URIs for project
  scope where it previously wrote absolute paths (`expand_lib_uri` already understood
  them). Happy to split out if you would rather keep this symbol-only.
- `KiCadSymbolSource` memoises tables and install dirs in `OnceLock`s: the default global
  table indirects to ~200 bundled entries that each re-probe the install roots when
  `${KICAD*_DIR}` is unset, and one placement asks for candidates at least twice.

## Testing

Gate green — `cargo fmt --check`, `cargo clippy --workspace -D warnings`, 484 tests, 3
doctests. `crates/schematic-viewer` untouched.

New coverage: a single-file library whose filename differs from its nickname (the shape
that could not be placed before); project entries preceding install dirs; `${KIPRJMOD}`
expanding against the table's own directory; the empty-`table_dir` regression; both
registrars agreeing on table path and URI.

Also worth a look: `sch_components`' stub library now registers itself through a project
`sym-lib-table`. The global table's `Device` entry had been resolving to the developer's
*real* installed library and silently shadowing the fixture — those tests passed only
because real `Device:R` also has two pins. A `stub://device` marker now asserts the
fixture is the one in use, verified to fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
