### PR TITLE
fix(library): repair a lib-table whose root declares the wrong kind

### DIFF
--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -1198,7 +1198,7 @@ async fn handle_register_footprint_library(
         ));
     };
 
-    register_in_lib_table(
+    let repaired_root = register_in_lib_table(
         &table_path,
         nickname,
         lib_path.to_str().unwrap_or(""),
@@ -1211,7 +1211,8 @@ async fn handle_register_footprint_library(
             "success": true,
             "nickname": nickname,
             "scope": scope,
-            "table": table_path.to_str().unwrap_or("")
+            "table": table_path.to_str().unwrap_or(""),
+            "repaired_table_root": repaired_root
         }))
         .unwrap(),
     ))
@@ -1281,7 +1282,7 @@ async fn handle_register_symbol_library(
         ));
     };
 
-    register_in_lib_table(
+    let repaired_root = register_in_lib_table(
         &table_path,
         nickname,
         lib_path.to_str().unwrap_or(""),
@@ -1294,7 +1295,8 @@ async fn handle_register_symbol_library(
             "success": true,
             "nickname": nickname,
             "scope": scope,
-            "table": table_path.to_str().unwrap_or("")
+            "table": table_path.to_str().unwrap_or(""),
+            "repaired_table_root": repaired_root
         }))
         .unwrap(),
     ))
@@ -1361,26 +1363,73 @@ fn table_root_element(table_path: &Path) -> &'static str {
     }
 }
 
+/// Correct a lib-table whose root element is the wrong kind, returning the
+/// content and whether anything changed.
+///
+/// A `sym-lib-table` whose root says `(fp_lib_table` — or the reverse — is
+/// rejected outright: *"Library table … has type FOOTPRINT but expected SYMBOL;
+/// skipping"*. #54 stopped Konnect from **creating** such a file, but a table
+/// an older build already wrote stays broken forever, because every later
+/// registration appends into whatever root it finds. Repairing on write is what
+/// makes the earlier fix reach existing projects.
+///
+/// Only a root element is rewritten: the wrong token has to be the first thing
+/// in the file, so the same words appearing inside a `(descr …)` are left alone.
+fn repair_table_root(content: String, expected_root: &str) -> (String, bool) {
+    let wrong_root = if expected_root == "sym_lib_table" {
+        "fp_lib_table"
+    } else {
+        "sym_lib_table"
+    };
+    let opening = format!("({wrong_root}");
+    match content.find(&opening) {
+        Some(pos) if content[..pos].trim().is_empty() => {
+            let repaired = format!(
+                "{}({expected_root}{}",
+                &content[..pos],
+                &content[pos + opening.len()..]
+            );
+            (repaired, true)
+        }
+        _ => (content, false),
+    }
+}
+
 /// Insert a new `(lib ...)` entry into a lib-table file (fp-lib-table or sym-lib-table).
