### PR TITLE
fix(pcb): read KiCad 10 net nodes by shape, not by fixed index

### DIFF
--- a/crates/konnect-core/src/tools/pcb_board.rs
+++ b/crates/konnect-core/src/tools/pcb_board.rs
@@ -161,7 +161,8 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "get_board_info",
-            "Return metadata about the PCB: title, revision, company, layer count, paper size.",
+            "Return metadata about the PCB: title, revision, company, layer count, paper size, \
+             and the number of distinct nets (excluding the unconnected pseudo-net).",
             json!({
                 "type": "object",
                 "properties": {
@@ -422,7 +423,11 @@ async fn handle_get_board_info(
         .unwrap_or("A4")
         .to_string();
 
-    let net_count = tree.find_all("net").len().saturating_sub(1); // exclude net 0
+    // Not find_all("net"): that counts only direct children of (kicad_pcb …),
+    // i.e. the top-level net table — which KiCad 10 does not write at all, so
+    // every KiCad 10 board reported 0. Collect from wherever the nets actually
+    // are and de-duplicate; see konnect_sexp::net.
+    let net_count = konnect_sexp::net::count_distinct_nets(&tree);
 
     Ok(CallToolResult::json(&json!({
         "file": board_path.display().to_string(),
@@ -975,5 +980,78 @@ mod svg_logo_tests {
 
         let result = handle_import_svg_logo(&args, &ctx).await.unwrap();
         assert!(result.is_error);
+    }
+}
+
+#[cfg(test)]
+mod net_count_tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::ServerConfig;
+    use std::sync::Arc;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    async fn net_count_of(board: &str) -> i64 {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("board.kicad_pcb");
+        std::fs::write(&path, board).unwrap();
+        let result =
+            handle_get_board_info(&json!({ "board": path.to_str().unwrap() }), &test_ctx())
+                .await
+                .expect("handler should succeed");
+        let body = match &result.content[0] {
+            crate::mcp::protocol::ToolContent::Text { text } => text.clone(),
+            _ => panic!("expected text content"),
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        parsed["net_count"].as_i64().expect("net_count")
+    }
+
+    /// KiCad 10 has no top-level net table, so the old
+    /// `find_all("net").len().saturating_sub(1)` — direct children only —
+    /// reported 0 for every board saved by KiCad 10, however many nets it had.
+    #[tokio::test]
+    async fn a_kicad_10_board_with_no_net_table_still_counts_its_nets() {
+        let board = "(kicad_pcb\n\
+            \t(version 20260206)\n\
+            \t(footprint \"R\"\n\t\t(pad \"1\" smd rect (at 0 0) (net \"GND\"))\n\
+            \t\t(pad \"2\" smd rect (at 1 0) (net \"VCC\"))\n\t)\n\
+            \t(segment (start 0 0) (end 1 0) (net \"GND\"))\n\
+            )\n";
+        assert_eq!(net_count_of(board).await, 2);
+    }
+
+    /// A KiCad ≤ 9 net is declared once and referenced many times; the old
+    /// code happened to be right here only because it looked at the table.
+    #[tokio::test]
+    async fn a_kicad_9_board_counts_each_net_once() {
+        let board = "(kicad_pcb\n\
+            \t(version 20241229)\n\
+            \t(net 0 \"\")\n\t(net 1 \"GND\")\n\t(net 2 \"VCC\")\n\
+            \t(segment (start 0 0) (end 1 0) (net 1))\n\
+            \t(via (at 1 0) (net 1))\n\
+            )\n";
+        assert_eq!(net_count_of(board).await, 2);
+    }
+
+    #[tokio::test]
+    async fn a_board_with_only_the_unconnected_pseudo_net_counts_zero() {
+        assert_eq!(
+            net_count_of("(kicad_pcb\n  (version 20250610)\n  (net 0 \"\")\n)\n").await,
+            0
+        );
     }
 }

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -950,7 +950,10 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "get_component_pads",
-            "Return the pad positions and net assignments for a footprint.",
+            "Return the pad positions and net assignments for a footprint. \
+             A pad's 'net' is its net name, \"\" if the pad carries no net node \
+             (unconnected), or null if the node is present but unreadable — \
+             treat null as an error, not as an unconnected pad.",
             json!({
                 "type": "object",
                 "properties": {
@@ -1332,12 +1335,19 @@ async fn handle_get_component_pads(
             // Uses the canonical KiCAD transform — see konnect_sexp::geometry.
             let (board_x, board_y) =
                 konnect_sexp::geometry::transform_pad(local_x, local_y, fp_x, fp_y, fp_rot);
-            let net = pad
-                .find("net")
-                .and_then(|n| n.get(2))
-                .and_then(|n| n.as_str())
-                .unwrap_or("")
-                .to_string();
+            // Three outcomes, deliberately distinguishable. No (net …) node at
+            // all is an unconnected pad, and "" says so. A node we can read
+            // gives its name. A node that is present but unreadable gives
+            // null — previously it gave "" too, so a fully connected KiCad 10
+            // pad was indistinguishable from an unconnected one. See
+            // konnect_sexp::net for the two shapes.
+            let net = match pad.find("net") {
+                None => json!(""),
+                Some(node) => match konnect_sexp::net::net_name(node) {
+                    Some(name) => json!(name),
+                    None => serde_json::Value::Null,
+                },
+            };
             Some(json!({ "number": number, "x": board_x, "y": board_y, "net": net }))
         })
         .collect();
@@ -2451,5 +2461,114 @@ mod field_placement_tests {
         let placement = extract_field_placement("(footprint \"bare\")");
         assert_eq!(placement.reference_at, None);
         assert_eq!(placement.value_at, None);
+    }
+}
+
+#[cfg(test)]
+mod pad_net_shape_tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::ServerConfig;
+    use std::sync::Arc;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    async fn pads_of(board: &str) -> serde_json::Value {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("board.kicad_pcb");
+        std::fs::write(&path, board).unwrap();
+        let result = handle_get_component_pads(
+            &json!({ "board": path.to_str().unwrap(), "reference": "R1" }),
+            &test_ctx(),
+        )
+        .await
+        .expect("handler should succeed");
+        let body = match &result.content[0] {
+            crate::mcp::protocol::ToolContent::Text { text } => text.clone(),
+            _ => panic!("expected text content"),
+        };
+        serde_json::from_str(&body).unwrap()
+    }
+
+    fn board_with_pads(pads: &str) -> String {
+        format!(
+            "(kicad_pcb\n\t(version 20260206)\n\t(footprint \"TestPad\"\n\t\t(layer \"F.Cu\")\n\t\t(at 100 100)\n\
+             \t\t(property \"Reference\" \"R1\" (at 0 0 0) (layer \"F.SilkS\"))\n{pads}\t)\n)\n"
+        )
+    }
+
+    /// The reported bug: KiCad 10 puts the name at index 1, the old reader
+    /// took index 2, and `.unwrap_or("")` turned that miss into a plausible
+    /// empty string — so a fully connected pad looked exactly like an
+    /// unconnected one.
+    #[tokio::test]
+    async fn kicad_10_pads_report_their_net_names() {
+        let pads = pads_of(&board_with_pads(
+            "\t\t(pad \"1\" smd rect (at -1 0) (size 1 1) (net \"GND\"))\n\
+             \t\t(pad \"2\" smd rect (at 1 0) (size 1 1) (net \"VCC\"))\n",
+        ))
+        .await;
+        assert_eq!(pads["pads"][0]["net"], json!("GND"));
+        assert_eq!(pads["pads"][1]["net"], json!("VCC"));
+    }
+
+    #[tokio::test]
+    async fn legacy_pads_still_report_their_net_names() {
+        let pads = pads_of(&board_with_pads(
+            "\t\t(pad \"1\" smd rect (at -1 0) (size 1 1) (net 1 \"GND\"))\n\
+             \t\t(pad \"2\" smd rect (at 1 0) (size 1 1) (net 2 \"VCC\"))\n",
+        ))
+        .await;
+        assert_eq!(pads["pads"][0]["net"], json!("GND"));
+        assert_eq!(pads["pads"][1]["net"], json!("VCC"));
+    }
+
+    /// A pad with no net node is genuinely unconnected, and "" says so. This
+    /// is the one case where the empty string is the right answer, which is
+    /// why the unreadable case must not share it.
+    #[tokio::test]
+    async fn a_pad_with_no_net_node_reports_an_empty_name() {
+        let pads = pads_of(&board_with_pads(
+            "\t\t(pad \"1\" smd rect (at -1 0) (size 1 1))\n",
+        ))
+        .await;
+        assert_eq!(pads["pads"][0]["net"], json!(""));
+    }
+
+    /// Present but unreadable is now loud. A bare `(net 1)` reference names no
+    /// net, and null forces a caller to notice rather than concluding the pad
+    /// is floating.
+    #[tokio::test]
+    async fn a_net_node_we_cannot_read_reports_null_not_empty() {
+        let pads = pads_of(&board_with_pads(
+            "\t\t(pad \"1\" smd rect (at -1 0) (size 1 1) (net 1))\n\
+             \t\t(pad \"2\" smd rect (at 1 0) (size 1 1) (net))\n",
+        ))
+        .await;
+        assert_eq!(pads["pads"][0]["net"], serde_json::Value::Null);
+        assert_eq!(pads["pads"][1]["net"], serde_json::Value::Null);
+    }
+
+    /// The unconnected pseudo-net is named, and its name is empty — that is a
+    /// real answer, not a failure, so it must not become null.
+    #[tokio::test]
+    async fn the_unconnected_pseudo_net_reports_an_empty_name() {
+        let pads = pads_of(&board_with_pads(
+            "\t\t(pad \"1\" smd rect (at -1 0) (size 1 1) (net 0 \"\"))\n",
+        ))
+        .await;
+        assert_eq!(pads["pads"][0]["net"], json!(""));
     }
 }

--- a/crates/konnect-core/src/tools/pcb_routing.rs
+++ b/crates/konnect-core/src/tools/pcb_routing.rs
@@ -81,7 +81,10 @@ pub fn tools() -> Vec<ToolDef> {
     vec![
         tool!(
             "add_net",
-            "Add a new net entry to the PCB file (S-expression insert, no KiCAD IPC required).",
+            "Add a new net entry to the top-level net table of a pre-KiCad-10 board \
+             (S-expression insert, no KiCAD IPC required). Fails on a KiCad 10 board, which \
+             has no net table — there, name the net on copper (route_trace, add_via, \
+             add_copper_pour) instead.",
             json!({
                 "type": "object",
                 "properties": {
@@ -288,8 +291,32 @@ async fn handle_add_net(
     };
 
     let content = std::fs::read_to_string(&board_path)?;
-    // Count existing nets to determine next net ID
-    let net_id = content.matches("(net ").count() as i32;
+    let tree = konnect_sexp::parse_sexp(&content)?;
+
+    if board_is_kicad_10(&tree) {
+        return Ok(CallToolResult::error(format!(
+            "Cannot add net '{net_name}' to this board: it is in the KiCad 10 format, which has \
+             no top-level net table. A net exists only by being named on an item — \
+             (net \"{net_name}\") on a pad, segment, via or zone — so there is nothing for a \
+             file-level insert to add, and appending a net node would report success while \
+             KiCad discarded it on load. Create the net by naming it on copper instead: \
+             route_trace / add_via / add_copper_pour take a net_name, as does assigning a pad \
+             in KiCad. get_nets_list reads the live net list over IPC."
+        )));
+    }
+
+    // Pre-KiCad-10: the top-level table is real, so an insert is meaningful.
+    // The next id is one past the highest in use — not the number of "(net "
+    // occurrences in the file, which counted every reference on every pad,
+    // segment and zone and so collided with existing ids almost immediately.
+    let net_id = tree
+        .find_all("net")
+        .iter()
+        .filter_map(|n| konnect_sexp::net::net_id(n))
+        .filter_map(|id| id.parse::<i32>().ok())
+        .max()
+        .map(|max| max + 1)
+        .unwrap_or(1);
     let net_sexp = format!("\n  (net {net_id} \"{net_name}\")");
     // Insert before the last closing paren
     let close_pos = content.rfind(')').unwrap_or(content.len());
@@ -299,6 +326,37 @@ async fn handle_add_net(
     Ok(CallToolResult::json(
         &json!({ "net_id": net_id, "net_name": net_name }),
     ))
+}
+
+/// Whether a board is in the KiCad 10 format, where nets are implicit.
+///
+/// Structure first: a single name-only `(net "GND")` node anywhere is
+/// conclusive, because no earlier format ever wrote that shape. Only when the
+/// board names no net at all — a blank board, where the structure cannot say —
+/// does this fall back to the format version. 20260101 is below KiCad 10's
+/// first release format (20260206) and above every 9.x one including the 9.99
+/// development builds, which still wrote `(net N "name")`.
+fn board_is_kicad_10(tree: &konnect_sexp::SexpNode) -> bool {
+    fn has_name_only_net(node: &konnect_sexp::SexpNode) -> bool {
+        let Some(children) = node.children() else {
+            return false;
+        };
+        if node.head() == Some("net")
+            && matches!(children.get(1), Some(konnect_sexp::SexpNode::Str(_)))
+        {
+            return true;
+        }
+        children.iter().any(has_name_only_net)
+    }
+
+    if has_name_only_net(tree) {
+        return true;
+    }
+    tree.find("version")
+        .and_then(|n| n.get(1))
+        .and_then(|n| n.as_str())
+        .and_then(|v| v.parse::<u64>().ok())
+        .is_some_and(|v| v >= 20260101)
 }
 
 async fn handle_route_trace(
@@ -797,4 +855,109 @@ async fn handle_route_diff_pair(
         "net_pos": net_pos, "net_neg": net_neg,
         "layer": layer, "width": width, "gap": gap
     })))
+}
+
+#[cfg(test)]
+mod add_net_format_tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::ServerConfig;
+    use std::sync::Arc;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    /// Runs add_net against a throwaway copy of `board` and returns the
+    /// handler result together with the file as it stands afterwards, so a
+    /// test can assert both what the caller was told and what was written.
+    async fn add_net_to(board: &str) -> (CallToolResult, String) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("board.kicad_pcb");
+        std::fs::write(&path, board).unwrap();
+        let result = handle_add_net(
+            &json!({ "board": path.to_str().unwrap(), "net_name": "NEWNET" }),
+            &test_ctx(),
+        )
+        .await
+        .expect("handler should return");
+        let after = std::fs::read_to_string(&path).unwrap();
+        (result, after)
+    }
+
+    fn text_of(result: &CallToolResult) -> String {
+        match &result.content[0] {
+            crate::mcp::protocol::ToolContent::Text { text } => text.clone(),
+            _ => panic!("expected text content"),
+        }
+    }
+
+    /// A KiCad 10 board has no net table at all, so there is nothing an insert
+    /// can add. Writing one anyway is the "reports success, does nothing"
+    /// pattern — the board would be unchanged in KiCad's eyes while the caller
+    /// was told the net existed.
+    #[tokio::test]
+    async fn a_kicad_10_board_is_refused_rather_than_silently_edited() {
+        let board = "(kicad_pcb\n\t(version 20260206)\n\
+            \t(segment (start 0 0) (end 1 0) (net \"GND\"))\n)\n";
+        let (result, after) = add_net_to(board).await;
+        assert!(result.is_error, "must fail closed: {}", text_of(&result));
+        let msg = text_of(&result);
+        assert!(msg.contains("KiCad 10"), "{msg}");
+        assert!(msg.contains("route_trace"), "must point somewhere: {msg}");
+        assert_eq!(after, board, "the board must not be touched");
+    }
+
+    /// Even with no net named anywhere, the format version still identifies a
+    /// KiCad 10 board, and refusing is the safe direction when structure alone
+    /// cannot say.
+    #[tokio::test]
+    async fn a_blank_kicad_10_board_is_refused_on_its_version() {
+        let board = "(kicad_pcb\n\t(version 20260306)\n\t(generator \"pcbnew\")\n)\n";
+        let (result, after) = add_net_to(board).await;
+        assert!(result.is_error, "{}", text_of(&result));
+        assert_eq!(after, board);
+    }
+
+    #[tokio::test]
+    async fn a_legacy_board_still_gets_its_net() {
+        let board = "(kicad_pcb\n  (version 20241229)\n  (net 0 \"\")\n  (net 1 \"GND\")\n)\n";
+        let (result, after) = add_net_to(board).await;
+        assert!(!result.is_error, "{}", text_of(&result));
+        assert!(after.contains("(net 2 \"NEWNET\")"), "{after}");
+    }
+
+    /// The old id was `content.matches("(net ").count()`, which counted every
+    /// reference on every pad, segment and zone — so on any real board the
+    /// "next" id collided with ids already in use.
+    #[tokio::test]
+    async fn the_next_id_is_one_past_the_highest_not_a_count_of_occurrences() {
+        let board = "(kicad_pcb\n  (version 20241229)\n  (net 0 \"\")\n  (net 1 \"GND\")\n  \
+            (net 7 \"VCC\")\n  (segment (start 0 0) (end 1 0) (net 7))\n  \
+            (segment (start 1 0) (end 2 0) (net 7))\n)\n";
+        let (result, after) = add_net_to(board).await;
+        assert!(!result.is_error, "{}", text_of(&result));
+        assert!(after.contains("(net 8 \"NEWNET\")"), "{after}");
+    }
+
+    /// A 9.99 development build wrote the legacy shape with a 2025 version
+    /// number; treating it as KiCad 10 on the version alone would refuse a
+    /// board that an insert works perfectly well on.
+    #[tokio::test]
+    async fn a_9_99_development_format_is_treated_as_legacy() {
+        let board = "(kicad_pcb\n  (version 20250610)\n  (net 0 \"\")\n)\n";
+        let (result, after) = add_net_to(board).await;
+        assert!(!result.is_error, "{}", text_of(&result));
+        assert!(after.contains("(net 1 \"NEWNET\")"), "{after}");
+    }
 }

--- a/crates/konnect-sexp/src/lib.rs
+++ b/crates/konnect-sexp/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod command;
 pub mod error;
 pub mod geometry;
+pub mod net;
 pub mod parser;
 pub mod schematic;
 pub mod transaction;

--- a/crates/konnect-sexp/src/net.rs
+++ b/crates/konnect-sexp/src/net.rs
@@ -1,0 +1,245 @@
+//! KiCad `(net …)` node shapes.
+//!
+//! A net node is written two different ways depending on the file format, and
+//! the difference is positional, so a fixed index silently reads the wrong
+//! child rather than failing:
+//!
+//! | file | declaration | reference on an item |
+//! |---|---|---|
+//! | KiCad ≤ 9 | `(net 1 "GND")` at top level | `(net 1)` |
+//! | KiCad 10  | *no top-level table at all* | `(net "GND")` |
+//!
+//! So in KiCad 10 the name sits at index 1; in KiCad ≤ 9 index 1 is the
+//! numeric id and the name is at index 2. Reading index 2 unconditionally —
+//! which is what Konnect did — yields `None` on every KiCad 10 pad.
+//!
+//! These helpers read by **shape** instead: whether child 1 is a quoted string
+//! or a bare atom is what distinguishes the formats, so no version sniffing is
+//! needed and a file that mixes them still reads correctly.
+
+use crate::SexpNode;
+use std::collections::HashSet;
+
+/// The net name carried by a `(net …)` node, whichever shape wrote it.
+///
+/// Returns `None` when the node carries no name — a bare `(net 1)` reference,
+/// or a malformed node. `None` is *not* the same as `Some("")`: the empty name
+/// is KiCad's unconnected pseudo-net, which is a real answer, whereas `None`
+/// means this node did not tell us. Callers surfacing a net to a user should
+/// keep that distinction rather than flattening both to `""` — an empty string
+/// looks like a clean answer and is the failure mode this module exists to
+/// remove.
+///
+/// ```
+/// use konnect_sexp::{parse_sexp, net::net_name};
+/// let k10 = parse_sexp("(net \"GND\")").unwrap();
+/// let k9 = parse_sexp("(net 1 \"GND\")").unwrap();
+/// assert_eq!(net_name(&k10), Some("GND"));
+/// assert_eq!(net_name(&k9), Some("GND"));
+/// assert_eq!(net_name(&parse_sexp("(net 1)").unwrap()), None);
+/// ```
+pub fn net_name(node: &SexpNode) -> Option<&str> {
+    let children = node.children()?;
+    if node.head() != Some("net") {
+        return None;
+    }
+    match children.get(1)? {
+        // (net "GND") — KiCad 10 names the net in place.
+        SexpNode::Str(name) => Some(name.as_str()),
+        // (net 1 "GND") — KiCad ≤ 9 declaration; the name follows the id.
+        SexpNode::Atom(_) => match children.get(2)? {
+            SexpNode::Str(name) => Some(name.as_str()),
+            _ => None,
+        },
+        SexpNode::List(_) => None,
+    }
+}
+
+/// The numeric net id of a `(net …)` node, for the formats that carry one.
+///
+/// `(net 1 "GND")` and `(net 1)` both give `Some("1")`; KiCad 10's
+/// `(net "GND")` gives `None`, because the format dropped net numbers.
+pub fn net_id(node: &SexpNode) -> Option<&str> {
+    if node.head() != Some("net") {
+        return None;
+    }
+    match node.children()?.get(1)? {
+        SexpNode::Atom(id) => Some(id.as_str()),
+        _ => None,
+    }
+}
+
+/// Every distinct real net in a board tree, excluding the unconnected
+/// pseudo-net.
+///
+/// Names are used as the key whenever any node carries one, and numeric ids
+/// only as a fallback. That is what keeps both formats honest: in KiCad 10 the
+/// name is the *only* identity a net has, while in KiCad ≤ 9 the same net
+/// appears once as `(net 1 "GND")` and again as `(net 1)` on every item that
+/// touches it — keying on the name collapses those correctly, and keying on
+/// the id would drop KiCad 10 entirely. De-duplication is not a nicety: a
+/// 4-layer KiCad 10 board reported in #133 has 872 `(net …)` occurrences for 65
+/// distinct nets, and an 8-layer one measured here has 5423 for 776 — roughly
+/// 7–13× over if a collector simply counts occurrences.
+///
+/// The walk is recursive because KiCad 10 has no top-level table: the nets are
+/// wherever the pads, segments, vias and zones are.
+pub fn collect_net_keys(tree: &SexpNode) -> HashSet<String> {
+    let mut names = HashSet::new();
+    let mut ids = HashSet::new();
+    walk(tree, &mut names, &mut ids);
+    if names.is_empty() {
+        ids
+    } else {
+        names
+    }
+}
+
+/// How many distinct real nets a board tree contains. See [`collect_net_keys`].
+pub fn count_distinct_nets(tree: &SexpNode) -> usize {
+    collect_net_keys(tree).len()
+}
+
+fn walk(node: &SexpNode, names: &mut HashSet<String>, ids: &mut HashSet<String>) {
+    let Some(children) = node.children() else {
+        return;
+    };
+    if node.head() == Some("net") {
+        // The unconnected pseudo-net is net 0 / the empty name. It is not a
+        // net a user has, and counting it makes an empty board look wired.
+        match net_name(node) {
+            Some(name) if !name.is_empty() => {
+                names.insert(name.to_string());
+            }
+            Some(_) => {}
+            None => {
+                if let Some(id) = net_id(node) {
+                    if id != "0" {
+                        ids.insert(id.to_string());
+                    }
+                }
+            }
+        }
+    }
+    for child in children {
+        walk(child, names, ids);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse_sexp;
+
+    fn node(src: &str) -> SexpNode {
+        parse_sexp(src).unwrap()
+    }
+
+    #[test]
+    fn reads_the_kicad_10_name_only_shape() {
+        assert_eq!(net_name(&node("(net \"GND\")")), Some("GND"));
+        assert_eq!(net_id(&node("(net \"GND\")")), None);
+    }
+
+    #[test]
+    fn reads_the_legacy_id_and_name_shape() {
+        assert_eq!(net_name(&node("(net 1 \"GND\")")), Some("GND"));
+        assert_eq!(net_id(&node("(net 1 \"GND\")")), Some("1"));
+    }
+
+    #[test]
+    fn a_bare_reference_has_an_id_but_no_name() {
+        assert_eq!(net_name(&node("(net 7)")), None);
+        assert_eq!(net_id(&node("(net 7)")), Some("7"));
+    }
+
+    #[test]
+    fn the_unconnected_pseudo_net_has_a_name_and_it_is_empty() {
+        // Some("") and None are different answers: this node *did* tell us the
+        // net, and the answer is "unconnected".
+        assert_eq!(net_name(&node("(net 0 \"\")")), Some(""));
+        assert_eq!(net_name(&node("(net \"\")")), Some(""));
+    }
+
+    #[test]
+    fn a_malformed_or_foreign_node_yields_nothing() {
+        assert_eq!(net_name(&node("(net)")), None);
+        assert_eq!(net_id(&node("(net)")), None);
+        // A node that is not a net at all must not be read as one, or a
+        // shape-based reader becomes a shape-based guesser.
+        assert_eq!(net_name(&node("(layer \"F.Cu\")")), None);
+        assert_eq!(net_id(&node("(at 1 2)")), None);
+    }
+
+    #[test]
+    fn a_name_that_looks_like_a_number_is_still_a_name() {
+        // Quoting is the discriminator, not the character class.
+        assert_eq!(net_name(&node("(net \"12\")")), Some("12"));
+        assert_eq!(net_id(&node("(net \"12\")")), None);
+    }
+
+    /// KiCad 10: no top-level table, the name on every item, tab-indented.
+    const KICAD_10: &str = "(kicad_pcb\n\
+        \t(version 20260206)\n\
+        \t(footprint \"R\"\n\t\t(pad \"1\" smd rect (at 0 0) (net \"GND\"))\n\
+        \t\t(pad \"2\" smd rect (at 1 0) (net \"VCC\"))\n\t)\n\
+        \t(segment (start 0 0) (end 1 0) (net \"GND\"))\n\
+        \t(via (at 1 0) (net \"GND\"))\n\
+        \t(zone (net \"GND\") (polygon (pts (xy 0 0) (xy 1 1))))\n\
+        )\n";
+
+    /// KiCad ≤ 9: a top-level table plus numeric references on the items.
+    const KICAD_9: &str = "(kicad_pcb\n\
+        \t(version 20241229)\n\
+        \t(net 0 \"\")\n\t(net 1 \"GND\")\n\t(net 2 \"VCC\")\n\
+        \t(footprint \"R\"\n\t\t(pad \"1\" smd rect (at 0 0) (net 1 \"GND\"))\n\
+        \t\t(pad \"2\" smd rect (at 1 0) (net 2 \"VCC\"))\n\t)\n\
+        \t(segment (start 0 0) (end 1 0) (net 1))\n\
+        \t(via (at 1 0) (net 1))\n\
+        )\n";
+
+    #[test]
+    fn counts_a_kicad_10_board_that_has_no_net_table() {
+        assert_eq!(count_distinct_nets(&node(KICAD_10)), 2);
+    }
+
+    #[test]
+    fn counts_a_kicad_9_board_without_double_counting_declarations() {
+        // 2, not 7: GND is declared once and referenced four more times.
+        assert_eq!(count_distinct_nets(&node(KICAD_9)), 2);
+    }
+
+    #[test]
+    fn the_unconnected_pseudo_net_does_not_count() {
+        assert_eq!(count_distinct_nets(&node("(kicad_pcb (net 0 \"\"))")), 0);
+        assert_eq!(
+            count_distinct_nets(&node("(kicad_pcb (segment (net 0)))")),
+            0
+        );
+        assert_eq!(
+            count_distinct_nets(&node("(kicad_pcb (pad (net \"\")))")),
+            0
+        );
+    }
+
+    #[test]
+    fn a_file_with_only_bare_references_falls_back_to_ids() {
+        // No name anywhere — the ids are the only identity available.
+        let t = node("(kicad_pcb (segment (net 1)) (segment (net 1)) (via (net 2)))");
+        assert_eq!(count_distinct_nets(&t), 2);
+    }
+
+    #[test]
+    fn names_win_over_ids_when_both_are_present() {
+        // Mixed file: the two shapes name the same two nets. Keying on ids
+        // here would count the bare references as extra nets.
+        let t = node("(kicad_pcb (net 1 \"GND\") (segment (net 1)) (pad (net \"VCC\")))");
+        assert_eq!(count_distinct_nets(&t), 2);
+    }
+
+    #[test]
+    fn nets_are_found_at_any_depth() {
+        let t = node("(kicad_pcb (group (footprint (pad (net \"DEEP\")))))");
+        assert_eq!(collect_net_keys(&t), HashSet::from(["DEEP".to_string()]));
+    }
+}


### PR DESCRIPTION
Fixes the three sites in #133 (`get_component_pads`, `get_board_info`, `add_net`). Follows #140, which fixed a fourth site with the same root cause in `manufacturing.rs`.

## Problem

KiCad 10 changed the net node in two ways at once: a pad's net is written `(net "GND")` rather than `(net 1 "GND")`, and the top-level net table is gone entirely — a net exists only by being named on the items that carry it. Konnect read the name positionally at index 2, and the miss went through `.unwrap_or("")`, so on any board saved by KiCad 10:

| call | result on a KiCad 10 board |
| --- | --- |
| `get_component_pads` | `net: ""` for **every** pad — a connected pad is indistinguishable from an unconnected one |
| `get_board_info` | `net_count: 0` — `find_all("net")` sees only direct children of `(kicad_pcb …)`, and there is no table to see |
| `add_net` | next id = `content.matches("(net ").count()`, i.e. every reference on every pad, segment and zone; and it emits the legacy two-element node into a file whose format has no table for it |

@cvaldess's correlation datum from the issue is what makes this safe to fix by shape rather than by version: across ~40 `.kicad_pcb` files, `8.0/9.0/9.99 → two-space indent and (net N "x")`, `10.0 → tabs and (net "x")` — the two changes travel together, so a probe that assumes one is also wrong about the other. That is why nothing here sniffs indentation and nothing infers the net shape from the format version.

## Fix

New `konnect_sexp::net` reads by **shape**: whether child 1 is a quoted string or a bare atom is what distinguishes the formats, so both read correctly with no version check, and a file that mixes them still works.

- `net_name` / `net_id` — one node, either shape.
- `collect_net_keys` / `count_distinct_nets` — walks the tree (the nets are wherever the pads, segments, vias and zones are) and keys on **names when any are present, numeric ids otherwise**. That is the same rule #140 used, and it is load-bearing in both directions: keying on ids drops KiCad 10 entirely, and keying on names would drop a KiCad 9 file's bare `(net 1)` references. De-duplication is not a nicety — the 4-layer board in #133 has 872 `(net …)` occurrences for 65 distinct nets, and an 8-layer one measured here has 5423 for 776.

The pseudo-net rule also matches #140: the empty name and id `0` are excluded, so an empty board does not look wired.

## Verification

Against a real 8-layer KiCad 10 board (format `20260206`), through the MCP server over stdio:

- `get_board_info` → `net_count: 776`, cross-checked against an independent quote-aware scan of the same file that also reports 776 from 5423 occurrences. (A naive `\(net[^)]*\)` regex says 571 — KiCad's auto-generated names contain parentheses, e.g. `unconnected-(U59-PGOOD-Pad6)`, so the cross-check had to tokenize. Worth knowing for anyone else counting nets from these files.)
- `get_component_pads` on a 30-pad power part → real net names (`VBUS_SLOT_FUSED`, `GND`) where every pad previously read `""`; its four mechanical pads, which carry no `(net …)` node at all, still read `""`.
- `add_net` → refused, and the board file is byte-identical afterwards (sha256 unchanged).

Gate green: `cargo fmt --all --check`, `cargo clippy --workspace --locked -D warnings`, `cargo test --workspace --locked --lib --tests` and `--doc`. 20 new tests cover the KiCad 8/9 shape, the KiCad 10 shape, mixed files, a name that looks like a number, the pseudo-net, and the unreadable case.

## Two decisions I would like a ruling on

Both are judgement calls; I have implemented what I believe is right and will amend either without argument if you rule the other way.

**1. `get_component_pads` returns `null`, not `""`, for a net node it cannot read.**

Three outcomes are now distinguishable where there were two: no `(net …)` node at all is an unconnected pad and stays `""`; a readable node gives its name; a node that is *present but unreadable* gives `null`.

*Chosen because* `""` is a clean-looking answer that means nothing, which is the exact failure mode of this bug — a caller sanity-checking connectivity before fab ("is every pad on a net?") got a tidy, wrong answer on every KiCad 10 board. `null` makes the caller notice.

*The alternative* is to keep `""` for both and preserve the current contract exactly. This **is** a behaviour change for existing callers, and it is the reason I am flagging it: anyone treating `net` as a `string` will now see `null`. If you would rather not break that, say so and I will fold the unreadable case back into `""` — or, if you prefer a third way, emit `""` plus a separate boolean field.

**2. `add_net` fails closed on a KiCad 10 board rather than writing a matching-shape node.**

*Chosen because* KiCad 10 has no top-level net table, so there is nothing for a file-level insert to add. Writing `(net "NAME")` at top level would report success while KiCad discarded it on load — the same "reports success, does nothing" pattern as #58/#99 (`add_via`), which is what this class of bug keeps producing. The error names the format, says why, and points at the tools that create a net by naming it on copper (`route_trace` / `add_via` / `add_copper_pour`), plus `get_nets_list` for reading live nets over IPC.

*The alternative* — the one I started with — is to emit the shape matching the file, name-only in a KiCad 10 file and legacy in a legacy file, on a least-surprise argument for mixed-version installs. I moved off it once I confirmed the node has nowhere to live in KiCad 10. If you would rather `add_net` stay total and write the matching shape, that variant is a small change and I will send it.

Legacy boards are unaffected except for one repair: the next id is now one past the highest in use, instead of a count of `"(net "` occurrences, which collided with existing ids on any real board.

Format detection for that refusal is structural first — a single name-only node anywhere is conclusive, since no earlier format ever wrote that shape — and falls back to the format version only for a board that names no net at all. The threshold (`>= 20260101`) sits above every 9.x format including the 9.99 development builds that still wrote the legacy shape, per the correlation above; there is a test for that case.

## Notes

- **Sequencing with #140:** no textual overlap — that PR touches only `manufacturing.rs`, this one touches `konnect-sexp` and the three `pcb_*` tools — so they merge cleanly in either order. There is a semantic overlap: #140 carries a private `count_nets_and_tracks` with the same name/id rule. Whichever lands second, I will follow up with a commit pointing `manufacturing.rs` at `konnect_sexp::net` so there is one copy of the rule.
- **#84 (remaining hardcoded-indentation scans):** nothing here scans indentation, by design. Per @cvaldess's note on #133, `manufacturing.rs` is effectively a fourth file for that issue and #140 closes that slice; worth linking so the sweep does not re-land on it.
- **Adjacent, deliberately not touched:** `find_net_id` (in both `pcb_routing.rs` and `pcb_board.rs`) has the same legacy assumption on the *write* side, used by zone and pour creation; and `get_board_info` reports `layer_count: 0` on the 8-layer board above, from `find_all("")`, which is an unrelated silent zero of the same family. Both are outside the scope of #133 and I would rather not widen this PR without a nod — happy to take either as a follow-up.
- @cvaldess offered to keep testing against real KiCad 10 boards once a fix was up. This is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
