### PR TITLE
fix(export): give kicad-cli a directory for drills and split NPTH out

### DIFF
--- a/crates/konnect-core/src/tools/cli.rs
+++ b/crates/konnect-core/src/tools/cli.rs
@@ -374,18 +374,56 @@ pub async fn export_gerber(cli: &str, pcb: &Path, output_dir: &Path) -> Result<(
     Ok(())
 }
 
-/// KiCAD 10: `pcb export drill --output <dir> <input>`
-pub async fn export_drill(cli: &str, pcb: &Path, output: &Path) -> Result<()> {
-    let args = [
+/// Argument vector for the drill export, factored out so the flags can be
+/// asserted without a kicad-cli on the machine.
+fn drill_args<'a>(output_dir: &'a str, pcb: &'a str) -> Vec<&'a str> {
+    vec![
         "pcb",
         "export",
         "drill",
+        // Plated and non-plated holes as separate files. Without this flag
+        // KiCad emits ONE `MixedPlating` file in which the NPTH tools are
+        // distinguished only by an `#@! TA.AperFunction ... NonPlated`
+        // comment — a comment most Excellon readers drop, so the fab plates
+        // holes that must stay unplated (connector flanges, mounting holes).
+        "--excellon-separate-th",
         "--output",
-        output.to_str().unwrap(),
-        pcb.to_str().unwrap(),
-    ];
+        output_dir,
+        pcb,
+    ]
+}
+
+/// The `.drl` files in `dir`, sorted.
+async fn drill_files_in(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    if let Ok(mut rd) = tokio::fs::read_dir(dir).await {
+        while let Ok(Some(entry)) = rd.next_entry().await {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("drl") {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    files
+}
+
+/// KiCAD 10: `pcb export drill --output <dir> <input>`
+///
+/// `--output` is a **directory**, not a file: kicad-cli names the outputs after
+/// the board (`<board>-PTH.drl` and `<board>-NPTH.drl`). Handing it a filename
+/// makes KiCad create a *directory* of that name and hide the real drill files
+/// one level down.
+///
+/// Returns the `.drl` files produced, sorted.
+pub async fn export_drill(cli: &str, pcb: &Path, output_dir: &Path) -> Result<Vec<PathBuf>> {
+    tokio::fs::create_dir_all(output_dir).await?;
+    let args = drill_args(
+        output_dir.to_str().unwrap_or(""),
+        pcb.to_str().unwrap_or(""),
+    );
     run_cli(cli, &args, LONG_TIMEOUT).await?;
-    Ok(())
+    Ok(drill_files_in(output_dir).await)
 }
 
 /// KiCAD 10: `pcb export pdf --output <path> [--layers <layer>]... <input>`
@@ -679,5 +717,51 @@ mod erc_parse_tests {
             parse_erc_json(&serde_json::json!({ "violations": [{ "severity": "error" }] }))
                 .is_empty()
         );
+    }
+}
+
+#[cfg(test)]
+mod drill_export_tests {
+    use super::*;
+
+    /// Non-plated holes must come out as their own Excellon file. The merged
+    /// default marks them with nothing but an `#@! TA.AperFunction` comment,
+    /// which most fab-side Excellon readers discard — so a connector flange or
+    /// mounting hole arrives plated.
+    #[test]
+    fn drill_export_separates_plated_from_non_plated_holes() {
+        let args = drill_args("/out/gerbers", "/tmp/board.kicad_pcb");
+        assert!(
+            args.contains(&"--excellon-separate-th"),
+            "NPTH holes need their own file: {args:?}"
+        );
+    }
+
+    /// `--output` is a directory. Passing a filename makes kicad-cli create a
+    /// directory with that name and write the real drill files inside it.
+    #[test]
+    fn drill_export_output_is_the_directory_it_was_given() {
+        let args = drill_args("/out/gerbers", "/tmp/board.kicad_pcb");
+        let output = args
+            .iter()
+            .position(|a| *a == "--output")
+            .map(|i| args[i + 1])
+            .expect("--output");
+        assert_eq!(output, "/out/gerbers");
+        assert_eq!(args.last().copied(), Some("/tmp/board.kicad_pcb"));
+    }
+
+    #[tokio::test]
+    async fn drill_files_are_collected_sorted_and_filtered_by_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        for name in ["board-PTH.drl", "board-NPTH.drl", "board-drl_map.pdf"] {
+            std::fs::write(dir.path().join(name), "").unwrap();
+        }
+        let files = drill_files_in(dir.path()).await;
+        let names: Vec<_> = files
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(names, ["board-NPTH.drl", "board-PTH.drl"]);
     }
 }

--- a/crates/konnect-core/src/tools/manufacturing.rs
+++ b/crates/konnect-core/src/tools/manufacturing.rs
@@ -140,15 +140,26 @@ async fn handle_export_manufacturing_package(
         }
     }
 
