### PR TITLE
fix(sexp): decode string escapes in one pass

### DIFF
--- a/crates/konnect-sexp/src/parser.rs
+++ b/crates/konnect-sexp/src/parser.rs
@@ -157,11 +157,40 @@ fn parse_atom(input: &str) -> IResult<&str, SexpNode> {
     .parse(input)
 }
 
+/// Decode the escape sequences KiCad writes inside quoted strings.
+///
+/// Must be a single left-to-right pass. Chained `replace` calls collapse
+/// backslashes *last*, so an already-escaped backslash gets re-read as the
+/// introducer of the following escape: `C:\\new` (a literal `C:\new`) came
+/// back as `C:\` + a newline, and `a\\tb` as `a\` + a tab. KiCad escapes
+/// backslashes in property values, so any Windows path whose next character
+/// was `n` or `t` decoded wrongly.
 fn unescape(s: &str) -> String {
-    s.replace("\\\"", "\"")
-        .replace("\\n", "\n")
-        .replace("\\t", "\t")
-        .replace("\\\\", "\\")
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('n') => out.push('\n'),
+            Some('t') => out.push('\t'),
+            Some('r') => out.push('\r'),
+            Some('"') => out.push('"'),
+            Some('\\') => out.push('\\'),
+            // Unknown escape: keep both characters rather than guessing, so
+            // the value round-trips instead of silently losing a backslash.
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+
+    out
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -207,5 +236,32 @@ mod tests {
         let n = parse_sexp(s).unwrap();
         assert_eq!(n.find_str("uuid"), None); // uuid is the head
         assert_eq!(n.get(1).and_then(|n| n.as_str()), Some("abc-123-def"));
+    }
+
+    /// Chained `replace` collapsed backslashes last, so an escaped backslash
+    /// followed by `n` or `t` was re-read as a control escape. KiCad escapes
+    /// backslashes in property values, so Windows paths decoded wrongly.
+    #[test]
+    fn escaped_backslash_is_not_reread_as_an_escape() {
+        // Serialized `C:\\new\\temp` is the literal path `C:\new\temp`.
+        let n = parse_sexp(r#"(p "C:\\new\\temp")"#).unwrap();
+        assert_eq!(n.get(1).and_then(|c| c.as_str()), Some(r"C:\new\temp"));
+
+        let n = parse_sexp(r#"(p "a\\tb")"#).unwrap();
+        assert_eq!(n.get(1).and_then(|c| c.as_str()), Some(r"a\tb"));
+    }
+
+    /// Genuine control escapes must still decode.
+    #[test]
+    fn control_escapes_still_decode() {
+        let n = parse_sexp(r#"(p "line1\nline2\tend")"#).unwrap();
+        assert_eq!(n.get(1).and_then(|c| c.as_str()), Some("line1\nline2\tend"));
+    }
+
+    /// An escaped quote inside a string stays a quote.
+    #[test]
+    fn escaped_quote_decodes() {
+        let n = parse_sexp(r#"(p "say \"hi\"")"#).unwrap();
+        assert_eq!(n.get(1).and_then(|c| c.as_str()), Some(r#"say "hi""#));
     }
 }


### PR DESCRIPTION
unescape chained four replace calls with the backslash collapse last, so an already-escaped backslash was re-read as the introducer of the next escape. KiCad escapes backslashes in property values, so a serialized `C:\\new` (the literal path `C:\new`) decoded to `C:\` followed by a real newline, and `a\\tb` to `a\` plus a tab. Any Windows path whose next character was n, t or r came back corrupted.

Replaced with a single left-to-right scan. Unknown escapes now keep both characters rather than dropping the backslash, so values round-trip.

Blast radius was limited to reads: the parser is read-only and all writes go through targeted text edits, so no file was ever damaged by this — the wrong string was just handed to the caller.
