### PR TITLE
fix(export): let the BOM carry custom fields and honor exclude_dnp

### DIFF
--- a/crates/konnect-core/src/tools/cli.rs
+++ b/crates/konnect-core/src/tools/cli.rs
@@ -308,18 +308,68 @@ pub async fn export_schematic_pdf(cli: &str, schematic: &Path, output: &Path) ->
     Ok(())
 }
 
-/// KiCAD 10: `sch export bom --output <path> <input>`
-/// Note: v10 BOM does NOT use --format. It uses --fields, --labels, --field-delimiter.
-/// Default output is CSV-like with Reference,Value,Footprint,Qty,DNP fields.
-pub async fn export_bom(cli: &str, schematic: &Path, output: &Path, _format: &str) -> Result<()> {
-    let args = [
-        "sch",
-        "export",
-        "bom",
-        "--output",
-        output.to_str().unwrap(),
-        schematic.to_str().unwrap(),
-    ];
+/// Column and filtering options for `sch export bom`.
+///
+/// All-`None`/`false` reproduces kicad-cli's own defaults: the fixed
+/// `Reference,Value,Footprint,QUANTITY,DNP` column set, ungrouped, DNP rows
+/// included.
+#[derive(Debug, Default, Clone)]
+pub struct BomOptions<'a> {
+    /// Ordered field list, e.g. `Reference,Value,Footprint,MPN,${QUANTITY}`.
+    /// Any schematic field name works, which is how MPN/LCSC columns reach the
+    /// fab; generated fields (`QUANTITY`, `DNP`, `ITEM_NUMBER`, …) may be
+    /// written with or without `${}`.
+    pub fields: Option<&'a str>,
+    /// Ordered column headings. When omitted KiCad labels each column with its
+    /// field name.
+    pub labels: Option<&'a str>,
+    /// Fields whose matching references collapse into one row, e.g.
+    /// `Value,Footprint`.
+    pub group_by: Option<&'a str>,
+    /// Drop Do-Not-Populate symbols.
+    pub exclude_dnp: bool,
+}
+
+/// Argument vector for the BOM export, factored out so the flags can be
+/// asserted without a kicad-cli on the machine.
+fn bom_args<'a>(output: &'a str, schematic: &'a str, options: &BomOptions<'a>) -> Vec<&'a str> {
+    let mut args = vec!["sch", "export", "bom", "--output", output];
+    if let Some(fields) = options.fields {
+        args.push("--fields");
+        args.push(fields);
+    }
+    if let Some(labels) = options.labels {
+        args.push("--labels");
+        args.push(labels);
+    }
+    if let Some(group_by) = options.group_by {
+        args.push("--group-by");
+        args.push(group_by);
+    }
+    if options.exclude_dnp {
+        args.push("--exclude-dnp");
+    }
+    args.push(schematic);
+    args
+}
+
+/// KiCAD 10: `sch export bom --output <path> [--fields …] [--labels …]
+/// [--group-by …] [--exclude-dnp] <input>`
+///
+/// Note: v10 BOM does NOT use `--format`. Without `--fields` kicad-cli emits
+/// its fixed `Reference,Value,Footprint,QUANTITY,DNP` set, so every custom
+/// schematic field (MPN, LCSC, supplier part numbers) is dropped.
+pub async fn export_bom(
+    cli: &str,
+    schematic: &Path,
+    output: &Path,
+    options: &BomOptions<'_>,
+) -> Result<()> {
+    let args = bom_args(
+        output.to_str().unwrap_or(""),
+        schematic.to_str().unwrap_or(""),
+        options,
+    );
     run_cli(cli, &args, LONG_TIMEOUT).await?;
     Ok(())
 }
