### PR TITLE
fix(agents): use the "sonnet" model alias instead of a pinned model id

### DIFF
--- a/crates/konnect/assets/agents/kicad-design-review-agent.md
+++ b/crates/konnect/assets/agents/kicad-design-review-agent.md
@@ -1,7 +1,7 @@
 ---
 name: kicad-design-review-agent
 description: "Performs a thorough hardware design review of a KiCAD project. Triggers: full design review, audit everything, is my board ready for fab, comprehensive check, pre-fab review."
-model: claude-sonnet-4-20250514
+model: sonnet
 tools:
   - mcp__konnect__*
 maxTurns: 25

--- a/crates/konnect/assets/agents/kicad-schematic-build-agent.md
+++ b/crates/konnect/assets/agents/kicad-schematic-build-agent.md
@@ -1,7 +1,7 @@
 ---
 name: kicad-schematic-build-agent
 description: "Builds complete circuits from requirements or reference designs. Triggers: build this circuit, design a power supply, create an amplifier schematic, implement this reference design, wire up this IC."
-model: claude-sonnet-4-20250514
+model: sonnet
 tools:
   - mcp__konnect__*
 maxTurns: 40


### PR DESCRIPTION
## Problem

Both shipped agents pin an exact model id:

```yaml
model: claude-sonnet-4-20250514
```

A hard-coded model id inside an installed asset goes stale on its own schedule.
That id is from May 2025; running the agents later, I hit failures that only a
manual `model` override worked around. Every user of the installed agent hits the
same wall, and the asset can only be fixed by a new Konnect release.

## Changes

Two lines: `model: sonnet` in both agent files. The alias always resolves to the
current Sonnet, so the intended model *tier* is preserved without the asset
needing a bump each time a model is superseded.

## Alternatives

If you'd rather go a different way, both are one-line changes and I'm happy to
adjust:

- **Drop `model:` entirely** — each agent then inherits the user's session model.
  Most robust against future changes, but gives up the tier choice (someone
  running Opus would get Opus for a bulk schematic build).
- **Pin a newer id** — works today, but just moves the expiry date.

No code paths touched: the files are `include_str!`'d assets. `cargo test -p konnect` passes.