### PR TITLE
fix(mcp): serialize image content as mimeType, not mime_type

### DIFF
--- a/crates/konnect-core/src/mcp/protocol.rs
+++ b/crates/konnect-core/src/mcp/protocol.rs
@@ -148,8 +148,15 @@ pub struct CallToolResult {
     pub is_error: bool,
 }
 
+/// MCP content block. `rename_all` covers the variant tags; the fields need
+/// `rename_all_fields` of their own, or `mime_type` ships instead of the
+/// spec's `mimeType` and clients reject the whole result.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "lowercase")]
+#[serde(
+    tag = "type",
+    rename_all = "lowercase",
+    rename_all_fields = "camelCase"
+)]
 pub enum ToolContent {
     Text { text: String },
     Image { data: String, mime_type: String },
@@ -190,3 +197,44 @@ impl CallToolResult {
 
 /// Sent by server when the tool list changes (after load_toolset / unload_toolset).
 pub const TOOLS_LIST_CHANGED: &str = "notifications/tools/list_changed";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact keys MCP clients validate against — a rename here breaks them.
+    #[test]
+    fn image_content_serializes_with_spec_keys() {
+        let v = serde_json::to_value(CallToolResult::image("QUJD", "image/png")).unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({
+                "content": [{ "type": "image", "data": "QUJD", "mimeType": "image/png" }],
+                "isError": false,
+            })
+        );
+    }
+
+    #[test]
+    fn text_content_serializes_with_spec_keys() {
+        let v = serde_json::to_value(CallToolResult::error("boom")).unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({
+                "content": [{ "type": "text", "text": "boom" }],
+                "isError": true,
+            })
+        );
+    }
+
+    #[test]
+    fn tool_description_serializes_input_schema_as_camel_case() {
+        let v = serde_json::to_value(McpToolDescription {
+            name: "get_board_2d_view".into(),
+            description: "Render the board.".into(),
+            input_schema: serde_json::json!({ "type": "object" }),
+        })
+        .unwrap();
+        assert!(v.get("inputSchema").is_some(), "got {v}");
+    }
+}


### PR DESCRIPTION
`get_board_2d_view` — the only tool that returns an image — is unusable from any spec-compliant MCP client. The result fails client-side schema validation before the caller ever sees it:

```
content.0: invalid_union
  image branch -> mimeType: expected string, received undefined
```

## Cause

`ToolContent` carries `#[serde(tag = "type", rename_all = "lowercase")]`. On a container, `rename_all` renames the *variants*, not their fields — so the tag serializes correctly as `"image"` while the field ships as `mime_type`. The MCP spec requires `mimeType`.

`CallToolResult` directly above it gets this right with `rename_all = "camelCase"` → `isError`, which is why only the image path is affected.

## Fix

`rename_all_fields = "camelCase"` on the `ToolContent` container. `ToolContent` is only ever deserialized from our own Rust, never off the wire, so the matching rename on the read side breaks no callers.

## Tests

Nothing covered these key names, which is how this shipped. Three tests now pin the exact wire shape of the image content block, the text content block, and `inputSchema`.

## Verification

Against a live KiCad 10 session (Fedora): `get_board_2d_view` over stdio returns `['data', 'mimeType', 'type']` where the released binary returns `['data', 'mime_type', 'type']`, and the call now completes through Claude Code's own client validation.

Not linked to an issue — I could not find one for this. #118 is a different problem in the same tool (`get_board_2d_view` being a 3-D render rather than a layer plot) and stays open; this PR does not address it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)