### PR TITLE
Make main the VNS working version: current upstream plus ten fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,6 +1109,7 @@ name = "konnect-schematic-editor"
 version = "0.2.2"
 dependencies = [
  "konnect-sexp",
+ "serde_json",
  "tempfile",
  "thiserror 1.0.69",
  "uuid",

--- a/DEV.md
+++ b/DEV.md
@@ -227,9 +227,9 @@ Source: [`crates/konnect-core/src/observability.rs`](crates/konnect-core/src/obs
 
 ## Tool Routing (Starter Kit + On-Demand Loading)
 
-The server does NOT expose all 187 tools (193 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
+The server does NOT expose all 187 tools (194 total with the 7 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
 
-- **Startup**: only `STARTER_KIT` toolsets are pre-loaded (see `router/registry.rs::STARTER_KIT`). Currently: `project`, `config`. Combined with the 6 meta-tools, baseline `tools/list` is ~19 tools ≈ 2K tokens.
+- **Startup**: only `STARTER_KIT` toolsets are pre-loaded (see `router/registry.rs::STARTER_KIT`). Currently: `project`, `config`. Combined with the 7 meta-tools, baseline `tools/list` is ~20 tools ≈ 2K tokens.
 - **On demand**: the LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose a toolset's tools in subsequent `tools/list` responses. `unload_toolset(name)` prunes them when the task shifts.
 - **`tools/list_changed` notification**: sent on every load/unload so MCP clients refresh their local tool cache.
 - **Error recovery**: if the LLM calls an unloaded tool, `handler.rs` returns an actionable error naming the toolset that owns it (so the LLM can load it and retry in one hop — no extra `list_toolboxes` round-trip).
@@ -289,9 +289,9 @@ convention for other `kicad-cli`-calling code.
 
 ## Current Stats
 
-- **18 toolsets, 187 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
+- **18 toolsets, 187 tools** + 7 meta-tools (4 routing + 2 observability + 1 maintenance — see `tool-directory.md`)
 - Baseline `tools/list`: ~19 tools / ~2K tokens (starter kit + meta-tools)
-- Full-catalog `tools/list` (all loaded): 193 tools (187 registered + 6 meta) / ~25K tokens
+- Full-catalog `tools/list` (all loaded): 194 tools (187 registered + 7 meta) / ~25K tokens
 - **0 IPC stubs** (all protobuf methods implemented)
 - **0 unimplemented tools**
 - **3 CLI commands removed in KiCAD v10** (specctra DSN/SES, pcb sync — return clear errors)

--- a/crates/konnect-core/src/router/meta_tools.rs
+++ b/crates/konnect-core/src/router/meta_tools.rs
@@ -1,10 +1,13 @@
-//! The 6 always-visible meta-tools.
+//! The 7 always-visible meta-tools.
 //!
 //! Discovery / routing:
 //!   list_toolboxes()          — show all 18 toolsets with descriptions and load state
 //!   load_toolset(name)        — activate a toolset, expose its tools in tools/list
 //!   unload_toolset(name)      — deactivate a toolset, remove its tools from tools/list
 //!   get_active_toolsets()     — list currently loaded toolsets
+//!
+//! Maintenance:
+//!   reload_server(confirm)    — exec into the binary on disk, keeping the connection
 //!
 //! Observability:
 //!   get_recent_calls(limit?)  — last N tool calls (newest first) with timing + status
@@ -19,7 +22,7 @@ use crate::mcp::protocol::{CallToolResult, McpToolDescription};
 use crate::tools::ToolContext;
 use serde_json::{json, Value};
 
-/// Return the 6 meta-tool MCP descriptions (always in the tools/list response).
+/// Return the 7 meta-tool MCP descriptions (always in the tools/list response).
 pub fn meta_tool_descriptions() -> Vec<McpToolDescription> {
     vec![
         McpToolDescription {
@@ -120,6 +123,26 @@ pub fn meta_tool_descriptions() -> Vec<McpToolDescription> {
                 "required": []
             }),
         },
+        McpToolDescription {
+            name: "reload_server".to_string(),
+            description: "Restart the server in place from the binary on disk, so a freshly built \
+                 Konnect takes effect without restarting the MCP client. The process image \
+                 is replaced (same PID, same stdio pipes), so the connection survives. The \
+                 new binary is verified before the switch, and the call is refused if it \
+                 does not run. Loaded toolsets reset to the starter kit afterwards — reload \
+                 the ones you need. Unix only."
+                .to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "confirm": {
+                        "type": "boolean",
+                        "description": "Must be true. Guards against an accidental reload mid-task."
+                    }
+                },
+                "required": ["confirm"]
+            }),
+        },
     ]
 }
 
@@ -136,7 +159,123 @@ pub async fn handle_meta_tool(
         "get_active_toolsets" => Some(handle_get_active_toolsets(ctx).await),
         "get_recent_calls" => Some(handle_get_recent_calls(args, ctx).await),
         "server_stats" => Some(handle_server_stats(ctx).await),
+        "reload_server" => Some(handle_reload_server(args).await),
         _ => None,
+    }
+}
+
+/// Replace this process with a fresh copy of the binary on disk.
+///
+/// A stdio MCP server cannot meaningfully "restart itself": the client owns the
+/// process, and exiting just drops the transport — the client does not respawn
+/// it mid-session. `exec` sidesteps that. It replaces the process *image* while
+/// keeping the PID and, crucially, the inherited stdin/stdout pipes, so the
+/// client's connection is never broken and it goes on talking to what is now
+/// the new build.
+///
+/// Two things the caller should know:
+///
+/// * Router state does not survive. The new image starts at the starter kit, so
+///   previously loaded toolsets must be loaded again. A call to a tool that was
+///   loaded before returns the usual `toolset_not_loaded` error naming its
+///   toolset, so recovery is one hop.
+/// * The reply is written before the switch. `exec` never returns on success,
+///   so the response has to reach the client first; a short delay covers the
+///   transport's flush.
+async fn handle_reload_server(args: &Value) -> CallToolResult {
+    if !args
+        .get("confirm")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return CallToolResult::error_kind(
+            crate::mcp::error::ToolErrorKind::InvalidArgument {
+                field: "confirm".to_string(),
+                reason: "must be true — reload_server restarts the server in place".to_string(),
+            },
+            "reload_server requires confirm=true.",
+        );
+    }
+
+    #[cfg(not(unix))]
+    {
+        CallToolResult::error_kind(
+            crate::mcp::error::ToolErrorKind::HandlerError {
+                reason: "exec-in-place is Unix only".to_string(),
+            },
+            "reload_server is not supported on this platform: replacing the process image \
+             while keeping the stdio pipes requires exec(), which Windows has no equivalent \
+             for. Restart the MCP client instead.",
+        )
+    }
+
+    #[cfg(unix)]
+    {
+        let exe = match std::env::current_exe() {
+            Ok(p) => p,
+            Err(e) => {
+                return CallToolResult::error_kind(
+                    crate::mcp::error::ToolErrorKind::HandlerError {
+                        reason: format!("cannot determine current executable: {e}"),
+                    },
+                    format!("reload_server could not find its own binary: {e}"),
+                );
+            }
+        };
+
+        // Verify before switching. `exec` is a one-way door: if the binary on
+        // disk is broken — a half-written copy, a build that fails to link, an
+        // unsigned binary macOS will kill — the server is simply gone and the
+        // client has nothing to talk to. Running it once first turns that into
+        // a refused call.
+        match std::process::Command::new(&exe).arg("--version").output() {
+            Ok(out) if out.status.success() => {
+                let version = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                tracing::info!(exe = %exe.display(), %version, "reload_server: exec into new image");
+
+                let exe_for_task = exe.clone();
+                tokio::spawn(async move {
+                    // Let the transport flush this call's reply before the
+                    // process image is replaced.
+                    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                    use std::os::unix::process::CommandExt;
+                    let err = std::process::Command::new(&exe_for_task).exec();
+                    // exec only returns on failure.
+                    tracing::error!(error = %err, "reload_server: exec failed; server still running old image");
+                });
+
+                CallToolResult::json(&json!({
+                    "reloading": true,
+                    "binary": exe.display().to_string(),
+                    "version": version,
+                    "note": "Server is replacing its process image. The connection survives \
+                             (same PID, same pipes). Loaded toolsets reset to the starter kit — \
+                             call load_toolset again for the ones you need.",
+                }))
+            }
+            Ok(out) => CallToolResult::error_kind(
+                crate::mcp::error::ToolErrorKind::HandlerError {
+                    reason: format!("binary exited with {}", out.status),
+                },
+                format!(
+                    "Refusing to reload: {} does not run cleanly (exit {}). \
+                     stderr: {}",
+                    exe.display(),
+                    out.status,
+                    String::from_utf8_lossy(&out.stderr).trim()
+                ),
+            ),
+            Err(e) => CallToolResult::error_kind(
+                crate::mcp::error::ToolErrorKind::HandlerError {
+                    reason: format!("cannot execute binary: {e}"),
+                },
+                format!(
+                    "Refusing to reload: {} could not be executed ({e}). On macOS a freshly \
+                     copied binary needs re-signing: codesign --force -s - <path>",
+                    exe.display()
+                ),
+            ),
+        }
     }
 }
 
@@ -316,4 +455,75 @@ async fn handle_get_active_toolsets(ctx: &std::sync::Arc<ToolContext>) -> CallTo
             .filter_map(|t| t["tool_count"].as_u64())
             .sum::<u64>()
     }))
