### PR TITLE
fix(project): refuse to overwrite existing designs

### DIFF
--- a/crates/konnect-core/src/mcp/error.rs
+++ b/crates/konnect-core/src/mcp/error.rs
@@ -49,6 +49,8 @@ pub enum ToolErrorKind {
     InvalidArgument { field: String, reason: String },
     /// A referenced file doesn't exist or can't be read.
     FileNotFound { path: String },
+    /// A mutation would replace one or more existing filesystem targets.
+    Conflict { paths: Vec<String> },
     /// Catch-all for handler `anyhow::Error` that hasn't been migrated yet.
     /// Eventually each variant above subsumes a subset of these.
     HandlerError { reason: String },
@@ -64,6 +66,7 @@ impl ToolErrorKind {
             Self::UnknownTool { .. } => "unknown_tool",
             Self::InvalidArgument { .. } => "invalid_argument",
             Self::FileNotFound { .. } => "file_not_found",
+            Self::Conflict { .. } => "conflict",
             Self::HandlerError { .. } => "handler_error",
         }
     }
@@ -160,6 +163,9 @@ mod tests {
                 reason: "r".into(),
             },
             ToolErrorKind::FileNotFound { path: "p".into() },
+            ToolErrorKind::Conflict {
+                paths: vec!["p".into()],
+            },
             ToolErrorKind::HandlerError { reason: "r".into() },
         ];
         for kind in kinds {

--- a/crates/konnect-core/src/tools/project.rs
+++ b/crates/konnect-core/src/tools/project.rs
@@ -9,11 +9,12 @@
 //!   - get_project_info → file system read
 //!   - snapshot_project → kicad-cli export PDF
 
-use crate::mcp::protocol::CallToolResult;
+use crate::mcp::{error::ToolErrorKind, protocol::CallToolResult};
 use crate::tool;
 use crate::tools::{get_path, opt_str, require_str, ToolContext, ToolDef};
+use konnect_sexp::{commit_file_transaction, FileTransition, SexpError};
 use serde_json::json;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub fn tools() -> Vec<ToolDef> {
     vec![
@@ -21,7 +22,7 @@ pub fn tools() -> Vec<ToolDef> {
             "create_project",
             "Create a new KiCAD project at the given path. Creates the directory, \
              a blank .kicad_pro file, an empty .kicad_sch schematic, and a blank \
-             .kicad_pcb board file.",
+             .kicad_pcb board file. Refuses to replace any existing project file.",
             json!({
                 "type": "object",
                 "properties": {
@@ -133,6 +134,52 @@ pub fn tools() -> Vec<ToolDef> {
 
 // ─── Handlers ─────────────────────────────────────────────────────────────────
 
+fn existing_project_paths(paths: &[PathBuf]) -> std::io::Result<Vec<PathBuf>> {
+    let mut existing = Vec::new();
+    for path in paths {
+        match std::fs::symlink_metadata(path) {
+            Ok(_) => existing.push(path.clone()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(existing)
+}
+
+fn project_conflict(paths: Vec<PathBuf>) -> CallToolResult {
+    let paths: Vec<String> = paths
+        .into_iter()
+        .map(|path| path.display().to_string())
+        .collect();
+    CallToolResult::error_kind(
+        ToolErrorKind::Conflict {
+            paths: paths.clone(),
+        },
+        format!(
+            "Project creation would replace existing path(s): {}",
+            paths.join(", ")
+        ),
+    )
+}
+
+fn create_project_files(
+    project_dir: &Path,
+    name: &str,
+    pro_path: &Path,
+    sch_path: &Path,
+    pcb_path: &Path,
+) -> Result<(), SexpError> {
+    commit_file_transaction(
+        project_dir,
+        vec![
+            FileTransition::create(pro_path, blank_kicad_pro(name)),
+            FileTransition::create(sch_path, blank_kicad_sch()),
+            FileTransition::create(pcb_path, blank_kicad_pcb()),
+        ],
+    )?;
+    Ok(())
+}
+
 async fn handle_create_project(
     args: &serde_json::Value,
     _ctx: &ToolContext,
@@ -143,18 +190,38 @@ async fn handle_create_project(
         Err(e) => return Ok(e),
     };
 
-    tokio::fs::create_dir_all(&path).await?;
-
     let pro_path = path.join(format!("{}.kicad_pro", name));
     let sch_path = path.join(format!("{}.kicad_sch", name));
     let pcb_path = path.join(format!("{}.kicad_pcb", name));
+    let project_paths = vec![pro_path.clone(), sch_path.clone(), pcb_path.clone()];
 
-    // Write blank project file
-    tokio::fs::write(&pro_path, blank_kicad_pro(&name)).await?;
-    // Write blank schematic
-    tokio::fs::write(&sch_path, blank_kicad_sch()).await?;
-    // Write blank PCB
-    tokio::fs::write(&pcb_path, blank_kicad_pcb()).await?;
+    let existing = tokio::task::spawn_blocking({
+        let project_paths = project_paths.clone();
+        move || existing_project_paths(&project_paths)
+    })
+    .await??;
+    if !existing.is_empty() {
+        return Ok(project_conflict(existing));
+    }
+
+    tokio::fs::create_dir_all(&path).await?;
+
+    let transaction = tokio::task::spawn_blocking({
+        let project_dir = path.clone();
+        let name = name.clone();
+        let pro_path = pro_path.clone();
+        let sch_path = sch_path.clone();
+        let pcb_path = pcb_path.clone();
+        move || create_project_files(&project_dir, &name, &pro_path, &sch_path, &pcb_path)
+    })
+    .await?;
+    match transaction {
+        Ok(()) => {}
+        Err(SexpError::TransactionConflict { path, .. }) => {
+            return Ok(project_conflict(vec![path]));
+        }
+        Err(error) => return Err(error.into()),
+    }
 
     Ok(CallToolResult::json(&json!({
         "created": true,
@@ -482,6 +549,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_project_rejects_a_partially_populated_directory_without_changes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let existing_path = dir.path().join("widget.kicad_sch");
+        tokio::fs::write(&existing_path, b"existing schematic")
+            .await
+            .unwrap();
+        let ctx = test_ctx();
+        let args = json!({
+            "path": dir.path().to_str().unwrap(),
+            "name": "widget"
+        });
+
+        let result = handle_create_project(&args, &ctx)
+            .await
+            .expect("handler should return a structured conflict");
+
+        assert!(result.is_error);
+        assert_eq!(extract_error_kind(&result).as_deref(), Some("conflict"));
+        let body = response_json(&result);
+        assert_eq!(
+            body["error"]["paths"],
+            json!([existing_path.display().to_string()])
+        );
+        assert_eq!(
+            tokio::fs::read(&existing_path).await.unwrap(),
+            b"existing schematic"
+        );
+        assert!(!dir.path().join("widget.kicad_pro").exists());
+        assert!(!dir.path().join("widget.kicad_pcb").exists());
+    }
+
+    #[tokio::test]
+    async fn create_project_rejects_a_completed_project_without_changes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ctx = test_ctx();
+        let args = json!({
+            "path": dir.path().to_str().unwrap(),
+            "name": "widget"
+        });
+        handle_create_project(&args, &ctx)
+            .await
+            .expect("initial creation should succeed");
+        let paths = [
+            dir.path().join("widget.kicad_pro"),
+            dir.path().join("widget.kicad_sch"),
+            dir.path().join("widget.kicad_pcb"),
+        ];
+        let before = [
+            tokio::fs::read(&paths[0]).await.unwrap(),
+            tokio::fs::read(&paths[1]).await.unwrap(),
+            tokio::fs::read(&paths[2]).await.unwrap(),
+        ];
+
+        let result = handle_create_project(&args, &ctx)
+            .await
+            .expect("repeat creation should return a conflict");
+
+        assert!(result.is_error);
+        assert_eq!(extract_error_kind(&result).as_deref(), Some("conflict"));
+        let body = response_json(&result);
+        assert_eq!(body["error"]["paths"].as_array().unwrap().len(), 3);
+        for (path, original) in paths.iter().zip(before) {
+            assert_eq!(tokio::fs::read(path).await.unwrap(), original);
+        }
+    }
+
+    #[tokio::test]
     async fn create_project_missing_name_returns_structured_error() {
         let dir = tempfile::tempdir().expect("tempdir");
         let ctx = test_ctx();
@@ -543,5 +677,12 @@ mod tests {
             extract_error_kind(&result).as_deref(),
             Some("file_not_found")
         );
+    }
+
+    fn response_json(result: &CallToolResult) -> serde_json::Value {
+        match &result.content[0] {
+            crate::mcp::protocol::ToolContent::Text { text } => serde_json::from_str(text).unwrap(),
+            _ => panic!("expected text content"),
+        }
     }
 }

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -44,7 +44,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 
 | Tool | Description |
 |------|-------------|
-| `create_project` | Create a new KiCAD project at the given path. Creates the directory, a blank `.kicad_pro`, empty `.kicad_sch`, and blank `.kicad_pcb`. |
+| `create_project` | Create a new KiCAD project at the given path. Creates the directory, a blank `.kicad_pro`, empty `.kicad_sch`, and blank `.kicad_pcb`; refuses to replace any existing project file. |
 | `open_project` | Check whether a KiCAD project is currently open in the running KiCAD UI. Returns the active project path and whether KiCAD IPC is available. |
 | `save_project` | Save the currently open PCB board file via KiCAD IPC. Requires KiCAD to be running with IPC enabled. |
 | `get_project_info` | Read project metadata from a `.kicad_pro` file. Returns name, schematic/PCB paths, last-modified times. |


### PR DESCRIPTION
## Summary

Make `create_project` non-destructive. It now refuses to replace any existing `.kicad_pro`, `.kicad_sch`, or `.kicad_pcb` target and creates the three files through Konnect's existing durable multi-file transaction layer.

Closes #167

## Approach

The previous handler called `tokio::fs::write` three times. Each call truncates an existing file, and the independent writes provided no project-level transaction.

This change keeps the solution narrow:

- derive and inspect all three target paths before making project-file changes;
- return a structured `conflict` error containing every existing target path;
- submit three `FileTransition::create` entries to `commit_file_transaction`;
- map a transaction-layer race conflict to the same structured error;
- document the no-overwrite behavior in the MCP tool description and tool directory.

No overwrite or force option is introduced.

## Compatibility and safety

Successful `create_project` calls keep the existing input schema and response fields. Calls that previously overwrote a project now return a structured error with `error.kind = "conflict"` and `error.paths`.

The transaction layer locks and verifies the complete target set before committing, uses no-clobber file creation, and leaves a durable recovery journal if a process is interrupted during a multi-file commit.

## Validation

- [x] `cargo test --workspace --locked --lib --tests`
- [x] `cargo test --workspace --locked --doc`
- [x] `cargo clippy --workspace --locked -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Partial-directory regression proves the existing file is unchanged and missing siblings are not created
- [x] Completed-project regression proves all three files remain byte-for-byte unchanged
- [x] Real-KiCad checks are not applicable; this change is limited to filesystem project creation

## Review checklist

- [x] The diff is focused and contains no generated output, personal data, or unrelated cleanup.
- [x] New names follow `docs/NAMING_CONVENTIONS.md`; there are no public renames.
- [x] New behavior and failure paths have regression coverage.
- [x] File creation uses the existing durable multi-file transaction layer.
- [x] No IPC mutations are involved.
- [x] No tools were added or removed.