@@ -678,6 +728,71 @@ mod erc_parse_tests {
         assert!(
             parse_erc_json(&serde_json::json!({ "violations": [{ "severity": "error" }] }))
                 .is_empty()
+        );
+    }
+}
+
+#[cfg(test)]
+mod bom_export_tests {
+    use super::*;
+
+    /// Custom schematic fields are the whole point of a fab BOM: without
+    /// `--fields` kicad-cli emits only Reference,Value,Footprint,QUANTITY,DNP
+    /// and an MPN column never reaches the manufacturer.
+    #[test]
+    fn requested_fields_and_labels_reach_kicad_cli() {
+        let options = BomOptions {
+            fields: Some("Reference,Value,Footprint,MPN,${QUANTITY}"),
+            labels: Some("Refs,Value,Footprint,MPN,Qty"),
+            group_by: Some("Value,Footprint"),
+            exclude_dnp: false,
+        };
+        let args = bom_args("/out/bom.csv", "/tmp/board.kicad_sch", &options);
+        let flag = |name: &str| {
+            args.iter()
+                .position(|a| *a == name)
+                .map(|i| args[i + 1])
+                .unwrap_or_else(|| panic!("{name} missing from {args:?}"))
+        };
+        assert_eq!(
+            flag("--fields"),
+            "Reference,Value,Footprint,MPN,${QUANTITY}"
+        );
+        assert_eq!(flag("--labels"), "Refs,Value,Footprint,MPN,Qty");
+        assert_eq!(flag("--group-by"), "Value,Footprint");
+        assert_eq!(flag("--output"), "/out/bom.csv");
+        assert_eq!(args.last().copied(), Some("/tmp/board.kicad_sch"));
+    }
+
+    /// `exclude_dnp` has been in the export_bom schema (default true) since the
+    /// tool shipped, but the handler never read it and the flag was never sent.
+    #[test]
+    fn exclude_dnp_is_passed_only_when_asked_for() {
+        let on = BomOptions {
+            exclude_dnp: true,
+            ..Default::default()
+        };
+        assert!(bom_args("/out/bom.csv", "/s.kicad_sch", &on).contains(&"--exclude-dnp"));
+
+        let off = BomOptions::default();
+        assert!(!bom_args("/out/bom.csv", "/s.kicad_sch", &off).contains(&"--exclude-dnp"));
+    }
+
+    /// Defaults must reproduce the previous argv exactly, so a caller that
+    /// wants KiCAD's own BOM keeps getting it.
+    #[test]
+    fn default_options_are_the_bare_kicad_cli_invocation() {
+        let args = bom_args("/out/bom.csv", "/s.kicad_sch", &BomOptions::default());
+        assert_eq!(
+            args,
+            [
+                "sch",
+                "export",
+                "bom",
+                "--output",
+                "/out/bom.csv",
+                "/s.kicad_sch"
+            ]
         );
     }
 }

--- a/crates/konnect-core/src/tools/manufacturing.rs
+++ b/crates/konnect-core/src/tools/manufacturing.rs
@@ -41,6 +41,18 @@ pub fn tools() -> Vec<ToolDef> {
                         "type": "integer",
                         "description": "Production quantity (for BOM pricing context)",
                         "default": 5
+                    },
+                    "bom_fields": {
+                        "type": "string",
+                        "description": "Ordered, comma-separated BOM columns, e.g. 'Reference,Value,Footprint,MPN,${QUANTITY}'. Any schematic field name works — this is how MPN/LCSC columns reach the fab. Omit for KiCAD's default Reference,Value,Footprint,QUANTITY,DNP."
+                    },
+                    "bom_labels": {
+                        "type": "string",
+                        "description": "Ordered, comma-separated BOM column headings matching 'bom_fields'. Omit to label each column with its field name."
+                    },
+                    "bom_group_by": {
+                        "type": "string",
+                        "description": "Comma-separated fields whose matching references collapse into one BOM row, e.g. 'Value,Footprint'."
                     }
                 },
                 "required": ["board", "output_dir"]