-    // 2. Export drill files
-    let drill_path = output_dir.join("drill.drl");
-    match cli::export_drill(cli_path, &board, &drill_path).await {
-        Ok(()) => {
-            info!("[BETA] Drill export succeeded");
-            files_generated.push(json!({
-                "type": "drill",
-                "path": drill_path.to_str().unwrap_or("")
-            }));
+    // 2. Export drill files, into the gerber directory so a fab receives the
+    //    plated and non-plated Excellon files alongside the layers they belong
+    //    to. `--output` is a directory; the old `output_dir.join("drill.drl")`
+    //    made KiCad create a directory named drill.drl, so the package
+    //    advertised a "drill" file that was really an empty-looking folder and
+    //    the real Excellon output never appeared in the file list at all.
+    match cli::export_drill(cli_path, &board, &gerber_dir).await {
+        Ok(drill_files) => {
+            if drill_files.is_empty() {
+                warn!("[BETA] Drill export produced no .drl files");
+                warnings.push("Drill export produced no .drl files.".to_string());
+            } else {
+                info!(files = drill_files.len(), "[BETA] Drill export succeeded");
+                for file in &drill_files {
+                    files_generated.push(json!({
+                        "type": "drill",
+                        "path": file.to_str().unwrap_or("")
+                    }));
+                }
+            }
         }
         Err(e) => {
             warn!(error = %e, "[BETA] Drill export failed (may be included in gerbers)");

--- a/crates/konnect-core/src/tools/pcb_export.rs
+++ b/crates/konnect-core/src/tools/pcb_export.rs
@@ -316,9 +316,13 @@ async fn handle_export_gerber(
     cli::export_gerber(cli, &board, &output_dir).await?;
 
     if drill {
-        // kicad-cli also has a dedicated drill export
-        let drill_path = output_dir.join("drill.drl");
-        let _ = cli::export_drill(cli, &board, &drill_path).await; // best-effort
+        // kicad-cli also has a dedicated drill export. Its --output is a
+        // directory: the gerber directory itself, so the PTH and NPTH files
+        // land beside the gerbers the way a fab expects them. The previous
+        // `output_dir.join("drill.drl")` made KiCad create a *directory*
+        // called drill.drl and bury the drill files inside it, where the
+        // listing below never saw them.
+        let _ = cli::export_drill(cli, &board, &output_dir).await; // best-effort
     }
 
     // List produced files


### PR DESCRIPTION
## Problem

The drill half of `export_manufacturing_package` (and of `export_gerber`) does not produce a usable drill package.

- The package reports `{"type":"drill","path":"<output_dir>/drill.drl"}` — but `drill.drl` is a **directory**, not a file, and the real Excellon output is one level down inside it. The `files` listing walks `output_dir` and `gerbers/` only, so it never names the actual drill file. A consumer that follows the manifest ships a board with no drill data.
- Whatever drill file does get written is a single merged `MixedPlating` Excellon file. Non-plated holes are in it, but they are distinguished **only** by an `; #@! TA.AperFunction,NonPlated,NPTH,…` comment. Most fab-side Excellon readers discard comments, so mounting holes and connector flange holes come back plated.

## Root cause

**1. `--output` is a directory.** `kicad-cli pcb export drill` names its outputs after the board and writes them into the directory given to `--output`. Both callers passed a *filename*:

```rust
let drill_path = output_dir.join("drill.drl");
cli::export_drill(cli_path, &board, &drill_path).await
```

Verified against kicad-cli 10.0.4:

```
$ kicad-cli pcb export drill --output /tmp/pkg/drill.drl board.kicad_pcb
Created file '/tmp/pkg/drill.drl/board.drl'
```

`drill.drl` is a directory containing `board.drl`. The handler then reports `drill.drl` as the drill file and, because the listing does not recurse, never mentions `board.drl` at all.

**2. No `--excellon-separate-th`.** The default merges PTH and NPTH. On a board with one `thru_hole` pad and one `np_thru_hole` pad, kicad-cli 10.0.4 gives:

```
$ kicad-cli pcb export drill --output out/ mixed.kicad_pcb
Created file 'out/mixed.drl'

; #@! TF.FileFunction,MixedPlating,1,2
; #@! TA.AperFunction,Plated,PTH,ComponentDrill
T1C0.800
; #@! TA.AperFunction,NonPlated,NPTH,ComponentDrill
T2C3.450
```

One file, two tools, and the plating distinction carried by a comment. With the flag:

```
$ kicad-cli pcb export drill --excellon-separate-th --output out/ mixed.kicad_pcb
Created file 'out/mixed-PTH.drl'
Created file 'out/mixed-NPTH.drl'
```

That `-PTH` / `-NPTH` pair is what JLCPCB's and PCBWay's standard upload flows expect, and it survives a reader that ignores attributes.

## Fix

- `cli::export_drill` takes an output **directory**, creates it, passes `--excellon-separate-th`, and returns the `.drl` files it produced (sorted).
- The argv is built by a small `drill_args` helper so the flags are assertable without a kicad-cli on the machine.
- `export_manufacturing_package` exports the drills into `gerbers/`, so a fab receives the Excellon files beside the layers they belong to, and pushes **every** produced file into `files_generated` — plus a warning if the export produced none.
- `export_gerber` exports drills into the gerber directory it was already given, instead of creating a `drill.drl/` subdirectory inside it.

## Compatibility

Output paths change, which is the point: `<output_dir>/drill.drl/<board>.drl` becomes `<output_dir>/gerbers/<board>-PTH.drl` and `…-NPTH.drl`. `export_drill`'s return type goes from `Result<()>` to `Result<Vec<PathBuf>>`; it is an internal `cli` helper with two in-tree callers, both updated. No MCP tool schema changes.

## Changes

- `crates/konnect-core/src/tools/cli.rs` — `drill_args`, `drill_files_in`, new `export_drill` signature and flags; `drill_export_tests`.
- `crates/konnect-core/src/tools/manufacturing.rs` — export into `gerbers/`, list every drill file, warn on none.
- `crates/konnect-core/src/tools/pcb_export.rs` — export into the gerber directory.

## Testing

New `cli::drill_export_tests`:

- `drill_export_separates_plated_from_non_plated_holes` — asserts `--excellon-separate-th` is in the argv. **Fails before the fix.**
- `drill_export_output_is_the_directory_it_was_given` — asserts `--output` receives the directory verbatim and the board is the trailing positional.
- `drill_files_are_collected_sorted_and_filtered_by_extension` — `drill_files_in` on a tempdir holding `board-PTH.drl`, `board-NPTH.drl` and a `drl_map.pdf` returns the two `.drl` files, sorted, and drops the map.

Checklist commands, all clean:

- `cargo test --workspace --locked --lib --tests` — 19 suites green, 236 lib tests (233 before + 3 new)
- `cargo test --workspace --locked --doc` — clean
- `cargo clippy --workspace --locked -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Manual, against kicad-cli 10.0.4 on macOS: the exact argv this change now builds produces `mixed-PTH.drl` + `mixed-NPTH.drl` (transcript above); the pre-change argv produces the `drill.drl/` directory (transcript above).

## Not in this PR

`export_bom` in the same package drops custom fields (it takes kicad-cli's default `Reference,Value,Footprint,QUANTITY,DNP`, so MPN/LCSC columns never reach the fab) and ignores the `exclude_dnp` its own schema advertises. Unrelated outcome, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
