### PR TITLE
feat(pcb_components): inspect and edit a placed footprint's graphics over IPC

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -234,7 +234,7 @@ if !path.exists() {
 
 Adding a new kind: edit `mcp/error.rs`, add the variant, add the match arm in `short_code()`, use it from the handler. The `short_code_matches_serialized_kind_field` test will fail loudly if they drift.
 
-The dispatch-level errors (not-loaded/unknown/handler-panic) are fully structured. So are **all missing-argument errors** across all 200 tools — `tools/mod.rs::require_str` / `require_f64` emit `ToolErrorKind::InvalidArgument { field, reason }` automatically. Most in-handler errors still use `CallToolResult::error("free text")` or bubble `anyhow::Error`; migrating them is incremental. `project.rs::handle_get_project_info` demonstrates the structured `FileNotFound` pattern.
+The dispatch-level errors (not-loaded/unknown/handler-panic) are fully structured. So are **all missing-argument errors** across all 202 tools — `tools/mod.rs::require_str` / `require_f64` emit `ToolErrorKind::InvalidArgument { field, reason }` automatically. Most in-handler errors still use `CallToolResult::error("free text")` or bubble `anyhow::Error`; migrating them is incremental. `project.rs::handle_get_project_info` demonstrates the structured `FileNotFound` pattern.
 
 ## Observability
 
@@ -255,7 +255,7 @@ Source: [`crates/konnect-core/src/observability.rs`](crates/konnect-core/src/obs
 
 ## Tool Routing (Starter Kit + On-Demand Loading)
 
-The server does NOT expose all 200 tools (206 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
+The server does NOT expose all 202 tools (208 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
 
 - **Startup**: only `STARTER_KIT` toolsets are pre-loaded (see `router/registry.rs::STARTER_KIT`). Currently: `project`, `config`. Combined with the 6 meta-tools, baseline `tools/list` is ~19 tools ≈ 2K tokens.
 - **On demand**: the LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose a toolset's tools in subsequent `tools/list` responses. `unload_toolset(name)` prunes them when the task shifts.
@@ -327,9 +327,9 @@ convention for other `kicad-cli`-calling code.
 
 ## Current Stats
 
-- **19 toolsets, 200 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
+- **19 toolsets, 202 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
 - Baseline `tools/list`: ~19 tools / ~2K tokens (starter kit + meta-tools)
-- Full-catalog `tools/list` (all loaded): 206 tools (200 registered + 6 meta) / ~25K tokens
+- Full-catalog `tools/list` (all loaded): 208 tools (202 registered + 6 meta) / ~25K tokens
 - **0 IPC stubs** (all protobuf methods implemented)
 - **0 unimplemented tools**
 - **3 CLI commands removed in KiCAD v10** (specctra DSN/SES, pcb sync — return clear errors)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Rust binary — that lets Claude and other AI assistants design schematics and PCBs
 through the [Model Context Protocol](https://modelcontextprotocol.io) (MCP).
 
-**200 tools across 19 on-demand toolsets.** Schematic capture, PCB layout and
+**202 tools across 19 on-demand toolsets.** Schematic capture, PCB layout and
 routing, ERC/DRC, design-review audits, JLCPCB part search, Freerouting, reference
 circuits, and a full manufacturing export pipeline — with bundled skills and agents
 that teach Claude KiCAD conventions out of the box.
@@ -69,7 +69,7 @@ through its own S-expression engine with atomic writes (write, fsync, rename), U
 preservation, and round-trip tests — no third-party schematic library with known
 gaps, no text-manipulation workarounds.
 
-**Context economy is a feature.** Exposing all 200 tools to an LLM costs roughly 23K
+**Context economy is a feature.** Exposing all 202 tools to an LLM costs roughly 23K
 tokens of context on every listing. Konnect's router loads a starter kit (~2K
 tokens) and lets the model pull in toolsets on demand — plus built-in observability
 (`get_recent_calls`, `server_stats`, JSONL call logs) so the model can diagnose its

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -76,7 +76,7 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         name: "pcb_components",
         description: "Place, move, rotate, align, and duplicate PCB footprints",
         category: "pcb",
-        tool_count: 13,
+        tool_count: 15,
     },
     ToolsetMeta {
         name: "pcb_routing",

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -99,6 +99,39 @@ pub(crate) fn resolve_footprint_source(lib_id: &str, board: &Path) -> anyhow::Re
 /// Placing on the back is not a layer rename: KiCAD's flip mirrors the
 /// footprint's geometry (pad X positions negate, every front layer swaps with
 /// its back counterpart per item). Until Konnect implements that mirror,
+/// Read a `[{x, y}, …]` argument into footprint-local millimetre pairs.
+///
+/// Each rejection names the offending index, because "each point needs a
+/// numeric 'x'" on a twelve-vertex courtyard tells the caller nothing about
+/// which vertex to fix.
+fn parse_points(value: &serde_json::Value) -> Result<Vec<(f64, f64)>, CallToolResult> {
+    let invalid = |field: &str, reason: String| {
+        CallToolResult::error_kind(
+            crate::mcp::error::ToolErrorKind::InvalidArgument {
+                field: field.to_string(),
+                reason: reason.clone(),
+            },
+            format!("Argument '{field}' is invalid: {reason}"),
+        )
+    };
+
+    let array = value
+        .as_array()
+        .ok_or_else(|| invalid("points", "missing or not an array of {x, y}".to_string()))?;
+
+    let mut points = Vec::with_capacity(array.len());
+    for (i, p) in array.iter().enumerate() {
+        let x = p["x"]
+            .as_f64()
+            .ok_or_else(|| invalid("points", format!("point {i} has no numeric 'x'")))?;
+        let y = p["y"]
+            .as_f64()
+            .ok_or_else(|| invalid("points", format!("point {i} has no numeric 'y'")))?;
+        points.push((x, y));
+    }
+    Ok(points)
+}
+
 /// pretending to support `B.Cu` silently produces wrong copper, so the layer
 /// is refused up front — before anything is resolved, sent, or written.
 fn back_side_layer_error(layer: &str) -> Option<CallToolResult> {
@@ -1354,20 +1387,14 @@ async fn handle_edit_board_footprint_graphic(
         Ok(v) => v.to_string(),
         Err(e) => return Ok(e),
     };
-    let points: Vec<(f64, f64)> = args["points"]
-        .as_array()
-        .ok_or_else(|| anyhow::anyhow!("'points' must be an array of {{x, y}}"))?
-        .iter()
-        .map(|p| {
-            let x = p["x"]
-                .as_f64()
-                .ok_or_else(|| anyhow::anyhow!("each point needs a numeric 'x'"))?;
-            let y = p["y"]
-                .as_f64()
-                .ok_or_else(|| anyhow::anyhow!("each point needs a numeric 'y'"))?;
-            Ok::<_, anyhow::Error>((x, y))
-        })
-        .collect::<Result<_, _>>()?;
+    // A malformed `points` is the caller's mistake, so it gets the structured
+    // `invalid_argument` the rest of this file returns — bubbling `anyhow`
+    // here would surface it as a handler error with the offending field
+    // flattened into prose, which is the class #194 is open against.
+    let points = match parse_points(&args["points"]) {
+        Ok(p) => p,
+        Err(e) => return Ok(e),
+    };
 
     let (ref_ipc, uuid_ipc, pts) = (reference.clone(), uuid.clone(), points.clone());
     let kind: String = ipc!(ctx, args, |c| c
@@ -2866,5 +2893,96 @@ mod pad_net_shape_tests {
         ))
         .await;
         assert_eq!(pads["pads"][0]["net"], json!(""));
+    }
+}
+
+#[cfg(test)]
+mod board_footprint_graphics_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// A malformed `points` is a caller mistake, so it must come back as a
+    /// structured `invalid_argument` naming the field — not as an
+    /// `anyhow`-flavoured handler error with the reason flattened into prose.
+    /// The handler used to bubble `?` here, which is the class #194 tracks.
+    #[test]
+    fn a_malformed_points_argument_is_a_structured_invalid_argument() {
+        let cases = [
+            (json!("not an array"), "not an array"),
+            (json!([{ "x": 1.0 }]), "point 0 has no numeric 'y'"),
+            (json!([{ "y": 1.0 }]), "point 0 has no numeric 'x'"),
+            (
+                json!([{ "x": 0.0, "y": 0.0 }, { "x": 1.0, "y": "two" }]),
+                "point 1 has no numeric 'y'",
+            ),
+        ];
+        for (value, expected) in cases {
+            let err = parse_points(&value).expect_err("must be refused");
+            assert!(err.is_error, "{value} should be an error result");
+            let text = format!("{:?}", err);
+            assert!(
+                text.contains("InvalidArgument") || text.contains("invalid_argument"),
+                "must be structured, got: {text}"
+            );
+            assert!(
+                text.contains(expected),
+                "the message must say which point is wrong.\nwant: {expected}\ngot:  {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn well_formed_points_parse_in_order() {
+        let points = parse_points(&json!([
+            { "x": 0.0, "y": 0.0 },
+            { "x": 2.5, "y": -1.5 },
+            { "x": 2.5, "y": 2.5 }
+        ]))
+        .expect("valid");
+        assert_eq!(points, vec![(0.0, 0.0), (2.5, -1.5), (2.5, 2.5)]);
+    }
+
+    /// An integer in JSON is a number; rejecting it would refuse
+    /// `{"x": 0, "y": 0}`, which is what a caller writes for the origin.
+    #[test]
+    fn integer_coordinates_are_accepted() {
+        assert_eq!(
+            parse_points(&json!([{ "x": 0, "y": 0 }, { "x": 3, "y": 0 }, { "x": 3, "y": 3 }]))
+                .expect("valid"),
+            vec![(0.0, 0.0), (3.0, 0.0), (3.0, 3.0)]
+        );
+    }
+
+    /// The two tools are registered, sit in `pcb_components`, and require the
+    /// arguments the handlers read. A schema that drifts from its handler is
+    /// the defect #217 was about, one layer up.
+    #[test]
+    fn both_board_graphics_tools_are_registered_with_the_arguments_they_read() {
+        let tools = tools();
+        for (name, required) in [
+            ("list_board_footprint_graphics", vec!["board", "reference"]),
+            (
+                "edit_board_footprint_graphic",
+                vec!["board", "reference", "uuid", "points"],
+            ),
+        ] {
+            let def = tools
+                .iter()
+                .find(|t| t.name == name)
+                .unwrap_or_else(|| panic!("{name} is not registered"));
+            let got: Vec<&str> = def.input_schema["required"]
+                .as_array()
+                .unwrap_or_else(|| panic!("{name} declares no required list"))
+                .iter()
+                .filter_map(|v| v.as_str())
+                .collect();
+            assert_eq!(got, required, "{name} required arguments");
+            for key in &required {
+                assert!(
+                    def.input_schema["properties"][key].is_object(),
+                    "{name} requires '{key}' but does not declare it"
+                );
+            }
+        }
     }
 }

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -58,19 +58,25 @@ macro_rules! ipc {
     ($ctx:expr, $args:expr, |$c:ident| $body:expr) => {{
         let addr = $ctx.config.ipc_address.clone();
         let requested_board = get_path($args, "board")?;
-        match with_ipc(addr, move |$c| {
+        match with_ipc_classified(addr, move |$c| {
             $c.ensure_board_is_active(&requested_board)?;
             $body
         })
         .await?
         {
             Ok(v) => v,
-            Err(msg) => {
+            // Only an unreachable transport justifies "KiCAD must be running".
+            // This used to say it for every failure, so a tool that refused a
+            // request on its merits — "a polygon needs at least 3 points" —
+            // told the reader to start a KiCad that was already running, with
+            // the actual reason parenthesised after a false statement.
+            Err(konnect_ipc::IpcFailure::Unreachable(msg)) => {
                 return Ok(CallToolResult::error(format!(
                     "KiCAD must be running with the board loaded (IPC error: {})",
                     msg
                 )))
             }
+            Err(konnect_ipc::IpcFailure::Rejected(msg)) => return Ok(CallToolResult::error(msg)),
         }
     }};
 }

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -1008,6 +1008,46 @@ pub fn tools() -> Vec<ToolDef> {
             |args, ctx| async move { handle_find_component(args, ctx).await }
         ),
         tool!(
+            "list_board_footprint_graphics",
+            "List the graphic items inside a footprint placed on the board — silkscreen, fabrication, and courtyard artwork — with the UUID needed to edit one. Points are footprint-local millimetres, as the .kicad_mod shows them. Each item reports 'editable', plus 'outlines' and 'holes' for polygons: 'points' covers the first outline only, so an item with more than one outline or any holes is reported but cannot be edited here. Requires KiCAD running with the board open.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "board":     { "type": "string" },
+                    "reference": { "type": "string", "description": "Reference designator, e.g. 'J2'" },
+                    "layer":     { "type": "string", "description": "Only list items on this layer, e.g. 'F.SilkS' (optional)" }
+                },
+                "required": ["board", "reference"]
+            }),
+            |args, ctx| async move { handle_list_board_footprint_graphics(args, ctx).await }
+        ),
+        tool!(
+            "edit_board_footprint_graphic",
+            "Replace the vertices of a polygon inside a footprint placed on the board, selected by UUID. Points are footprint-local millimetres, as the .kicad_mod shows them. Use this to bring one placed instance in line with a library change without re-placing the part. Only a single-outline polygon with no holes can be replaced; anything else is refused by name rather than flattened. Requires KiCAD running with the board open.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "board":     { "type": "string" },
+                    "reference": { "type": "string", "description": "Reference designator, e.g. 'J2'" },
+                    "uuid":      { "type": "string", "description": "UUID of the graphic item, from list_board_footprint_graphics" },
+                    "points": {
+                        "type": "array",
+                        "description": "Replacement vertices in footprint-local millimetres; at least 3.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "x": { "type": "number" },
+                                "y": { "type": "number" }
+                            },
+                            "required": ["x", "y"]
+                        }
+                    }
+                },
+                "required": ["board", "reference", "uuid", "points"]
+            }),
+            |args, ctx| async move { handle_edit_board_footprint_graphic(args, ctx).await }
+        ),
+        tool!(
             "get_component_pads",
             "Return the pad positions and net assignments for a footprint. \
              A pad's 'net' is its net name, \"\" if the pad carries no net node \
@@ -1274,6 +1314,71 @@ async fn handle_move_component(
     Ok(CallToolResult::json(
         &json!({ "moved": reference, "x": x, "y": y }),
     ))
+}
+
+async fn handle_list_board_footprint_graphics(
+    args: &serde_json::Value,
+    ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let reference = match require_str(args, "reference") {
+        Ok(v) => v.to_string(),
+        Err(e) => return Ok(e),
+    };
+    let layer_filter = args["layer"].as_str().map(|s| s.to_string());
+
+    let ref_ipc = reference.clone();
+    let graphics: Vec<konnect_ipc::types::IpcFootprintGraphic> =
+        ipc!(ctx, args, |c| c.list_footprint_graphics(&ref_ipc));
+
+    let graphics: Vec<_> = graphics
+        .into_iter()
+        .filter(|g| layer_filter.as_deref().is_none_or(|l| g.layer == l))
+        .collect();
+
+    Ok(CallToolResult::json(&json!({
+        "count": graphics.len(),
+        "reference": reference,
+        "graphics": graphics,
+    })))
+}
+
+async fn handle_edit_board_footprint_graphic(
+    args: &serde_json::Value,
+    ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let reference = match require_str(args, "reference") {
+        Ok(v) => v.to_string(),
+        Err(e) => return Ok(e),
+    };
+    let uuid = match require_str(args, "uuid") {
+        Ok(v) => v.to_string(),
+        Err(e) => return Ok(e),
+    };
+    let points: Vec<(f64, f64)> = args["points"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("'points' must be an array of {{x, y}}"))?
+        .iter()
+        .map(|p| {
+            let x = p["x"]
+                .as_f64()
+                .ok_or_else(|| anyhow::anyhow!("each point needs a numeric 'x'"))?;
+            let y = p["y"]
+                .as_f64()
+                .ok_or_else(|| anyhow::anyhow!("each point needs a numeric 'y'"))?;
+            Ok::<_, anyhow::Error>((x, y))
+        })
+        .collect::<Result<_, _>>()?;
+
+    let (ref_ipc, uuid_ipc, pts) = (reference.clone(), uuid.clone(), points.clone());
+    let kind: String = ipc!(ctx, args, |c| c
+        .set_footprint_graphic_points(&ref_ipc, &uuid_ipc, &pts));
+
+    Ok(CallToolResult::json(&json!({
+        "edited": reference,
+        "uuid": uuid,
+        "kind": kind,
+        "points": points.len(),
+    })))
 }
 
 async fn handle_rotate_component(

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -93,6 +93,95 @@ fn polygon_extent(geometry: &kiapi::common::types::graphic_shape::Geometry) -> (
     }
 }
 
