### PR TITLE
fix(validate): count nets and tracks from the tree, not indented text

### DIFF
--- a/crates/konnect-core/src/tools/manufacturing.rs
+++ b/crates/konnect-core/src/tools/manufacturing.rs
@@ -320,8 +320,7 @@ async fn handle_validate_for_manufacturing(
     }
 
     // Check for unrouted nets (ratsnest)
-    let net_count = content.matches("\n  (net ").count();
-    let track_count = content.matches("(segment ").count() + content.matches("(via ").count();
+    let (net_count, track_count) = count_nets_and_tracks(&tree);
     if net_count > 3 && track_count == 0 {
         issues.push(json!({
             "severity": "error",
@@ -465,6 +464,58 @@ async fn handle_estimate_cost(
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
+/// Distinct nets and routed items on the board, read from the parsed tree.
+///
+/// Both net shapes have to be handled. KiCad ≤ 9 declares each net once at top
+/// level — `(net 1 "GND")` — and items refer to it by number, `(net 1)`. KiCad
+/// 10 dropped the top-level table entirely and writes the name on every item,
+/// `(net "GND")`. Counting names when any are present covers both without
+/// double-counting a KiCad 9 net through its declaration *and* its references.
+///
+/// Tracks are always direct children of `(kicad_pcb …)`, so they are counted
+/// there rather than by walking: `(arc …)` also appears inside `(pts …)` of a
+/// zone outline, which is not routed copper.
+fn count_nets_and_tracks(tree: &konnect_sexp::SexpNode) -> (usize, usize) {
+    use std::collections::HashSet;
+
+    fn walk(node: &konnect_sexp::SexpNode, names: &mut HashSet<String>, ids: &mut HashSet<String>) {
+        let Some(children) = node.children() else {
+            return;
+        };
+        if node.head() == Some("net") {
+            match children.last() {
+                // (net 1 "GND") and (net "GND") both end in the quoted name.
+                Some(konnect_sexp::SexpNode::Str(name)) if !name.is_empty() => {
+                    names.insert(name.clone());
+                }
+                // (net 1) — a bare reference in a file whose table we have not
+                // seen. Net 0 is the unconnected pseudo-net.
+                Some(konnect_sexp::SexpNode::Atom(id)) if id != "0" => {
+                    ids.insert(id.clone());
+                }
+                _ => {}
+            }
+        }
+        for child in children {
+            walk(child, names, ids);
+        }
+    }
+
+    let mut names = HashSet::new();
+    let mut ids = HashSet::new();
+    walk(tree, &mut names, &mut ids);
+    let net_count = if names.is_empty() {
+        ids.len()
+    } else {
+        names.len()
+    };
+
+    let track_count =
+        tree.find_all("segment").len() + tree.find_all("via").len() + tree.find_all("arc").len();
+
+    (net_count, track_count)
+}
+
 fn find_setup_value(content: &str, key: &str) -> Option<f64> {
     let pat = format!("({} ", key);
     let pos = content.find(&pat)?;
@@ -541,4 +592,140 @@ fn extract_coord(block: &str, keyword: &str, index: usize) -> Option<f64> {
     let rest = &block[pos..];
     let parts: Vec<&str> = rest.split([' ', ')']).collect();
     parts.get(index)?.parse().ok()
+}
+
+#[cfg(test)]
+mod net_track_count_tests {
+    use super::*;
+    use konnect_sexp::parser::parse_sexp;
+
+    /// KiCad 10 (file format 20260206) writes tab indentation, puts each
+    /// `(segment …)` / `(via …)` on its own multi-line form, and has **no**
+    /// top-level net table — every item names its net instead. The old
+    /// substring probes (`"\n  (net "`, `"(segment "`, `"(via "`) match none of
+    /// that, so a fully routed board reported net_count 0 / track_count 0 and
+    /// still came back READY.
+    const KICAD_10_BOARD: &str = "(kicad_pcb\n\
+        \t(version 20260206)\n\
+        \t(generator \"pcbnew\")\n\
+        \t(segment\n\t\t(start 110 110)\n\t\t(end 120 110)\n\t\t(width 0.2)\n\t\t(layer \"F.Cu\")\n\t\t(net \"GND\")\n\t)\n\
+        \t(segment\n\t\t(start 120 110)\n\t\t(end 130 120)\n\t\t(width 0.2)\n\t\t(layer \"F.Cu\")\n\t\t(net \"GND\")\n\t)\n\
+        \t(via\n\t\t(at 130 120)\n\t\t(size 0.6)\n\t\t(drill 0.3)\n\t\t(net \"GND\")\n\t)\n\
+        \t(segment\n\t\t(start 110 130)\n\t\t(end 120 130)\n\t\t(width 0.2)\n\t\t(layer \"B.Cu\")\n\t\t(net \"VCC\")\n\t)\n\
+        )\n";
+
+    /// KiCad ≤ 9: a top-level net table plus numeric references on the items.
+    /// The same net must not be counted once for its declaration and again for
+    /// every segment that mentions it.
+    const KICAD_9_BOARD: &str = "(kicad_pcb\n\
+        \t(version 20241229)\n\
+        \t(net 0 \"\")\n\
+        \t(net 1 \"GND\")\n\
+        \t(net 2 \"VCC\")\n\
+        \t(segment (start 110 110) (end 120 110) (width 0.2) (layer \"F.Cu\") (net 1))\n\
+        \t(segment (start 120 110) (end 130 120) (width 0.2) (layer \"F.Cu\") (net 1))\n\
+        \t(via (at 130 120) (size 0.6) (drill 0.3) (layers \"F.Cu\" \"B.Cu\") (net 1))\n\
+        \t(segment (start 110 130) (end 120 130) (width 0.2) (layer \"B.Cu\") (net 2))\n\
+        )\n";
+
+    #[test]
+    fn counts_a_kicad_10_board_with_no_top_level_net_table() {
+        let tree = parse_sexp(KICAD_10_BOARD).unwrap();
+        assert_eq!(count_nets_and_tracks(&tree), (2, 4));
+    }
+
+    #[test]
+    fn counts_a_kicad_9_board_without_double_counting_declarations() {
+        let tree = parse_sexp(KICAD_9_BOARD).unwrap();
+        assert_eq!(count_nets_and_tracks(&tree), (2, 4));
+    }
+
+    #[test]
+    fn the_unconnected_pseudo_net_does_not_count() {
+        let tree = parse_sexp("(kicad_pcb\n\t(net 0 \"\")\n)\n").unwrap();
+        assert_eq!(count_nets_and_tracks(&tree), (0, 0));
+    }
+
+    /// A zone outline may carry `(arc …)` inside its `(pts …)`; that is a
+    /// polygon corner, not routed copper.
+    #[test]
+    fn zone_outline_arcs_are_not_routed_copper() {
+        let board = "(kicad_pcb\n\
+            \t(zone\n\t\t(net \"GND\")\n\t\t(polygon\n\t\t\t(pts\n\t\t\t\t(xy 0 0)\n\t\t\t\t(arc (start 1 0) (mid 2 1) (end 1 2))\n\t\t\t)\n\t\t)\n\t)\n\
+            )\n";
+        let tree = parse_sexp(board).unwrap();
+        assert_eq!(count_nets_and_tracks(&tree), (1, 0));
+    }
+
+    // ─── End to end through the tool ─────────────────────────────────────────
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            crate::tools::ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+            },
+            std::sync::Arc::new(crate::router::ToolRouter::new()),
+        )
+    }
+
+    async fn validate(board_text: &str) -> serde_json::Value {
+        let dir = tempfile::tempdir().unwrap();
+        let board = dir.path().join("board.kicad_pcb");
+        std::fs::write(&board, board_text).unwrap();
+        let result = handle_validate_for_manufacturing(
+            &json!({ "board": board.to_str().unwrap() }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        match result.content.first() {
+            Some(crate::mcp::protocol::ToolContent::Text { text }) => {
+                serde_json::from_str(text).unwrap()
+            }
+            other => panic!("expected text content, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_routed_kicad_10_board_reports_its_nets_and_tracks() {
+        let report = validate(KICAD_10_BOARD).await;
+        assert_eq!(report["board_info"]["net_count"], json!(2));
+        assert_eq!(report["board_info"]["track_count"], json!(4));
+    }
+
+    /// The symptom that surfaced this: an unrouted board came back READY on the
+    /// routing check because both counts read zero, so the `net_count > 3 &&
+    /// track_count == 0` guard could never fire.
+    #[tokio::test]
+    async fn an_unrouted_kicad_10_board_is_flagged_not_ready() {
+        let board = "(kicad_pcb\n\
+            \t(version 20260206)\n\
+            \t(gr_line (start 0 0) (end 10 0) (layer \"Edge.Cuts\"))\n\
+            \t(footprint \"R:R_0402\"\n\
+            \t\t(pad \"1\" smd rect (at 0 0) (size 1 1) (net \"GND\"))\n\
+            \t\t(pad \"2\" smd rect (at 1 0) (size 1 1) (net \"VCC\"))\n\
+            \t)\n\
+            \t(footprint \"R:R_0402\"\n\
+            \t\t(pad \"1\" smd rect (at 5 0) (size 1 1) (net \"SDA\"))\n\
+            \t\t(pad \"2\" smd rect (at 6 0) (size 1 1) (net \"SCL\"))\n\
+            \t)\n\
+            )\n";
+        let report = validate(board).await;
+        assert_eq!(report["board_info"]["net_count"], json!(4));
+        assert_eq!(report["board_info"]["track_count"], json!(0));
+        assert_eq!(report["verdict"], json!("NOT READY"));
+        let issues = report["issues"].as_array().unwrap();
+        assert!(
+            issues.iter().any(|i| i["issue"]
+                .as_str()
+                .unwrap_or("")
+                .contains("no traces routed")),
+            "{issues:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

`validate_for_manufacturing` reports `net_count: 0` and `track_count: 0` on a fully routed board — and, because the routing check is guarded by those numbers, still returns `READY` for a board with no copper on it at all.

Measured on a real 8-layer KiCad 10 board (file format `20260206`) that contains **1534 segments and 553 vias**:

```
konnect net_count   = 0
konnect track_count = 0
```

## Root cause

The check probes the raw file text:

```rust
let net_count = content.matches("\n  (net ").count();
let track_count = content.matches("(segment ").count() + content.matches("(via ").count();
```

Three separate things make every one of those probes miss on a KiCad 10 file:

1. **Indentation is a TAB**, not two spaces, so `"\n  (net "` cannot match.
2. **Segments and vias are multi-line forms.** KiCad writes `(segment\n\t\t(start …`, so `"(segment "` — with its trailing space — never appears. Same for `(via`.
3. **KiCad 10 removed the top-level net table.** There is no `(net 1 "GND")` block any more; each item names its net inline as `(net "GND")`. So even a tab-corrected `"\n\t(net "` probe finds zero.

Round-tripping a small board through `kicad-cli pcb upgrade` (10.0.4) shows all three at once — before upgrade the file is 2-space indented with a net table; after, it is tab indented, multi-line, and has no net table.

Because `net_count` is stuck at 0, the guard

```rust
if net_count > 3 && track_count == 0 {   // "N nets defined but no traces routed"
```

can never fire. An unrouted board collects no routing issue and the verdict comes back `READY`.

## Fix

`count_nets_and_tracks(&tree)` replaces the substring probes and reads the tree the handler already parsed:

- **Nets** — walk the tree collecting `(net …)` references. `(net 1 "GND")` and `(net "GND")` both end in the quoted name; `(net 1)` is a bare numeric reference. Names win when any are present, so a KiCad ≤ 9 net is not counted once for its declaration and again for every `(net 1)` that refers to it. Net `0` / `""` (the unconnected pseudo-net) is excluded.
- **Tracks** — `segment` + `via` + `arc` counted as **direct children** of `(kicad_pcb …)`, which is the only place routed copper lives. Walking instead would sweep up the `(arc …)` corners inside a zone outline's `(pts …)`.

Works unchanged on KiCad ≤ 9 files, which is why both formats are pinned by tests.

## Compatibility

No schema change. `board_info.net_count` / `board_info.track_count` start reporting real numbers, and a board that is genuinely unrouted now correctly reports `NOT READY` where it previously said `READY` — that is the bug being fixed, but it is a verdict change for anyone who had normalised to the old output.

## Changes

- `crates/konnect-core/src/tools/manufacturing.rs` — `count_nets_and_tracks`; handler uses it; new `net_track_count_tests`.

## Testing

New `manufacturing::net_track_count_tests`, all against tab-indented, multi-line fixtures in the real KiCad 10 shape:

- `a_routed_kicad_10_board_reports_its_nets_and_tracks` — end to end through `handle_validate_for_manufacturing`; expects `net_count 2`, `track_count 4`. **Before the fix: FAILS, `left: Number(0), right: Number(2)`.**
- `an_unrouted_kicad_10_board_is_flagged_not_ready` — 4 nets on footprint pads, zero segments; expects `NOT READY` and the "no traces routed" issue. **Before the fix: FAILS** — the counts read 0 and the verdict was `READY`. This is the reported symptom.
- `counts_a_kicad_10_board_with_no_top_level_net_table` — the unit, KiCad 10 shape.
- `counts_a_kicad_9_board_without_double_counting_declarations` — KiCad 9 net table plus numeric references still counts 2, not 2 + one per reference.
- `the_unconnected_pseudo_net_does_not_count` — `(net 0 "")` alone gives 0.
- `zone_outline_arcs_are_not_routed_copper` — an `(arc …)` inside a zone `(pts …)` is not a track.

Checklist commands, all clean:

- `cargo test --workspace --locked --lib --tests` — 239 lib tests (233 before + 6 new), all suites green
- `cargo test --workspace --locked --doc` — clean
- `cargo clippy --workspace --locked -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Relationship to #133

Same root cause family, different site. #133 catalogues three places that assume the KiCad ≤ 9 net shape — `get_component_pads` (name at index 2), `get_board_info` (`tree.find_all("net")` on the vanished top-level table), and `add_net` (counts every `(net …)` to synthesize an id). `validate_for_manufacturing` is a fourth, and it is not listed there; it also fails for two reasons #133 does not cover, the tab indentation and the multi-line `(segment`/`(via` forms. This PR fixes only the fourth site and leaves #133's three alone, so it can merge before or after a fix for those without conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
