### PR TITLE
fix(pcb): read layers by shape, and stop add_layer writing unopenable boards

### DIFF
--- a/crates/konnect-core/src/tools/pcb_board.rs
+++ b/crates/konnect-core/src/tools/pcb_board.rs
@@ -139,6 +139,53 @@ fn find_net_id(content: &str, net_name: &str) -> Option<i32> {
     before[num_start..num_start + num_end].parse().ok()
 }
 
+/// Byte offset of the `)` that closes the block opening at `open_pos`.
+///
+/// Balances parens while skipping quoted strings, so it is independent of how
+/// the file is indented — KiCad 9 writes two spaces, KiCad 10 writes tabs, and
+/// a probe for either is wrong on the other.
+fn close_of_block(content: &str, open_pos: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut in_str = false;
+    let mut escaped = false;
+    for (i, c) in content[open_pos..].char_indices() {
+        if in_str {
+            match c {
+                _ if escaped => escaped = false,
+                '\\' => escaped = true,
+                '"' => in_str = false,
+                _ => {}
+            }
+            continue;
+        }
+        match c {
+            '"' => in_str = true,
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(open_pos + i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// The leading whitespace of the first entry inside the block at `open_pos`,
+/// so an inserted sibling matches the file it is written into.
+fn entry_indent(content: &str, open_pos: usize) -> Option<String> {
+    let after = &content[open_pos..];
+    let nl = after.find('\n')?;
+    let line = &after[nl + 1..];
+    let indent: String = line
+        .chars()
+        .take_while(|c| *c == ' ' || *c == '\t')
+        .collect();
+    (!indent.is_empty() && line[indent.len()..].starts_with('(')).then_some(indent)
+}
+
 // ─── Tool definitions ─────────────────────────────────────────────────────────
 
 pub fn tools() -> Vec<ToolDef> {
@@ -411,10 +458,12 @@ async fn handle_get_board_info(
         .unwrap_or("")
         .to_string();
 
-    let layers = tree
-        .find("layers")
-        .map(|n| n.find_all("").len())
-        .unwrap_or(0);
+    // A layer is `(0 "F.Cu" signal)`, keyed by its ordinal rather than by a
+    // tag, so find_all("") — which matches on the head — never matched one and
+    // this was always 0. See konnect_sexp::layers.
+    let stack = konnect_sexp::layers::layers(&tree);
+    let layer_count = stack.len();
+    let copper_layer_count = konnect_sexp::layers::copper(&stack).len();
     let paper = tree
         .find("paper")
         .and_then(|n| n.get(1))
@@ -428,7 +477,8 @@ async fn handle_get_board_info(
         "file": board_path.display().to_string(),
         "title": title, "date": date, "revision": rev, "company": company,
         "paper": paper,
-        "layer_count": layers,
+        "layer_count": layer_count,
+        "copper_layer_count": copper_layer_count,
         "net_count": net_count
     })))
 }
@@ -504,28 +554,25 @@ async fn handle_get_layer_list(
     let content = std::fs::read_to_string(&board_path)?;
     let tree = parse_sexp(&content)?;
 
-    let layers_node = match tree.find("layers") {
-        Some(n) => n,
-        None => {
-            return Ok(CallToolResult::error(
-                "No (layers) section found in board file",
-            ))
-        }
-    };
+    if tree.find("layers").is_none() {
+        return Ok(CallToolResult::error(
+            "No (layers) section found in board file",
+        ));
+    }
 
-    // Each child of layers looks like: (0 "F.Cu" signal)
-    let layers: Vec<serde_json::Value> = layers_node
-        .find_all("")
-        .iter()
-        .filter_map(|node| {
-            let id = node.get_f64(1).map(|n| n as i32)?;
-            let name = node.get(2)?.as_str()?.to_string();
-            let kind = node
-                .get(3)
-                .and_then(|n| n.as_str())
-                .unwrap_or("user")
-                .to_string();
-            Some(json!({ "id": id, "name": name, "type": kind }))
+    // Each child of layers looks like: (0 "F.Cu" signal). The ordinal is the
+    // head of the list, so the fields sit one place earlier than the accessors
+    // used to assume — and find_all("") never returned any of them anyway.
+    let layers: Vec<serde_json::Value> = konnect_sexp::layers::layers(&tree)
+        .into_iter()
+        .map(|l| {
+            json!({
+                "id": l.id,
+                "name": l.name,
+                "type": l.kind,
+                "user_name": l.user_name,
+                "copper": l.is_copper(),
+            })
         })
         .collect();
 
@@ -545,6 +592,21 @@ async fn handle_add_layer(
     };
     let layer_type = args["layer_type"].as_str().unwrap_or("signal");
 
+    // Fail closed on a name KiCad does not define. The layer set is closed, and
+    // a board carrying an unknown name does not open at all — so writing one
+    // returns success and hands back a file the user cannot load. Verified
+    // against KiCAD 10: `(53 "User.8" user)` loads, `(53 "TestLayer" user)` is
+    // refused with "Failed to load board".
+    if !konnect_sexp::layers::is_canonical_name(&layer_name) {
+        return Ok(CallToolResult::error(format!(
+            "'{layer_name}' is not a KiCAD layer name, and a board containing one \
+             cannot be opened. Names are fixed: F.Cu, B.Cu, In1.Cu..In30.Cu, \
+             User.1..User.45, and the technical layers (Edge.Cuts, F.Mask, …). \
+             To give a layer your own label, add the canonical layer and set its \
+             user name — `(53 \"User.8\" user \"{layer_name}\")`."
+        )));
+    }
+
     let content = std::fs::read_to_string(&board_path)?;
 
     // Find the (layers ...) block and insert before its closing paren
@@ -553,28 +615,45 @@ async fn handle_add_layer(
         None => return Ok(CallToolResult::error("No (layers) section found")),
     };
 
-    // Determine the next available inner copper ID (first unused ID in 1-30 range)
+    // Determine the next available inner copper ID (first unused ID in 1-30 range).
+    // The ids have to be read by shape — see konnect_sexp::layers. Reading them
+    // with find_all("") returned nothing, so every call allocated id 1 and
+    // duplicated In1.Cu on any board that already had an inner layer.
     let tree = parse_sexp(&content)?;
-    let used_ids: std::collections::HashSet<i32> = tree
-        .find("layers")
-        .map(|n| {
-            n.find_all("")
-                .iter()
-                .filter_map(|node| node.get_f64(1).map(|n| n as i32))
-                .collect()
-        })
-        .unwrap_or_default();
-    let new_id = (1..=30).find(|id| !used_ids.contains(id)).unwrap_or(1);
+    let used_ids: std::collections::HashSet<i32> = konnect_sexp::layers::layers(&tree)
+        .iter()
+        .map(|l| l.id)
+        .collect();
+    let new_id = match (1..=30).find(|id| !used_ids.contains(id)) {
+        Some(id) => id,
+        None => {
+            return Ok(CallToolResult::error(
+                "No free inner copper layer id: 1-30 are all in use",
+            ))
+        }
+    };
 
-    // Find close of the layers block
-    let layers_block = &content[layers_pos..];
-    let close_rel = layers_block
-        .find("\n  )")
-        .or_else(|| layers_block.find(')'))
-        .unwrap_or(layers_block.len().saturating_sub(1));
-    let insert_pos = layers_pos + close_rel;
+    // Close of the layers block, by paren balance. The previous probe looked for
+    // a literal "\n  )", which a tab-indented KiCad 10 file never contains; the
+    // fallback then found the first ')' in the block — the close of the *first
+    // layer entry* — and the new layer was written inside it.
+    let close = match close_of_block(&content, layers_pos) {
+        Some(p) => p,
+        None => {
+            return Ok(CallToolResult::error(
+                "Unbalanced (layers) block; refusing to write",
+            ))
+        }
+    };
+    // Insert after the last entry rather than immediately before the close, so
+    // the newline and indent that already sit in front of `)` stay in front of
+    // it and the block keeps KiCad's own layout.
+    let insert_pos = content[..close].trim_end().len();
 
-    let new_layer = format!("\n    ({new_id} \"{layer_name}\" {layer_type})");
+    // Match whatever the file already indents entries with, rather than
+    // hardcoding spaces into a file that may be tab-indented.
+    let indent = entry_indent(&content, layers_pos).unwrap_or_else(|| "    ".to_string());
+    let new_layer = format!("\n{indent}({new_id} \"{layer_name}\" {layer_type})");
     let new_content = apply_edits(content, vec![SexpEdit::insert(insert_pos, new_layer)]);
     write_atomic(&board_path, &new_content)?;
 
@@ -859,6 +938,113 @@ async fn handle_import_svg_logo(
         "width_mm": width_mm,
         "source": "file"
     })))
+}
+
+#[cfg(test)]
+mod layers_block_tests {
+    use super::*;
+
+    // Both indent styles, same content: KiCad 9 writes two spaces, 10 writes tabs.
+    const SPACES: &str =
+        "(kicad_pcb\n  (layers\n    (0 \"F.Cu\" signal)\n    (2 \"B.Cu\" signal)\n  )\n)";
+    const TABS: &str =
+        "(kicad_pcb\n\t(layers\n\t\t(0 \"F.Cu\" signal)\n\t\t(2 \"B.Cu\" signal)\n\t)\n)";
+
+    fn layers_close(content: &str) -> usize {
+        close_of_block(content, content.find("(layers").unwrap()).unwrap()
+    }
+
+    #[test]
+    fn close_of_block_finds_the_same_close_under_either_indent() {
+        for content in [SPACES, TABS] {
+            let close = layers_close(content);
+            // Everything up to the close balances, and the block ends after the
+            // last entry rather than inside the first one.
+            assert_eq!(&content[close..close + 1], ")");
+            assert!(content[..close].contains("B.Cu"));
+        }
+    }
+
+    #[test]
+    fn close_of_block_is_not_the_first_paren_in_the_block() {
+        // The old probe fell back to the first ')' — the close of entry one —
+        // and wrote the new layer inside it.
+        let content = TABS;
+        let start = content.find("(layers").unwrap();
+        let first = start + content[start..].find(')').unwrap();
+        assert_ne!(layers_close(content), first);
+    }
+
+    #[test]
+    fn close_of_block_ignores_parens_inside_strings() {
+        let content = "(kicad_pcb\n\t(layers\n\t\t(0 \"F.Cu)(\" signal)\n\t)\n)";
+        let close = layers_close(content);
+        assert!(content[..close].contains("F.Cu)("));
+    }
+
+    #[test]
+    fn close_of_block_refuses_an_unbalanced_block() {
+        assert_eq!(close_of_block("(layers\n\t(0 \"F.Cu\" signal)", 0), None);
+    }
+
+    #[test]
+    fn entry_indent_matches_the_file() {
+        assert_eq!(
+            entry_indent(SPACES, SPACES.find("(layers").unwrap()).as_deref(),
+            Some("    ")
+        );
+        assert_eq!(
+            entry_indent(TABS, TABS.find("(layers").unwrap()).as_deref(),
+            Some("\t\t")
+        );
+    }
+
+    #[test]
+    fn entry_indent_declines_an_empty_block_rather_than_guessing() {
+        let empty = "(kicad_pcb\n\t(layers\n\t)\n)";
+        assert_eq!(entry_indent(empty, empty.find("(layers").unwrap()), None);
+    }
+
+    #[test]
+    fn layers_canonical_names_match_kicads_own_enum() {
+        // Guards konnect_sexp::layers::is_canonical_name against drift: the
+        // authority is KiCAD's BoardLayer enum, shipped in the API protos.
+        // Variant name -> file name is `BL_` off, remaining `_` to `.`.
+        use konnect_ipc::gen::kiapi::board::types::BoardLayer;
+        let sentinels = ["BL_UNKNOWN", "BL_UNDEFINED", "BL_UNSELECTED"];
+        let mut checked = 0;
+        for i in 0..=200i32 {
+            let Ok(layer) = BoardLayer::try_from(i) else {
+                continue;
+            };
+            let variant = layer.as_str_name();
+            if sentinels.contains(&variant) {
+                continue;
+            }
+            let name = variant.trim_start_matches("BL_").replacen('_', ".", 1);
+            assert!(
+                konnect_sexp::layers::is_canonical_name(&name),
+                "{variant} maps to '{name}', which is_canonical_name rejects"
+            );
+            checked += 1;
+        }
+        // Cheap guard against the loop silently matching nothing.
+        assert!(checked > 90, "only {checked} layers checked");
+    }
+
+    #[test]
+    fn ids_in_use_are_seen_so_a_new_layer_does_not_collide() {
+        // The regression this PR is about: with the ids unreadable, the free-id
+        // search always returned 1 and duplicated an existing In1.Cu.
+        let four_layer = "(kicad_pcb\n\t(layers\n\t\t(0 \"F.Cu\" signal)\n\t\t(1 \"In1.Cu\" signal)\n\t\t(2 \"B.Cu\" signal)\n\t)\n)";
+        let tree = parse_sexp(four_layer).unwrap();
+        let used: std::collections::HashSet<i32> = konnect_sexp::layers::layers(&tree)
+            .iter()
+            .map(|l| l.id)
+            .collect();
+        assert!(used.contains(&1));
+        assert_eq!((1..=30).find(|id| !used.contains(id)), Some(3));
+    }
 }
 
 #[cfg(test)]

--- a/crates/konnect-sexp/src/layers.rs
+++ b/crates/konnect-sexp/src/layers.rs
@@ -1,0 +1,268 @@
+//! Reading the `(layers …)` stackup table of a `.kicad_pcb`.
+//!
+//! Layer entries are the one table in the board file that is *not* keyed by a
+//! tag. Everything else is `(tag …)` and can be found with [`SexpNode::find_all`];
+//! a layer is `(0 "F.Cu" signal)`, whose head is the ordinal itself. There is no
+//! tag to match on, so the entries have to be read by shape: every list child of
+//! the `(layers …)` node is a layer.
+//!
+//! ```
+//! use konnect_sexp::{parse_sexp, layers};
+//! let board = parse_sexp(r#"(kicad_pcb (layers (0 "F.Cu" signal) (2 "B.Cu" signal) (9 "F.Adhes" user)))"#).unwrap();
+//! let stack = layers::layers(&board);
+//! assert_eq!(stack.len(), 3);
+//! assert_eq!(stack[0].name, "F.Cu");
+//! assert_eq!(layers::copper(&stack).len(), 2);
+//! ```
+
+use crate::parser::SexpNode;
+
+/// One entry of the board stackup.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Layer {
+    /// Ordinal as written in the file. Not an index: KiCad leaves gaps
+    /// (`0 F.Cu`, `2 B.Cu`, `9 F.Adhes` …) and inner copper occupies 1..=30.
+    pub id: i32,
+    /// Canonical name — `F.Cu`, `In1.Cu`, `Edge.Cuts`.
+    pub name: String,
+    /// `signal`, `power`, `mixed`, `jumper` or `user`.
+    pub kind: String,
+    /// Optional user-facing rename, e.g. `(0 "F.Cu" signal "Top Layer")`.
+    pub user_name: Option<String>,
+}
+
+impl Layer {
+    /// Copper is decided by the canonical name, not by `kind`.
+    ///
+    /// KiCad marks copper with four different kinds (`signal`, `power`,
+    /// `mixed`, `jumper`) and a board that uses `power` for a plane would be
+    /// undercounted by a kind allow-list. The `.Cu` suffix is the invariant.
+    pub fn is_copper(&self) -> bool {
+        self.name.ends_with(".Cu")
+    }
+}
+
+/// Read the stackup from a parsed board. Empty if there is no `(layers …)`.
+pub fn layers(board: &SexpNode) -> Vec<Layer> {
+    let Some(node) = board.find("layers") else {
+        return Vec::new();
+    };
+    node.children()
+        .unwrap_or(&[])
+        .iter()
+        // Skips the head atom (`layers`), which is a child like any other, and
+        // any stray atom: a layer is always a list.
+        .filter(|child| child.children().is_some())
+        .filter_map(layer_from)
+        .collect()
+}
+
+/// Copper layers only, in file order — the "how many layers is this board"
+/// answer, and what a fab house quotes on.
+pub fn copper(stack: &[Layer]) -> Vec<&Layer> {
+    stack.iter().filter(|l| l.is_copper()).collect()
+}
+
+/// The fixed layer names, i.e. every `BoardLayer` variant that is neither
+/// `In<n>.Cu` nor `User.<n>` nor a sentinel.
+const FIXED_NAMES: &[&str] = &[
+    "F.Cu",
+    "B.Cu",
+    "B.Adhes",
+    "F.Adhes",
+    "B.Paste",
+    "F.Paste",
+    "B.SilkS",
+    "F.SilkS",
+    "B.Mask",
+    "F.Mask",
+    "Dwgs.User",
+    "Cmts.User",
+    "Eco1.User",
+    "Eco2.User",
+    "Edge.Cuts",
+    "Margin",
+    "B.CrtYd",
+    "F.CrtYd",
+    "B.Fab",
+    "F.Fab",
+    "Rescue",
+];
+
+/// Highest `In<n>.Cu` / `User.<n>` KiCad defines (`BL_In30_Cu`, `BL_User_45`).
+const MAX_INNER_COPPER: u32 = 30;
+const MAX_USER: u32 = 45;
+
+/// Is this a layer name KiCad will accept in a board file?
+///
+/// KiCad does not take arbitrary layer names: the set is closed, and it is the
+/// `BoardLayer` enum of the official API protos
+/// (`konnect-ipc/proto/board/board_types.proto`), whose variant names map onto
+/// file names by dropping the `BL_` prefix and turning the remaining `_` into a
+/// `.` — `BL_F_Cu` → `F.Cu`, `BL_User_1` → `User.1`.
+///
+/// A board carrying a name outside that set is **rejected outright** by KiCad —
+/// it does not degrade, the file simply will not open. `layers_canonical_names`
+/// in konnect-core keeps this in step with the enum.
+pub fn is_canonical_name(name: &str) -> bool {
+    if FIXED_NAMES.contains(&name) {
+        return true;
+    }
+    if let Some(n) = name.strip_prefix("In").and_then(|s| s.strip_suffix(".Cu")) {
+        return matches!(n.parse::<u32>(), Ok(n) if (1..=MAX_INNER_COPPER).contains(&n))
+            && !n.starts_with('0');
+    }
+    if let Some(n) = name.strip_prefix("User.") {
+        return matches!(n.parse::<u32>(), Ok(n) if (1..=MAX_USER).contains(&n))
+            && !n.starts_with('0');
+    }
+    false
+}
+
+fn layer_from(node: &SexpNode) -> Option<Layer> {
+    // `(0 "F.Cu" signal "Top Layer")` — the ordinal is child 0, being the head
+    // of the list, so every field sits one place earlier than in a tagged node.
+    let id = node.get_f64(0)? as i32;
+    let name = node.get(1)?.as_str()?.to_string();
+    let kind = node
+        .get(2)
+        .and_then(|n| n.as_str())
+        .unwrap_or("user")
+        .to_string();
+    let user_name = node.get(3).and_then(|n| n.as_str()).map(str::to_string);
+    Some(Layer {
+        id,
+        name,
+        kind,
+        user_name,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse_sexp;
+
+    fn board(inner: &str) -> SexpNode {
+        parse_sexp(&format!("(kicad_pcb (layers {inner}))")).unwrap()
+    }
+
+    #[test]
+    fn reads_id_name_and_kind() {
+        let stack = layers(&board(r#"(0 "F.Cu" signal)"#));
+        assert_eq!(
+            stack,
+            vec![Layer {
+                id: 0,
+                name: "F.Cu".into(),
+                kind: "signal".into(),
+                user_name: None
+            }]
+        );
+    }
+
+    #[test]
+    fn reads_the_optional_user_name() {
+        let stack = layers(&board(r#"(0 "F.Cu" signal "Top Layer")"#));
+        assert_eq!(stack[0].user_name.as_deref(), Some("Top Layer"));
+    }
+
+    #[test]
+    fn the_head_atom_is_not_a_layer() {
+        // `(layers …)` yields `layers` itself as a child; counting children
+        // blindly overcounts by exactly one.
+        let stack = layers(&board(r#"(0 "F.Cu" signal) (2 "B.Cu" signal)"#));
+        assert_eq!(stack.len(), 2);
+    }
+
+    #[test]
+    fn ids_are_read_as_written_not_as_positions() {
+        // KiCad leaves gaps; a positional read would report 0,1,2.
+        let stack = layers(&board(
+            r#"(0 "F.Cu" signal) (2 "B.Cu" signal) (9 "F.Adhes" user)"#,
+        ));
+        assert_eq!(
+            stack.iter().map(|l| l.id).collect::<Vec<_>>(),
+            vec![0, 2, 9]
+        );
+    }
+
+    #[test]
+    fn copper_is_by_name_not_by_kind() {
+        // `power` and `mixed` are copper too; `user` never is, even on a layer
+        // whose name merely contains "Cu".
+        let stack = layers(&board(
+            r#"(0 "F.Cu" signal) (1 "In1.Cu" power) (2 "In2.Cu" mixed) (3 "B.Cu" jumper) (9 "F.Adhes" user) (60 "Cu.Marks" user)"#,
+        ));
+        assert_eq!(
+            copper(&stack).iter().map(|l| &l.name).collect::<Vec<_>>(),
+            vec!["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
+        );
+    }
+
+    #[test]
+    fn a_board_without_a_layers_block_is_empty_not_a_panic() {
+        assert!(layers(&parse_sexp("(kicad_pcb)").unwrap()).is_empty());
+    }
+
+    #[test]
+    fn a_malformed_entry_is_skipped_and_the_rest_survive() {
+        let stack = layers(&board(r#"(0 "F.Cu" signal) (nonsense) (2 "B.Cu" signal)"#));
+        assert_eq!(
+            stack.iter().map(|l| &l.name).collect::<Vec<_>>(),
+            vec!["F.Cu", "B.Cu"]
+        );
+    }
+
+    #[test]
+    fn canonical_names_are_accepted() {
+        for name in [
+            "F.Cu",
+            "B.Cu",
+            "In1.Cu",
+            "In30.Cu",
+            "Edge.Cuts",
+            "Margin",
+            "Rescue",
+            "User.1",
+            "User.45",
+            "Dwgs.User",
+            "F.CrtYd",
+        ] {
+            assert!(is_canonical_name(name), "{name} should be canonical");
+        }
+    }
+
+    #[test]
+    fn invented_names_are_rejected() {
+        // The one that matters: a caller-supplied name KiCad has never heard of
+        // produces a board that will not open at all.
+        for name in [
+            "TestLayer",
+            "MyLayer",
+            "",
+            "f.cu",
+            "F_Cu",
+            "In0.Cu",
+            "User.0",
+        ] {
+            assert!(!is_canonical_name(name), "{name} should not be canonical");
+        }
+    }
+
+    #[test]
+    fn out_of_range_and_padded_ordinals_are_rejected() {
+        // KiCad stops at In30.Cu / User.45, and does not zero-pad.
+        for name in ["In31.Cu", "User.46", "In01.Cu", "User.01", "In.Cu", "User."] {
+            assert!(!is_canonical_name(name), "{name} should not be canonical");
+        }
+    }
+
+    #[test]
+    fn tab_indentation_is_irrelevant_to_a_tree_read() {
+        // The shape is what matters; KiCad 10 writes tabs, 9 writes spaces.
+        let spaces = parse_sexp("(kicad_pcb\n  (layers\n    (0 \"F.Cu\" signal)\n  )\n)").unwrap();
+        let tabs = parse_sexp("(kicad_pcb\n\t(layers\n\t\t(0 \"F.Cu\" signal)\n\t)\n)").unwrap();
+        assert_eq!(layers(&spaces), layers(&tabs));
+    }
+}

--- a/crates/konnect-sexp/src/lib.rs
+++ b/crates/konnect-sexp/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod command;
 pub mod error;
 pub mod geometry;
+pub mod layers;
 pub mod parser;
 pub mod schematic;
 pub mod transaction;


### PR DESCRIPTION
A layer entry is `(0 "F.Cu" signal)` — its head is the ordinal, so unlike every other table in the board file there is no tag to match on. All three sites that read the stackup used `find_all("")`, which filters children by head and so never matched a layer.

This is **not** a KiCad 10 format change: layers have always been written this way, and these have always returned nothing.

| | before | after | board |
|---|---|---|---|
| `get_board_info.layer_count` | `0` | `27` | 27 declared |
| `get_board_info.copper_layer_count` | — | `2` | F.Cu, B.Cu |
| `get_layer_list.count` | `0` | `27` | 27 declared |

`get_layer_list` was doubly broken: its accessors read `get_f64(1)`/`get(2)`/`get(3)`, one place late, because the ordinal occupies the slot a tag would. Even with the filter fixed it would have returned an empty list.

## `add_layer` wrote boards that do not open

Three separate faults, all of which returned success.

**It never saw the ids in use.** With the entries unreadable, the "first free id in 1..30" search always returned `1` — duplicating `In1.Cu` on any board that has one.

**It wrote the new layer inside the first entry.** The end of the block was located with a literal `"\n  )"` probe, falling back to the first `')'` in the block. On a tab-indented KiCad 10 file the probe never matches and the fallback is the close of the *first layer entry*. Actual output of v0.2.2 on a real board:

```
(layers
		(0 "F.Cu" signal "Top Layer"
    (1 "TestLayer" user))
		(2 "B.Cu" signal "Bottom Layer")
```

Now located by paren balance, which is indentation-agnostic, and the entry is indented to match whatever the file already uses.

**It accepted any `layer_name`.** KiCad's layer set is closed. A board carrying a name outside it does not degrade — it does not open at all. Measured with `kicad-cli pcb export svg` on a KiCad 10 board:

| inserted | result |
|---|---|
| `(53 "User.8" user)` | loads |
| `(4 "User.8" user)` | loads |
| `(53 "TestLayer" user)` | **`Failed to load board`** |

So the id was never what KiCad validated — the name was, and the tool invited the caller to invent one. `add_layer` now refuses a non-canonical name and leaves the file untouched, pointing the caller at the real mechanism for a custom label: add the canonical layer and give it a user name, `(53 "User.8" user "My Label")`.

## Notes on the implementation

Stackup reading moves to `konnect-sexp::layers`, next to `geometry`, as file-format knowledge rather than tool-level code.

**Copper is decided by the `.Cu` suffix, not by an allow-list of kinds.** KiCad marks copper as `signal`, `power`, `mixed` *or* `jumper`, so a board using `power` for a plane would be undercounted by a kind check.

**`layer_count` stays the count of declared entries** and `copper_layer_count` is added alongside, rather than redefining `layer_count` to mean copper. It keeps `get_board_info` and `get_layer_list` reporting the same number for the same board, and "how many layers is this board" — the fab-house question — still gets a direct answer.

**The name check is backed by KiCad's own `BoardLayer` enum** from the API protos already vendored in `konnect-ipc`, mapping `BL_F_Cu` → `F.Cu` and `BL_User_1` → `User.1`. A test walks every variant of that enum and asserts the checker accepts it, so the list cannot drift from KiCad as the protos are updated.

## Verification

`cargo clippy --workspace --locked -- -D warnings`, `cargo fmt --all -- --check` and `cargo test --workspace --locked --lib --tests` all clean on `x86_64-pc-windows-msvc`; **488 passed, 0 failed**, of which 22 are new.

End-to-end against a real KiCad 10 board (`version 20260206`, tab-indented, 27 layers / 2 copper), driving the built binary over MCP:

- the read figures in the table above;
- `add_layer "TestLayer"` → refused, file **byte-identical** to the original;
- `add_layer "User.8"` → id **4**, the first genuinely free ordinal on that board (it uses 0,1,2,3,5), written after the last entry, and **the result loads in KiCad** where the previous output did not.

## Relationship to #133 / #142

Independent of both. #133 is about the *shape* of `(net …)` nodes under KiCad 10, and #142 fixes it; this is a table that was never readable on any version. They touch neighbouring lines of `handle_get_board_info`, so whichever lands second may want a trivial rebase — happy to do that on this one either way.

`layer_count` is also the one item I flagged as still `0` after applying #142, so this closes it.