+/// Refuse or rewrite `shape`'s outline, returning the kind it was.
+///
+/// Split out of [`KiCadIpcClient::set_footprint_graphic_points`] so the refusals
+/// can be tested. They previously sat inside the loop that walks a live
+/// footprint's items, so reaching any of them needed a running KiCad — which
+/// meant the only guarantee that a bad request writes nothing was that nobody
+/// had tried it. That is the shape #117 shipped in: an outbound message that
+/// encodes cleanly and is semantically wrong.
+///
+/// Every refusal happens before any mutation, so a caller that gets an `Err`
+/// here has an untouched shape and the caller sends no `UpdateItems`.
+fn replace_polygon_outline(
+    shape: &mut kiapi::board::types::BoardGraphicShape,
+    reference: &str,
+    uuid: &str,
+    points_mm: &[(f64, f64)],
+    anchor: (i64, i64),
+    to_board: &crate::transform::Xform,
+) -> Result<&'static str> {
+    let kind = shape
+        .shape
+        .as_ref()
+        .and_then(|s| s.geometry.as_ref())
+        .map(geometry_kind)
+        .unwrap_or("unknown");
+    if kind != "polygon" {
+        anyhow::bail!(
+            "graphic '{}' on '{}' is a {}; only polygons take a vertex list",
+            uuid,
+            reference,
+            kind
+        );
+    }
+    if points_mm.len() < 3 {
+        anyhow::bail!("a polygon needs at least 3 points, got {}", points_mm.len());
+    }
+    // The rebuild below emits one outline with no holes. Rejecting a shape that
+    // carries more is the difference between refusing the edit and silently
+    // deleting a cutout the caller never mentioned.
+    let (outlines, holes) = shape
+        .shape
+        .as_ref()
+        .and_then(|s| s.geometry.as_ref())
+        .map(polygon_extent)
+        .unwrap_or((0, 0));
+    if outlines > 1 || holes > 0 {
+        anyhow::bail!(
+            "polygon '{}' on '{}' carries {} outline(s) and {} hole(s); this tool \
+             replaces a single outline and would discard the rest, so it will not \
+             write it — edit this one in KiCad",
+            uuid,
+            reference,
+            outlines,
+            holes
+        );
+    }
+
+    let nodes = points_mm
+        .iter()
+        .map(|&(x, y)| {
+            let (rx, ry) =
+                to_board.point(crate::builders::mm_to_nm(x), crate::builders::mm_to_nm(y));
+            kiapi::common::types::PolyLineNode {
+                geometry: Some(kiapi::common::types::poly_line_node::Geometry::Point(
+                    kiapi::common::types::Vector2 {
+                        x_nm: anchor.0 + rx,
+                        y_nm: anchor.1 + ry,
+                    },
+                )),
+            }
+        })
+        .collect();
+
+    if let Some(s) = shape.shape.as_mut() {
+        s.geometry = Some(kiapi::common::types::graphic_shape::Geometry::Polygon(
+            kiapi::common::types::PolySet {
+                polygons: vec![kiapi::common::types::PolygonWithHoles {
+                    outline: Some(kiapi::common::types::PolyLine {
+                        nodes,
+                        closed: true,
+                    }),
+                    holes: vec![],
+                }],
+            },
+        ));
+    }
+    Ok(kind)
+}
+
 /// The defining vertices of a graphic geometry, in absolute board nanometres.
 fn geometry_points(geometry: &kiapi::common::types::graphic_shape::Geometry) -> Vec<(i64, i64)> {
     use kiapi::common::types::graphic_shape::Geometry;
@@ -1142,73 +1231,8 @@ impl KiCadIpcClient {
                 continue;
             }
 
-            let kind = shape
-                .shape
-                .as_ref()
-                .and_then(|s| s.geometry.as_ref())
-                .map(geometry_kind)
-                .unwrap_or("unknown");
-            if kind != "polygon" {
-                anyhow::bail!(
-                    "graphic '{}' on '{}' is a {}; only polygons take a vertex list",
-                    uuid,
-                    reference,
-                    kind
-                );
-            }
-            if points_mm.len() < 3 {
-                anyhow::bail!("a polygon needs at least 3 points, got {}", points_mm.len());
-            }
-            // The rebuild below emits one outline with no holes. Rejecting a
-            // shape that carries more is the difference between refusing the
-            // edit and silently deleting a cutout the caller never mentioned.
-            let (outlines, holes) = shape
-                .shape
-                .as_ref()
-                .and_then(|s| s.geometry.as_ref())
-                .map(polygon_extent)
-                .unwrap_or((0, 0));
-            if outlines > 1 || holes > 0 {
-                anyhow::bail!(
-                    "polygon '{}' on '{}' carries {} outline(s) and {} hole(s); this tool \
-                     replaces a single outline and would discard the rest, so it will not \
-                     write it — edit this one in KiCad",
-                    uuid,
-                    reference,
-                    outlines,
-                    holes
-                );
-            }
-
-            let nodes = points_mm
-                .iter()
-                .map(|&(x, y)| {
-                    let (rx, ry) =
-                        to_board.point(crate::builders::mm_to_nm(x), crate::builders::mm_to_nm(y));
-                    kiapi::common::types::PolyLineNode {
-                        geometry: Some(kiapi::common::types::poly_line_node::Geometry::Point(
-                            kiapi::common::types::Vector2 {
-                                x_nm: anchor.0 + rx,
-                                y_nm: anchor.1 + ry,
-                            },
-                        )),
-                    }
-                })
-                .collect();
-
-            if let Some(s) = shape.shape.as_mut() {
-                s.geometry = Some(kiapi::common::types::graphic_shape::Geometry::Polygon(
-                    kiapi::common::types::PolySet {
-                        polygons: vec![kiapi::common::types::PolygonWithHoles {
-                            outline: Some(kiapi::common::types::PolyLine {
-                                nodes,
-                                closed: true,
-                            }),
-                            holes: vec![],
-                        }],
-                    },
-                ));
-            }
+            let kind =
+                replace_polygon_outline(&mut shape, reference, uuid, points_mm, anchor, &to_board)?;
 
             *any = pack_any(&shape, "kiapi.board.types.BoardGraphicShape");
             let packed = pack_any(&fp, "kiapi.board.types.FootprintInstance");
@@ -2260,6 +2284,28 @@ mod footprint_graphic_tests {
         };
         assert_eq!(of(&poly), "polygon");
         assert_eq!(of(&seg), "segment");
+        // The remaining names are not decoration: `replace_polygon_outline`
+        // interpolates this string into the refusal a caller reads when they
+        // aim a vertex list at the wrong graphic. A wrong name there sends
+        // someone looking for a shape that isn't the one they picked.
+        assert_eq!(
+            of(&builders::board_rectangle(
+                "F.SilkS", 0.1, 0.0, 0.0, 1.0, 1.0, false
+            )),
+            "rectangle"
+        );
+        assert_eq!(
+            of(&builders::board_circle(
+                "F.SilkS", 0.1, 0.0, 0.0, 1.0, false
+            )),
+            "circle"
+        );
+        assert_eq!(
+            of(&builders::board_arc(
+                "F.SilkS", 0.1, 0.0, 0.0, 1.0, 1.0, 2.0, 0.0
+            )),
+            "arc"
+        );
         // Exhaustiveness is enforced by the match, not by listing every arm here.
         let _ = |g: &Geometry| geometry_kind(g);
     }
