### PR TITLE
fix(ipc): return track UUIDs from query_traces so delete_trace can use them

### DIFF
--- a/crates/konnect-core/src/tools/pcb_routing.rs
+++ b/crates/konnect-core/src/tools/pcb_routing.rs
@@ -180,7 +180,8 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "query_traces",
-            "List trace segments on the board, optionally filtered by net and/or layer.",
+            "List trace segments on the board, optionally filtered by net and/or layer. \
+             Each result includes the track's UUID, which delete_trace takes.",
             json!({
                 "type": "object",
                 "properties": {
@@ -543,6 +544,7 @@ async fn handle_query_traces(
         .iter()
         .map(|t| {
             json!({
+                "uuid": t.uuid,
                 "net": t.net_name, "layer": t.layer, "width": t.width,
                 "x1": t.start.x, "y1": t.start.y,
                 "x2": t.end.x,   "y2": t.end.y

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -877,7 +877,13 @@ impl KiCadIpcClient {
 
                 let start = track.start.as_ref();
                 let end = track.end.as_ref();
+                let uuid = track
+                    .id
+                    .as_ref()
+                    .map(|id| id.value.clone())
+                    .unwrap_or_default();
                 tracks.push(IpcTrack {
+                    uuid,
                     net_name: net_name.to_string(),
                     layer: layer_name.to_string(),
                     width: track

--- a/crates/konnect-ipc/src/types.rs
+++ b/crates/konnect-ipc/src/types.rs
@@ -94,6 +94,9 @@ pub enum IpcGraphicDefinition {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IpcTrack {
+    /// KIID of the track, needed to delete it via delete_track. Empty only if
+    /// KiCAD returned a track without an id.
+    pub uuid: String,
     pub net_name: String,
     pub layer: String,
     pub width: f64,


### PR DESCRIPTION
## Problem

`delete_trace` requires a track UUID, but `query_traces` never returned one:
`get_tracks` decoded the `Track` protobuf and dropped its `id` field. The two
tools could not be used together at all — the documented "query, then delete"
flow was impossible.

The workaround was to save the board and parse UUIDs out of the `.kicad_pcb`
file, which defeats the point of the IPC path (and needs a save first).

## Changes

- `IpcTrack` gains a `uuid` field, filled from `Track.id`.
- `query_traces` includes it in each result.
- Tool description mentions that the UUID is what `delete_trace` takes.

12 added lines across three files; no behaviour change for existing fields.

## Verification

Tested against KiCad 10.0.4 with a board open over IPC: `query_traces` returned
70 of 70 segments carrying a UUID, and feeding one straight into `delete_trace`
removed that segment — the round-trip that was previously impossible.

`cargo test -p konnect-core -p konnect-ipc` — 233 + 23 passed.