-/// Creates the file with minimal scaffolding if it doesn't exist.
+/// Creates the file with minimal scaffolding if it doesn't exist, and repairs a
+/// mismatched root element on an existing one.
+///
+/// Returns whether the root element had to be repaired.
 async fn register_in_lib_table(
     table_path: &Path,
     nickname: &str,
     uri: &str,
     lib_type: &str,
-) -> anyhow::Result<()> {
-    let content = if table_path.exists() {
-        tokio::fs::read_to_string(table_path).await?
+) -> anyhow::Result<bool> {
+    // The root element must match the table kind: a sym-lib-table with an
+    // (fp_lib_table root is rejected by KiCad. Decide from the filename, which
+    // is fixed by convention.
+    let root = table_root_element(table_path);
+    let (content, repaired_root) = if table_path.exists() {
+        repair_table_root(tokio::fs::read_to_string(table_path).await?, root)
     } else {
-        // The scaffold's root element must match the table kind: a
-        // sym-lib-table created with an (fp_lib_table root is rejected by
-        // KiCad. Decide from the filename, which is fixed by convention.
-        format!("({}\n  (version 7)\n)\n", table_root_element(table_path))
+        (format!("({root}\n  (version 7)\n)\n"), false)
     };
+    if repaired_root {
+        tracing::warn!(
+            "Repaired the root element of {} — it declared the wrong table kind, so KiCad was skipping the whole table",
+            table_path.display()
+        );
+    }
 
     // Check if nickname already registered
     if content.contains(&format!("(name \"{}\")", nickname)) {
-        return Ok(()); // already registered, idempotent
+        // Idempotent — but a repaired root still has to reach disk, or a table
+        // that already lists this nickname stays rejected forever.
+        if repaired_root {
+            write_atomic(table_path, &content)?;
+        }
+        return Ok(repaired_root);
     }
 
     // Find closing paren of the root expression
@@ -1396,7 +1445,7 @@ async fn register_in_lib_table(
         tokio::fs::create_dir_all(parent).await?;
     }
     write_atomic(table_path, &new_content)?;
-    Ok(())
+    Ok(repaired_root)
 }
 
 // ─── Symbol library tools ─────────────────────────────────────────────────────
@@ -3282,15 +3331,91 @@ mod tests {
     async fn registering_a_symbol_library_scaffolds_a_sym_root() {
         let tmp = tempfile::tempdir().unwrap();
         let table = tmp.path().join("sym-lib-table");
-        register_in_lib_table(&table, "MySyms", "${KIPRJMOD}/my.kicad_sym", "KiCad")
+        let repaired = register_in_lib_table(&table, "MySyms", "${KIPRJMOD}/my.kicad_sym", "KiCad")
             .await
             .unwrap();
+        assert!(!repaired, "a fresh scaffold has nothing to repair");
         let content = std::fs::read_to_string(&table).unwrap();
         assert!(
             content.starts_with("(sym_lib_table"),
             "scaffold root must match the table kind, got: {content}"
         );
         assert!(content.contains("\"MySyms\""));
+    }
+
+    /// A sym-lib-table an older build wrote with an `(fp_lib_table` root is
+    /// rejected wholesale by KiCad ("has type FOOTPRINT but expected SYMBOL;
+    /// skipping"). #54 stopped new files being written that way; without a
+    /// repair the existing ones stay broken through every later registration.
+    const BROKEN_SYM_TABLE: &str = "(fp_lib_table\n  (version 7)\n  (lib (name \"Old\") (type \"KiCad\") (uri \"/abs/old.kicad_sym\") (options \"\") (descr \"\"))\n)\n";
+
+    #[tokio::test]
+    async fn an_existing_sym_table_with_an_fp_root_is_repaired() {
+        let tmp = tempfile::tempdir().unwrap();
+        let table = tmp.path().join("sym-lib-table");
+        std::fs::write(&table, BROKEN_SYM_TABLE).unwrap();
+
+        let repaired = register_in_lib_table(&table, "MySyms", "/abs/my.kicad_sym", "KiCad")
+            .await
+            .unwrap();
+
+        assert!(
+            repaired,
+            "the wrong root must be reported, not fixed mutely"
+        );
+        let content = std::fs::read_to_string(&table).unwrap();
+        assert!(
+            content.starts_with("(sym_lib_table"),
+            "root must be repaired, got: {content}"
+        );
+        assert!(!content.contains("fp_lib_table"), "{content}");
+        assert!(
+            content.contains("\"Old\""),
+            "existing entry lost: {content}"
+        );
+        assert!(content.contains("\"MySyms\""), "{content}");
+    }
+
+    /// The idempotent "already registered" early return used to skip the write
+    /// entirely, so re-registering the same nickname left the bad root in place.
+    #[tokio::test]
+    async fn a_repair_still_lands_when_the_nickname_is_already_registered() {
+        let tmp = tempfile::tempdir().unwrap();
+        let table = tmp.path().join("sym-lib-table");
+        std::fs::write(&table, BROKEN_SYM_TABLE).unwrap();
+
+        let repaired = register_in_lib_table(&table, "Old", "/abs/old.kicad_sym", "KiCad")
+            .await
+            .unwrap();
+
+        assert!(repaired);
+        let content = std::fs::read_to_string(&table).unwrap();
+        assert!(content.starts_with("(sym_lib_table"), "{content}");
+        assert_eq!(
+            content.matches("(lib ").count(),
+            1,
+            "an already-registered nickname must not be duplicated: {content}"
+        );
+    }
+
+    #[test]
+    fn a_correct_root_and_a_mention_inside_a_descr_are_left_alone() {
+        let ok = "(fp_lib_table\n  (version 7)\n)\n".to_string();
+        assert_eq!(
+            repair_table_root(ok.clone(), "fp_lib_table"),
+            (ok, false),
+            "a correct table must not be rewritten"
+        );
+
+        // The wrong token appears, but not as the root element.
+        let nested =
+            "(sym_lib_table\n  (lib (name \"X\") (descr \"copied from fp_lib_table\"))\n)\n"
+                .to_string();
+        assert_eq!(
+            repair_table_root(nested.clone(), "sym_lib_table"),
+            (nested, false),
+            "only the root element may be rewritten"
+        );
     }
 
     fn pad(number: &str, t: &str, x: f64, y: f64, w: f64, h: f64) -> PadGeom {


### PR DESCRIPTION
## Problem

A project's `sym-lib-table` can begin with `(fp_lib_table`, and once it does, nothing Konnect offers will fix it. KiCad rejects the whole file:

```
Library table 'sym-lib-table' has type FOOTPRINT but expected SYMBOL; skipping
```

So every symbol library registered in that project is invisible to KiCad, `register_symbol_library` keeps reporting `success: true`, and the only way out is to delete the file by hand.

## Root cause

#54 fixed the **creation** path: `table_root_element` picks the root from the filename, so a *new* `sym-lib-table` is scaffolded as `(sym_lib_table`. But that scaffold is only used when the file does not exist:

```rust
let content = if table_path.exists() {
    tokio::fs::read_to_string(table_path).await?   // whatever is there, root and all
} else {
    format!("({}\n  (version 7)\n)\n", table_root_element(table_path))
};
```

A table an older Konnect build wrote with the hardcoded `fp_lib_table` root is read back verbatim and appended into, so the bad root is carried forward by every subsequent registration. #54 never reaches a project that already tripped over the bug.

There is a second, sharper edge on the idempotent path:

```rust
if content.contains(&format!("(name \"{}\")", nickname)) {
    return Ok(()); // already registered, idempotent
}
```

Re-registering the same nickname — the obvious thing to try when a library will not resolve — returns success without writing anything at all, so even a repair placed above this line would never reach disk.

## Fix

`repair_table_root(content, expected_root)` rewrites a root element of the wrong kind and reports whether it did. `register_in_lib_table` calls it on the existing content, writes the repaired file even when the nickname is already registered, and returns the flag.

The rewrite is deliberately narrow: the wrong token must be the **first** thing in the file (`content[..pos].trim().is_empty()`), so `fp_lib_table` mentioned inside a `(descr …)` is left alone.

`register_symbol_library` and `register_footprint_library` add `"repaired_table_root": true` to their result and a `tracing::warn!` fires, because a project that was silently broken should say so rather than be mutely fixed.

## Compatibility

`register_in_lib_table` returns `anyhow::Result<bool>` instead of `Result<()>`; it is a private helper with two in-tree callers, both updated. The tool results gain one additive boolean field. Correct tables are byte-for-byte untouched — pinned by a test.

## Changes

- `crates/konnect-core/src/tools/library.rs` — `repair_table_root`; `register_in_lib_table` repairs and reports; both register handlers surface `repaired_table_root`; four tests.

## Testing

- `an_existing_sym_table_with_an_fp_root_is_repaired` — a pre-existing `(fp_lib_table`-rooted `sym-lib-table` with one entry; after registering a second library the file starts with `(sym_lib_table`, contains no `fp_lib_table`, and still has both entries. **Fails before the fix.**
- `a_repair_still_lands_when_the_nickname_is_already_registered` — re-registering the nickname that is already listed still repairs the root, and does not duplicate the entry. **Fails before the fix** (the early return wrote nothing).
- `a_correct_root_and_a_mention_inside_a_descr_are_left_alone` — a correct table is returned unchanged, and `fp_lib_table` inside a `(descr …)` of a `sym_lib_table` is not rewritten.
- `registering_a_symbol_library_scaffolds_a_sym_root` — extended to assert the new flag is `false` for a fresh scaffold.

Checklist commands, all clean:

- `cargo test --workspace --locked --lib --tests` — 236 lib tests (233 before + 3 new), all suites green
- `cargo test --workspace --locked --doc` — clean
- `cargo clippy --workspace --locked -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Aside, not fixed here

Project-scope registration writes the **absolute** path as the URI. `${KIPRJMOD}/…` would be the portable form and `expand_lib_uri` already resolves it (it is what `register_footprint_library`'s own test exercises), but choosing it unconditionally would break registering a library that lives outside the project directory, so it wants a rule rather than a one-liner. Happy to open a separate issue if that is worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