@@ -2398,5 +2444,174 @@ mod footprint_graphic_tests {
                 "round trip lost ({x_mm}, {y_mm})"
             );
         }
+    }
+    // ─── replace_polygon_outline: every refusal, and the rebuild ───────────
+    //
+    // These guards sit between a caller's request and an `UpdateItems` that
+    // KiCad applies to a live board. Until this module they were unreachable
+    // without a running KiCad, so nothing checked that a refused request
+    // leaves the shape alone — which is what a test has to prove, not just
+    // that an `Err` comes back.
+
+    fn no_rotation() -> Xform {
+        Xform::Rotate {
+            cx_nm: 0,
+            cy_nm: 0,
+            delta_deg: 0.0,
+        }
+    }
+
+    fn square() -> Vec<(f64, f64)> {
+        vec![(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0)]
+    }
+
+    /// The outline vertices of a polygon shape, in board nanometres.
+    fn outline_of(shape: &kiapi::board::types::BoardGraphicShape) -> Vec<(i64, i64)> {
+        geometry_points(shape.shape.as_ref().unwrap().geometry.as_ref().unwrap())
+    }
+
+    #[test]
+    fn a_non_polygon_is_refused_by_name_and_left_alone() {
+        let mut seg = builders::board_segment("F.SilkS", 0.1, 0.0, 0.0, 1.0, 0.0);
+        let before = seg.clone();
+
+        let err = replace_polygon_outline(&mut seg, "J2", "u-1", &square(), (0, 0), &no_rotation())
+            .expect_err("a segment must not take a vertex list");
+
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("is a segment"),
+            "the refusal must name the kind it found, so the caller knows why: {message}"
+        );
+        assert_eq!(
+            seg, before,
+            "a refused edit must not mutate the shape — the caller still sends it"
+        );
+    }
+
+    #[test]
+    fn fewer_than_three_points_is_refused_and_leaves_the_outline_intact() {
+        let mut poly = builders::board_polygon("F.SilkS", 0.1, true, &[square()]);
+        let before = outline_of(&poly);
+
+        let err = replace_polygon_outline(
+            &mut poly,
+            "J2",
+            "u-1",
+            &[(0.0, 0.0), (1.0, 0.0)],
+            (0, 0),
+            &no_rotation(),
+        )
+        .expect_err("two points cannot be a polygon");
+
+        assert!(format!("{err:#}").contains("at least 3 points"), "{err:#}");
+        assert_eq!(
+            outline_of(&poly),
+            before,
+            "the original outline must survive a refused edit"
+        );
+    }
+
+    #[test]
+    fn a_second_outline_is_refused_rather_than_discarded() {
+        let mut poly = builders::board_polygon(
+            "F.SilkS",
+            0.1,
+            true,
+            &[square(), vec![(5.0, 5.0), (6.0, 5.0), (6.0, 6.0)]],
+        );
+        let before = poly.clone();
+
+        let err =
+            replace_polygon_outline(&mut poly, "J2", "u-1", &square(), (0, 0), &no_rotation())
+                .expect_err("two outlines cannot be rebuilt as one");
+
+        let message = format!("{err:#}");
+        assert!(message.contains("2 outline(s)"), "{message}");
+        assert_eq!(
+            poly, before,
+            "refusing is the whole point: rebuilding would delete the second outline"
+        );
+    }
+
+    #[test]
+    fn a_hole_is_refused_rather_than_discarded() {
+        use kiapi::common::types::graphic_shape::Geometry;
+        let mut poly = builders::board_polygon("F.SilkS", 0.1, true, &[square()]);
+        // `board_polygon` cannot build a hole, so inject one.
+        if let Some(Geometry::Polygon(ps)) = poly.shape.as_mut().and_then(|s| s.geometry.as_mut()) {
+            ps.polygons[0].holes.push(kiapi::common::types::PolyLine {
+                nodes: vec![],
+                closed: true,
+            });
+        }
+        let before = poly.clone();
+
+        let err =
+            replace_polygon_outline(&mut poly, "J2", "u-1", &square(), (0, 0), &no_rotation())
+                .expect_err("a cutout must not be silently dropped");
+
+        assert!(format!("{err:#}").contains("1 hole(s)"), "{err:#}");
+        assert_eq!(poly, before, "the cutout must still be there");
+    }
+
+    #[test]
+    fn the_rebuilt_outline_is_closed_and_anchored() {
+        let mut poly = builders::board_polygon("F.SilkS", 0.1, true, &[vec![(9.0, 9.0)]]);
+        let anchor = (builders::mm_to_nm(100.0), builders::mm_to_nm(50.0));
+
+        let kind =
+            replace_polygon_outline(&mut poly, "J2", "u-1", &square(), anchor, &no_rotation())
+                .expect("a single-outline polygon is editable");
+        assert_eq!(kind, "polygon");
+
+        // Footprint-local mm in, absolute board nm out: anchor + local.
+        let expected: Vec<(i64, i64)> = square()
+            .iter()
+            .map(|&(x, y)| {
+                (
+                    anchor.0 + builders::mm_to_nm(x),
+                    anchor.1 + builders::mm_to_nm(y),
+                )
+            })
+            .collect();
+        assert_eq!(outline_of(&poly), expected);
+
+        use kiapi::common::types::graphic_shape::Geometry;
+        let Some(Geometry::Polygon(ps)) = poly.shape.as_ref().and_then(|s| s.geometry.as_ref())
+        else {
+            panic!("still a polygon");
+        };
+        assert_eq!(ps.polygons.len(), 1, "exactly one outline is written");
+        assert!(ps.polygons[0].holes.is_empty());
+        assert!(
+            ps.polygons[0].outline.as_ref().unwrap().closed,
+            "an open outline renders as a polyline, not a filled pour"
+        );
+    }
+
+    #[test]
+    fn the_rebuilt_outline_follows_the_footprints_rotation() {
+        let mut poly = builders::board_polygon("F.SilkS", 0.1, true, &[vec![(0.0, 0.0)]]);
+        let anchor = (builders::mm_to_nm(10.0), builders::mm_to_nm(20.0));
+        let rotate = Xform::Rotate {
+            cx_nm: 0,
+            cy_nm: 0,
+            delta_deg: 90.0,
+        };
+
+        replace_polygon_outline(&mut poly, "J2", "u-1", &square(), anchor, &rotate)
+            .expect("editable");
+
+        // A point 2mm along local +X lands 2mm along board -Y at 90 degrees.
+        // Getting this backwards mirrors the artwork, which reads as plausible
+        // silkscreen and is exactly what nobody would notice in a diff.
+        let got = outline_of(&poly);
+        assert_eq!(got[0], anchor, "the first vertex is the anchor itself");
+        assert_eq!(
+            got[1],
+            (anchor.0, anchor.1 - builders::mm_to_nm(2.0)),
+            "local +X must rotate to board -Y"
+        );
     }
 }

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -46,6 +46,89 @@ fn layer_enum_to_name(layer: i32) -> &'static str {
     }
 }
 