@@ -182,13 +194,23 @@ async fn handle_export_manufacturing_package(
         // BOM
         if let Some(ref sch) = schematic {
             let bom_path = output_dir.join("bom.csv");
-            match cli::export_bom(cli_path, sch, &bom_path, "csv").await {
+            // Without bom_fields the package gets kicad-cli's fixed
+            // Reference,Value,Footprint,QUANTITY,DNP set — no MPN, no supplier
+            // part number, nothing a fab can source a part from.
+            let bom_options = cli::BomOptions {
+                fields: args["bom_fields"].as_str(),
+                labels: args["bom_labels"].as_str(),
+                group_by: args["bom_group_by"].as_str(),
+                ..Default::default()
+            };
+            match cli::export_bom(cli_path, sch, &bom_path, &bom_options).await {
                 Ok(()) => {
                     info!("[BETA] BOM export succeeded");
                     files_generated.push(json!({
                         "type": "bom",
                         "path": bom_path.to_str().unwrap_or(""),
-                        "format": "csv"
+                        "format": "csv",
+                        "fields": bom_options.fields
                     }));
                 }
                 Err(e) => {

--- a/crates/konnect-core/src/tools/pcb_export.rs
+++ b/crates/konnect-core/src/tools/pcb_export.rs
@@ -135,6 +135,18 @@ pub fn tools() -> Vec<ToolDef> {
                         "description": "BOM format passed to kicad-cli: 'csv' (default)",
                         "default": "csv"
                     },
+                    "fields": {
+                        "type": "string",
+                        "description": "Ordered, comma-separated columns to export, e.g. 'Reference,Value,Footprint,MPN,${QUANTITY}'. Any schematic field name works — this is how MPN/LCSC columns reach the fab. Omit for KiCAD's default Reference,Value,Footprint,QUANTITY,DNP."
+                    },
+                    "labels": {
+                        "type": "string",
+                        "description": "Ordered, comma-separated column headings matching 'fields'. Omit to label each column with its field name."
+                    },
+                    "group_by": {
+                        "type": "string",
+                        "description": "Comma-separated fields whose matching references collapse into one row, e.g. 'Value,Footprint'. Omit for one row per symbol."
+                    },
                     "exclude_dnp": {
                         "type": "boolean",
                         "description": "Exclude 'Do Not Place' components",
@@ -426,15 +438,24 @@ async fn handle_export_bom(
 ) -> anyhow::Result<CallToolResult> {
     let schematic = get_path(args, "schematic")?;
     let output = get_path(args, "output")?;
-    let format = args["format"].as_str().unwrap_or("csv");
+    let options = cli::BomOptions {
+        fields: args["fields"].as_str(),
+        labels: args["labels"].as_str(),
+        group_by: args["group_by"].as_str(),
+        // The schema has advertised this default since the tool shipped; the
+        // handler never read it, so DNP parts landed in every BOM.
+        exclude_dnp: args["exclude_dnp"].as_bool().unwrap_or(true),
+    };
 
     let cli = &ctx.config.kicad_cli;
-    cli::export_bom(cli, &schematic, &output, format).await?;
+    cli::export_bom(cli, &schematic, &output, &options).await?;
 
     Ok(CallToolResult::text(
         serde_json::to_string(&json!({
             "success": true,
-            "output": output.to_str().unwrap_or("")
+            "output": output.to_str().unwrap_or(""),
+            "fields": options.fields,
+            "exclude_dnp": options.exclude_dnp
         }))
         .unwrap(),
     ))


### PR DESCRIPTION
## Problem

Every BOM Konnect produces has the same five columns and no way to change them:

```
"Refs","Value","Footprint","Qty","DNP"
"R1","10k","Resistor_SMD:R_0402_1005Metric","1",""
"R2","4.7k","Resistor_SMD:R_0402_1005Metric","1","DNP"
```

The schematic's `MPN` field — and every other custom field a fab needs to source a part — is silently dropped, from both `export_bom` and the BOM inside `export_manufacturing_package`. There is no error, no warning; the column simply is not there.

Separately, `export_bom`'s schema has advertised `exclude_dnp` (default `true`) since the tool shipped, and the handler never read it. The flag never reached kicad-cli, so DNP parts landed in every BOM regardless of what the caller asked for.

## Root cause

`cli::export_bom` built a fixed six-token argv and threw away its `_format` argument:

```rust
pub async fn export_bom(cli: &str, schematic: &Path, output: &Path, _format: &str) -> Result<()> {
    let args = ["sch", "export", "bom", "--output", output…, schematic…];
```

`kicad-cli sch export bom` defaults `--fields` to `Reference,Value,Footprint,QUANTITY,DNP`, so a bare invocation can only ever produce those five columns. `--fields` accepts any schematic field name; the wrapper never offered a way to set it. Likewise `--exclude-dnp` was never passed, so the handler's documented default was inert.

## Fix

`cli::export_bom` takes a `BomOptions { fields, labels, group_by, exclude_dnp }`, and a `bom_args` helper builds the argv so the flags are assertable without a kicad-cli on the machine. `BomOptions::default()` produces the previous argv token for token.

- `export_bom` gains `fields`, `labels` and `group_by` inputs, and now reads `exclude_dnp`.
- `export_manufacturing_package` gains `bom_fields`, `bom_labels` and `bom_group_by`, and reports the field list it used in the `bom` entry of `files_generated`.

Verified against kicad-cli 10.0.4 on a two-resistor schematic carrying an `MPN` field:

```
$ kicad-cli sch export bom --fields "Reference,Value,Footprint,MPN,${QUANTITY}" --output bom.csv bom2.kicad_sch
"Reference","Value","Footprint","MPN","QUANTITY"
"R1","10k","Resistor_SMD:R_0402_1005Metric","RC0402FR-0710KL","1"
"R2","4.7k","Resistor_SMD:R_0402_1005Metric","RC0402FR-074K7L","1"

$ kicad-cli sch export bom --exclude-dnp --group-by Value \
    --fields "Reference,Value,Footprint,MPN,${QUANTITY}" --labels "Refs,Value,Footprint,MPN,Qty" …
"Refs","Value","Footprint","MPN","Qty"
"R1","10k","Resistor_SMD:R_0402_1005Metric","RC0402FR-0710KL","1"
```

`--labels` is genuinely optional: with `--fields` alone KiCad heads each column with its field name, so callers who only want an extra column do not have to restate all of them.

## Compatibility

- `BomOptions::default()` is byte-identical to the old argv, so `export_manufacturing_package` with no `bom_*` arguments produces exactly the BOM it produced before. That equivalence is pinned by a test.
- **One behaviour change:** `export_bom` now honors `exclude_dnp`, whose schema default is `true`. A caller who passed nothing previously got DNP rows and will now get them filtered. Passing `"exclude_dnp": false` restores the old output. This is the schema's documented contract finally taking effect; leaving it inert would mean the field keeps lying.
- `cli::export_bom`'s signature changes (`_format: &str` → `&BomOptions`). It is an internal `cli` helper with two in-tree callers, both updated. No tools added or removed, so `tool_count`, `tool-directory.md` and the README counts are untouched.

## Changes

- `crates/konnect-core/src/tools/cli.rs` — `BomOptions`, `bom_args`, new `export_bom` signature; `bom_export_tests`.
- `crates/konnect-core/src/tools/pcb_export.rs` — `export_bom` schema gains `fields`/`labels`/`group_by`; handler reads them and `exclude_dnp`.
- `crates/konnect-core/src/tools/manufacturing.rs` — `export_manufacturing_package` schema gains `bom_fields`/`bom_labels`/`bom_group_by`; BOM entry reports the fields used.

## Testing

New `cli::bom_export_tests`:

- `requested_fields_and_labels_reach_kicad_cli` — `--fields`, `--labels`, `--group-by`, `--output` and the trailing schematic all land where kicad-cli expects them. **Fails before the fix** (the flags do not exist in the argv).
- `exclude_dnp_is_passed_only_when_asked_for` — `--exclude-dnp` present when requested, absent otherwise. **Fails before the fix.**
- `default_options_are_the_bare_kicad_cli_invocation` — asserts the exact six-token argv, so the no-arguments path can never drift.

Checklist commands, all clean:

- `cargo test --workspace --locked --lib --tests` — 236 lib tests (233 before + 3 new), all suites green
- `cargo test --workspace --locked --doc` — clean
- `cargo clippy --workspace --locked -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Manual: the kicad-cli 10.0.4 transcripts above, run against a schematic with an `MPN` field and one DNP symbol.

## Relationship to #138

Both touch `cli.rs`, in different functions (`export_drill` vs `export_bom`) and different test modules, and `manufacturing.rs` in different blocks. They merge in either order without conflict. #138 is the drill half of the same "the fab package is not actually fabbable" complaint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