+}
+
+#[cfg(test)]
+mod meta_tool_tests {
+    use super::*;
+    use crate::mcp::protocol::ToolContent;
+
+    /// The meta-tool count is quoted in DEV.md, README.md and tool-directory.md
+    /// ("187 registered + 6 meta = 193"). Pin it so adding one forces those to
+    /// be updated in the same commit rather than drifting.
+    #[test]
+    fn meta_tool_count_is_pinned() {
+        let names: Vec<String> = meta_tool_descriptions()
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
+        assert_eq!(
+            names.len(),
+            7,
+            "meta-tool count changed — update DEV.md, README.md and tool-directory.md too. \
+             Current: {names:?}"
+        );
+    }
+
+    /// Every meta-tool advertised in tools/list must actually dispatch, or the
+    /// model sees a tool it cannot call.
+    #[tokio::test]
+    async fn every_advertised_meta_tool_dispatches() {
+        use crate::router::ToolRouter;
+        use crate::tools::{ServerConfig, ToolContext};
+        use std::sync::Arc;
+
+        let ctx = Arc::new(ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+            },
+            Arc::new(ToolRouter::new()),
+        ));
+
+        for desc in meta_tool_descriptions() {
+            // reload_server would replace the process; check dispatch only, with
+            // confirm omitted so it returns the InvalidArgument guard instead.
+            let args = json!({});
+            let handled = handle_meta_tool(&desc.name, &args, &ctx).await;
+            assert!(
+                handled.is_some(),
+                "meta-tool '{}' is advertised but not dispatched",
+                desc.name
+            );
+        }
+    }
+
+    /// The guard exists so a stray call cannot restart the server mid-task.
+    #[tokio::test]
+    async fn reload_server_refuses_without_confirm() {
+        let result = handle_reload_server(&json!({})).await;
+        assert!(result.is_error);
+
+        let ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text content");
+        };
+        assert!(
+            text.contains("confirm"),
+            "error should name the missing confirm flag, got: {text}"
+        );
+    }
 }

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -37,6 +37,12 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         tool_count: 19,
     },
     ToolsetMeta {
+        name: "sch_bus",
+        description: "Buses, bus entries, and fanning a group of pins out onto a bus",
+        category: "schematic",
+        tool_count: 4,
+    },
+    ToolsetMeta {
         name: "sch_analysis",
         description: "Net connectivity, pin queries, trace paths, overlap/orphan detection",
         category: "schematic",
@@ -135,6 +141,7 @@ pub fn tools_for(name: &str) -> Option<Vec<ToolDef>> {
         "project" => Some(project::tools()),
         "sch_components" => Some(sch_components::tools()),
         "sch_wiring" => Some(sch_wiring::tools()),
+        "sch_bus" => Some(sch_bus::tools()),
         "sch_analysis" => Some(sch_analysis::tools()),
         "sch_batch" => Some(sch_batch::tools()),
         "sch_export" => Some(sch_export::tools()),

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -20,9 +20,9 @@ pub static STARTER_KIT: &[&str] = &["project", "config"];
 pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
     ToolsetMeta {
         name: "project",
-        description: "Create, open, save, snapshot KiCAD projects, and launch the live schematic viewer",
+        description: "Create, open, save, rename, snapshot KiCAD projects, and launch the live schematic viewer",
         category: "project",
-        tool_count: 6,
+        tool_count: 7,
     },
     ToolsetMeta {
         name: "sch_components",

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -26,9 +26,9 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
     },
     ToolsetMeta {
         name: "sch_components",
-        description: "Add, edit, move, rotate, and delete schematic symbols",
+        description: "Add, edit, move, rotate, and delete schematic symbols, and set the page size",
         category: "schematic",
-        tool_count: 17,
+        tool_count: 18,
     },
     ToolsetMeta {
         name: "sch_wiring",

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -28,7 +28,7 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         name: "sch_components",
         description: "Add, edit, move, rotate, and delete schematic symbols, and set the page size",
         category: "schematic",
-        tool_count: 18,
+        tool_count: 19,
     },
     ToolsetMeta {
         name: "sch_wiring",

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -28,7 +28,7 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         name: "sch_components",
         description: "Add, edit, move, rotate, and delete schematic symbols",
         category: "schematic",
-        tool_count: 17,
+        tool_count: 18,
     },
     ToolsetMeta {
         name: "sch_wiring",

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -34,7 +34,7 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         name: "sch_wiring",
         description: "Wires, net labels, power symbols, junctions, no-connects, pin-to-pin connections",
         category: "schematic",
-        tool_count: 19,
+        tool_count: 20,
     },
     ToolsetMeta {
         name: "sch_analysis",

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -14,6 +14,7 @@ pub mod project;
 pub mod sch_analysis;
 pub mod sch_batch;
 pub mod sch_bridge;
+pub mod sch_bus;
 pub mod sch_components;
 pub mod sch_export;
 pub mod sch_hierarchy;

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -472,7 +472,24 @@ pub(crate) fn positioned_property(
 /// a hand-authored library sets) but never a `lib_id`. Only placed instances
 /// have one, so that's the discriminator.
 pub fn find_symbol_instance_block(content: &str, reference: &str) -> Option<(usize, usize)> {
+    find_all_symbol_instance_blocks(content, reference)
+        .into_iter()
+        .next()
+}
+
+/// Byte ranges of *every* placed `(symbol …)` block whose Reference property is
+/// `reference`, in file order.
+///
+/// A multi-unit part is placed as one instance **per unit**, and every instance
+/// repeats the same reference — a 74HC14 is seven `U6` blocks. Anything the
+/// units share rather than own (a field value, the part's very existence) has to
+/// be applied to all of them: eeschema writes a field edit into every unit, and
+/// deleting one unit's block leaves the rest behind as orphans. Use this rather
+/// than [`find_symbol_instance_block`] wherever the operation is about the
+/// *component*; the singular form is for operations about one placement.
+pub fn find_all_symbol_instance_blocks(content: &str, reference: &str) -> Vec<(usize, usize)> {
     let ref_search = format!(r#"(property "Reference" "{reference}""#);
+    let mut blocks: Vec<(usize, usize)> = Vec::new();
     let mut from = 0usize;
 
     while let Some(rel) = content[from..].find(&ref_search) {
@@ -480,13 +497,16 @@ pub fn find_symbol_instance_block(content: &str, reference: &str) -> Option<(usi
         if let Some((start, end)) =
             konnect_sexp::writer::find_enclosing_block(content, "symbol", ref_pos)
         {
-            if content[start..end].contains("(lib_id ") {
-                return Some((start, end));
+            // Skip lib_symbols definitions: they carry a Reference property of
+            // their own but never a lib_id.
+            if content[start..end].contains("(lib_id ") && !blocks.iter().any(|&(s, _)| s == start)
+            {
+                blocks.push((start, end));
             }
         }
         from = ref_pos + ref_search.len();
     }
-    None
+    blocks
 }
 
 #[cfg(test)]

--- a/crates/konnect-core/src/tools/project.rs
+++ b/crates/konnect-core/src/tools/project.rs
@@ -66,6 +66,25 @@ pub fn tools() -> Vec<ToolDef> {
             |args, ctx| async move { handle_save_project(args, ctx).await }
         ),
         tool!(
+            "rename_project",
+            "Rename a KiCAD project: renames the .kicad_pro/.kicad_sch/.kicad_pcb/.kicad_prl \
+             files and rewrites the internal references that carry the old name. Renaming the \
+             files alone is NOT enough — every symbol instance stores (project \"name\"), and \
+             a mismatch there makes KiCAD treat the design as unannotated, losing every \
+             reference designator. Equivalent to eeschema's File > Save As. Use dry_run first.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "project": { "type": "string", "description": "Path to the existing .kicad_pro file" },
+                    "new_name": { "type": "string", "description": "New project name, without extension" },
+                    "rename_directory": { "type": "boolean", "description": "Also rename the containing folder when it matches the old project name. Default false.", "default": false },
+                    "dry_run": { "type": "boolean", "description": "Report the planned changes without touching anything. Default false.", "default": false }
+                },
+                "required": ["project", "new_name"]
+            }),
+            |args, ctx| async move { handle_rename_project(args, ctx).await }
+        ),
+        tool!(
             "get_project_info",
             "Read project metadata from a .kicad_pro file. Returns the project name, \
              schematic and PCB paths, and last modified times.",
@@ -544,4 +563,151 @@ mod tests {
             Some("file_not_found")
         );
     }
+}
+
+// ─── rename_project ──────────────────────────────────────────────────────────
+
+/// Project files that carry the project name, in the order they are renamed.
+const PROJECT_EXTS: [&str; 4] = ["kicad_pro", "kicad_sch", "kicad_pcb", "kicad_prl"];
+
+async fn handle_rename_project(
+    args: &serde_json::Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let pro_path = get_path(args, "project")?;
+    let new_name = match require_str(args, "new_name") {
+        Ok(v) => v.to_string(),
+        Err(e) => return Ok(e),
+    };
+    let dry_run = args
+        .get("dry_run")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let rename_dir = args
+        .get("rename_directory")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
+    if !pro_path.exists() {
+        return Ok(CallToolResult::error_kind(
+            crate::mcp::error::ToolErrorKind::FileNotFound {
+                path: pro_path.display().to_string(),
+            },
+            format!("Project file not found: {}", pro_path.display()),
+        ));
+    }
+    let Some(dir) = pro_path.parent().map(std::path::Path::to_path_buf) else {
+        return Ok(CallToolResult::error(
+            "project path has no parent directory",
+        ));
+    };
+    let Some(old_name) = pro_path.file_stem().and_then(|s| s.to_str()) else {
+        return Ok(CallToolResult::error("project path has no file stem"));
+    };
+    let old_name = old_name.to_string();
+
+    if new_name == old_name {
+        return Ok(CallToolResult::json(&json!({
+            "renamed": false, "note": "new_name matches the current name"
+        })));
+    }
+    // A name with a path separator would move the project, not rename it.
+    if new_name.contains('/') || new_name.contains('\\') {
+        return Ok(CallToolResult::error_kind(
+            crate::mcp::error::ToolErrorKind::InvalidArgument {
+                field: "new_name".to_string(),
+                reason: "must be a bare name, not a path".to_string(),
+            },
+            "new_name must not contain a path separator.",
+        ));
+    }
+
+    let mut planned_files = Vec::new();
+    let mut collisions = Vec::new();
+    for ext in PROJECT_EXTS {
+        let from = dir.join(format!("{old_name}.{ext}"));
+        if !from.exists() {
+            continue;
+        }
+        let to = dir.join(format!("{new_name}.{ext}"));
+        if to.exists() {
+            collisions.push(to.display().to_string());
+        }
+        planned_files.push((from, to));
+    }
+    if !collisions.is_empty() {
+        return Ok(CallToolResult::error(format!(
+            "Refusing to rename: these target files already exist: {}",
+            collisions.join(", ")
+        )));
+    }
+
+    // Rewriting content is what keeps annotations attached: each symbol
+    // instance in the schematic stores `(project "NAME"`, and the .kicad_pro
+    // and .kicad_prl embed their own filenames.
+    let mut rewritten = Vec::new();
+    if !dry_run {
+        for (from, to) in &planned_files {
+            std::fs::rename(from, to)?;
+        }
+        for (_, to) in &planned_files {
+            let text = std::fs::read_to_string(to)?;
+            if text.contains(&old_name) {
+                let hits = text.matches(&old_name).count();
+                let updated = text.replace(&old_name, &new_name);
+                konnect_sexp::writer::write_atomic(to, &updated)?;
+                rewritten.push(json!({
+                    "file": to.file_name().and_then(|s| s.to_str()).unwrap_or_default(),
+                    "references_updated": hits,
+                }));
+            }
+        }
+    } else {
+        for (from, to) in &planned_files {
+            let text = std::fs::read_to_string(from).unwrap_or_default();
+            rewritten.push(json!({
+                "file": to.file_name().and_then(|s| s.to_str()).unwrap_or_default(),
+                "references_updated": text.matches(&old_name).count(),
+            }));
+        }
+    }
+
+    // The auto-backup folder is named after the project too.
+    let backups_from = dir.join(format!("{old_name}-backups"));
+    let mut backups = serde_json::Value::Null;
+    if backups_from.is_dir() {
+        let backups_to = dir.join(format!("{new_name}-backups"));
+        if !dry_run && !backups_to.exists() {
+            std::fs::rename(&backups_from, &backups_to)?;
+        }
+        backups = json!(backups_to.file_name().and_then(|s| s.to_str()));
+    }
+
+    let mut directory = serde_json::Value::Null;
+    if rename_dir && dir.file_name().and_then(|s| s.to_str()) == Some(old_name.as_str()) {
+        if let Some(parent) = dir.parent() {
+            let new_dir = parent.join(&new_name);
+            if !new_dir.exists() {
+                if !dry_run {
+                    std::fs::rename(&dir, &new_dir)?;
+                }
+                directory = json!(new_dir.display().to_string());
+            }
+        }
+    }
+
+    Ok(CallToolResult::json(&json!({
+        "dry_run": dry_run,
+        "old_name": old_name,
+        "new_name": new_name,
+        "files": planned_files.iter()
+            .map(|(f, t)| json!({
+                "from": f.file_name().and_then(|s| s.to_str()),
+                "to": t.file_name().and_then(|s| s.to_str())
+            }))
+            .collect::<Vec<_>>(),
+        "content_rewrites": rewritten,
+        "backups_folder": backups,
+        "directory": directory,
+    })))
 }

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -934,19 +934,28 @@ async fn handle_add_schematic_text(
     let rotation = args["rotation"].as_f64().unwrap_or(0.0);
     let uuid = new_uuid();
 
-    // Escape quotes in text content
-    let escaped = text.replace('\\', "\\\\").replace('"', "\\\"");
+    // Escape for a KiCad quoted string. Newlines and tabs must become their
+    // two-character escapes: KiCad's reader rejects a literal newline inside
+    // quotes, and it fails at the *file* level — a multi-line annotation makes
+    // the whole schematic unloadable with only "Failed to load schematic".
+    let escaped = text
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\r', "")
+        .replace('\n', "\\n")
+        .replace('\t', "\\t");
 
     let text_sexp = format!(
         "\n  (text \"{escaped}\"\n    (at {x} {y} {rotation})\n    \
          (effects (font (size {size} {size})))\n    (uuid \"{uuid}\")\n  )"
     );
 
+    // Before the first symbol instance, not at the end of the file: KiCad 10
+    // requires symbol instances to come last and refuses to load a schematic
+    // with a `(text …)` after them.
     let content = read_consistent(&sch_path)?;
     let expected = content.clone();
-    let close_pos = content.rfind(')').unwrap_or(content.len());
-    let edits = vec![SexpEdit::insert(close_pos, text_sexp)];
-    let new_content = apply_edits(content, edits);
+    let new_content = crate::tools::sch_wiring::insert_before_close(&content, &text_sexp);
     write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
 
     Ok(CallToolResult::json(&json!({
@@ -1564,5 +1573,81 @@ mod midwire_pin_tests {
                 "with_junction={with_junction}: {body}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod add_text_placement_tests {
+    use super::tools;
+    use crate::tools::ToolContext;
+    use serde_json::json;
+    use std::io::Write;
+    use std::sync::Arc;
+
+    const SCH: &str = "(kicad_sch\n\t(version 20260306)\n\t(generator \"eeschema\")\n\t(uuid \"root\")\n\t(lib_symbols\n\t\t(symbol \"Device:R\"\n\t\t\t(property \"Reference\" \"R\")\n\t\t)\n\t)\n\t(symbol\n\t\t(lib_id \"Device:R\")\n\t\t(at 100 80 0)\n\t\t(unit 1)\n\t\t(uuid \"u1\")\n\t\t(property \"Reference\" \"R1\"\n\t\t\t(at 100 75 0)\n\t\t)\n\t)\n\t(sheet_instances\n\t\t(path \"/\" (page \"1\"))\n\t)\n)\n";
+
+    async fn add_text(text: &str) -> String {
+        let mut f = tempfile::NamedTempFile::with_suffix(".kicad_sch").unwrap();
+        f.write_all(SCH.as_bytes()).unwrap();
+        f.flush().unwrap();
+
+        let def = tools()
+            .into_iter()
+            .find(|t| t.name == "add_schematic_text")
+            .unwrap();
+        let cfg = crate::tools::ServerConfig {
+            kicad_cli: String::new(),
+            kicad_binary: String::new(),
+            ipc_address: String::new(),
+            project_dir: None,
+            jlcpcb_db_path: None,
+            auto_load_toolsets: false,
+        };
+        let router = Arc::new(crate::router::ToolRouter::new());
+        let ctx = Arc::new(ToolContext::new(cfg, router));
+        let args = json!({
+            "schematic": f.path().to_str().unwrap(),
+            "text": text, "x": 30.0, "y": 114.3
+        });
+        (def.handler)(&args, ctx).await.unwrap();
+        std::fs::read_to_string(f.path()).unwrap()
+    }
+
+    /// The regression: the text was spliced in at the file's last `)`, which
+    /// puts it *after* the symbol instances and `sheet_instances`. KiCad 10
+    /// requires instances last and rejects the whole file — "Failed to load
+    /// schematic", with no hint as to which element is misplaced.
+    #[tokio::test]
+    async fn text_goes_before_the_symbol_instances() {
+        let out = add_text("hello").await;
+        let text_at = out.find("(text \"hello\"").expect("text written");
+        let sym_at = out.find("(symbol\n\t\t(lib_id").expect("instance present");
+        let sheets_at = out
+            .find("(sheet_instances")
+            .expect("sheet_instances present");
+        assert!(
+            text_at < sym_at && text_at < sheets_at,
+            "text must precede symbol instances (text {text_at}, symbol {sym_at})"
+        );
+        // and it must land after lib_symbols, not inside it
+        assert!(text_at > out.find("(lib_symbols").unwrap());
+    }
+
+    /// The other half of the same incident: the content was written with the
+    /// newline as a literal byte inside the quoted string. KiCad wants the
+    /// two-character escape and refuses the file otherwise.
+    #[tokio::test]
+    async fn multiline_text_escapes_its_newlines() {
+        let out = add_text("line one\nline two").await;
+        let text_at = out
+            .find(r#"(text "line one\nline two""#)
+            .expect("newline must be written as an escape, not a raw byte");
+        assert!(text_at < out.find("(symbol\n\t\t(lib_id").unwrap());
+    }
+
+    #[tokio::test]
+    async fn quotes_backslashes_and_tabs_are_escaped() {
+        let out = add_text("a \"b\" c\\d\te").await;
+        assert!(out.contains(r#"(text "a \"b\" c\\d\te""#), "got:\n{out}");
     }
 }

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -15,8 +15,8 @@ use konnect_schematic_editor as cse;
 use konnect_sexp::{
     geometry::{point_on_segment, points_coincident, snap_point},
     schematic::{
-        extract_labels, extract_lib_pins, extract_symbol_instances, extract_wires,
-        format_net_label, format_wire, pin_endpoint, read_schematic,
+        extract_labels, extract_lib_pins, extract_lib_pins_for_unit, extract_symbol_instances,
+        extract_wires, format_net_label, format_wire, pin_endpoint, read_schematic,
     },
     writer::{
         apply_edits, find_block_with_leading_whitespace, find_enclosing_direct_child_block,
@@ -367,20 +367,25 @@ async fn handle_batch_connect_to_net(
             }
         };
 
-        let inst = match instances.iter().find(|i| i.reference == reference) {
-            Some(i) => i,
-            None => {
-                errors.push(format!("Component '{}' not found", reference));
-                continue;
-            }
-        };
-
-        let lib_sym = lib_syms
+        // A multi-unit symbol is placed as one instance PER UNIT, all sharing
+        // the reference. The requested pin lives in exactly one of them and
+        // must be transformed by *that* instance's placement. Taking the first
+        // instance and transforming every pin by it puts the label on unit 1's
+        // pin instead — silently shorting two nets together, with no error.
+        let candidates: Vec<_> = instances
             .iter()
-            .find(|n| n.get(1).and_then(|c| c.as_str()) == Some(&inst.lib_id));
+            .filter(|i| i.reference == reference)
+            .collect();
+        if candidates.is_empty() {
+            errors.push(format!("Component '{}' not found", reference));
+            continue;
+        }
 
-        let pin_ep = lib_sym.and_then(|sym| {
-            extract_lib_pins(sym)
+        let pin_ep = candidates.iter().find_map(|inst| {
+            let sym = lib_syms
+                .iter()
+                .find(|n| n.get(1).and_then(|c| c.as_str()) == Some(&inst.lib_id))?;
+            extract_lib_pins_for_unit(sym, inst.unit)
                 .into_iter()
                 .find(|p| p.number == pin_number)
                 .map(|p| pin_endpoint(&p, inst.pin_transform()))
@@ -1564,5 +1569,106 @@ mod midwire_pin_tests {
                 "with_junction={with_junction}: {body}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod multi_unit_pin_tests {
+    use crate::tools::sch_batch::tools;
+    use konnect_sexp::schematic::{
+        extract_lib_pins_for_unit, extract_symbol_instances, pin_endpoint, read_schematic,
+    };
+    use std::io::Write;
+
+    /// Two units of one symbol, placed 15.24mm apart. Unit 1 owns pin 1, unit 2
+    /// owns pin 3; both sit at local x = -7.62 in their own unit's drawing.
+    const SCH: &str = r#"(kicad_sch
+	(version 20241209)
+	(lib_symbols
+		(symbol "74xx:74HC14"
+			(symbol "74HC14_1_1"
+				(pin input line (at -7.62 0 0) (length 2.54)
+					(name "A" (effects (font (size 1.27 1.27))))
+					(number "1" (effects (font (size 1.27 1.27))))
+				)
+			)
+			(symbol "74HC14_2_1"
+				(pin input line (at -7.62 0 0) (length 2.54)
+					(name "A" (effects (font (size 1.27 1.27))))
+					(number "3" (effects (font (size 1.27 1.27))))
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "74xx:74HC14")
+		(at 100 100 0)
+		(unit 1)
+		(property "Reference" "U1" (at 100 100 0))
+		(property "Value" "74HC14" (at 100 100 0))
+	)
+	(symbol
+		(lib_id "74xx:74HC14")
+		(at 100 115.24 0)
+		(unit 2)
+		(property "Reference" "U1" (at 100 115.24 0))
+		(property "Value" "74HC14" (at 100 115.24 0))
+	)
+)
+"#;
+
+    /// The regression: resolving a pin used the FIRST instance with a matching
+    /// reference, so every pin of a multi-unit part was transformed by unit 1's
+    /// placement. Two nets then landed on one coordinate and were silently
+    /// shorted — no error, no warning.
+    #[test]
+    fn each_unit_resolves_its_own_pin_position() {
+        let mut f = tempfile::NamedTempFile::with_suffix(".kicad_sch").unwrap();
+        f.write_all(SCH.as_bytes()).unwrap();
+        f.flush().unwrap();
+
+        let (_c, tree) = read_schematic(f.path()).unwrap();
+        let instances = extract_symbol_instances(&tree);
+        let lib_syms = tree
+            .find("lib_symbols")
+            .map(|n| n.find_all("symbol"))
+            .unwrap_or_default();
+
+        let resolve = |number: &str| -> Option<(f64, f64)> {
+            instances
+                .iter()
+                .filter(|i| i.reference == "U1")
+                .find_map(|inst| {
+                    let sym = lib_syms
+                        .iter()
+                        .find(|n| n.get(1).and_then(|c| c.as_str()) == Some(&inst.lib_id))?;
+                    extract_lib_pins_for_unit(sym, inst.unit)
+                        .into_iter()
+                        .find(|p| p.number == number)
+                        .map(|p| pin_endpoint(&p, inst.pin_transform()))
+                })
+        };
+
+        let p1 = resolve("1").expect("unit 1 pin 1");
+        let p3 = resolve("3").expect("unit 2 pin 3");
+
+        assert!(
+            (p1.1 - p3.1).abs() > 1.0,
+            "unit 1 and unit 2 pins must not land on the same point \
+             (got {p1:?} and {p3:?}) — that is the short this guards against"
+        );
+        assert!(
+            (p1.1 - 100.0).abs() < 0.01,
+            "unit 1 pin should sit at y=100, got {p1:?}"
+        );
+        assert!(
+            (p3.1 - 115.24).abs() < 0.01,
+            "unit 2 pin should sit at y=115.24, got {p3:?}"
+        );
+    }
+
+    #[test]
+    fn batch_connect_to_net_is_registered() {
+        assert!(tools().iter().any(|t| t.name == "batch_connect_to_net"));
     }
 }

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -8,7 +8,7 @@
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
 use crate::tools::{
-    find_symbol_instance_block, get_path, opt_str, project_name_for, require_f64, require_str,
+    find_all_symbol_instance_blocks, get_path, opt_str, project_name_for, require_f64, require_str,
     ToolDef,
 };
 use konnect_schematic_editor as cse;
@@ -300,28 +300,39 @@ pub fn tools() -> Vec<ToolDef> {
 
 // ─── Private helpers ──────────────────────────────────────────────────────────
 
-/// Find the `(symbol ...)` block for a reference designator, plus its leading
-/// whitespace so deletion leaves clean formatting.
+/// Find every `(symbol ...)` block for a reference designator, each with its
+/// leading whitespace so deletion leaves clean formatting.
+///
+/// One entry per unit: deleting a multi-unit part means deleting all of them.
 /// Returns `(block_start, block_end)` byte offsets in `content`.
-fn find_symbol_block(content: &str, reference: &str) -> Option<(usize, usize)> {
-    let (sym_start, _) = find_symbol_instance_block(content, reference)?;
-    find_block_with_leading_whitespace(content, sym_start)
+fn find_symbol_blocks(content: &str, reference: &str) -> Vec<(usize, usize)> {
+    find_all_symbol_instance_blocks(content, reference)
+        .into_iter()
+        .filter_map(|(sym_start, _)| find_block_with_leading_whitespace(content, sym_start))
+        .collect()
 }
 
 /// Return `(val_start, val_end)` byte offsets in `content` for the *value* portion
-/// of a `(property "FieldName" "VALUE" ...)` node within the symbol identified by
+/// of a `(property "FieldName" "VALUE" ...)` node, once per placed instance of
 /// `reference`. Only the bytes inside the opening quote are included (i.e. the
 /// replacement does NOT need to include surrounding quotes).
-fn field_value_range(content: &str, reference: &str, field: &str) -> Option<(usize, usize)> {
-    let (sym_start, sym_end) = find_symbol_instance_block(content, reference)?;
-    let sym_block = &content[sym_start..sym_end];
+///
+/// Multi-unit parts repeat their fields in every unit's block and KiCad expects
+/// those copies to agree, so a field edit has to rewrite all of them.
+fn field_value_ranges(content: &str, reference: &str, field: &str) -> Vec<(usize, usize)> {
+    find_all_symbol_instance_blocks(content, reference)
+        .into_iter()
+        .filter_map(|(sym_start, sym_end)| {
+            let sym_block = &content[sym_start..sym_end];
 
-    let field_search = format!(r#"(property "{field}" ""#);
-    let field_rel = sym_block.find(&field_search)?;
-    let val_start = sym_start + field_rel + field_search.len();
-    // find the closing quote of the current value
-    let val_end = val_start + content[val_start..].find('"')?;
-    Some((val_start, val_end))
+            let field_search = format!(r#"(property "{field}" ""#);
+            let field_rel = sym_block.find(&field_search)?;
+            let val_start = sym_start + field_rel + field_search.len();
+            // find the closing quote of the current value
+            let val_end = val_start + content[val_start..].find('"')?;
+            Some((val_start, val_end))
+        })
+        .collect()
 }
 
 // ─── Handlers ─────────────────────────────────────────────────────────────────
@@ -612,14 +623,21 @@ async fn handle_batch_delete(
                 Some(r) => r,
                 None => continue,
             };
-            match find_symbol_block(&content, reference) {
-                Some((del_start, del_end)) => {
-                    if delete_ranges.insert((del_start, del_end)) {
-                        edits.push(SexpEdit::delete(del_start, del_end));
-                        deleted.push(reference.to_string());
-                    }
+            let blocks = find_symbol_blocks(&content, reference);
+            if blocks.is_empty() {
+                errors.push(format!("Component '{}' not found", reference));
+                continue;
+            }
+            // Every unit of a multi-unit part, or the whole component is not gone.
+            let mut any = false;
+            for (del_start, del_end) in blocks {
+                if delete_ranges.insert((del_start, del_end)) {
+                    edits.push(SexpEdit::delete(del_start, del_end));
+                    any = true;
                 }
-                None => errors.push(format!("Component '{}' not found", reference)),
+            }
+            if any {
+                deleted.push(reference.to_string());
             }
         }
     }
@@ -690,55 +708,64 @@ async fn handle_bulk_move(
             None => continue,
         };
 
-        // Locate symbol block for this reference
-        let (sym_start, sym_end) = match find_symbol_instance_block(&content, reference) {
-            Some(r) => r,
-            None => {
-                errors.push(format!("'{}' not found", reference));
-                continue;
-            }
-        };
+        // Every placement of this reference — a multi-unit part has one block
+        // per unit, and shifting only the first would tear the part apart.
+        let blocks = find_all_symbol_instance_blocks(&content, reference);
+        if blocks.is_empty() {
+            errors.push(format!("'{}' not found", reference));
+            continue;
+        }
 
-        // Find first (at X Y [ROT]) inside this symbol block
-        let sym_block = &content[sym_start..sym_end];
-        let at_pat = "(at ";
-        let at_rel = match sym_block.find(at_pat) {
-            Some(r) => r,
-            None => {
-                errors.push(format!("No (at) in symbol '{}'", reference));
-                continue;
-            }
-        };
-        let at_abs = sym_start + at_rel + at_pat.len();
-        let close_rel = sym_block[at_rel..].find(')').unwrap_or(0);
-        let at_end = sym_start + at_rel + close_rel;
+        let mut placements: Vec<serde_json::Value> = Vec::new();
+        for (sym_start, sym_end) in blocks {
+            // Find first (at X Y [ROT]) inside this symbol block
+            let sym_block = &content[sym_start..sym_end];
+            let at_pat = "(at ";
+            let at_rel = match sym_block.find(at_pat) {
+                Some(r) => r,
+                None => {
+                    errors.push(format!("No (at) in symbol '{}'", reference));
+                    continue;
+                }
+            };
+            let at_abs = sym_start + at_rel + at_pat.len();
+            let close_rel = sym_block[at_rel..].find(')').unwrap_or(0);
+            let at_end = sym_start + at_rel + close_rel;
 
-        let at_str = &content[at_abs..at_end];
-        let parts: Vec<&str> = at_str.split_whitespace().collect();
-        let x = parts
-            .first()
-            .and_then(|s| s.parse::<f64>().ok())
-            .unwrap_or(0.0);
-        let y = parts
-            .get(1)
-            .and_then(|s| s.parse::<f64>().ok())
-            .unwrap_or(0.0);
-        let rot = parts
-            .get(2)
-            .and_then(|s| s.parse::<f64>().ok())
-            .unwrap_or(0.0);
+            let at_str = &content[at_abs..at_end];
+            let parts: Vec<&str> = at_str.split_whitespace().collect();
+            let x = parts
+                .first()
+                .and_then(|s| s.parse::<f64>().ok())
+                .unwrap_or(0.0);
+            let y = parts
+                .get(1)
+                .and_then(|s| s.parse::<f64>().ok())
+                .unwrap_or(0.0);
+            let rot = parts
+                .get(2)
+                .and_then(|s| s.parse::<f64>().ok())
+                .unwrap_or(0.0);
 
-        let (new_x, new_y) = snap_point(x + dx, y + dy, 1.27);
-        edits.push(SexpEdit::replace(
-            at_abs,
-            at_end,
-            format!("{new_x} {new_y} {rot}"),
-        ));
-        moved.push(json!({
-            "reference": reference,
-            "old_x": x, "old_y": y,
-            "new_x": new_x, "new_y": new_y
-        }));
+            let (new_x, new_y) = snap_point(x + dx, y + dy, 1.27);
+            edits.push(SexpEdit::replace(
+                at_abs,
+                at_end,
+                format!("{new_x} {new_y} {rot}"),
+            ));
+            placements.push(json!({
+                "old_x": x, "old_y": y,
+                "new_x": new_x, "new_y": new_y
+            }));
+        }
+
+        if !placements.is_empty() {
+            moved.push(json!({
+                "reference": reference,
+                "units": placements.len(),
+                "placements": placements
+            }));
+        }
     }
 
     let new_content = apply_edits(content, edits);
@@ -779,35 +806,35 @@ async fn handle_batch_edit(
 
         let mut component_changes: Vec<String> = Vec::new();
 
-        // Standard fields
-        for (field, key) in &[("Value", "value"), ("Footprint", "footprint")] {
-            if let Some(new_val) = edit_spec[key].as_str() {
-                match field_value_range(&content, reference, field) {
-                    Some((start, end)) => {
-                        file_edits.push(SexpEdit::replace(start, end, new_val.to_string()));
-                        component_changes.push(format!("{} → {}", field, new_val));
-                    }
-                    None => errors.push(format!("Field '{}' not found on '{}'", field, reference)),
-                }
-            }
-        }
+        // Standard fields, then arbitrary extra fields from the "fields" object.
+        // Each is rewritten in every unit's block, which is where a multi-unit
+        // part keeps its copies of the value.
+        let extra = edit_spec["fields"].as_object();
+        let specs = [("Value", "value"), ("Footprint", "footprint")]
+            .into_iter()
+            .filter_map(|(field, key)| Some((field.to_string(), edit_spec[key].as_str()?)))
+            .chain(
+                extra
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|(name, val)| Some((name.clone(), val.as_str()?))),
+            );
 
-        // Arbitrary extra fields from "fields" object
-        if let Some(fields_obj) = edit_spec["fields"].as_object() {
-            for (field_name, field_val) in fields_obj {
-                if let Some(new_val) = field_val.as_str() {
-                    match field_value_range(&content, reference, field_name) {
-                        Some((start, end)) => {
-                            file_edits.push(SexpEdit::replace(start, end, new_val.to_string()));
-                            component_changes.push(format!("{} → {}", field_name, new_val));
-                        }
-                        None => errors.push(format!(
-                            "Field '{}' not found on '{}'",
-                            field_name, reference
-                        )),
-                    }
-                }
+        for (field, new_val) in specs {
+            let ranges = field_value_ranges(&content, reference, &field);
+            if ranges.is_empty() {
+                errors.push(format!("Field '{}' not found on '{}'", field, reference));
+                continue;
             }
+            let units = ranges.len();
+            for (start, end) in ranges {
+                file_edits.push(SexpEdit::replace(start, end, new_val.to_string()));
+            }
+            component_changes.push(if units > 1 {
+                format!("{} → {} ({} units)", field, new_val, units)
+            } else {
+                format!("{} → {}", field, new_val)
+            });
         }
 
         if !component_changes.is_empty() {
@@ -849,13 +876,16 @@ async fn handle_batch_delete_components(
             Some(r) => r,
             None => continue,
         };
-        match find_symbol_block(&content, reference) {
-            Some((del_start, del_end)) => {
-                edits.push(SexpEdit::delete(del_start, del_end));
-                deleted.push(reference.to_string());
-            }
-            None => errors.push(format!("Component '{}' not found", reference)),
+        let blocks = find_symbol_blocks(&content, reference);
+        if blocks.is_empty() {
+            errors.push(format!("Component '{}' not found", reference));
+            continue;
         }
+        // Every unit of a multi-unit part, or the whole component is not gone.
+        for (del_start, del_end) in blocks {
+            edits.push(SexpEdit::delete(del_start, del_end));
+        }
+        deleted.push(reference.to_string());
     }
 
     let new_content = apply_edits(content, edits);
@@ -1670,5 +1700,129 @@ mod multi_unit_pin_tests {
     #[test]
     fn batch_connect_to_net_is_registered() {
         assert!(tools().iter().any(|t| t.name == "batch_connect_to_net"));
+    }
+}
+
+#[cfg(test)]
+mod multi_unit_field_tests {
+    use super::{field_value_ranges, find_symbol_blocks};
+    use konnect_sexp::writer::{apply_edits, SexpEdit};
+
+    /// A 3-unit part plus an unrelated single-unit part. Every unit repeats the
+    /// reference and carries its own copy of the shared fields, which is how
+    /// eeschema writes them.
+    const SCH: &str = r#"(kicad_sch
+	(version 20241209)
+	(lib_symbols
+		(symbol "74xx:74HC14"
+			(property "Reference" "U")
+			(property "Footprint" "")
+		)
+	)
+	(symbol
+		(lib_id "74xx:74HC14")
+		(at 100 100 0)
+		(unit 1)
+		(property "Reference" "U6" (at 100 100 0))
+		(property "Value" "74HC14" (at 100 100 0))
+		(property "Footprint" "" (at 100 100 0))
+	)
+	(symbol
+		(lib_id "74xx:74HC14")
+		(at 100 115.24 0)
+		(unit 2)
+		(property "Reference" "U6" (at 100 115.24 0))
+		(property "Value" "74HC14" (at 100 115.24 0))
+		(property "Footprint" "" (at 100 115.24 0))
+	)
+	(symbol
+		(lib_id "74xx:74HC14")
+		(at 100 130.48 0)
+		(unit 7)
+		(property "Reference" "U6" (at 100 130.48 0))
+		(property "Value" "74HC14" (at 100 130.48 0))
+		(property "Footprint" "" (at 100 130.48 0))
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 200 100 0)
+		(unit 1)
+		(property "Reference" "R1" (at 200 100 0))
+		(property "Value" "10k" (at 200 100 0))
+		(property "Footprint" "" (at 200 100 0))
+	)
+)
+"#;
+
+    /// The regression: field lookup stopped at the first instance, so assigning
+    /// a footprint to a multi-unit part left units 2..n blank. KiCad then had
+    /// one part claiming two different footprints.
+    #[test]
+    fn field_edit_reaches_every_unit() {
+        let ranges = field_value_ranges(SCH, "U6", "Footprint");
+        assert_eq!(
+            ranges.len(),
+            3,
+            "expected one Footprint per unit: {ranges:?}"
+        );
+
+        let edits = ranges
+            .iter()
+            .map(|&(s, e)| SexpEdit::replace(s, e, "Package_SO:SOIC-14".to_string()))
+            .collect();
+        let out = apply_edits(SCH.to_string(), edits);
+        assert_eq!(
+            out.matches(r#"(property "Footprint" "Package_SO:SOIC-14""#)
+                .count(),
+            3
+        );
+        // The neighbouring single-unit part must be untouched.
+        assert!(out.contains(r#"(property "Reference" "R1" (at 200 100 0))"#));
+        assert_eq!(
+            out.matches(r#"(property "Footprint" "" (at 200"#).count(),
+            1
+        );
+    }
+
+    #[test]
+    fn single_unit_part_still_edits_once() {
+        let ranges = field_value_ranges(SCH, "R1", "Value");
+        assert_eq!(ranges.len(), 1);
+    }
+
+    #[test]
+    fn missing_field_yields_no_ranges() {
+        assert!(field_value_ranges(SCH, "U6", "Datasheet").is_empty());
+        assert!(field_value_ranges(SCH, "U99", "Value").is_empty());
+    }
+
+    /// Deleting one unit's block used to leave the other six behind as orphans
+    /// referencing a component the caller believes is gone.
+    #[test]
+    fn delete_removes_every_unit() {
+        let blocks = find_symbol_blocks(SCH, "U6");
+        assert_eq!(blocks.len(), 3, "expected one block per unit: {blocks:?}");
+
+        let edits = blocks
+            .iter()
+            .map(|&(s, e)| SexpEdit::delete(s, e))
+            .collect();
+        let out = apply_edits(SCH.to_string(), edits);
+        assert!(
+            !out.contains(r#""Reference" "U6""#),
+            "no U6 unit should survive:\n{out}"
+        );
+        assert!(out.contains(r#""Reference" "R1""#), "R1 must survive");
+        // The lib_symbols definition is not an instance and must stay.
+        assert!(out.contains(r#"(symbol "74xx:74HC14""#));
+    }
+
+    /// The blocks must not overlap, or apply_edits would splice the file wrong.
+    #[test]
+    fn unit_blocks_are_disjoint_and_ordered() {
+        let blocks = find_symbol_blocks(SCH, "U6");
+        for w in blocks.windows(2) {
+            assert!(w[0].1 <= w[1].0, "blocks overlap: {:?} {:?}", w[0], w[1]);
+        }
     }
 }

--- a/crates/konnect-core/src/tools/sch_bus.rs
+++ b/crates/konnect-core/src/tools/sch_bus.rs
@@ -1,0 +1,445 @@
+//! `sch_bus` toolset — buses, bus entries, and pin-to-bus fan-out.
+//!
+//! A KiCad bus is three things drawn together, and all three have to agree or
+//! the bus carries nothing:
+//!
+//!   1. the **bus segment** itself — geometrically a wire, distinguished only
+//!      by the node name and by the label attached to it;
+//!   2. a **bus entry** per member — the 45° tick that bridges the gap between
+//!      a wire and the bus. It is not decoration: without it the wire and the
+//!      bus do not touch, because they are deliberately drawn apart;
+//!   3. a **label on every wire stub**, naming the member signal, plus a label
+//!      on the bus naming the group.
+//!
+//! Membership is by *name*, never by geometry: a stub joins the bus because its
+//! label matches a member of the bus label, so `connect_pins_to_bus` writes all
+//! three parts from one call rather than leaving the caller to line them up.
+//!
+//! Bus label syntax, both accepted by `add_schematic_net_label`:
+//!   - vector  `X_DIG[1..6]`   — members `X_DIG1` … `X_DIG6`
+//!   - group   `{A B C}`       — members named individually
+
+use crate::mcp::protocol::CallToolResult;
+use crate::tool;
+use crate::tools::{get_path, opt_f64, opt_str, require_f64, ToolContext, ToolDef};
+use konnect_sexp::{
+    parser::parse_sexp,
+    schematic::{
+        extract_lib_pins_for_unit, extract_symbol_instances, format_bus, format_bus_entry,
+        format_net_label, format_wire, pin_endpoint, BusEntryDirection,
+    },
+    writer::write_atomic,
+};
+use serde_json::json;
+
+pub fn tools() -> Vec<ToolDef> {
+    vec![
+        tool!(
+            "add_bus",
+            "Add a bus segment between two points. Geometrically a wire, but KiCad treats it as a \
+             bus: it carries the members named by the bus label attached to it (vector \
+             'NAME[1..6]' or group '{A B C}'), and ordinary wires join it only through a bus entry.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "schematic": { "type": "string", "description": "Path to .kicad_sch file" },
+                    "x1": { "type": "number" },
+                    "y1": { "type": "number" },
+                    "x2": { "type": "number" },
+                    "y2": { "type": "number" }
+                },
+                "required": ["schematic", "x1", "y1", "x2", "y2"]
+            }),
+            |args, ctx| async move { handle_add_bus(args, ctx).await }
+        ),
+        tool!(
+            "batch_add_bus",
+            "Add multiple bus segments in a single file read/write cycle.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "schematic": { "type": "string", "description": "Path to .kicad_sch file" },
+                    "buses": {
+                        "type": "array",
+                        "description": "List of {x1,y1,x2,y2} segments",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "x1": { "type": "number" }, "y1": { "type": "number" },
+                                "x2": { "type": "number" }, "y2": { "type": "number" }
+                            },
+                            "required": ["x1", "y1", "x2", "y2"]
+                        }
+                    }
+                },
+                "required": ["schematic", "buses"]
+            }),
+            |args, ctx| async move { handle_batch_add_bus(args, ctx).await }
+        ),
+        tool!(
+            "add_bus_entry",
+            "Add a bus entry — the 45-degree tick that connects a wire to a bus. Required: a wire \
+             and a bus that merely touch are NOT connected without one. 'at' is the end on the \
+             wire side; 'direction' says which way the tick runs to reach the bus.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "schematic": { "type": "string", "description": "Path to .kicad_sch file" },
+                    "x": { "type": "number", "description": "X of the wire-side end" },
+                    "y": { "type": "number", "description": "Y of the wire-side end" },
+                    "direction": {
+                        "type": "string",
+                        "description": "Which way the tick runs from 'at' to the bus",
+                        "enum": ["down_right", "down_left", "up_right", "up_left"],
+                        "default": "down_right"
+                    }
+                },
+                "required": ["schematic", "x", "y"]
+            }),
+            |args, ctx| async move { handle_add_bus_entry(args, ctx).await }
+        ),
+        tool!(
+            "connect_pins_to_bus",
+            "Fan a set of pins out onto a bus: for each pin, a wire stub from the pin to the bus \
+             entry, the bus entry itself, and a net label naming the member. This is the whole \
+             connection — a stub without a label joins nothing, since bus membership is by name. \
+             Give the bus's fixed coordinate ('bus_y' for a horizontal bus, 'bus_x' for a \
+             vertical one); the bus segment itself is drawn separately with add_bus.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "schematic": { "type": "string", "description": "Path to .kicad_sch file" },
+                    "bus_y": { "type": "number", "description": "Y of a horizontal bus (omit if vertical)" },
+                    "bus_x": { "type": "number", "description": "X of a vertical bus (omit if horizontal)" },
+                    "connections": {
+                        "type": "array",
+                        "description": "List of {reference, pin_number, net} — net is the bus member name",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "reference": { "type": "string" },
+                                "pin_number": { "type": "string" },
+                                "net": { "type": "string" }
+                            },
+                            "required": ["reference", "pin_number", "net"]
+                        }
+                    },
+                },
+                "required": ["schematic", "connections"]
+            }),
+            |args, ctx| async move { handle_connect_pins_to_bus(args, ctx).await }
+        ),
+    ]
+}
+
+// ─── Handlers ─────────────────────────────────────────────────────────────────
+
+async fn handle_add_bus(
+    args: &serde_json::Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let sch_path = get_path(args, "schematic")?;
+    let (x1, y1, x2, y2) = match read_xy_pair(args) {
+        Ok(v) => v,
+        Err(e) => return Ok(e),
+    };
+    if (x1 - x2).abs() > 0.01 && (y1 - y2).abs() > 0.01 {
+        return Ok(CallToolResult::error(
+            "Bus segment must be horizontal or vertical",
+        ));
+    }
+
+    let content = std::fs::read_to_string(&sch_path)?;
+    let new_content =
+        crate::tools::sch_wiring::insert_before_close(&content, &format_bus(x1, y1, x2, y2));
+    write_atomic(&sch_path, &new_content)?;
+
+    Ok(CallToolResult::json(&json!({
+        "added": "bus",
+        "from": { "x": x1, "y": y1 },
+        "to": { "x": x2, "y": y2 }
+    })))
+}
+
+async fn handle_batch_add_bus(
+    args: &serde_json::Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let sch_path = get_path(args, "schematic")?;
+    let items = match args["buses"].as_array() {
+        Some(a) => a.clone(),
+        None => return Ok(CallToolResult::error("Missing 'buses' array")),
+    };
+
+    let mut inserts = String::new();
+    let mut added: Vec<serde_json::Value> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+
+    for (i, item) in items.iter().enumerate() {
+        let (x1, y1, x2, y2) = match read_xy_pair(item) {
+            Ok(v) => v,
+            Err(_) => {
+                errors.push(format!("Segment {i}: needs x1, y1, x2, y2"));
+                continue;
+            }
+        };
+        if (x1 - x2).abs() > 0.01 && (y1 - y2).abs() > 0.01 {
+            errors.push(format!("Segment {i}: must be horizontal or vertical"));
+            continue;
+        }
+        inserts.push('\n');
+        inserts.push_str("  ");
+        inserts.push_str(&format_bus(x1, y1, x2, y2));
+        added.push(json!({ "from": {"x": x1, "y": y1}, "to": {"x": x2, "y": y2} }));
+    }
+
+    let content = std::fs::read_to_string(&sch_path)?;
+    let new_content = crate::tools::sch_wiring::insert_before_close(&content, &inserts);
+    write_atomic(&sch_path, &new_content)?;
+
+    Ok(CallToolResult::json(&json!({
+        "added_count": added.len(),
+        "added": added,
+        "errors": errors
+    })))
+}
+
+async fn handle_add_bus_entry(
+    args: &serde_json::Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let sch_path = get_path(args, "schematic")?;
+    let x = match require_f64(args, "x") {
+        Ok(v) => v,
+        Err(e) => return Ok(e),
+    };
+    let y = match require_f64(args, "y") {
+        Ok(v) => v,
+        Err(e) => return Ok(e),
+    };
+    let raw = opt_str(args, "direction").unwrap_or("down_right");
+    let direction = match parse_direction(raw) {
+        Some(d) => d,
+        None => {
+            return Ok(CallToolResult::error(format!(
+                "Unknown direction '{raw}'. Valid: down_right, down_left, up_right, up_left"
+            )))
+        }
+    };
+
+    let content = std::fs::read_to_string(&sch_path)?;
+    let new_content =
+        crate::tools::sch_wiring::insert_before_close(&content, &format_bus_entry(x, y, direction));
+    write_atomic(&sch_path, &new_content)?;
+
+    Ok(CallToolResult::json(&json!({
+        "added": "bus_entry",
+        "wire_side": { "x": x, "y": y },
+        "bus_side": { "x": x + direction.size().0, "y": y + direction.size().1 }
+    })))
+}
+
+async fn handle_connect_pins_to_bus(
+    args: &serde_json::Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let sch_path = get_path(args, "schematic")?;
+    let conns = match args["connections"].as_array() {
+        Some(a) => a.clone(),
+        None => return Ok(CallToolResult::error("Missing 'connections' array")),
+    };
+    let bus_y = opt_f64(args, "bus_y");
+    let bus_x = opt_f64(args, "bus_x");
+    let size = 2.54; // BusEntryDirection fixes the tick at one grid step
+
+    let horizontal = match (bus_y, bus_x) {
+        (Some(_), None) => true,
+        (None, Some(_)) => false,
+        _ => {
+            return Ok(CallToolResult::error(
+                "Give exactly one of 'bus_y' (horizontal bus) or 'bus_x' (vertical bus)",
+            ))
+        }
+    };
+
+    let content = std::fs::read_to_string(&sch_path)?;
+    let tree = match parse_sexp(&content) {
+        Ok(t) => t,
+        Err(e) => return Ok(CallToolResult::error(format!("Parse error: {e}"))),
+    };
+    let instances = extract_symbol_instances(&tree);
+    let lib_syms = tree
+        .find("lib_symbols")
+        .map(|n| n.find_all("symbol"))
+        .unwrap_or_default();
+
+    let mut inserts = String::new();
+    let mut added: Vec<serde_json::Value> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+
+    for conn in &conns {
+        let (reference, pin_number, net) = match (
+            conn["reference"].as_str(),
+            conn["pin_number"].as_str(),
+            conn["net"].as_str(),
+        ) {
+            (Some(r), Some(p), Some(n)) => (r, p, n),
+            _ => {
+                errors.push("Each connection needs reference, pin_number and net".into());
+                continue;
+            }
+        };
+
+        // Resolve against the unit that actually owns the pin — a multi-unit
+        // part repeats its reference on every unit.
+        let ep = instances
+            .iter()
+            .filter(|i| i.reference == reference)
+            .find_map(|inst| {
+                let sym = lib_syms
+                    .iter()
+                    .find(|n| n.get(1).and_then(|c| c.as_str()) == Some(&inst.lib_id))?;
+                extract_lib_pins_for_unit(sym, inst.unit)
+                    .into_iter()
+                    .find(|p| p.number == pin_number)
+                    .map(|p| pin_endpoint(&p, inst.pin_transform()))
+            });
+
+        let (px, py) = match ep {
+            Some(v) => v,
+            None => {
+                errors.push(format!("Pin {pin_number} of '{reference}' not found"));
+                continue;
+            }
+        };
+
+        // The entry bridges the last `size` before the bus; the stub covers the
+        // rest of the way from the pin.
+        let (entry_x, entry_y, dx, dy, sx, sy) = if horizontal {
+            let by = bus_y.unwrap();
+            let dir = if by > py { 1.0 } else { -1.0 };
+            let ey = by - dir * size;
+            (px, ey, dir * size, dir * size, px, py)
+        } else {
+            let bx = bus_x.unwrap();
+            let dir = if bx > px { 1.0 } else { -1.0 };
+            let ex = bx - dir * size;
+            (ex, py, dir * size, dir * size, px, py)
+        };
+
+        // Stub from the pin up to the entry's wire-side end. Zero-length when
+        // the pin already sits there; KiCad rejects a degenerate wire.
+        if (sx - entry_x).abs() > 0.01 || (sy - entry_y).abs() > 0.01 {
+            inserts.push_str("\n  ");
+            inserts.push_str(&format_wire(sx, sy, entry_x, entry_y));
+        }
+        inserts.push_str("\n  ");
+        inserts.push_str(&format_bus_entry(entry_x, entry_y, entry_dir(dx, dy)));
+        // The label is what actually puts this stub on the bus.
+        let rot = if horizontal { 90.0 } else { 0.0 };
+        inserts.push_str("\n  ");
+        inserts.push_str(&format_net_label(net, sx, sy, rot));
+
+        added.push(json!({
+            "reference": reference, "pin": pin_number, "net": net,
+            "pin_at": { "x": px, "y": py },
+            "entry_at": { "x": entry_x, "y": entry_y }
+        }));
+    }
+
+    let new_content = crate::tools::sch_wiring::insert_before_close(&content, &inserts);
+    write_atomic(&sch_path, &new_content)?;
+
+    Ok(CallToolResult::json(&json!({
+        "connected_count": added.len(),
+        "connected": added,
+        "errors": errors
+    })))
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Map a signed (dx, dy) tick offset onto KiCad's four bus-entry directions.
+fn entry_dir(dx: f64, dy: f64) -> BusEntryDirection {
+    match (dx > 0.0, dy > 0.0) {
+        (true, true) => BusEntryDirection::DownRight,
+        (false, true) => BusEntryDirection::DownLeft,
+        (true, false) => BusEntryDirection::UpRight,
+        (false, false) => BusEntryDirection::UpLeft,
+    }
+}
+
+fn parse_direction(s: &str) -> Option<BusEntryDirection> {
+    Some(match s {
+        "down_right" => BusEntryDirection::DownRight,
+        "down_left" => BusEntryDirection::DownLeft,
+        "up_right" => BusEntryDirection::UpRight,
+        "up_left" => BusEntryDirection::UpLeft,
+        _ => return None,
+    })
+}
+
+fn read_xy_pair(v: &serde_json::Value) -> Result<(f64, f64, f64, f64), CallToolResult> {
+    Ok((
+        require_f64(v, "x1")?,
+        require_f64(v, "y1")?,
+        require_f64(v, "x2")?,
+        require_f64(v, "y2")?,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bus_sexp_is_a_bus_node_not_a_wire() {
+        let s = format_bus(10.0, 20.0, 50.0, 20.0);
+        assert!(s.starts_with("(bus"), "got {s}");
+        assert!(s.contains("(xy 10 20) (xy 50 20)"));
+    }
+
+    /// `size` is the offset to the bus side, so the two ends are `at` and
+    /// `at + size`. Getting the sign wrong puts the tick on the far side of the
+    /// bus, where it connects nothing.
+    #[test]
+    fn entry_direction_follows_the_offset_signs() {
+        assert!(matches!(
+            entry_dir(2.54, 2.54),
+            BusEntryDirection::DownRight
+        ));
+        assert!(matches!(
+            entry_dir(-2.54, 2.54),
+            BusEntryDirection::DownLeft
+        ));
+        assert!(matches!(entry_dir(2.54, -2.54), BusEntryDirection::UpRight));
+        assert!(matches!(entry_dir(-2.54, -2.54), BusEntryDirection::UpLeft));
+    }
+
+    #[test]
+    fn direction_names_round_trip() {
+        for (name, dir) in [
+            ("down_right", BusEntryDirection::DownRight),
+            ("down_left", BusEntryDirection::DownLeft),
+            ("up_right", BusEntryDirection::UpRight),
+            ("up_left", BusEntryDirection::UpLeft),
+        ] {
+            assert_eq!(parse_direction(name).unwrap().size(), dir.size());
+        }
+        assert!(parse_direction("sideways").is_none());
+    }
+
+    #[test]
+    fn all_four_tools_are_registered() {
+        let names: Vec<_> = tools().iter().map(|t| t.name).collect();
+        assert_eq!(
+            names,
+            vec![
+                "add_bus",
+                "batch_add_bus",
+                "add_bus_entry",
+                "connect_pins_to_bus"
+            ]
+        );
+    }
+}

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -1944,90 +1944,6 @@ mod tests {
     }
 }
 
-<<<<<<< HEAD
-#[cfg(test)]
-mod page_tests {
-    use super::{tools, PAPER_SIZES};
-    use crate::tools::ToolContext;
-    use serde_json::json;
-    use std::io::Write;
-    use std::sync::Arc;
-
-    async fn set_page(body: &str, size: &str, portrait: bool) -> String {
-        let mut f = tempfile::NamedTempFile::with_suffix(".kicad_sch").unwrap();
-        f.write_all(body.as_bytes()).unwrap();
-        f.flush().unwrap();
-        let def = tools()
-            .into_iter()
-            .find(|t| t.name == "set_schematic_page")
-            .unwrap();
-        let cfg = crate::tools::ServerConfig {
-            kicad_cli: String::new(),
-            kicad_binary: String::new(),
-            ipc_address: String::new(),
-            project_dir: None,
-            jlcpcb_db_path: None,
-            auto_load_toolsets: false,
-        };
-        let ctx = Arc::new(ToolContext::new(
-            cfg,
-            Arc::new(crate::router::ToolRouter::new()),
-        ));
-        let args = json!({
-            "schematic": f.path().to_str().unwrap(),
-            "size": size, "portrait": portrait
-        });
-        (def.handler)(&args, ctx).await.unwrap();
-        std::fs::read_to_string(f.path()).unwrap()
-    }
-
-    const WITH_PAPER: &str =
-        "(kicad_sch\n  (version 20260306)\n  (uuid \"root\")\n  (paper \"A4\")\n  (symbol)\n)\n";
-    const NO_PAPER: &str = "(kicad_sch\n  (version 20260306)\n  (uuid \"root\")\n  (symbol)\n)\n";
-
-    #[tokio::test]
-    async fn replaces_an_existing_paper_node() {
-        let out = set_page(WITH_PAPER, "A2", false).await;
-        assert!(out.contains("(paper \"A2\")"), "got {out}");
-        assert!(!out.contains("A4"), "old size must be gone: {out}");
-        assert_eq!(out.matches("(paper").count(), 1);
-    }
-
-    /// A blank sheet from `create_schematic` has no paper node at all; the new
-    /// one has to land in the header, before any element.
-    #[tokio::test]
-    async fn inserts_when_absent_and_stays_in_the_header() {
-        let out = set_page(NO_PAPER, "A3", false).await;
-        assert!(out.contains("(paper \"A3\")"), "got {out}");
-        assert!(out.find("(paper").unwrap() < out.find("(symbol").unwrap());
-    }
-
-    #[tokio::test]
-    async fn portrait_is_marked_on_the_node() {
-        let out = set_page(WITH_PAPER, "A3", true).await;
-        assert!(out.contains("(paper \"A3\" portrait)"), "got {out}");
-    }
-
-    #[tokio::test]
-    async fn unknown_size_leaves_the_file_alone() {
-        let out = set_page(WITH_PAPER, "A9", false).await;
-        assert!(
-            out.contains("(paper \"A4\")"),
-            "must not have written: {out}"
-        );
-    }
-
-    #[test]
-    fn paper_table_is_landscape_and_unique() {
-        let mut names: Vec<_> = PAPER_SIZES.iter().map(|(n, _, _)| *n).collect();
-        let count = names.len();
-        names.sort_unstable();
-        names.dedup();
-        assert_eq!(names.len(), count, "duplicate paper size name");
-        for (n, w, h) in PAPER_SIZES {
-            assert!(w > h, "{n} is listed portrait; the table is landscape");
-        }
-=======
 // ─── update_symbols_from_library ─────────────────────────────────────────────
 
 /// Byte range of the `(lib_symbols …)` block, and of each top-level
@@ -2287,6 +2203,91 @@ mod update_symbols_tests {
         let a = r#"(pin (at 1 2 0)) (pin (at 3 4 90))"#;
         let b = r#"(pin (at 3 4 90)) (pin (at 1 2 0))"#;
         assert_eq!(pin_anchors(a), pin_anchors(b));
->>>>>>> up/update-symbols
+    }
+}
+
+#[cfg(test)]
+#[cfg(test)]
+mod page_tests {
+    use super::{tools, PAPER_SIZES};
+    use crate::tools::ToolContext;
+    use serde_json::json;
+    use std::io::Write;
+    use std::sync::Arc;
+
+    async fn set_page(body: &str, size: &str, portrait: bool) -> String {
+        let mut f = tempfile::NamedTempFile::with_suffix(".kicad_sch").unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        f.flush().unwrap();
+        let def = tools()
+            .into_iter()
+            .find(|t| t.name == "set_schematic_page")
+            .unwrap();
+        let cfg = crate::tools::ServerConfig {
+            kicad_cli: String::new(),
+            kicad_binary: String::new(),
+            ipc_address: String::new(),
+            project_dir: None,
+            jlcpcb_db_path: None,
+            auto_load_toolsets: false,
+        };
+        let ctx = Arc::new(ToolContext::new(
+            cfg,
+            Arc::new(crate::router::ToolRouter::new()),
+        ));
+        let args = json!({
+            "schematic": f.path().to_str().unwrap(),
+            "size": size, "portrait": portrait
+        });
+        (def.handler)(&args, ctx).await.unwrap();
+        std::fs::read_to_string(f.path()).unwrap()
+    }
+
+    const WITH_PAPER: &str =
+        "(kicad_sch\n  (version 20260306)\n  (uuid \"root\")\n  (paper \"A4\")\n  (symbol)\n)\n";
+    const NO_PAPER: &str = "(kicad_sch\n  (version 20260306)\n  (uuid \"root\")\n  (symbol)\n)\n";
+
+    #[tokio::test]
+    async fn replaces_an_existing_paper_node() {
+        let out = set_page(WITH_PAPER, "A2", false).await;
+        assert!(out.contains("(paper \"A2\")"), "got {out}");
+        assert!(!out.contains("A4"), "old size must be gone: {out}");
+        assert_eq!(out.matches("(paper").count(), 1);
+    }
+
+    /// A blank sheet from `create_schematic` has no paper node at all; the new
+    /// one has to land in the header, before any element.
+    #[tokio::test]
+    async fn inserts_when_absent_and_stays_in_the_header() {
+        let out = set_page(NO_PAPER, "A3", false).await;
+        assert!(out.contains("(paper \"A3\")"), "got {out}");
+        assert!(out.find("(paper").unwrap() < out.find("(symbol").unwrap());
+    }
+
+    #[tokio::test]
+    async fn portrait_is_marked_on_the_node() {
+        let out = set_page(WITH_PAPER, "A3", true).await;
+        assert!(out.contains("(paper \"A3\" portrait)"), "got {out}");
+    }
+
+    #[tokio::test]
+    async fn unknown_size_leaves_the_file_alone() {
+        let out = set_page(WITH_PAPER, "A9", false).await;
+        assert!(
+            out.contains("(paper \"A4\")"),
+            "must not have written: {out}"
+        );
+    }
+
+    #[test]
+    fn paper_table_is_landscape_and_unique() {
+        let mut names: Vec<_> = PAPER_SIZES.iter().map(|(n, _, _)| *n).collect();
+        let count = names.len();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), count, "duplicate paper size name");
+        for (n, w, h) in PAPER_SIZES {
+            assert!(w > h, "{n} is listed portrait; the table is landscape");
+        }
     }
 }

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -41,6 +41,32 @@ pub fn tools() -> Vec<ToolDef> {
             |args, ctx| async move { handle_create_schematic(args, ctx).await }
         ),
         tool!(
+            "set_schematic_page",
+            "Set the sheet's paper size (A0-A5, A-E, USLetter, USLegal, USLedger) and \
+             orientation. Content outside the frame still exports and still nets up, so a \
+             too-small page is a silent defect — check the layout extents against the size.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "schematic": { "type": "string", "description": "Path to .kicad_sch file" },
+                    "size": {
+                        "type": "string",
+                        "description": "Paper size, e.g. 'A4', 'A3', 'A2', 'USLetter'",
+                        "enum": ["A0", "A1", "A2", "A3", "A4", "A5",
+                                 "A", "B", "C", "D", "E",
+                                 "USLetter", "USLegal", "USLedger"]
+                    },
+                    "portrait": {
+                        "type": "boolean",
+                        "description": "Portrait instead of the default landscape",
+                        "default": false
+                    }
+                },
+                "required": ["schematic", "size"]
+            }),
+            |args, ctx| async move { handle_set_page(args, ctx).await }
+        ),
+        tool!(
             "add_schematic_component",
             "Add a symbol from a KiCAD library to the schematic. The symbol is snapped \
              to the 1.27mm schematic grid. Specify position in schematic mm coordinates.",
@@ -305,6 +331,93 @@ async fn handle_create_schematic(
     Ok(CallToolResult::json(
         &json!({ "created": path.display().to_string() }),
     ))
+}
+
+/// Paper sizes KiCad accepts in a `(paper …)` node, with their landscape
+/// dimensions in mm — reported back so the caller can sanity-check the layout
+/// against the frame instead of discovering the overflow at print time.
+const PAPER_SIZES: &[(&str, f64, f64)] = &[
+    ("A0", 1189.0, 841.0),
+    ("A1", 841.0, 594.0),
+    ("A2", 594.0, 420.0),
+    ("A3", 420.0, 297.0),
+    ("A4", 297.0, 210.0),
+    ("A5", 210.0, 148.0),
+    ("A", 279.4, 215.9),
+    ("B", 431.8, 279.4),
+    ("C", 558.8, 431.8),
+    ("D", 863.6, 558.8),
+    ("E", 1117.6, 863.6),
+    ("USLetter", 279.4, 215.9),
+    ("USLegal", 355.6, 215.9),
+    ("USLedger", 431.8, 279.4),
+];
+
+async fn handle_set_page(
+    args: &serde_json::Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let sch_path = get_path(args, "schematic")?;
+    let size = match require_str(args, "size") {
+        Ok(v) => v.to_string(),
+        Err(e) => return Ok(e),
+    };
+    let portrait = args["portrait"].as_bool().unwrap_or(false);
+
+    let dims = match PAPER_SIZES.iter().find(|(n, _, _)| *n == size) {
+        Some(&(_, w, h)) => (w, h),
+        None => {
+            let valid = PAPER_SIZES
+                .iter()
+                .map(|(n, _, _)| *n)
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Ok(CallToolResult::error_kind(
+                crate::mcp::error::ToolErrorKind::InvalidArgument {
+                    field: "size".into(),
+                    reason: format!("unknown paper size '{size}'; valid: {valid}"),
+                },
+                format!("Argument 'size' is invalid: unknown paper size '{size}'; valid: {valid}"),
+            ));
+        }
+    };
+    let (w, h) = if portrait { (dims.1, dims.0) } else { dims };
+
+    let node = if portrait {
+        format!("(paper \"{size}\" portrait)")
+    } else {
+        format!("(paper \"{size}\")")
+    };
+
+    let mut content = read_consistent(&sch_path)?;
+    let expected = content.clone();
+    match content.find("(paper ") {
+        Some(start) => {
+            let end = start
+                + content[start..]
+                    .find(')')
+                    .map(|p| p + 1)
+                    .unwrap_or(content.len() - start);
+            content.replace_range(start..end, &node);
+        }
+        None => {
+            // A freshly created blank sheet has no paper node; it belongs in
+            // the header, right after the uuid.
+            let anchor = content
+                .find("(uuid ")
+                .and_then(|p| content[p..].find(')').map(|q| p + q + 1))
+                .unwrap_or_else(|| content.find('\n').map(|p| p + 1).unwrap_or(0));
+            content.insert_str(anchor, &format!("\n  {node}"));
+        }
+    }
+    write_atomic_if_unchanged(&sch_path, &expected, &content)?;
+
+    Ok(CallToolResult::json(&json!({
+        "size": size,
+        "portrait": portrait,
+        "width_mm": w,
+        "height_mm": h
+    })))
 }
 
 async fn handle_add_schematic_component(
@@ -1807,5 +1920,90 @@ mod tests {
             !val_sexp.contains("hide"),
             "Value stays visible: {val_sexp}"
         );
+    }
+}
+
+#[cfg(test)]
+mod page_tests {
+    use super::{tools, PAPER_SIZES};
+    use crate::tools::ToolContext;
+    use serde_json::json;
+    use std::io::Write;
+    use std::sync::Arc;
+
+    async fn set_page(body: &str, size: &str, portrait: bool) -> String {
+        let mut f = tempfile::NamedTempFile::with_suffix(".kicad_sch").unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        f.flush().unwrap();
+        let def = tools()
+            .into_iter()
+            .find(|t| t.name == "set_schematic_page")
+            .unwrap();
+        let cfg = crate::tools::ServerConfig {
+            kicad_cli: String::new(),
+            kicad_binary: String::new(),
+            ipc_address: String::new(),
+            project_dir: None,
+            jlcpcb_db_path: None,
+            auto_load_toolsets: false,
+        };
+        let ctx = Arc::new(ToolContext::new(
+            cfg,
+            Arc::new(crate::router::ToolRouter::new()),
+        ));
+        let args = json!({
+            "schematic": f.path().to_str().unwrap(),
+            "size": size, "portrait": portrait
+        });
+        (def.handler)(&args, ctx).await.unwrap();
+        std::fs::read_to_string(f.path()).unwrap()
+    }
+
+    const WITH_PAPER: &str =
+        "(kicad_sch\n  (version 20260306)\n  (uuid \"root\")\n  (paper \"A4\")\n  (symbol)\n)\n";
+    const NO_PAPER: &str = "(kicad_sch\n  (version 20260306)\n  (uuid \"root\")\n  (symbol)\n)\n";
+
+    #[tokio::test]
+    async fn replaces_an_existing_paper_node() {
+        let out = set_page(WITH_PAPER, "A2", false).await;
+        assert!(out.contains("(paper \"A2\")"), "got {out}");
+        assert!(!out.contains("A4"), "old size must be gone: {out}");
+        assert_eq!(out.matches("(paper").count(), 1);
+    }
+
+    /// A blank sheet from `create_schematic` has no paper node at all; the new
+    /// one has to land in the header, before any element.
+    #[tokio::test]
+    async fn inserts_when_absent_and_stays_in_the_header() {
+        let out = set_page(NO_PAPER, "A3", false).await;
+        assert!(out.contains("(paper \"A3\")"), "got {out}");
+        assert!(out.find("(paper").unwrap() < out.find("(symbol").unwrap());
+    }
+
+    #[tokio::test]
+    async fn portrait_is_marked_on_the_node() {
+        let out = set_page(WITH_PAPER, "A3", true).await;
+        assert!(out.contains("(paper \"A3\" portrait)"), "got {out}");
+    }
+
+    #[tokio::test]
+    async fn unknown_size_leaves_the_file_alone() {
+        let out = set_page(WITH_PAPER, "A9", false).await;
+        assert!(
+            out.contains("(paper \"A4\")"),
+            "must not have written: {out}"
+        );
+    }
+
+    #[test]
+    fn paper_table_is_landscape_and_unique() {
+        let mut names: Vec<_> = PAPER_SIZES.iter().map(|(n, _, _)| *n).collect();
+        let count = names.len();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), count, "duplicate paper size name");
+        for (n, w, h) in PAPER_SIZES {
+            assert!(w > h, "{n} is listed portrait; the table is landscape");
+        }
     }
 }

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -274,6 +274,27 @@ pub fn tools() -> Vec<ToolDef> {
             |args, ctx| async move { handle_replace_component(args, ctx).await }
         ),
         tool!(
+            "update_symbols_from_library",
+            "Refresh the schematic's embedded lib_symbols definitions from the on-disk \
+             libraries — the equivalent of eeschema's Tools > Update Symbols from Library. \
+             Use after editing a symbol in its library: placing or replacing a component \
+             reuses the copy already embedded in the schematic, so library edits are \
+             otherwise invisible. Refuses any symbol whose pins moved, because existing \
+             wires and labels sit at the old pin coordinates and would be silently \
+             orphaned; pass allow_pin_moves to override and re-check connectivity after.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "schematic": { "type": "string", "description": "Path to .kicad_sch file" },
+                    "lib_id": { "type": "string", "description": "Only update this Library:Symbol. Omit to update every embedded symbol." },
+                    "dry_run": { "type": "boolean", "description": "Report what would change without writing. Default false.", "default": false },
+                    "allow_pin_moves": { "type": "boolean", "description": "Update even when pin positions changed. Connectivity will need re-checking. Default false.", "default": false }
+                },
+                "required": ["schematic"]
+            }),
+            |args, ctx| async move { handle_update_symbols_from_library(args, ctx).await }
+        ),
+        tool!(
             "get_schematic_view",
             "Render the schematic to a PNG image (base64-encoded) via kicad-cli.",
             json!({
@@ -1807,5 +1828,267 @@ mod tests {
             !val_sexp.contains("hide"),
             "Value stays visible: {val_sexp}"
         );
+    }
+}
+
+// ─── update_symbols_from_library ─────────────────────────────────────────────
+
+/// Byte range of the `(lib_symbols …)` block, and of each top-level
+/// `(symbol "LIB:NAME" …)` inside it.
+fn lib_symbol_blocks(content: &str) -> Vec<(String, usize, usize)> {
+    let Some(ls_start) = content.find("(lib_symbols") else {
+        return Vec::new();
+    };
+    // End of the lib_symbols block, by paren balance.
+    let mut depth = 0i32;
+    let mut ls_end = content.len();
+    for (i, ch) in content[ls_start..].char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    ls_end = ls_start + i + 1;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let section = &content[ls_start..ls_end];
+    let mut out = Vec::new();
+    // Top-level entries are `(symbol "LIB:NAME"` at depth 1 within the section.
+    let mut d = 0i32;
+    let mut i = 0usize;
+    let bytes = section.as_bytes();
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' => {
+                if d == 1 && section[i..].starts_with("(symbol \"") {
+                    let name_start = i + "(symbol \"".len();
+                    if let Some(rel) = section[name_start..].find('"') {
+                        let lib_id = section[name_start..name_start + rel].to_string();
+                        // balance this symbol block
+                        let mut sd = 0i32;
+                        let mut j = i;
+                        while j < bytes.len() {
+                            match bytes[j] {
+                                b'(' => sd += 1,
+                                b')' => {
+                                    sd -= 1;
+                                    if sd == 0 {
+                                        break;
+                                    }
+                                }
+                                _ => {}
+                            }
+                            j += 1;
+                        }
+                        out.push((lib_id, ls_start + i, ls_start + j + 1));
+                        d += 1;
+                        i = j + 1;
+                        d -= 1;
+                        continue;
+                    }
+                }
+                d += 1;
+            }
+            b')' => d -= 1,
+            _ => {}
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Pin anchors of a symbol definition as `(x, y, angle)`, sorted, so two
+/// definitions can be compared for geometry drift.
+fn pin_anchors(sym_block: &str) -> Vec<(String, String, String)> {
+    let mut v: Vec<(String, String, String)> = regex_lite_pin_at(sym_block);
+    v.sort();
+    v
+}
+
+/// `(at X Y A)` immediately following a `(pin ` opener.
+fn regex_lite_pin_at(s: &str) -> Vec<(String, String, String)> {
+    let mut out = Vec::new();
+    let mut from = 0usize;
+    while let Some(rel) = s[from..].find("(pin ") {
+        let start = from + rel;
+        if let Some(at_rel) = s[start..].find("(at ") {
+            let at = start + at_rel + "(at ".len();
+            if let Some(close) = s[at..].find(')') {
+                let parts: Vec<&str> = s[at..at + close].split_whitespace().collect();
+                if parts.len() >= 2 {
+                    out.push((
+                        parts[0].to_string(),
+                        parts[1].to_string(),
+                        parts.get(2).unwrap_or(&"0").to_string(),
+                    ));
+                }
+            }
+        }
+        from = start + 5;
+    }
+    out
+}
+
+async fn handle_update_symbols_from_library(
+    args: &serde_json::Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let sch_path = get_path(args, "schematic")?;
+    let only = opt_str(args, "lib_id");
+    let dry_run = args
+        .get("dry_run")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let allow_pin_moves = args
+        .get("allow_pin_moves")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
+    let blocks = lib_symbol_blocks(&content);
+    if blocks.is_empty() {
+        return Ok(CallToolResult::json(&json!({
+            "updated": [], "unchanged": [], "skipped": [],
+            "note": "schematic has no lib_symbols section"
+        })));
+    }
+
+    let mut updated = Vec::new();
+    let mut unchanged = Vec::new();
+    let mut skipped = Vec::new();
+    let mut edits: Vec<SexpEdit> = Vec::new();
+
+    for (lib_id, start, end) in blocks {
+        if let Some(want) = only {
+            if want != lib_id {
+                continue;
+            }
+        }
+        let embedded = &content[start..end];
+
+        // The library copy is stored under its bare symbol name; the embedded
+        // copy is prefixed with the library nickname. Resolve, then re-prefix
+        // so the two are comparable and the replacement stays valid.
+        let Some(fresh) = konnect_schematic_editor::library::resolve_lib_symbol_flattened(&lib_id)
+        else {
+            skipped.push(json!({ "lib_id": lib_id, "reason": "not found in any library" }));
+            continue;
+        };
+
+        if fresh.trim() == embedded.trim() {
+            unchanged.push(lib_id);
+            continue;
+        }
+
+        let before = pin_anchors(embedded);
+        let after = pin_anchors(&fresh);
+        if before != after && !allow_pin_moves {
+            skipped.push(json!({
+                "lib_id": lib_id,
+                "reason": "pin positions changed — wires and labels sit at the old \
+                           coordinates and would be orphaned",
+                "pins_before": before.len(),
+                "pins_after": after.len(),
+                "hint": "pass allow_pin_moves=true to update anyway, then re-run \
+                         validate_component_connections and run_erc",
+            }));
+            continue;
+        }
+
+        updated.push(json!({
+            "lib_id": lib_id,
+            "pins_moved": before != after,
+        }));
+        if !dry_run {
+            edits.push(SexpEdit::replace(start, end, fresh));
+        }
+    }
+
+    if !dry_run && !edits.is_empty() {
+        let new_content = apply_edits(content, edits);
+        write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
+    }
+
+    Ok(CallToolResult::json(&json!({
+        "dry_run": dry_run,
+        "updated": updated,
+        "unchanged": unchanged,
+        "skipped": skipped,
+    })))
+}
+
+#[cfg(test)]
+mod update_symbols_tests {
+    use super::*;
+
+    const SCH: &str = r#"(kicad_sch
+	(version 20241209)
+	(lib_symbols
+		(symbol "Lib:Part"
+			(pin passive line (at -11.43 2.54 0) (length 5.08)
+				(name "A" (effects (font (size 1.27 1.27))))
+				(number "1" (effects (font (size 1.27 1.27))))
+			)
+		)
+		(symbol "Lib:Other"
+			(pin passive line (at 5.08 0 180) (length 2.54)
+				(name "B" (effects (font (size 1.27 1.27))))
+				(number "1" (effects (font (size 1.27 1.27))))
+			)
+		)
+	)
+)
+"#;
+
+    #[test]
+    fn finds_each_top_level_lib_symbol_block() {
+        let blocks = lib_symbol_blocks(SCH);
+        let ids: Vec<&str> = blocks.iter().map(|(id, _, _)| id.as_str()).collect();
+        assert_eq!(ids, vec!["Lib:Part", "Lib:Other"]);
+        // ranges must isolate whole, balanced blocks
+        for (id, a, b) in &blocks {
+            let blk = &SCH[*a..*b];
+            assert!(
+                blk.starts_with(&format!("(symbol \"{id}\"")),
+                "block: {blk}"
+            );
+            assert_eq!(
+                blk.matches('(').count(),
+                blk.matches(')').count(),
+                "unbalanced block for {id}"
+            );
+        }
+    }
+
+    #[test]
+    fn no_lib_symbols_section_yields_no_blocks() {
+        assert!(lib_symbol_blocks("(kicad_sch (version 20241209))").is_empty());
+    }
+
+    /// The guard that matters: pin anchors are what wires and labels attach to,
+    /// so a definition whose pins moved must be detectable.
+    #[test]
+    fn pin_anchors_detect_geometry_drift() {
+        let narrow = r#"(symbol "X" (pin passive line (at -11.43 2.54 0) (length 5.08)))"#;
+        let same = r#"(symbol "X" (pin passive line (at -11.43 2.54 0) (length 1.27)))"#;
+        let moved = r#"(symbol "X" (pin passive line (at -20.32 2.54 0) (length 1.27)))"#;
+
+        // Body/length changes alone leave the anchor put — that is the safe case
+        // exploited when widening a symbol without disturbing wiring.
+        assert_eq!(pin_anchors(narrow), pin_anchors(same));
+        assert_ne!(pin_anchors(narrow), pin_anchors(moved));
+    }
+
+    #[test]
+    fn pin_anchors_are_order_independent() {
+        let a = r#"(pin (at 1 2 0)) (pin (at 3 4 90))"#;
+        let b = r#"(pin (at 3 4 90)) (pin (at 1 2 0))"#;
+        assert_eq!(pin_anchors(a), pin_anchors(b));
     }
 }

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -264,6 +264,29 @@ pub fn tools() -> Vec<ToolDef> {
             |args, ctx| async move { handle_batch_delete_no_connect(args, ctx).await }
         ),
         tool!(
+            "batch_add_no_connect",
+            "Add multiple no-connect flags in a single file read/write cycle. Marking the unused \
+             pins of one MCU is routinely 15-20 flags, which is 15-20 round trips through \
+             add_no_connect.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "schematic": { "type": "string" },
+                    "positions": {
+                        "type": "array",
+                        "description": "Pin endpoints to flag, as {x, y}",
+                        "items": {
+                            "type": "object",
+                            "properties": { "x": { "type": "number" }, "y": { "type": "number" } },
+                            "required": ["x", "y"]
+                        }
+                    }
+                },
+                "required": ["schematic", "positions"]
+            }),
+            |args, ctx| async move { handle_batch_add_no_connect(args, ctx).await }
+        ),
+        tool!(
             "add_junction",
             "Add a junction dot at a point where wires cross or T-intersect, or where \
              a pin lands mid-wire. A junction alone connects a mid-wire pin; \
@@ -1337,6 +1360,38 @@ async fn handle_add_no_connect(
     Ok(CallToolResult::json(
         &json!({ "added_no_connect": { "x": x, "y": y } }),
     ))
+}
+
+async fn handle_batch_add_no_connect(
+    args: &serde_json::Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let sch_path = get_path(args, "schematic")?;
+    let positions = match args["positions"].as_array() {
+        Some(a) => a.clone(),
+        None => return Ok(CallToolResult::error("Missing 'positions' array")),
+    };
+
+    let mut sch = cse::Schematic::load(&sch_path)?;
+    let mut added: Vec<serde_json::Value> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+
+    for (i, p) in positions.iter().enumerate() {
+        match (p["x"].as_f64(), p["y"].as_f64()) {
+            (Some(x), Some(y)) => {
+                sch.add_no_connect(x, y);
+                added.push(json!({ "x": x, "y": y }));
+            }
+            _ => errors.push(format!("Position {i}: needs numeric x and y")),
+        }
+    }
+    sch.overwrite()?;
+
+    Ok(CallToolResult::json(&json!({
+        "added_count": added.len(),
+        "added": added,
+        "errors": errors
+    })))
 }
 
 async fn handle_delete_no_connect(
@@ -2471,5 +2526,70 @@ mod no_connect_delete_tests {
         let after = std::fs::read_to_string(&path).unwrap();
         assert!(!after.contains("nc-1"));
         assert!(after.contains("nc-2"));
+    }
+}
+
+#[cfg(test)]
+mod batch_no_connect_tests {
+    use super::tools;
+    use crate::tools::ToolContext;
+    use serde_json::json;
+    use std::io::Write;
+    use std::sync::Arc;
+
+    const SCH: &str = "(kicad_sch\n  (version 20260306)\n  (generator \"eeschema\")\n  (uuid \"root\")\n  (paper \"A4\")\n  (lib_symbols)\n  (sheet_instances (path \"/\" (page \"1\")))\n)\n";
+
+    async fn run(positions: serde_json::Value) -> (String, serde_json::Value) {
+        let mut f = tempfile::NamedTempFile::with_suffix(".kicad_sch").unwrap();
+        f.write_all(SCH.as_bytes()).unwrap();
+        f.flush().unwrap();
+        let def = tools()
+            .into_iter()
+            .find(|t| t.name == "batch_add_no_connect")
+            .unwrap();
+        let cfg = crate::tools::ServerConfig {
+            kicad_cli: String::new(),
+            kicad_binary: String::new(),
+            ipc_address: String::new(),
+            project_dir: None,
+            jlcpcb_db_path: None,
+            auto_load_toolsets: false,
+        };
+        let ctx = Arc::new(ToolContext::new(
+            cfg,
+            Arc::new(crate::router::ToolRouter::new()),
+        ));
+        let args = json!({ "schematic": f.path().to_str().unwrap(), "positions": positions });
+        let res = (def.handler)(&args, ctx).await.unwrap();
+        let crate::mcp::protocol::ToolContent::Text { text } = &res.content[0] else {
+            panic!("expected text content")
+        };
+        let body: serde_json::Value = serde_json::from_str(text).unwrap();
+        (std::fs::read_to_string(f.path()).unwrap(), body)
+    }
+
+    #[tokio::test]
+    async fn writes_every_flag_in_one_pass() {
+        let (out, body) = run(json!([{"x": 10.0, "y": 20.0}, {"x": 30.0, "y": 40.0}])).await;
+        assert_eq!(body["added_count"], 2);
+        assert_eq!(out.matches("(no_connect").count(), 2);
+    }
+
+    /// A malformed entry must not abort the rest — the useful failure mode when
+    /// flagging twenty pins is "nineteen landed and one is reported".
+    #[tokio::test]
+    async fn a_bad_entry_is_reported_without_losing_the_others() {
+        let (out, body) =
+            run(json!([{"x": 10.0, "y": 20.0}, {"x": "nope"}, {"x": 1.0, "y": 2.0}])).await;
+        assert_eq!(body["added_count"], 2);
+        assert_eq!(body["errors"].as_array().unwrap().len(), 1);
+        assert_eq!(out.matches("(no_connect").count(), 2);
+    }
+
+    #[tokio::test]
+    async fn empty_list_is_a_no_op() {
+        let (out, body) = run(json!([])).await;
+        assert_eq!(body["added_count"], 0);
+        assert_eq!(out.matches("(no_connect").count(), 0);
     }
 }

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -369,7 +369,7 @@ pub fn tools() -> Vec<ToolDef> {
 // So wires and labels must be inserted before the first (symbol block,
 // NOT at the end of the file.
 
-fn insert_before_close(content: &str, new_sexp: &str) -> String {
+pub(crate) fn insert_before_close(content: &str, new_sexp: &str) -> String {
     // Find the first top-level (symbol block — insert before it
     let insert_pos = find_first_symbol_instance(content)
         .unwrap_or_else(|| content.rfind(')').unwrap_or(content.len()));

--- a/crates/konnect-schematic-editor/Cargo.toml
+++ b/crates/konnect-schematic-editor/Cargo.toml
@@ -11,6 +11,7 @@ description = "Typed KiCAD schematic parser and manipulator with lossless round-
 thiserror.workspace = true
 uuid.workspace = true
 konnect-sexp.workspace = true  # For geometry (pin transforms, snap, T-junction detection)
+serde_json.workspace = true    # Reading KiCad's kicad_common.json path variables
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/konnect-schematic-editor/src/library.rs
+++ b/crates/konnect-schematic-editor/src/library.rs
@@ -11,7 +11,34 @@
 
 use crate::sexp::{parser, SexpNode};
 use crate::Schematic;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+/// Prefix a symbol block's outer name with its library, as eeschema expects
+/// in an embedded `lib_symbols` entry, and prefix any `(extends "PARENT")`
+/// to match.
+///
+/// Unit sub-symbols ("Name_0_1", "Name_1_1") deliberately stay UNPREFIXED:
+/// eeschema names only the outer symbol with the library prefix and refuses
+/// to load a schematic whose units carry it ("Failed to load schematic" —
+/// verified against kicad-cli 10.0 and the KiCAD demo corpus).
+fn prefix_symbol_block(block: &str, library_name: &str, symbol_name: &str) -> String {
+    let mut renamed = block.replacen(
+        &format!("(symbol \"{}\"", symbol_name),
+        &format!("(symbol \"{}:{}\"", library_name, symbol_name),
+        1,
+    );
+    if let Some(ext_pos) = renamed.find("(extends \"") {
+        let after = &renamed[ext_pos + 10..];
+        if let Some(end) = after.find('"') {
+            let parent = after[..end].to_string();
+            renamed = renamed.replace(
+                &format!("(extends \"{}\")", parent),
+                &format!("(extends \"{}:{}\")", library_name, parent),
+            );
+        }
+    }
+    renamed
+}
 
 /// Resolve a lib_id (e.g. "Device:R") to the full symbol S-expression string.
 /// The returned string is the raw content of the `(symbol "R" ...)` block,
@@ -22,6 +49,18 @@ pub fn resolve_lib_symbol(lib_id: &str) -> Option<String> {
         return None;
     }
     let (library_name, symbol_name) = (parts[0], parts[1]);
+
+    // sym-lib-table first: it is what KiCad itself uses, so it is the only
+    // source that knows about user libraries and about installs sitting
+    // outside the hardcoded paths in `find_symbol_dirs`. It also carries the
+    // nickname → file mapping, which a directory scan has to guess.
+    if let Some(path) = symbol_lib_path(library_name) {
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            if let Some(block) = extract_symbol_block(&content, symbol_name) {
+                return Some(prefix_symbol_block(&block, library_name, symbol_name));
+            }
+        }
+    }
 
     for base_dir in find_symbol_dirs() {
         // KiCAD 10: Library.kicad_symdir/SymbolName.kicad_sym
@@ -473,7 +512,165 @@ fn extract_symbol_block(content: &str, symbol_name: &str) -> Option<String> {
     }
 }
 
+// ─── KiCad library-table resolution ──────────────────────────────────────────
+//
+// KiCad finds a symbol library by nickname through `sym-lib-table`, not by
+// scanning directories for a file named after the nickname. Resolving by
+// directory scan alone misses two whole classes of library:
+//
+//   * every user library, wherever it lives on disk;
+//   * KiCad's own, whenever it is installed outside the hardcoded paths
+//     below (a macOS bundle dragged anywhere but /Applications, say).
+//
+// It also assumes nickname == filename, which KiCad never requires: a table
+// may register `.../TM16xx.kicad_sym` under the nickname `JY-TM16xx`.
+//
+// The table is therefore consulted first, and the directory scan kept as a
+// fallback for setups with no table at all.
+
+/// KiCad's per-user configuration directory, where `sym-lib-table` and
+/// `kicad_common.json` live. Newest supported version wins.
+fn kicad_config_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "windows")]
+    let base = PathBuf::from(std::env::var("APPDATA").ok()?).join("kicad");
+    #[cfg(target_os = "macos")]
+    let base = PathBuf::from(std::env::var("HOME").ok()?).join("Library/Preferences/kicad");
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    let base = PathBuf::from(std::env::var("HOME").ok()?).join(".config/kicad");
+
+    for ver in ["10.0", "9.0", "8.0"] {
+        let d = base.join(ver);
+        if d.is_dir() {
+            return Some(d);
+        }
+    }
+    base.is_dir().then_some(base)
+}
+
+/// Path variables the user defined in KiCad's Preferences → Configure Paths.
+///
+/// These live in `kicad_common.json`, not the process environment, so a plain
+/// `std::env::var` lookup never sees them — yet they are the normal way to
+/// write a portable library table (`${MY_LIB}/parts.kicad_sym`).
+fn kicad_user_path_vars() -> Vec<(String, String)> {
+    let Some(cfg) = kicad_config_dir() else {
+        return Vec::new();
+    };
+    let Ok(text) = std::fs::read_to_string(cfg.join("kicad_common.json")) else {
+        return Vec::new();
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return Vec::new();
+    };
+    json.get("environment")
+        .and_then(|e| e.get("vars"))
+        .and_then(|v| v.as_object())
+        .map(|m| {
+            m.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Expand a lib-table URI to a filesystem path.
+///
+/// `table_dir` is the directory of the table the URI came from: it is the
+/// expansion base for `${KIPRJMOD}` (KiCad's per-project variable), and the
+/// anchor for the `${KICAD*_SYMBOL_DIR}` fallback — KiCad's bundled table sits
+/// in `<share>/template` with the symbols beside it in `<share>/symbols`, so
+/// the install root is recoverable from the table's own location even when the
+/// variable is unset.
+fn expand_lib_uri(uri: &str, table_dir: Option<&Path>) -> Option<PathBuf> {
+    let Some(rest) = uri.strip_prefix("${") else {
+        return (!uri.is_empty()).then(|| PathBuf::from(uri));
+    };
+    let close = rest.find('}')?;
+    let var = &rest[..close];
+    let tail = rest[close + 1..].trim_start_matches(['/', '\\']);
+
+    if var == "KIPRJMOD" {
+        return table_dir.map(|d| d.join(tail));
+    }
+
+    if let Some(base) = std::env::var_os(var) {
+        return Some(PathBuf::from(base).join(tail));
+    }
+
+    for (k, v) in kicad_user_path_vars() {
+        if k == var {
+            return Some(PathBuf::from(v).join(tail));
+        }
+    }
+
+    // KiCad's own ${KICAD<n>_SYMBOL_DIR}, unset in our environment.
+    if var.ends_with("_SYMBOL_DIR") {
+        if let Some(d) = table_dir.and_then(|d| d.parent()) {
+            let p = d.join("symbols").join(tail);
+            if p.exists() {
+                return Some(p);
+            }
+        }
+        return find_symbol_dirs()
+            .into_iter()
+            .map(|d| d.join(tail))
+            .find(|p| p.exists());
+    }
+
+    None
+}
+
+/// Every `(lib …)` entry of a sym-lib-table as `(nickname, path)`, following
+/// `(type "Table")` indirection. `depth` bounds a table that references itself.
+fn read_sym_lib_table(path: &Path, depth: usize) -> Vec<(String, PathBuf)> {
+    if depth > 4 {
+        return Vec::new();
+    }
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let dir = path.parent();
+    let mut out = Vec::new();
+
+    for line in content.lines() {
+        let Some(name) = field(line, "name") else {
+            continue;
+        };
+        let Some(uri) = field(line, "uri") else {
+            continue;
+        };
+        let Some(resolved) = expand_lib_uri(&uri, dir) else {
+            continue;
+        };
+        if field(line, "type").as_deref() == Some("Table") {
+            out.extend(read_sym_lib_table(&resolved, depth + 1));
+        } else {
+            out.push((name, resolved));
+        }
+    }
+    out
+}
+
+/// Value of `(<key> "…")` on a lib-table line, if present.
+fn field(line: &str, key: &str) -> Option<String> {
+    let pat = format!("({key} \"");
+    let start = line.find(&pat)? + pat.len();
+    let end = line[start..].find('"')? + start;
+    Some(line[start..end].to_string())
+}
+
+/// On-disk `.kicad_sym` for a library nickname, via the global sym-lib-table.
+fn symbol_lib_path(nickname: &str) -> Option<PathBuf> {
+    let table = kicad_config_dir()?.join("sym-lib-table");
+    read_sym_lib_table(&table, 0)
+        .into_iter()
+        .find(|(nick, _)| nick == nickname)
+        .map(|(_, p)| p)
+}
+
 /// Find directories where KiCAD symbol libraries are stored.
+///
+/// Fallback only: `sym-lib-table` is authoritative and is consulted first.
 pub fn find_symbol_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
 
@@ -664,5 +861,139 @@ mod suggestion_tests {
             &mut sch,
             "Definitely_Not_A_Library_xyzzy:Nope"
         ));
+    }
+}
+
+#[cfg(test)]
+mod lib_table_tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write(dir: &Path, name: &str, body: &str) -> PathBuf {
+        let p = dir.join(name);
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = std::fs::File::create(&p).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        p
+    }
+
+    /// A plain URI is taken as written.
+    #[test]
+    fn expand_lib_uri_passes_through_a_plain_path() {
+        assert_eq!(
+            expand_lib_uri("/libs/parts.kicad_sym", None),
+            Some(PathBuf::from("/libs/parts.kicad_sym"))
+        );
+        assert_eq!(expand_lib_uri("", None), None);
+    }
+
+    /// ${KIPRJMOD} resolves against the table's own directory, because KiCad
+    /// sets it per open project — an exported value could name another project.
+    #[test]
+    fn expand_lib_uri_resolves_kiprjmod_from_the_table_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            expand_lib_uri("${KIPRJMOD}/local.kicad_sym", Some(dir.path())),
+            Some(dir.path().join("local.kicad_sym"))
+        );
+        // No table dir to anchor against: unresolvable rather than guessed.
+        assert_eq!(expand_lib_uri("${KIPRJMOD}/local.kicad_sym", None), None);
+    }
+
+    /// An exported environment variable is honoured.
+    #[test]
+    fn expand_lib_uri_expands_an_exported_env_var() {
+        std::env::set_var("KONNECT_TEST_LIBDIR", "/opt/parts");
+        assert_eq!(
+            expand_lib_uri("${KONNECT_TEST_LIBDIR}/x.kicad_sym", None),
+            Some(PathBuf::from("/opt/parts/x.kicad_sym"))
+        );
+        std::env::remove_var("KONNECT_TEST_LIBDIR");
+    }
+
+    /// An unknown variable fails rather than silently dropping the prefix and
+    /// producing a wrong relative path.
+    #[test]
+    fn expand_lib_uri_rejects_an_unknown_variable() {
+        assert_eq!(
+            expand_lib_uri("${NO_SUCH_VAR_HERE}/x.kicad_sym", None),
+            None
+        );
+    }
+
+    /// The regression this exists for: a nickname that does not match the
+    /// filename. KiCad allows it; resolving by directory scan cannot.
+    #[test]
+    fn table_maps_a_nickname_that_differs_from_the_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "TM16xx.kicad_sym", "(kicad_symbol_lib)");
+        let table = write(
+            dir.path(),
+            "sym-lib-table",
+            &format!(
+                "(sym_lib_table\n\t(version 7)\n\t(lib (name \"JY-TM16xx\") (type \"KiCad\") (uri \"{}/TM16xx.kicad_sym\") (options \"\") (descr \"\"))\n)\n",
+                dir.path().display()
+            ),
+        );
+        let entries = read_sym_lib_table(&table, 0);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, "JY-TM16xx");
+        assert!(entries[0].1.ends_with("TM16xx.kicad_sym"));
+    }
+
+    /// `(type "Table")` indirection is followed, which is how KiCad references
+    /// its own bundled libraries and how a shared master table is wired in.
+    #[test]
+    fn nested_table_indirection_is_followed() {
+        let dir = tempfile::tempdir().unwrap();
+        let inner_dir = dir.path().join("inner");
+        write(&inner_dir, "Parts.kicad_sym", "(kicad_symbol_lib)");
+        write(
+            &inner_dir,
+            "sym-lib-table",
+            &format!(
+                "(sym_lib_table\n\t(lib (name \"Inner\") (type \"KiCad\") (uri \"{}/Parts.kicad_sym\") (options \"\") (descr \"\"))\n)\n",
+                inner_dir.display()
+            ),
+        );
+        let outer = write(
+            dir.path(),
+            "sym-lib-table",
+            &format!(
+                "(sym_lib_table\n\t(lib (name \"Group\") (type \"Table\") (uri \"{}/sym-lib-table\") (options \"\") (descr \"\"))\n)\n",
+                inner_dir.display()
+            ),
+        );
+        let entries = read_sym_lib_table(&outer, 0);
+        assert_eq!(entries.len(), 1, "the nested table's entry should surface");
+        assert_eq!(entries[0].0, "Inner");
+    }
+
+    /// A table that references itself must terminate rather than recurse away.
+    #[test]
+    fn self_referencing_table_terminates() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("sym-lib-table");
+        write(
+            dir.path(),
+            "sym-lib-table",
+            &format!(
+                "(sym_lib_table\n\t(lib (name \"Loop\") (type \"Table\") (uri \"{}\") (options \"\") (descr \"\"))\n)\n",
+                p.display()
+            ),
+        );
+        let _ = read_sym_lib_table(&p, 0); // must return, not hang or overflow
+    }
+
+    #[test]
+    fn field_extracts_quoted_values() {
+        let line =
+            r#"(lib (name "A B") (type "KiCad") (uri "/x/y.kicad_sym") (options "") (descr ""))"#;
+        assert_eq!(field(line, "name").as_deref(), Some("A B"));
+        assert_eq!(field(line, "type").as_deref(), Some("KiCad"));
+        assert_eq!(field(line, "uri").as_deref(), Some("/x/y.kicad_sym"));
+        assert_eq!(field(line, "missing"), None);
     }
 }