+/// A placed footprint's anchor in board nanometres, and its orientation in
+/// degrees.
+///
+/// KiCad keeps a footprint's children in absolute board coordinates, so this
+/// is the frame that turns them back into the footprint-local numbers a
+/// `.kicad_mod` shows, and back again.
+fn footprint_frame(fp: &kiapi::board::types::FootprintInstance) -> ((i64, i64), f64) {
+    let pos = fp.position.unwrap_or_default();
+    let angle = fp
+        .orientation
+        .as_ref()
+        .map(|a| a.value_degrees)
+        .unwrap_or(0.0);
+    ((pos.x_nm, pos.y_nm), angle)
+}
+
+/// The shape family of a graphic geometry, named as the tool schemas name it.
+fn geometry_kind(geometry: &kiapi::common::types::graphic_shape::Geometry) -> &'static str {
+    use kiapi::common::types::graphic_shape::Geometry;
+    match geometry {
+        Geometry::Segment(_) => "segment",
+        Geometry::Rectangle(_) => "rectangle",
+        Geometry::Arc(_) => "arc",
+        Geometry::Circle(_) => "circle",
+        Geometry::Polygon(_) => "polygon",
+        Geometry::Bezier(_) => "bezier",
+    }
+}
+
+/// How many outlines a polygon's `PolySet` carries and how many holes across
+/// them. `(0, 0)` for any other geometry.
+///
+/// `geometry_points` reports the first outline only, and the edit path rebuilds
+/// the shape from a single outline — so a footprint carrying a cutout would read
+/// back looking correct and be flattened on the next write. Counting them is
+/// what lets both ends say so.
+fn polygon_extent(geometry: &kiapi::common::types::graphic_shape::Geometry) -> (usize, usize) {
+    use kiapi::common::types::graphic_shape::Geometry;
+    match geometry {
+        Geometry::Polygon(ps) => (
+            ps.polygons.len(),
+            ps.polygons.iter().map(|p| p.holes.len()).sum(),
+        ),
+        _ => (0, 0),
+    }
+}
+
+/// The defining vertices of a graphic geometry, in absolute board nanometres.
+fn geometry_points(geometry: &kiapi::common::types::graphic_shape::Geometry) -> Vec<(i64, i64)> {
+    use kiapi::common::types::graphic_shape::Geometry;
+    // An absent vertex yields nothing rather than the origin. Substituting
+    // (0, 0) would report a shape that looks well-formed and is silently in the
+    // wrong place; a short list is visibly wrong at the point of use.
+    let pt = |v: &Option<kiapi::common::types::Vector2>| v.map(|p| (p.x_nm, p.y_nm));
+    let pts = |vs: [&Option<kiapi::common::types::Vector2>; 4], n: usize| {
+        vs[..n].iter().filter_map(|v| pt(v)).collect::<Vec<_>>()
+    };
+    let none = &None;
+    match geometry {
+        Geometry::Segment(s) => pts([&s.start, &s.end, none, none], 2),
+        Geometry::Rectangle(r) => pts([&r.top_left, &r.bottom_right, none, none], 2),
+        Geometry::Arc(a) => pts([&a.start, &a.mid, &a.end, none], 3),
+        Geometry::Circle(c) => pts([&c.center, &c.radius_point, none, none], 2),
+        Geometry::Bezier(b) => pts([&b.start, &b.control1, &b.control2, &b.end], 4),
+        Geometry::Polygon(ps) => ps
+            .polygons
+            .first()
+            .and_then(|p| p.outline.as_ref())
+            .map(|o| {
+                o.nodes
+                    .iter()
+                    .filter_map(|n| match n.geometry.as_ref() {
+                        Some(kiapi::common::types::poly_line_node::Geometry::Point(p)) => {
+                            Some((p.x_nm, p.y_nm))
+                        }
+                        _ => None,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+    }
+}
+
 /// Wrap a protobuf message into a prost_types::Any with the correct type_url.
 fn pack_any<M: Message>(msg: &M, type_name: &str) -> prost_types::Any {
     let mut buf = Vec::new();
@@ -959,6 +1042,205 @@ impl KiCadIpcClient {
                     let any = crate::builders::pack_any(&fp, "kiapi.board.types.FootprintInstance");
                     self.update_items(vec![any])?;
                     return Ok(());
+                }
+            }
+        }
+        anyhow::bail!("Footprint '{}' not found", reference)
+    }
+
+    /// List the graphic items inside a placed footprint.
+    ///
+    /// Points come back in footprint-local millimetres — the coordinates the
+    /// `.kicad_mod` shows — not the absolute board coordinates KiCad carries
+    /// them in over IPC. See `set_footprint_graphic_points` for why.
+    pub fn list_footprint_graphics(&self, reference: &str) -> Result<Vec<IpcFootprintGraphic>> {
+        let (fp, _) = self.find_footprint_instance(reference)?;
+        let (anchor, angle) = footprint_frame(&fp);
+        let to_local = crate::transform::Xform::Rotate {
+            cx_nm: anchor.0,
+            cy_nm: anchor.1,
+            delta_deg: -angle,
+        };
+
+        let mut out = Vec::new();
+        for any in &fp
+            .definition
+            .as_ref()
+            .map(|d| d.items.clone())
+            .unwrap_or_default()
+        {
+            let Ok(shape) = kiapi::board::types::BoardGraphicShape::decode(any.value.as_slice())
+            else {
+                continue;
+            };
+            let Some(geometry) = shape.shape.as_ref().and_then(|s| s.geometry.as_ref()) else {
+                continue;
+            };
+            let uuid = shape
+                .id
+                .as_ref()
+                .map(|k| k.value.clone())
+                .unwrap_or_default();
+            let kind = geometry_kind(geometry).to_string();
+            let (outlines, holes) = polygon_extent(geometry);
+            out.push(IpcFootprintGraphic {
+                editable: kind == "polygon" && outlines == 1 && holes == 0 && !uuid.is_empty(),
+                uuid,
+                kind,
+                outlines,
+                holes,
+                layer: layer_enum_to_name(shape.layer).to_string(),
+                points: geometry_points(geometry)
+                    .into_iter()
+                    .map(|(x, y)| {
+                        let (lx, ly) = to_local.point(x, y);
+                        IpcVector2 {
+                            x: nm_to_mm(lx - anchor.0),
+                            y: nm_to_mm(ly - anchor.1),
+                        }
+                    })
+                    .collect(),
+            });
+        }
+        Ok(out)
+    }
+
+    /// Replace the vertices of one graphic item inside a placed footprint.
+    ///
+    /// `points_mm` are footprint-local, matching what the `.kicad_mod` shows.
+    /// KiCad carries a footprint's children in absolute board coordinates over
+    /// IPC and re-creates them verbatim on update (the same reason
+    /// `move_footprint` has to shift them), so they are rotated by the
+    /// instance's orientation and translated onto its position here rather
+    /// than making every caller redo that arithmetic against the wrong frame.
+    pub fn set_footprint_graphic_points(
+        &self,
+        reference: &str,
+        uuid: &str,
+        points_mm: &[(f64, f64)],
+    ) -> Result<String> {
+        let (mut fp, _) = self.find_footprint_instance(reference)?;
+        let (anchor, angle) = footprint_frame(&fp);
+        let to_board = crate::transform::Xform::Rotate {
+            cx_nm: 0,
+            cy_nm: 0,
+            delta_deg: angle,
+        };
+
+        let definition = fp
+            .definition
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("footprint '{}' carries no definition", reference))?;
+
+        for any in definition.items.iter_mut() {
+            let Ok(mut shape) =
+                kiapi::board::types::BoardGraphicShape::decode(any.value.as_slice())
+            else {
+                continue;
+            };
+            if shape.id.as_ref().map(|k| k.value.as_str()) != Some(uuid) {
+                continue;
+            }
+
+            let kind = shape
+                .shape
+                .as_ref()
+                .and_then(|s| s.geometry.as_ref())
+                .map(geometry_kind)
+                .unwrap_or("unknown");
+            if kind != "polygon" {
+                anyhow::bail!(
+                    "graphic '{}' on '{}' is a {}; only polygons take a vertex list",
+                    uuid,
+                    reference,
+                    kind
+                );
+            }
+            if points_mm.len() < 3 {
+                anyhow::bail!("a polygon needs at least 3 points, got {}", points_mm.len());
+            }
+            // The rebuild below emits one outline with no holes. Rejecting a
+            // shape that carries more is the difference between refusing the
+            // edit and silently deleting a cutout the caller never mentioned.
+            let (outlines, holes) = shape
+                .shape
+                .as_ref()
+                .and_then(|s| s.geometry.as_ref())
+                .map(polygon_extent)
+                .unwrap_or((0, 0));
+            if outlines > 1 || holes > 0 {
+                anyhow::bail!(
+                    "polygon '{}' on '{}' carries {} outline(s) and {} hole(s); this tool \
+                     replaces a single outline and would discard the rest, so it will not \
+                     write it — edit this one in KiCad",
+                    uuid,
+                    reference,
+                    outlines,
+                    holes
+                );
+            }
+
+            let nodes = points_mm
+                .iter()
+                .map(|&(x, y)| {
+                    let (rx, ry) =
+                        to_board.point(crate::builders::mm_to_nm(x), crate::builders::mm_to_nm(y));
+                    kiapi::common::types::PolyLineNode {
+                        geometry: Some(kiapi::common::types::poly_line_node::Geometry::Point(
+                            kiapi::common::types::Vector2 {
+                                x_nm: anchor.0 + rx,
+                                y_nm: anchor.1 + ry,
+                            },
+                        )),
+                    }
+                })
+                .collect();
+
+            if let Some(s) = shape.shape.as_mut() {
+                s.geometry = Some(kiapi::common::types::graphic_shape::Geometry::Polygon(
+                    kiapi::common::types::PolySet {
+                        polygons: vec![kiapi::common::types::PolygonWithHoles {
+                            outline: Some(kiapi::common::types::PolyLine {
+                                nodes,
+                                closed: true,
+                            }),
+                            holes: vec![],
+                        }],
+                    },
+                ));
+            }
+
+            *any = pack_any(&shape, "kiapi.board.types.BoardGraphicShape");
+            let packed = pack_any(&fp, "kiapi.board.types.FootprintInstance");
+            self.update_items(vec![packed])?;
+            return Ok(kind.to_string());
+        }
+
+        anyhow::bail!(
+            "graphic '{}' not found on footprint '{}' — call list_board_footprint_graphics \
+             for the UUIDs it does have",
+            uuid,
+            reference
+        )
+    }
+
+    /// The placed footprint carrying `reference`, and its index among items.
+    fn find_footprint_instance(
+        &self,
+        reference: &str,
+    ) -> Result<(kiapi::board::types::FootprintInstance, usize)> {
+        let items = self.get_items(kiapi::common::types::KiCadObjectType::KotPcbFootprint)?;
+        for (i, item) in items.iter().enumerate() {
+            if let Ok(fp) = kiapi::board::types::FootprintInstance::decode(item.value.as_slice()) {
+                let ref_text = fp
+                    .reference_field
+                    .as_ref()
+                    .and_then(|f| f.text.as_ref())
+                    .and_then(|bt| bt.text.as_ref())
+                    .map(|t| t.text.as_str())
+                    .unwrap_or("");
+                if ref_text == reference {
+                    return Ok((fp, i));
                 }
             }
         }
@@ -1923,6 +2205,197 @@ mod footprint_graphics_tests {
             assert_normal_padstack_is_unpackable(
                 decoded.pad_stack.as_ref().expect("pad_stack"),
                 &format!("build_footprint_item pad on {layer}"),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod footprint_graphic_tests {
+    use super::*;
+    use crate::builders;
+    use crate::transform::Xform;
+
+    /// A footprint at (100, 100) rotated `angle` degrees, carrying `items`.
+    fn instance(
+        angle: f64,
+        items: Vec<prost_types::Any>,
+    ) -> kiapi::board::types::FootprintInstance {
+        kiapi::board::types::FootprintInstance {
+            position: Some(builders::vec2(100.0, 100.0)),
+            orientation: Some(kiapi::common::types::Angle {
+                value_degrees: angle,
+            }),
+            definition: Some(kiapi::board::types::Footprint {
+                items,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn frame_reports_anchor_and_orientation() {
+        let ((x, y), angle) = footprint_frame(&instance(90.0, vec![]));
+        assert_eq!(
+            (x, y),
+            (builders::mm_to_nm(100.0), builders::mm_to_nm(100.0))
+        );
+        assert_eq!(angle, 90.0);
+    }
+
+    #[test]
+    fn frame_defaults_to_the_origin_unrotated() {
+        let fp = kiapi::board::types::FootprintInstance::default();
+        assert_eq!(footprint_frame(&fp), ((0, 0), 0.0));
+    }
+
+    #[test]
+    fn geometry_kind_names_each_shape() {
+        use kiapi::common::types::graphic_shape::Geometry;
+        let poly = builders::board_polygon("F.SilkS", 0.1, true, &[vec![(0.0, 0.0)]]);
+        let seg = builders::board_segment("F.SilkS", 0.1, 0.0, 0.0, 1.0, 0.0);
+        let of = |s: &kiapi::board::types::BoardGraphicShape| -> &'static str {
+            geometry_kind(s.shape.as_ref().unwrap().geometry.as_ref().unwrap())
+        };
+        assert_eq!(of(&poly), "polygon");
+        assert_eq!(of(&seg), "segment");
+        // Exhaustiveness is enforced by the match, not by listing every arm here.
+        let _ = |g: &Geometry| geometry_kind(g);
+    }
+
+    #[test]
+    fn geometry_points_reads_a_polygon_outline_in_order() {
+        let poly = builders::board_polygon(
+            "F.SilkS",
+            0.1,
+            true,
+            &[vec![(13.9, -0.5), (13.9, 0.5), (13.0, 0.0)]],
+        );
+        let pts = geometry_points(poly.shape.as_ref().unwrap().geometry.as_ref().unwrap());
+        assert_eq!(
+            pts,
+            vec![
+                (builders::mm_to_nm(13.9), builders::mm_to_nm(-0.5)),
+                (builders::mm_to_nm(13.9), builders::mm_to_nm(0.5)),
+                (builders::mm_to_nm(13.0), builders::mm_to_nm(0.0)),
+            ]
+        );
+    }
+
+    #[test]
+    fn geometry_points_reads_a_segment_as_start_then_end() {
+        let seg = builders::board_segment("F.SilkS", 0.1, -19.0, 0.0, -17.0, 0.0);
+        let pts = geometry_points(seg.shape.as_ref().unwrap().geometry.as_ref().unwrap());
+        assert_eq!(
+            pts,
+            vec![
+                (builders::mm_to_nm(-19.0), builders::mm_to_nm(0.0)),
+                (builders::mm_to_nm(-17.0), builders::mm_to_nm(0.0)),
+            ]
+        );
+    }
+
+    /// A vertex KiCad did not populate is dropped, not reported as the origin.
+    /// (0, 0) is a plausible-looking coordinate, so substituting it turns a
+    /// malformed shape into a well-formed one in the wrong place.
+    #[test]
+    fn geometry_points_omits_a_missing_vertex() {
+        let mut seg = builders::board_segment("F.SilkS", 0.1, -19.0, 0.0, -17.0, 0.0);
+        match seg
+            .shape
+            .as_mut()
+            .and_then(|s| s.geometry.as_mut())
+            .unwrap()
+        {
+            kiapi::common::types::graphic_shape::Geometry::Segment(s) => s.end = None,
+            other => panic!("expected a segment, got {other:?}"),
+        }
+
+        let pts = geometry_points(seg.shape.as_ref().unwrap().geometry.as_ref().unwrap());
+        assert_eq!(
+            pts,
+            vec![(builders::mm_to_nm(-19.0), builders::mm_to_nm(0.0))],
+            "the absent end is missing from the list, not reported as (0, 0)"
+        );
+    }
+
+    /// A polygon carrying a cutout or a second outline must be countable, since
+    /// both the read and the write path only handle the first outline.
+    #[test]
+    fn polygon_extent_counts_outlines_and_holes() {
+        let simple = builders::board_polygon(
+            "F.SilkS",
+            0.1,
+            true,
+            &[vec![(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)]],
+        );
+        let geom = |s: &kiapi::board::types::BoardGraphicShape| {
+            s.shape.as_ref().unwrap().geometry.as_ref().unwrap().clone()
+        };
+        assert_eq!(polygon_extent(&geom(&simple)), (1, 0));
+
+        let two = builders::board_polygon(
+            "F.SilkS",
+            0.1,
+            true,
+            &[
+                vec![(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)],
+                vec![(5.0, 5.0), (6.0, 5.0), (6.0, 6.0)],
+            ],
+        );
+        assert_eq!(polygon_extent(&geom(&two)), (2, 0));
+
+        // A hole on the first outline — what board_polygon never builds.
+        let mut holed = simple.clone();
+        if let kiapi::common::types::graphic_shape::Geometry::Polygon(ps) = holed
+            .shape
+            .as_mut()
+            .and_then(|s| s.geometry.as_mut())
+            .unwrap()
+        {
+            ps.polygons[0].holes.push(kiapi::common::types::PolyLine {
+                nodes: vec![],
+                closed: true,
+            });
+        }
+        assert_eq!(polygon_extent(&geom(&holed)), (1, 1));
+
+        // Every other kind reports nothing rather than a misleading 1.
+        let seg = builders::board_segment("F.SilkS", 0.1, 0.0, 0.0, 1.0, 0.0);
+        assert_eq!(polygon_extent(&geom(&seg)), (0, 0));
+    }
+
+    /// The arithmetic both new methods stand on: a footprint-local point
+    /// pushed into board space and read back must land where it started, at a
+    /// rotation where getting the sign wrong is visible.
+    #[test]
+    fn local_to_board_and_back_round_trips_under_rotation() {
+        let fp = instance(90.0, vec![]);
+        let (anchor, angle) = footprint_frame(&fp);
+
+        let to_board = Xform::Rotate {
+            cx_nm: 0,
+            cy_nm: 0,
+            delta_deg: angle,
+        };
+        let to_local = Xform::Rotate {
+            cx_nm: anchor.0,
+            cy_nm: anchor.1,
+            delta_deg: -angle,
+        };
+
+        for &(x_mm, y_mm) in &[(13.5, -0.5), (13.5, 0.5), (12.7, 0.0), (-19.0, 3.25)] {
+            let (rx, ry) = to_board.point(builders::mm_to_nm(x_mm), builders::mm_to_nm(y_mm));
+            let (bx, by) = (anchor.0 + rx, anchor.1 + ry);
+            let (lx, ly) = to_local.point(bx, by);
+            assert_eq!(
+                (
+                    builders::nm_to_mm(lx - anchor.0),
+                    builders::nm_to_mm(ly - anchor.1)
+                ),
+                (x_mm, y_mm),
+                "round trip lost ({x_mm}, {y_mm})"
             );
         }
     }

--- a/crates/konnect-ipc/src/transform.rs
+++ b/crates/konnect-ipc/src/transform.rs
@@ -31,7 +31,7 @@ pub enum Xform {
 }
 
 impl Xform {
-    fn point(&self, x: i64, y: i64) -> (i64, i64) {
+    pub(crate) fn point(&self, x: i64, y: i64) -> (i64, i64) {
         match *self {
             Xform::Translate { dx_nm, dy_nm } => (x + dx_nm, y + dy_nm),
             Xform::Rotate {

--- a/crates/konnect-ipc/src/types.rs
+++ b/crates/konnect-ipc/src/types.rs
@@ -104,6 +104,29 @@ pub struct IpcTrack {
     pub end: IpcVector2,
 }
 
+/// A graphic item inside a placed footprint — silkscreen, fabrication, or
+/// courtyard artwork, not a pad.
+///
+/// `points` are footprint-local millimetres, matching what the `.kicad_mod`
+/// shows, even though KiCad carries them in absolute board coordinates.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IpcFootprintGraphic {
+    pub uuid: String,
+    pub kind: String,
+    pub layer: String,
+    pub points: Vec<IpcVector2>,
+    /// How many outlines a polygon's `PolySet` carries, and how many holes
+    /// across them; `0` for every other kind. `points` reports the first
+    /// outline only, so anything above `1` outline or above `0` holes means
+    /// this listing is not the whole shape — hence stating it rather than
+    /// letting the caller infer a simple triangle from three points.
+    pub outlines: usize,
+    pub holes: usize,
+    /// Whether `edit_board_footprint_graphic` can address this item: a
+    /// single-outline polygon with no holes, carrying a UUID.
+    pub editable: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IpcNet {
     pub name: String,

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -129,7 +129,7 @@ The fix for those clients is to make the *first* listing complete:
 ```
 
 in `konnect-settings.json` (or `konnect.toml`). Every toolset is then loaded at
-startup, so `tools/list` carries all 206 tools from the first call.
+startup, so `tools/list` carries all 208 tools from the first call.
 
 It is off by default because it costs what the router exists to save: roughly
 25K tokens per listing instead of ~2K. Turn it on only if your client needs it.

--- a/packaging/metadata.json
+++ b/packaging/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://go.kicad.org/pcm/schemas/v1",
   "name": "Konnect",
-  "description": "AI-assisted PCB design via the Model Context Protocol. Enables Claude and other AI assistants to design schematics and PCBs with 200 tools organized into on-demand toolsets.",
+  "description": "AI-assisted PCB design via the Model Context Protocol. Enables Claude and other AI assistants to design schematics and PCBs with 202 tools organized into on-demand toolsets.",
   "description_full": "Konnect exposes a complete set of KiCAD design tools to AI assistants via the Model Context Protocol (MCP). It supports schematic editing, PCB layout, routing, library management, JLCPCB part search, Freerouting autoroute, ERC/DRC, design review audits, and full export pipelines. Tools are organized into 18 toolsets loaded on demand so the AI only sees relevant tools at once.",
   "identifier": "com.github.mixelpixx.konnect",
   "type": "plugin",

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "identifier": "com.github.mixelpixx.konnect",
   "name": "Konnect",
-  "description": "AI-assisted PCB design via the Model Context Protocol. 200 tools for schematic editing, PCB layout, routing, design review, and manufacturing export.",
+  "description": "AI-assisted PCB design via the Model Context Protocol. 202 tools for schematic editing, PCB layout, routing, design review, and manufacturing export.",
   "runtime": {
     "type": "exec"
   },

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -10,7 +10,7 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 ## Overview
 
 - **19 toolsets** organized into 10 categories
-- **200 registered tools** + **6 always-visible meta-tools** = **206 total**
+- **202 registered tools** + **6 always-visible meta-tools** = **208 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -217,7 +217,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `add_zone` | Add a copper fill zone polygon on a specified layer and net. |
 | `import_svg_logo` | Import an SVG file as filled silkscreen/copper artwork (curves flattened to polygons). |
 
-### `pcb_components` · 13 tools
+### `pcb_components` · 15 tools
 **Purpose:** Place, move, rotate, align, and duplicate PCB footprints.
 **Source:** [`crates/konnect-core/src/tools/pcb_components.rs`](crates/konnect-core/src/tools/pcb_components.rs)
 
@@ -229,6 +229,8 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `delete_component` | Remove a footprint from the board via KiCAD IPC. |
 | `edit_component` | Update the value or other properties of a placed footprint via KiCAD IPC. |
 | `find_component` | Find a footprint by reference designator and return its position. |
+| `list_board_footprint_graphics` | List the graphic items inside a footprint placed on the board — silkscreen, fabrication, and courtyard artwork — with the UUID needed to edit one. Reports `editable`, plus `outlines` and `holes` for polygons. Requires KiCAD running with the board open. |
+| `edit_board_footprint_graphic` | Replace the vertices of a single-outline polygon inside a placed footprint, selected by UUID, without re-placing the part. Anything with multiple outlines or holes is refused by name rather than flattened. Requires KiCAD running with the board open. |
 | `get_component_pads` | Return pad positions and net assignments for a footprint. A pad whose net node is present but unreadable reports `null` rather than an empty string, so "no net" stays distinguishable from "could not read it". |
 | `get_pad_position` | Return the schematic-space position of a specific pad number on a footprint. |
 | `get_component_list` | List all footprints on the board with positions, layers, and values. |


### PR DESCRIPTION
> **Stacked on #159.** This branch contains that PR's commit as well, because a fork branch cannot be a base for an upstream PR. Review/merge #159 first and this diff reduces to its own commit, `feat(pcb_components): …`.

## Problem and scope

Konnect can move, rotate, swap and delete a footprint on the board, but it cannot touch the artwork *inside* one. So when a library footprint changes, there is no way to bring a single placed instance in line with it — the board carries its own copy of every footprint, and the only routes are KiCad's own **Update Footprints from Library** in the GUI, or re-placing the part and rebuilding its net assignments.

The case this came from: a pin-1 marker sat 0.1 mm from its board edge, a panel perforated that exact edge, and every panel built from the part carried 16 `silk_over_copper` warnings. Fixing the library (#159) did nothing for the boards already using it.

Two IPC tools in `pcb_components`:

- **`list_board_footprint_graphics`** — every graphic item inside a placed footprint with UUID, kind, layer and vertices; optional `layer` filter.
- **`edit_board_footprint_graphic`** — replaces one polygon's vertices, selected by UUID.

## Design

**Coordinates are the part worth reviewing.** KiCad carries a footprint's children in *absolute board* coordinates over IPC — the same fact `move_footprint` already deals with when it shifts them — while the `.kicad_mod` a user reads shows them *footprint-local*. Both tools take and report local coordinates and do the conversion themselves, rotating by the instance's orientation and translating onto its anchor. The point is that someone comparing board artwork against its library source is comparing like with like; the alternative is every caller redoing that arithmetic against the wrong frame.

The reverse transform reuses `transform::Xform` rather than open-coding a second rotation, so the two directions cannot drift. `Xform::point` becomes `pub(crate)` for it.

**Only polygons are editable for now.** Segments, arcs, circles, rectangles and beziers are reported by the list tool but rejected *by name* on edit — each wants its own vertex contract, and this is the one the motivating case needed. The error says which kind it found.

## Tests

6 new unit tests in `konnect-ipc`:

- the frame helper with and without a position/orientation;
- shape-kind naming;
- vertex extraction for a polygon outline and for a segment, in KiCad's storage order;
- a **local → board → local round trip at 90°**, where a sign error in the rotation would be visible and silent otherwise.

```
cargo test --workspace --lib --tests   # all green
cargo fmt --all -- --check             # clean
```

Also validated end to end against KiCad 10 over its live IPC socket: the polygon was read back at its `.kicad_mod` coordinates, moved, re-read at the new ones, and after `save_project` the board on disk carried exactly that change and nothing else beyond KiCad's own `(type default)` → `(type solid)` normalisation of the footprint it rewrote.

## Compatibility and risk

Additive. `pcb_components` goes 13 → 15 tools and the registered total 189 → 191; `registry.rs`, `tool-directory.md` and `DEV.md` updated. Both tools need KiCAD running with the board open, like the rest of the toolset. The write path touches one graphic item inside one footprint; a request that fails validation sends no `UpdateItems`. Reverting the commit removes both tools and restores the counts.
