### PR TITLE
docs(skills): correct two fabricated tool signatures

### DIFF
--- a/crates/konnect/assets/skills/kicad-schematic/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-schematic/SKILL.md
@@ -93,7 +93,7 @@ Power symbols: GND uses 0 (arrow points down), VCC/VDD/+3V3/+5V use 0 (arrow poi
 |-----------------------------------------|-------------------------|------------------------------------------|
 | Two pins physically close (<30mm)       | `connect_pins`          | Direct wire, auto-routed                 |
 | Named signal (SDA, MOSI, EN, etc.)      | `connect_to_net`        | Stub wire + net label, cleaner           |
-| Power rail (VCC, GND, +3V3)             | `add_power_symbol`      | Proper power symbol, auto-connects       |
+| Power rail (VCC, GND, +3V3)             | `add_power_symbol`      | Proper power symbol, global net          |
 | Bus signals (D0-D7)                     | `connect_to_net`        | Net labels with bus naming               |
 | Cross-sheet signal                      | Global label            | Connects across schematic sheets         |
 | Multiple pins to same net (3+)          | `batch_connect_to_net`  | Efficient bulk operation                 |
@@ -103,7 +103,7 @@ Power symbols: GND uses 0 (arrow points down), VCC/VDD/+3V3/+5V use 0 (arrow poi
 Use for direct pin-to-pin connections. The tool auto-routes with L-bends.
 
 ```
-connect_pins(from_component, from_pin, to_component, to_pin)
+connect_pins(schematic, ref1, pin1, ref2, pin2)
 ```
 
 - Specify pins by pin number (from get_schematic_pin_locations)
@@ -125,15 +125,22 @@ connect_to_net(component_reference, pin_number, net_name)
 
 ### add_power_symbol
 
-Use for all power connections. Never manually wire to power symbols.
+Use for all power connections, in preference to labelling a pin with the rail name.
 
 ```
-add_power_symbol(component_reference, pin_number, power_net)
+add_power_symbol(schematic, power_net, x, y, rotation?)
 ```
 
-- Automatically places the correct power symbol (GND, VCC, etc.)
-- Handles orientation automatically
-- Connects the pin to the global power net
+- Takes coordinates, not a reference and pin number. Place it on the pin
+  endpoint (from `get_schematic_pin_locations`) — a power symbol carries its
+  pin at its own origin, so the two coinciding is the connection.
+- `power_net` is loaded as `power:<power_net>`, so it must name a symbol in
+  KiCad's power library: `+3V3` and `+12V`, never `3V3` or `12V`. A miss is an
+  error and nothing is placed.
+- `rotation` defaults to 0 — see Rotation Conventions above.
+- A power pin landing mid-segment on a wire gets its junction dot
+  automatically, in either order: symbol onto an existing wire, or a wire
+  routed across an already-placed symbol.
 
 ---
 
@@ -227,7 +234,7 @@ Finds floating wires, labels, and symbols that are not connected to anything.
 3. **Always verify after changes** — run validation tools after placing and wiring
 4. **Use the grid** — all placements on 1.27mm grid
 5. **Search before placing** — use `search_symbols` to confirm lib_id exists
-6. **Power symbols for power** — never manually wire power connections
+6. **Power symbols for power** — use `add_power_symbol` for rails, not net labels
 7. **Net labels for named signals** — keeps schematics readable
 8. **Save frequently** — call `save_project` after major operations
 9. **Load toolsets first** — check `get_active_toolsets()` and load what you need before starting


### PR DESCRIPTION
## Problem

Two of the three tool signatures in the schematic skill's Wiring section describe calls the tools do not accept:

| SKILL.md said | the tool takes |
|---|---|
| `connect_pins(from_component, from_pin, to_component, to_pin)` | `schematic`, `ref1`, `pin1`, `ref2`, `pin2` |
| `add_power_symbol(component_reference, pin_number, power_net)` | `schematic`, `power_net`, `x`, `y`, `rotation?` |

`connect_pins` is only wrong parameter names. `add_power_symbol` is worse: it has **no pin argument at all**, so the documented call cannot succeed, and the three bullets under it were wrong in the same direction —

- "Handles orientation automatically" — `rotation` is a caller argument, `opt_f64(…).unwrap_or(0.0)`.
- "Connects the pin to the global power net" — placement is by coordinate; the tool never sees a pin.
- The decision table's "auto-connects" said the same thing in four words.

An agent following this doc fails on every attempt, which is exactly what the skill exists to prevent.

## Fix

Both signatures corrected against the schemas, and the `add_power_symbol` bullets replaced with what the tool actually guarantees:

- **`power_net` is loaded as `power:<power_net>`**, so it must name a symbol KiCad's power library has. `+3V3` and `+12V` work; `3V3` and `12V` are errors that place nothing. Easy to miss, because the obvious examples (`GND`, `+3V3`) are both valid.
- **Junction dots need no ordering rule.** Every wire writer re-reads all pin endpoints from disk at call time and dots any pin it crosses mid-segment, so a wire routed across an already-placed power symbol is handled just like a symbol dropped onto an existing wire.

Placing at the pin endpoint is the connection: a power symbol carries its pin at its own origin with length 0, so the two coincide.

Also drops the Rules entry that still read "never manually wire power connections" — the duplicate of the sentence removed from the `add_power_symbol` intro, left contradicting it.

## Verification

Every claim checked against `sch_wiring.rs` and, for the library names and pin origin, against the installed `power.kicad_sym` rather than from memory.

The junction claim specifically: `pins_mid_segment` is called from `insert_wire_with_junctions` (`sch_wiring.rs:459`, reached by `connect_pins` / `add_schematic_connection` / `sch_batch.rs:534` via `route_between`), `handle_add_wire` (`:542`), `handle_batch_add_wire` (`:597`), and `handle_connect_to_net` (`:1539`) — each against `all_pin_endpoints` read fresh, which includes power symbol pins. `add_pin_midwire_junctions` covers the other order at `:1310`.

Docs only — no code, no tool count, no behaviour change. Gate green.

## Note on `connect_to_net`

The third signature in that section, `connect_to_net`, is also wrong on `main` and is **deliberately untouched here**: #148 corrects that exact line as part of making the named-pin form real. Editing it here too would conflict with that PR for no gain. Merge order does not matter — verified both ways — but if this lands first, `connect_to_net` stays wrong until #148 lands.

## Follow-ups (not in this PR)

- `add_power_symbol`'s `power_net` argument description reads "Net name (e.g. 'VCC', 'GND')", which invites `3V3`. The `power:` library constraint belongs there, where every caller sees it, not only in this skill.
- `handle_add_power_symbol` never checks that `(x, y)` lands on a pin or wire — 1 mm off returns success with `junctions_added: []` and nothing connected.
- `sch_batch.rs:866 handle_connect_passthrough` is the one wire writer with no junction backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