--- a/crates/konnect-sexp/src/parser.rs
+++ b/crates/konnect-sexp/src/parser.rs
@@ -157,11 +157,40 @@ fn parse_atom(input: &str) -> IResult<&str, SexpNode> {
     .parse(input)
 }
 
+/// Decode the escape sequences KiCad writes inside quoted strings.
+///
+/// Must be a single left-to-right pass. Chained `replace` calls collapse
+/// backslashes *last*, so an already-escaped backslash gets re-read as the
+/// introducer of the following escape: `C:\\new` (a literal `C:\new`) came
+/// back as `C:\` + a newline, and `a\\tb` as `a\` + a tab. KiCad escapes
+/// backslashes in property values, so any Windows path whose next character
+/// was `n` or `t` decoded wrongly.
 fn unescape(s: &str) -> String {
-    s.replace("\\\"", "\"")
-        .replace("\\n", "\n")
-        .replace("\\t", "\t")
-        .replace("\\\\", "\\")
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('n') => out.push('\n'),
+            Some('t') => out.push('\t'),
+            Some('r') => out.push('\r'),
+            Some('"') => out.push('"'),
+            Some('\\') => out.push('\\'),
+            // Unknown escape: keep both characters rather than guessing, so
+            // the value round-trips instead of silently losing a backslash.
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+
+    out
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -207,5 +236,32 @@ mod tests {
         let n = parse_sexp(s).unwrap();
         assert_eq!(n.find_str("uuid"), None); // uuid is the head
         assert_eq!(n.get(1).and_then(|n| n.as_str()), Some("abc-123-def"));
+    }
+
+    /// Chained `replace` collapsed backslashes last, so an escaped backslash
+    /// followed by `n` or `t` was re-read as a control escape. KiCad escapes
+    /// backslashes in property values, so Windows paths decoded wrongly.
+    #[test]
+    fn escaped_backslash_is_not_reread_as_an_escape() {
+        // Serialized `C:\\new\\temp` is the literal path `C:\new\temp`.
+        let n = parse_sexp(r#"(p "C:\\new\\temp")"#).unwrap();
+        assert_eq!(n.get(1).and_then(|c| c.as_str()), Some(r"C:\new\temp"));
+
+        let n = parse_sexp(r#"(p "a\\tb")"#).unwrap();
+        assert_eq!(n.get(1).and_then(|c| c.as_str()), Some(r"a\tb"));
+    }
+
+    /// Genuine control escapes must still decode.
+    #[test]
+    fn control_escapes_still_decode() {
+        let n = parse_sexp(r#"(p "line1\nline2\tend")"#).unwrap();
+        assert_eq!(n.get(1).and_then(|c| c.as_str()), Some("line1\nline2\tend"));
+    }
+
+    /// An escaped quote inside a string stays a quote.
+    #[test]
+    fn escaped_quote_decodes() {
+        let n = parse_sexp(r#"(p "say \"hi\"")"#).unwrap();
+        assert_eq!(n.get(1).and_then(|c| c.as_str()), Some(r#"say "hi""#));
     }
 }

--- a/crates/konnect/tests/protocol_stdio.rs
+++ b/crates/konnect/tests/protocol_stdio.rs
@@ -295,7 +295,7 @@ fn load_toolset_batch_form_loads_all_and_notifies_once() {
         .expect("expected a tools/call result")["result"]
         .clone();
     let body = McpProcess::tool_body(&r);
-    assert_eq!(body["tools_added"].as_u64(), Some(36));
+    assert_eq!(body["tools_added"].as_u64(), Some(37));
     // tools items are {name, description} objects, matching the legacy
     // single-name result shape -- not bare name strings.
     let tools = body["tools"].as_array().expect("tools array");

--- a/crates/konnect/tests/protocol_stdio.rs
+++ b/crates/konnect/tests/protocol_stdio.rs
@@ -295,7 +295,7 @@ fn load_toolset_batch_form_loads_all_and_notifies_once() {
         .expect("expected a tools/call result")["result"]
         .clone();
     let body = McpProcess::tool_body(&r);
-    assert_eq!(body["tools_added"].as_u64(), Some(37));
+    assert_eq!(body["tools_added"].as_u64(), Some(39));
     // tools items are {name, description} objects, matching the legacy
     // single-name result shape -- not bare name strings.
     let tools = body["tools"].as_array().expect("tools array");

--- a/crates/schematic-viewer/Cargo.lock
+++ b/crates/schematic-viewer/Cargo.lock
@@ -1690,6 +1690,7 @@ name = "konnect-schematic-editor"
 version = "0.2.2"
 dependencies = [
  "konnect-sexp",
+ "serde_json",
  "thiserror 1.0.69",
  "uuid",
 ]

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -9,8 +9,8 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 
 ## Overview
 
-- **18 toolsets** organized into 10 categories
-- **187 registered tools** + **6 always-visible meta-tools** = **193 total**
+- **19 toolsets** organized into 10 categories
+- **191 registered tools** + **6 always-visible meta-tools** = **197 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -22,7 +22,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 
 | Tool | Purpose |
 |------|---------|
-| `list_toolboxes` | List all 18 toolsets with category, tool count, and whether each is currently loaded. The LLM's starting point. |
+| `list_toolboxes` | List all 19 toolsets with category, tool count, and whether each is currently loaded. The LLM's starting point. |
 | `load_toolset` | Load a toolset by name to expose its tools in `tools/list`. Returns the list of tools added. |
 | `unload_toolset` | Unload a toolset to prune its tools from `tools/list`. Use when switching tasks to keep context small. |
 | `get_active_toolsets` | Return the currently loaded toolsets and how many tools each provides. |
@@ -104,6 +104,17 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `connect_to_net` | Connect a pin endpoint to a named net by adding a short wire stub + net label. |
 | `connect_pins` | Connect two component pins by reference+pin number. Looks up pin coordinates and routes a wire. |
 | `add_schematic_connection` | Connect two schematic points directly with a wire (auto H+V routing). Use `connect_pins` if you have references instead of coordinates. |
+
+### `sch_bus` · 4 tools
+**Purpose:** Buses, bus entries, and fanning a group of pins out onto a bus.
+**Source:** [`crates/konnect-core/src/tools/sch_bus.rs`](crates/konnect-core/src/tools/sch_bus.rs)
+
+| Tool | Description |
+|---|---|
+| `add_bus` | Add a bus segment. Geometrically a wire; KiCad treats it as a bus, carrying the members named by the bus label (`NAME[1..6]` or `{A B C}`). Wires join it only through a bus entry. |
+| `batch_add_bus` | Add multiple bus segments in one file read/write cycle. |
+| `add_bus_entry` | Add the 45° tick that connects a wire to a bus. Required — a wire and bus that merely touch are *not* connected. `at` is the wire-side end; `dx`/`dy` give the signed offset to the bus side. |
+| `connect_pins_to_bus` | Fan a set of pins onto a bus: wire stub + bus entry + member label per pin. Bus membership is by name, so the label is part of the connection, not decoration. |
 
 ### `sch_analysis` · 15 tools
 **Purpose:** Net connectivity, pin queries, trace paths, overlap/orphan detection.

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -10,13 +10,13 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 ## Overview
 
 - **19 toolsets** organized into 10 categories
-- **191 registered tools** + **6 always-visible meta-tools** = **197 total**
+- **195 registered tools** + **7 always-visible meta-tools** = **202 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
 ## Meta-tools (always visible)
 
-Six tools, grouped into *discovery/routing* and *observability*.
+Seven tools, grouped into *discovery/routing* and *observability*.
 
 ### Discovery / routing
 
@@ -33,12 +33,13 @@ Six tools, grouped into *discovery/routing* and *observability*.
 |------|---------|
 | `get_recent_calls` | Last N tool calls (newest first) — `call_id`, tool, toolset, duration, status (ok/error/not_found), `error_kind`. The LLM's debug log. Default limit 20, max 100. |
 | `server_stats` | Uptime, total/error call counts, per-tool totals + errors, and the JSONL log path. |
+| `reload_server` | Restart the server in place from the binary on disk. `exec`s the process image (same PID, same stdio pipes) so the MCP connection survives; the new binary is verified first. Unix only. |
 
 ---
 
 ## Project
 
-### `project` · 6 tools
+### `project` · 7 tools
 **Purpose:** Create, open, save, snapshot KiCAD projects, and launch the live schematic viewer.
 **Source:** [`crates/konnect-core/src/tools/project.rs`](crates/konnect-core/src/tools/project.rs)
 
@@ -48,6 +49,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `open_project` | Check whether a KiCAD project is currently open in the running KiCAD UI. Returns the active project path and whether KiCAD IPC is available. |
 | `save_project` | Save the currently open PCB board file via KiCAD IPC. Requires KiCAD to be running with IPC enabled. |
 | `get_project_info` | Read project metadata from a `.kicad_pro` file. Returns name, schematic/PCB paths, last-modified times. |
+| `rename_project` | Rename the `.kicad_pro`/`.kicad_sch`/`.kicad_pcb`/`.kicad_prl` files *and* the internal references that carry the old name. Renaming files alone makes KiCad treat the design as unannotated, losing every reference designator. Supports `dry_run`. |
 | `snapshot_project` | Export the schematic and PCB to PDF as a timestamped snapshot/checkpoint. Useful before major edits. |
 | `open_schematic_viewer` | Launch the live schematic viewer (SVG with auto-refresh on file change). Use after placing components so the user can see changes in real time. |
 
@@ -55,13 +57,14 @@ Six tools, grouped into *discovery/routing* and *observability*.
 
 ## Schematic
 
-### `sch_components` · 17 tools
+### `sch_components` · 19 tools
 **Purpose:** Add, edit, move, rotate, and delete schematic symbols.
 **Source:** [`crates/konnect-core/src/tools/sch_components.rs`](crates/konnect-core/src/tools/sch_components.rs)
 
 | Tool | Description |
 |------|-------------|
 | `create_schematic` | Create a new blank `.kicad_sch` schematic file. |
+| `set_schematic_page` | Set the sheet's paper size (A0–A5, A–E, US Letter/Legal/Ledger) and orientation. Returns the size in mm — content outside the frame still exports and still nets up, so a too-small page is a silent defect. |
 | `add_schematic_component` | Add a symbol from a KiCAD library to the schematic. Snaps to the 1.27mm grid. |
 | `delete_schematic_component` | Remove a symbol instance from the schematic by its reference designator. |
 | `edit_schematic_component` | Update fields (Reference, Value, Footprint, custom properties) of a symbol instance. |
@@ -78,8 +81,9 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `group_components` | Add a group property to multiple components in the schematic. |
 | `replace_component` | Replace a component's `lib_id` with a new library symbol (swap the component type). |
 | `get_schematic_view` | Render the schematic to a PNG image (base64-encoded) via kicad-cli. |
+| `update_symbols_from_library` | Refresh the schematic's embedded `lib_symbols` from the on-disk libraries — eeschema's *Update Symbols from Library*. Refuses any symbol whose pins moved, since wires and labels sit at the old coordinates. |
 
-### `sch_wiring` · 19 tools
+### `sch_wiring` · 20 tools
 **Purpose:** Wires, net labels, power symbols, junctions, no-connects, pin-to-pin connections.
 **Source:** [`crates/konnect-core/src/tools/sch_wiring.rs`](crates/konnect-core/src/tools/sch_wiring.rs)
 
@@ -99,6 +103,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `add_no_connect` | Add a no-connect flag (X marker) to an unconnected pin endpoint. |
 | `delete_no_connect` | Remove a no-connect flag at a given position. |
 | `batch_delete_no_connect` | Delete multiple no-connect flags in a single file read/write cycle. |
+| `batch_add_no_connect` | Add multiple no-connect flags in one write. Marking one MCU's unused pins is routinely 15–20 flags. |
 | `add_junction` | Add a junction dot at a point where wires cross or T-intersect. |
 | `batch_add_junction` | Add multiple junction dots in a single file read/write cycle. |
 | `connect_to_net` | Connect a pin endpoint to a named net by adding a short wire stub + net label. |

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -10,7 +10,7 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 ## Overview
 
 - **18 toolsets** organized into 10 categories
-- **187 registered tools** + **6 always-visible meta-tools** = **193 total**
+- **188 registered tools** + **6 always-visible meta-tools** = **194 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -55,7 +55,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 
 ## Schematic
 
-### `sch_components` · 17 tools
+### `sch_components` · 18 tools
 **Purpose:** Add, edit, move, rotate, and delete schematic symbols.
 **Source:** [`crates/konnect-core/src/tools/sch_components.rs`](crates/konnect-core/src/tools/sch_components.rs)
 
@@ -77,6 +77,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `add_component_annotation` | Add a custom property (annotation) to a symbol instance. |
 | `group_components` | Add a group property to multiple components in the schematic. |
 | `replace_component` | Replace a component's `lib_id` with a new library symbol (swap the component type). |
+| `update_symbols_from_library` | Refresh the schematic's embedded `lib_symbols` from the on-disk libraries — eeschema's *Update Symbols from Library*. Refuses any symbol whose pins moved, since wires and labels sit at the old coordinates. |
 | `get_schematic_view` | Render the schematic to a PNG image (base64-encoded) via kicad-cli. |
 
 ### `sch_wiring` · 19 tools

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -10,13 +10,13 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 ## Overview
 
 - **18 toolsets** organized into 10 categories
-- **187 registered tools** + **6 always-visible meta-tools** = **193 total**
+- **187 registered tools** + **7 always-visible meta-tools** = **194 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
 ## Meta-tools (always visible)
 
-Six tools, grouped into *discovery/routing* and *observability*.
+Seven tools, grouped into *discovery/routing* and *observability*.
 
 ### Discovery / routing
 
@@ -33,6 +33,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 |------|---------|
 | `get_recent_calls` | Last N tool calls (newest first) — `call_id`, tool, toolset, duration, status (ok/error/not_found), `error_kind`. The LLM's debug log. Default limit 20, max 100. |
 | `server_stats` | Uptime, total/error call counts, per-tool totals + errors, and the JSONL log path. |
+| `reload_server` | Restart the server in place from the binary on disk, so a freshly built Konnect takes effect without restarting the MCP client. `exec`s the process image (same PID, same stdio pipes) so the connection survives; the new binary is verified first and the call is refused if it does not run. Unix only. |
 
 ---
 

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -10,7 +10,7 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 ## Overview
 
 - **18 toolsets** organized into 10 categories
-- **187 registered tools** + **6 always-visible meta-tools** = **193 total**
+- **188 registered tools** + **6 always-visible meta-tools** = **194 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -79,7 +79,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `replace_component` | Replace a component's `lib_id` with a new library symbol (swap the component type). |
 | `get_schematic_view` | Render the schematic to a PNG image (base64-encoded) via kicad-cli. |
 
-### `sch_wiring` · 19 tools
+### `sch_wiring` · 20 tools
 **Purpose:** Wires, net labels, power symbols, junctions, no-connects, pin-to-pin connections.
 **Source:** [`crates/konnect-core/src/tools/sch_wiring.rs`](crates/konnect-core/src/tools/sch_wiring.rs)
 
@@ -99,6 +99,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `add_no_connect` | Add a no-connect flag (X marker) to an unconnected pin endpoint. |
 | `delete_no_connect` | Remove a no-connect flag at a given position. |
 | `batch_delete_no_connect` | Delete multiple no-connect flags in a single file read/write cycle. |
+| `batch_add_no_connect` | Add multiple no-connect flags in one write. Marking one MCU's unused pins is routinely 15–20 flags. |
 | `add_junction` | Add a junction dot at a point where wires cross or T-intersect. |
 | `batch_add_junction` | Add multiple junction dots in a single file read/write cycle. |
 | `connect_to_net` | Connect a pin endpoint to a named net by adding a short wire stub + net label. |

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -10,7 +10,7 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 ## Overview
 
 - **18 toolsets** organized into 10 categories
-- **187 registered tools** + **6 always-visible meta-tools** = **193 total**
+- **188 registered tools** + **6 always-visible meta-tools** = **194 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -55,13 +55,14 @@ Six tools, grouped into *discovery/routing* and *observability*.
 
 ## Schematic
 
-### `sch_components` · 17 tools
+### `sch_components` · 19 tools
 **Purpose:** Add, edit, move, rotate, and delete schematic symbols.
 **Source:** [`crates/konnect-core/src/tools/sch_components.rs`](crates/konnect-core/src/tools/sch_components.rs)
 
 | Tool | Description |
 |------|-------------|
 | `create_schematic` | Create a new blank `.kicad_sch` schematic file. |
+| `set_schematic_page` | Set the sheet's paper size (A0–A5, A–E, US Letter/Legal/Ledger) and orientation. Returns the size in mm — content outside the frame still exports and still nets up, so a too-small page is a silent defect. |
 | `add_schematic_component` | Add a symbol from a KiCAD library to the schematic. Snaps to the 1.27mm grid. |
 | `delete_schematic_component` | Remove a symbol instance from the schematic by its reference designator. |
 | `edit_schematic_component` | Update fields (Reference, Value, Footprint, custom properties) of a symbol instance. |

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -10,7 +10,7 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 ## Overview
 
 - **18 toolsets** organized into 10 categories
-- **187 registered tools** + **6 always-visible meta-tools** = **193 total**
+- **188 registered tools** + **6 always-visible meta-tools** = **194 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -38,7 +38,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 
 ## Project
 
-### `project` · 6 tools
+### `project` · 7 tools
 **Purpose:** Create, open, save, snapshot KiCAD projects, and launch the live schematic viewer.
 **Source:** [`crates/konnect-core/src/tools/project.rs`](crates/konnect-core/src/tools/project.rs)
 
@@ -48,6 +48,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `open_project` | Check whether a KiCAD project is currently open in the running KiCAD UI. Returns the active project path and whether KiCAD IPC is available. |
 | `save_project` | Save the currently open PCB board file via KiCAD IPC. Requires KiCAD to be running with IPC enabled. |
 | `get_project_info` | Read project metadata from a `.kicad_pro` file. Returns name, schematic/PCB paths, last-modified times. |
+| `rename_project` | Rename the `.kicad_pro`/`.kicad_sch`/`.kicad_pcb`/`.kicad_prl` files *and* the internal references that carry the old name. Renaming the files alone makes KiCad treat the design as unannotated, losing every reference designator, because each symbol instance stores `(project "name")`. Supports `dry_run`. |
 | `snapshot_project` | Export the schematic and PCB to PDF as a timestamped snapshot/checkpoint. Useful before major edits. |
 | `open_schematic_viewer` | Launch the live schematic viewer (SVG with auto-refresh on file change). Use after placing components so the user can see changes in real time. |
 


### PR DESCRIPTION
Brings this fork's `main` up to current upstream and makes it the VNS working version:
**`mixelpixx/Konnect@5cd6454` plus ten fixes**, merged and gated together.

Until now `main` here was a byte-identical mirror of upstream, and the fork's actual work
lived on `publish` — a branch built from a vendored v0.2.0 tarball with **no shared ancestry**
with upstream. That made it useless as a base: a diff against upstream showed 208 files and
6060 deletions, because git could only read it as reverting everything upstream had done
since. Every fix here has now been replayed onto real upstream history instead.

## Correctness fixes

**Multi-unit symbols were treated as one placement.** A multi-unit part is one `(symbol …)`
instance *per unit*, all sharing the reference, and four tools took the first match.
`batch_connect_to_net` resolved every pin against instance #1 and transformed it by that
unit's placement, so two different nets landed on one coordinate and were **silently
shorted** — no error, and the tool returned success. Found in real use: `X_CLK_IN` and
`X_DATA_IN` both on U6 pin 1 of a 74HC14. `batch_edit_schematic_components` wrote fields into
unit 1 only; the delete tools left the other units as orphans; `bulk_move` tore the part
apart.

**No user symbol library resolved.** `resolve_lib_symbol` scanned a hardcoded list of install
directories for a file named after the library nickname and never read `sym-lib-table`. On any
non-standard KiCad install — a macOS bundle outside `/Applications`, a portable Windows copy —
*nothing* resolved. Footprints got table-aware lookup in v0.2.1; symbols never did.

**`add_schematic_text` wrote files KiCad could not open.** It inserted the node after the
symbol instances (KiCad 10 requires those last) and wrote literal newlines where the format
wants `\n`. Either alone makes the schematic fail to load with no indication of which element
is at fault, while the tool reports success. Worse, once the file will not load `kicad-cli
sch erc` leaves the previous report in place — so a *stale* ERC result is what gets read next.

**String escapes decoded wrongly.** `unescape` collapsed backslashes last, so `C:\\new` came
back as `C:\` plus a real newline. Hits Windows paths in `Datasheet`, 3D-model references and
`Sheetfile`.

## Added tooling

- **`sch_bus`** — `add_bus`, `batch_add_bus`, `add_bus_entry`, `connect_pins_to_bus`.
  `konnect-sexp` already had `format_bus` and `BusEntryDirection` and `SchematicBuilder`
  already round-tripped bus nodes, but nothing could create one. `connect_pins_to_bus` writes
  the stub, the entry *and* the member label per pin, because bus membership in KiCad is by
  name — a stub without a label joins nothing.
- **`set_schematic_page`** — nothing could set the sheet size, and content off the frame still
  exports and still nets up, so an undersized page is a silent defect.
- **`update_symbols_from_library`** — eeschema's *Update Symbols from Library*. Refuses any
  symbol whose pin anchors moved, since wires sit at the old coordinates.
- **`rename_project`** — renames the four project files *and* the internal `(project "name")`
  references. Renaming files alone makes KiCad treat the design as unannotated, losing every
  reference designator.
- **`batch_add_no_connect`** — `batch_delete_no_connect` existed with no batch add; one MCU's
  unused pins is routinely 15–20 round trips.
- **`reload_server`** — `exec`s into the rebuilt binary in place, same PID and stdio pipes, so
  the MCP session survives a rebuild. Verifies the new binary first.

## Validation

`cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings`, and
`cargo test --workspace --lib --tests` — **515 passing**. `cargo check --locked
--manifest-path crates/schematic-viewer/Cargo.toml` passes too, which the viewer CI job
requires.

Counts reconciled across the merge: 19 toolsets, 195 registered tools + 7 meta-tools.
`sch_components` 17 → 19, `sch_wiring` 19 → 20, `project` 6 → 7, and the `tools_added`
assertion in `protocol_stdio.rs` 36 → 39.

Three merge hazards were resolved rather than papered over: two pairs of branches appended
test modules at the same point in `sch_batch.rs` and `sch_components.rs`, and every branch
claimed the same next `tool_count`.

## Relationship to the upstream PRs

Each fix is also offered upstream on its own branch, one per PR (`up/*`), each based directly
on `upstream/main` and carrying only its own change. This branch is the integrated result for
use here; those are the reviewable units. As they land upstream, rebuild this branch on the
new `upstream/main` rather than merging it back.

Not included, and still fork-only: `publish-to-fork.sh`, `version_history.md`, `CLAUDE.md`,
`docs/CODE_REVIEW.md` and the KiCad bug reports.
