### PR TITLE
fix(export): write drill files into a directory, not a path named "drill.drl"

### DIFF
--- a/crates/konnect-core/src/tools/cli.rs
+++ b/crates/konnect-core/src/tools/cli.rs
@@ -374,18 +374,45 @@ pub async fn export_gerber(cli: &str, pcb: &Path, output_dir: &Path) -> Result<(
     Ok(())
 }
 
-/// KiCAD 10: `pcb export drill --output <dir> <input>`
-pub async fn export_drill(cli: &str, pcb: &Path, output: &Path) -> Result<()> {
+/// KiCAD 10: `pcb export drill --output <dir>` writes Excellon file(s) *into*
+/// `output_dir`, named after the board (e.g. `MyBoard.drl`, or `-PTH`/`-NPTH`
+/// when separated). `--output` is therefore a DIRECTORY, not a file — passing
+/// a filename like `drill.drl` makes KiCAD create a directory by that name and
+/// hide the real `.drl` inside it. `output_dir` is created if missing and is
+/// passed with a trailing separator so KiCAD treats it as a directory. Returns
+/// the `.drl` file(s) produced.
+pub async fn export_drill(cli: &str, pcb: &Path, output_dir: &Path) -> Result<Vec<PathBuf>> {
+    tokio::fs::create_dir_all(output_dir)
+        .await
+        .with_context(|| format!("Cannot create drill output dir {}", output_dir.display()))?;
+
+    // KiCAD keys "directory vs file" off a trailing path separator.
+    let mut dir_arg = output_dir.to_string_lossy().to_string();
+    if !dir_arg.ends_with(['/', '\\']) {
+        dir_arg.push(std::path::MAIN_SEPARATOR);
+    }
+
     let args = [
         "pcb",
         "export",
         "drill",
         "--output",
-        output.to_str().unwrap(),
+        &dir_arg,
         pcb.to_str().unwrap(),
     ];
     run_cli(cli, &args, LONG_TIMEOUT).await?;
-    Ok(())
+
+    // Collect the .drl file(s) KiCAD wrote into the directory.
+    let mut drills = Vec::new();
+    let mut rd = tokio::fs::read_dir(output_dir).await?;
+    while let Ok(Some(entry)) = rd.next_entry().await {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("drl") {
+            drills.push(path);
+        }
+    }
+    drills.sort();
+    Ok(drills)
 }
 
 /// KiCAD 10: `pcb export pdf --output <path> [--layers <layer>]... <input>`

--- a/crates/konnect-core/src/tools/manufacturing.rs
+++ b/crates/konnect-core/src/tools/manufacturing.rs
@@ -140,15 +140,17 @@ async fn handle_export_manufacturing_package(
         }
     }
 
-    // 2. Export drill files
-    let drill_path = output_dir.join("drill.drl");
-    match cli::export_drill(cli_path, &board, &drill_path).await {
-        Ok(()) => {
-            info!("[BETA] Drill export succeeded");
-            files_generated.push(json!({
-                "type": "drill",
-                "path": drill_path.to_str().unwrap_or("")
-            }));
+    // 2. Export drill files. --output is a directory; KiCAD names the file(s)
+    // after the board and writes them inside it.
+    match cli::export_drill(cli_path, &board, &output_dir).await {
+        Ok(drills) => {
+            info!(count = drills.len(), "[BETA] Drill export succeeded");
+            for drill_path in drills {
+                files_generated.push(json!({
+                    "type": "drill",
+                    "path": drill_path.to_str().unwrap_or("")
+                }));
+            }
         }
         Err(e) => {
             warn!(error = %e, "[BETA] Drill export failed (may be included in gerbers)");

--- a/crates/konnect-core/src/tools/pcb_export.rs
+++ b/crates/konnect-core/src/tools/pcb_export.rs
@@ -316,9 +316,9 @@ async fn handle_export_gerber(
     cli::export_gerber(cli, &board, &output_dir).await?;
 
     if drill {
-        // kicad-cli also has a dedicated drill export
-        let drill_path = output_dir.join("drill.drl");
-        let _ = cli::export_drill(cli, &board, &drill_path).await; // best-effort
+        // Dedicated drill export. --output is the directory; KiCAD names the
+        // .drl file(s) after the board and writes them inside it.
+        let _ = cli::export_drill(cli, &board, &output_dir).await; // best-effort
     }
 
     // List produced files


### PR DESCRIPTION
## Problem

`kicad-cli pcb export drill --output` takes a **directory** and writes the 
file named after the board (`MyBoard.drl`) inside it. Both callers passed
`<output_dir>/drill.drl` as if it were a filename, so KiCad created a *directory*
literally named `drill.drl` containing the real `.drl` (plus a `debug.log`).

The reported path therefore pointed at a directory. Anything that opened the
"drill file" — a fab-package consumer, a script, a user — got a directory-read
error instead of Excellon data, while the export itself reported success.

Repro:

```
export_manufacturing_package { board: …, output_dir: "out" }
# → out/drill.drl/  (a directory)
#   out/drill.drl/MyBoard.drl   ← the actual file, one level down
```

kicad-cli's own help documents the argument as a directory:

```
  -o, --output    Output directory [nargs=0..1] [default: ""]
```

## Changes

- `export_drill` now takes the output **directory**, creates it if missing, and
  passes it with a trailing separator so KiCad treats it as a directory.
- It returns the `.drl` file(s) actually produced, so callers report real paths.
  Collecting every `.drl` in the directory also covers `--excellon-separate-th`,
  where KiCad writes two files instead of one.
- `export_manufacturing_package` and `export_gerber` updated accordingly; the
  fab package now lists one entry per drill file instead of one bogus path.

## Verification

Against KiCad 10.0.4 on Windows, board with a via, a through-hole pad and an
NPTH hole:

```
kicad-cli pcb export drill --output <dir>/ mini.kicad_pcb
→ "Datei ... mini.drl wurde erstellt"          (mini.drl, inside the directory)

kicad-cli pcb export drill --excellon-separate-th --output <dir>/ mini2.kicad_pcb
→ mini2-PTH.drl, mini2-NPTH.drl                (both picked up by the new return value)
```

`cargo test -p konnect-core` — 233 passed.