### PR TITLE
fix(sch): place instance fields at their library anchors

### DIFF
--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -520,6 +520,11 @@ pub(crate) fn add_pin_midwire_junctions(
 /// Hidden properties get KiCAD 10's property-level `(hide yes)` — a sibling
 /// before `(effects)`, exactly as eeschema writes instances (PR #96); the
 /// legacy hide-inside-effects form renders the same but round-trips dirty.
+///
+/// `justify` comes from the library field and is written through unchanged,
+/// like the angle in [`field_at`]: it is expressed in the text's own frame, so
+/// it stays true however the instance is rotated. Centred fields write no
+/// `(justify …)`, which is how KiCad spells centred.
 pub(crate) fn positioned_property(
     name: &str,
     value: &str,
@@ -527,6 +532,7 @@ pub(crate) fn positioned_property(
     y: f64,
     rotation: f64,
     hide: bool,
+    justify: konnect_schematic_editor::library::FieldJustify,
 ) -> konnect_schematic_editor::Property {
     use konnect_schematic_editor::sexp::{atom, SexpNode};
     use konnect_schematic_editor::types::fmt_f64;
@@ -542,15 +548,61 @@ pub(crate) fn positioned_property(
         prop.sub_nodes
             .push(SexpNode::List(vec![atom("hide"), atom("yes")]));
     }
-    prop.sub_nodes.push(SexpNode::List(vec![
+    let mut effects = vec![
         atom("effects"),
         SexpNode::List(vec![
             atom("font"),
             SexpNode::List(vec![atom("size"), atom("1.27"), atom("1.27")]),
         ]),
-    ]));
+    ];
+    let tokens = justify.tokens();
+    if !tokens.is_empty() {
+        let mut node = vec![atom("justify")];
+        node.extend(tokens.into_iter().map(atom));
+        effects.push(SexpNode::List(node));
+    }
+    prop.sub_nodes.push(SexpNode::List(effects));
     prop
 }
+
+/// Sheet-space `(x, y, rotation)` for one instance field, from its library
+/// anchor (#101).
+///
+/// The two halves are stored differently, which is easy to get backwards:
+///
+/// - **Position is absolute.** The anchor is library space (Y-up), the file
+///   wants sheet space (Y-down), so it goes through the same
+///   flip-rotate-mirror-translate as a pin —
+///   [`transform_pin`](konnect_sexp::geometry::transform_pin) is that math.
+///   This is what carries a label around with a rotated body instead of
+///   leaving it beside the wrong edge.
+/// - **Angle is relative.** KiCad adds the symbol's own rotation to a field's
+///   stored angle when it draws, so the library value is written through
+///   unchanged. Rotating it here too would double-count: verified by
+///   rendering a 90°-rotated `Device:R` with `kicad-cli sch export svg` —
+///   stored 0° draws the reference *vertically* over the horizontal body,
+///   stored 90° (the library's own value) draws it horizontally above it.
+///
+/// `fallback` is a library-space anchor too, used when the library defines
+/// none, so both halves behave identically either way.
+///
+/// The angle folds into 0°..180°: a field is horizontal or vertical, never
+/// upside down.
+pub(crate) fn field_at(
+    anchor: Option<(f64, f64, f64)>,
+    fallback: (f64, f64, f64),
+    t: konnect_sexp::geometry::PinTransform,
+) -> (f64, f64, f64) {
+    let (ax, ay, arot) = anchor.unwrap_or(fallback);
+    let (x, y) = konnect_sexp::geometry::transform_pin(ax, ay, t);
+    (x, y, arot.rem_euclid(180.0))
+}
+
+/// Library-space fallback anchors matching the pre-#101 hardcoded placement:
+/// Reference 3.81mm above the origin, Value 3.81mm below. Y is negated on the
+/// way to sheet coords, hence the sign flip against the old literals.
+pub(crate) const FALLBACK_REFERENCE_AT: (f64, f64, f64) = (0.0, 3.81, 0.0);
+pub(crate) const FALLBACK_VALUE_AT: (f64, f64, f64) = (0.0, -3.81, 0.0);
 
 // ─── Schematic text helpers ──────────────────────────────────────────────────
 

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -420,25 +420,48 @@ pub(crate) fn place_one_component(
     sym.at.rotation = Some(rotation);
     sym.unit = unit;
 
-    // Reference above the component, Value below; Footprint/Datasheet hidden.
+    // Reference and Value go where the library anchors them, carried through
+    // the placement transform so they follow a rotated body (#101);
+    // Footprint/Datasheet stay hidden at the origin.
     // Power symbols get their Reference hidden too, matching eeschema: a
     // #PWR designator is never shown on the sheet.
     let hide_reference = lib_id.starts_with("power:") || reference.starts_with("#PWR");
+    let anchors = cse::library::field_anchors(sch, lib_id);
+    let t = konnect_sexp::geometry::PinTransform {
+        comp_x: x,
+        comp_y: y,
+        rotation_deg: rotation,
+        mirror_x: false,
+        mirror_y: false,
+    };
+    let (ref_x, ref_y, ref_rot) =
+        crate::tools::field_at(anchors.reference_at, crate::tools::FALLBACK_REFERENCE_AT, t);
+    let (val_x, val_y, val_rot) =
+        crate::tools::field_at(anchors.value_at, crate::tools::FALLBACK_VALUE_AT, t);
     let positioned = crate::tools::positioned_property;
+    let centred = cse::library::FieldJustify::default();
     sym.properties.push(positioned(
         "Reference",
         reference,
-        x,
-        y - 3.81,
-        0.0,
+        ref_x,
+        ref_y,
+        ref_rot,
         hide_reference,
+        anchors.reference_justify,
+    ));
+    sym.properties.push(positioned(
+        "Value",
+        val_str,
+        val_x,
+        val_y,
+        val_rot,
+        false,
+        anchors.value_justify,
     ));
     sym.properties
-        .push(positioned("Value", val_str, x, y + 3.81, 0.0, false));
+        .push(positioned("Footprint", "", x, y, 0.0, true, centred));
     sym.properties
-        .push(positioned("Footprint", "", x, y, 0.0, true));
-    sym.properties
-        .push(positioned("Datasheet", "", x, y, 0.0, true));
+        .push(positioned("Datasheet", "", x, y, 0.0, true, centred));
 
     // Instance entry, keyed to the root sheet UUID like eeschema writes it:
     // (instances (project "<name>" (path "/<root-uuid>" (reference ...) (unit 1))))
@@ -2026,6 +2049,148 @@ mod tests {
         let msg = format!("{:?}", result.content);
         assert!(msg.contains("Device:CP"));
         assert!(msg.contains("no embedded definition"));
+    }
+
+    /// Fields follow the library anchor through the instance rotation (#101).
+    /// `Device:R` anchors Reference beside the body at (2.032, 0) rotated 90°,
+    /// so an upright resistor labels its right-hand side vertically and a
+    /// 90°-rotated one labels above, horizontally — a fixed ±3.81 offset at 0°
+    /// put both beside the wrong edge.
+    async fn place_rotated_resistor(rotation: f64) -> (String, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rot.kicad_sch");
+        std::fs::write(
+            &path,
+            "(kicad_sch\n  (version 20250610)\n  (generator \"konnect\")\n  (uuid \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\")\n  (paper \"A4\")\n  (lib_symbols\n    (symbol \"Device:R\"\n      (property \"Reference\" \"R\" (at 2.032 0 90))\n      (property \"Value\" \"R\" (at 0 0 90))\n    )\n  )\n)\n",
+        )
+        .unwrap();
+
+        let result = handle_add_schematic_component(
+            &json!({
+                "schematic": path.display().to_string(),
+                "lib_id": "Device:R",
+                // Already on the 1.27mm grid the placement snaps to, so the
+                // expected field coordinates are the anchors plus the origin.
+                "x": 101.6,
+                "y": 50.8,
+                "rotation": rotation,
+                "reference": "R1",
+                "value": "10k"
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error, "{result:?}");
+
+        let sch = cse::Schematic::load(&path).unwrap();
+        let sym = sch
+            .symbols
+            .iter()
+            .find(|s| s.reference() == Some("R1"))
+            .expect("placed resistor");
+        let field = |name: &str| {
+            cse::sexp::writer::write(
+                &sym.properties
+                    .iter()
+                    .find(|p| p.name == name)
+                    .unwrap()
+                    .to_sexp(),
+            )
+        };
+        (field("Reference"), field("Value"))
+    }
+
+    /// An anchor without its justification collides: this symbol anchors
+    /// Reference and Value on the same row and relies on `justify left` to
+    /// keep `U2` off `AP2112K-3.3`. Device:R, which the tests above place,
+    /// justifies nothing — centred stays spelled as no `(justify …)`.
+    #[tokio::test]
+    async fn placement_carries_the_librarys_field_justification() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("justify.kicad_sch");
+        std::fs::write(
+            &path,
+            "(kicad_sch\n  (version 20250610)\n  (generator \"konnect\")\n  (uuid \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\")\n  (paper \"A4\")\n  (lib_symbols\n    (symbol \"Regulator_Linear:AP2112K-3.3\"\n      (property \"Reference\" \"U\" (at -5.08 5.715 0) (effects (font (size 1.27 1.27)) (justify left)))\n      (property \"Value\" \"AP2112K-3.3\" (at 0 5.715 0) (effects (font (size 1.27 1.27)) (justify left)))\n    )\n  )\n)\n",
+        )
+        .unwrap();
+
+        let result = handle_add_schematic_component(
+            &json!({
+                "schematic": path.display().to_string(),
+                "lib_id": "Regulator_Linear:AP2112K-3.3",
+                "x": 101.6,
+                "y": 50.8,
+                "reference": "U2",
+                "value": "AP2112K-3.3"
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error, "{result:?}");
+
+        let sch = cse::Schematic::load(&path).unwrap();
+        let sym = sch
+            .symbols
+            .iter()
+            .find(|s| s.reference() == Some("U2"))
+            .expect("placed regulator");
+        let field = |name: &str| {
+            cse::sexp::writer::write(
+                &sym.properties
+                    .iter()
+                    .find(|p| p.name == name)
+                    .unwrap()
+                    .to_sexp(),
+            )
+        };
+        for name in ["Reference", "Value"] {
+            let written = field(name);
+            assert!(
+                written.contains("(justify left)"),
+                "{name} must keep the library's justification: {written}"
+            );
+        }
+        // Hidden fields have no library anchor here, so they stay centred.
+        assert!(!field("Footprint").contains("justify"));
+
+        let (reference, _) = place_rotated_resistor(0.0).await;
+        assert!(
+            !reference.contains("justify"),
+            "a centred library field must not gain a justify: {reference}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unrotated_symbol_takes_the_librarys_field_anchors() {
+        let (reference, value) = place_rotated_resistor(0.0).await;
+        // Same numbers eeschema writes for this library symbol at (100, 50).
+        assert!(
+            reference.contains("(at 103.632 50.8 90)"),
+            "Reference belongs beside the body, rotated: {reference}"
+        );
+        assert!(
+            value.contains("(at 101.6 50.8 90)"),
+            "Value belongs on the body's axis, rotated: {value}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rotated_symbol_carries_its_fields_around_with_it() {
+        let (reference, value) = place_rotated_resistor(90.0).await;
+        // The anchor rotates with the body: 2.032mm to the right of the
+        // origin becomes 2.032mm above it. The stored angle stays at the
+        // library's 90° — KiCad adds the symbol's rotation when it draws, so
+        // this renders horizontally above the now-horizontal body.
+        assert!(
+            reference.contains("(at 101.6 48.768 90)"),
+            "Reference must follow the rotated body: {reference}"
+        );
+        assert!(
+            value.contains("(at 101.6 50.8 90)"),
+            "Value must follow the rotated body: {value}"
+        );
     }
 
     #[tokio::test]

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -1290,15 +1290,46 @@ async fn handle_add_power_symbol(
     // Bare Property::new writes no (at); KiCad then defaults to (0,0) and every
     // #PWR piles up in the top-left corner. Hide Reference like eeschema does
     // (property-level `(hide yes)`, matching what KiCad 10 itself writes).
+    //
+    // The library anchors matter most here: GND anchors Value below the
+    // graphic but VCC/+5V/+3V3 anchor it above, so one fixed offset cannot
+    // suit both (#101).
+    let anchors = cse::library::field_anchors(&sch, &lib_id);
+    let t = konnect_sexp::geometry::PinTransform {
+        comp_x: x,
+        comp_y: y,
+        rotation_deg: rotation,
+        mirror_x: false,
+        mirror_y: false,
+    };
+    let (ref_x, ref_y, ref_rot) =
+        crate::tools::field_at(anchors.reference_at, crate::tools::FALLBACK_REFERENCE_AT, t);
+    let (val_x, val_y, val_rot) =
+        crate::tools::field_at(anchors.value_at, crate::tools::FALLBACK_VALUE_AT, t);
     let positioned = crate::tools::positioned_property;
+    let centred = cse::library::FieldJustify::default();
+    sym.properties.push(positioned(
+        "Reference",
+        &pwr_ref,
+        ref_x,
+        ref_y,
+        ref_rot,
+        true,
+        anchors.reference_justify,
+    ));
+    sym.properties.push(positioned(
+        "Value",
+        &power_net,
+        val_x,
+        val_y,
+        val_rot,
+        false,
+        anchors.value_justify,
+    ));
     sym.properties
-        .push(positioned("Reference", &pwr_ref, x, y - 3.81, 0.0, true));
+        .push(positioned("Footprint", "", x, y, 0.0, true, centred));
     sym.properties
-        .push(positioned("Value", &power_net, x, y + 3.81, 0.0, false));
-    sym.properties
-        .push(positioned("Footprint", "", x, y, 0.0, true));
-    sym.properties
-        .push(positioned("Datasheet", "", x, y, 0.0, true));
+        .push(positioned("Datasheet", "", x, y, 0.0, true, centred));
 
     // Instance entry, keyed to the root sheet UUID like eeschema writes it —
     // without a resolvable "/<root-uuid>" path KiCAD's netlister drops the
@@ -2559,7 +2590,9 @@ mod power_symbol_tests {
         let path = dir.path().join("power.kicad_sch");
         std::fs::write(
             &path,
-            "(kicad_sch\n  (version 20250610)\n  (generator \"konnect\")\n  (uuid \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\")\n  (paper \"A4\")\n  (lib_symbols\n    (symbol \"power:GND\"\n      (property \"Reference\" \"#PWR\" (at 0 0 0))\n      (property \"Value\" \"GND\" (at 0 0 0))\n    )\n  )\n)\n",
+            // Anchors copied from KiCad 10's power.kicad_sym: GND points down,
+            // so both fields anchor below the origin in Y-up library space.
+            "(kicad_sch\n  (version 20250610)\n  (generator \"konnect\")\n  (uuid \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\")\n  (paper \"A4\")\n  (lib_symbols\n    (symbol \"power:GND\"\n      (property \"Reference\" \"#PWR\" (at 0 -6.35 0))\n      (property \"Value\" \"GND\" (at 0 -3.81 0))\n    )\n  )\n)\n",
         )
         .unwrap();
 
@@ -2590,8 +2623,9 @@ mod power_symbol_tests {
             .unwrap();
         let ref_sexp = cse::sexp::writer::write(&ref_prop.to_sexp());
         assert!(
-            ref_sexp.contains("(at 100") && ref_sexp.contains("76.19"),
-            "Reference must sit near the symbol, not sheet origin: {ref_sexp}"
+            ref_sexp.contains("(at 100") && ref_sexp.contains("86.35"),
+            "Reference must sit at the library's anchor near the symbol, not \
+             sheet origin: {ref_sexp}"
         );
         let hide_at = ref_sexp
             .find("(hide yes)")
@@ -2614,6 +2648,46 @@ mod power_symbol_tests {
         assert!(
             !after.contains("(property \"Reference\" \"#PWR001\")\n"),
             "must not write a bare Reference with no (at)"
+        );
+    }
+
+    /// An up-pointing rail anchors its Value *above* the graphic, where a
+    /// fixed +3.81 offset used to put it below (#101). VCC's library anchor is
+    /// (0, +3.556) in Y-up space, so the sheet coordinate is y − 3.556.
+    #[tokio::test]
+    async fn up_pointing_power_symbol_puts_value_above_the_graphic() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vcc.kicad_sch");
+        std::fs::write(
+            &path,
+            "(kicad_sch\n  (version 20250610)\n  (generator \"konnect\")\n  (uuid \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\")\n  (paper \"A4\")\n  (lib_symbols\n    (symbol \"power:VCC\"\n      (property \"Reference\" \"#PWR\" (at 0 -3.81 0))\n      (property \"Value\" \"VCC\" (at 0 3.556 0))\n    )\n  )\n)\n",
+        )
+        .unwrap();
+
+        let result = handle_add_power_symbol(
+            &json!({
+                "schematic": path.display().to_string(),
+                "power_net": "VCC",
+                "x": 100.0,
+                "y": 80.0
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error, "{result:?}");
+
+        let sch = cse::Schematic::load(&path).unwrap();
+        let sym = sch
+            .symbols
+            .iter()
+            .find(|s| s.reference() == Some("#PWR001"))
+            .expect("power symbol instance");
+        let val_prop = sym.properties.iter().find(|p| p.name == "Value").unwrap();
+        let val_sexp = cse::sexp::writer::write(&val_prop.to_sexp());
+        assert!(
+            val_sexp.contains("76.444"),
+            "VCC's Value belongs above the symbol at y-3.556, not below: {val_sexp}"
         );
     }
 }

--- a/crates/konnect-schematic-editor/src/library.rs
+++ b/crates/konnect-schematic-editor/src/library.rs
@@ -290,6 +290,162 @@ pub fn ensure_lib_symbol(
     true
 }
 
+/// Library-space (Y-up) anchors of a symbol's Reference and Value text, each
+/// `(x, y, text_rotation)` as written in the library's `(property … (at …))`,
+/// plus the `(justify …)` that says which way the text runs from there.
+///
+/// eeschema places an instance's fields at these anchors pushed through the
+/// instance transform, so reading them is what keeps a placement looking like
+/// one eeschema made. A fixed ±3.81 offset only matches down-pointing symbols
+/// such as `power:GND`; `power:VCC` and every other up-pointing flavor anchor
+/// Value *above* the graphic, and `Device:R` anchors both fields beside the
+/// body at 90° (#101).
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct FieldAnchors {
+    /// `(x, y, rotation)` of the Reference text, library-local mm/degrees.
+    pub reference_at: Option<(f64, f64, f64)>,
+    /// `(x, y, rotation)` of the Value text, library-local mm/degrees.
+    pub value_at: Option<(f64, f64, f64)>,
+    /// `(justify …)` of the Reference text.
+    pub reference_justify: FieldJustify,
+    /// `(justify …)` of the Value text.
+    pub value_justify: FieldJustify,
+}
+
+/// The `(justify …)` of a field's `(effects …)`: which side of the anchor the
+/// text runs to. Default is KiCad's centred, written as no `(justify …)` at
+/// all.
+///
+/// An anchor without its justification is half the placement. Libraries that
+/// left-justify keep Reference and Value apart at the same `y` —
+/// `Regulator_Linear:AP2112K-3.3` anchors Reference at `(-5.08, 5.715)` and
+/// Value at `(0, 5.715)`, both `justify left`, so centring them prints `U2`
+/// on top of `AP2112K-3.3`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FieldJustify {
+    /// `left` / `right`; `None` is centred.
+    pub horizontal: Option<HorizontalJustify>,
+    /// `top` / `bottom`; `None` is centred.
+    pub vertical: Option<VerticalJustify>,
+    /// `mirror`: the text reads backwards.
+    pub mirror: bool,
+}
+
+/// Horizontal half of a [`FieldJustify`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HorizontalJustify {
+    Left,
+    Right,
+}
+
+/// Vertical half of a [`FieldJustify`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerticalJustify {
+    Top,
+    Bottom,
+}
+
+impl FieldJustify {
+    /// Read the `(justify …)` of a `(property …)` node's `(effects …)`.
+    ///
+    /// Tokens are order-independent and any KiCad does not define is ignored,
+    /// so an unknown one degrades to centred rather than failing a placement.
+    pub fn of_property(property: &SexpNode) -> Self {
+        let mut justify = Self::default();
+        let Some(node) = property.find("effects").and_then(|e| e.find("justify")) else {
+            return justify;
+        };
+        for token in node.scalar_args() {
+            match token {
+                "left" => justify.horizontal = Some(HorizontalJustify::Left),
+                "right" => justify.horizontal = Some(HorizontalJustify::Right),
+                "top" => justify.vertical = Some(VerticalJustify::Top),
+                "bottom" => justify.vertical = Some(VerticalJustify::Bottom),
+                "mirror" => justify.mirror = true,
+                _ => {}
+            }
+        }
+        justify
+    }
+
+    /// The tokens of a `(justify …)`, in the order KiCad writes them. Empty
+    /// when the field is centred, which is spelled by omitting the node.
+    pub fn tokens(&self) -> Vec<&'static str> {
+        let mut tokens = Vec::new();
+        if let Some(h) = self.horizontal {
+            tokens.push(match h {
+                HorizontalJustify::Left => "left",
+                HorizontalJustify::Right => "right",
+            });
+        }
+        if let Some(v) = self.vertical {
+            tokens.push(match v {
+                VerticalJustify::Top => "top",
+                VerticalJustify::Bottom => "bottom",
+            });
+        }
+        if self.mirror {
+            tokens.push("mirror");
+        }
+        tokens
+    }
+}
+
+/// Read the Reference/Value anchors of `lib_id` from the copy embedded in
+/// `schematic`'s `lib_symbols`.
+///
+/// The embedded copy — not the library on disk — is what KiCad draws, so it is
+/// also what a placement should anchor to; it is already flattened by
+/// [`ensure_lib_symbol`], so a derived symbol inherits its parent's anchors.
+/// A `lib_id` the schematic has no definition for yields `None` anchors and
+/// leaves the caller on its fallback.
+pub fn field_anchors(schematic: &Schematic, lib_id: &str) -> FieldAnchors {
+    embedded_lib_symbol(schematic, lib_id)
+        .map(field_anchors_of)
+        .unwrap_or_default()
+}
+
+/// The `lib_symbols` entry `schematic` carries for `lib_id`.
+fn embedded_lib_symbol<'a>(schematic: &'a Schematic, lib_id: &str) -> Option<&'a SexpNode> {
+    schematic
+        .raw_other
+        .iter()
+        .find(|n| n.tag() == Some("lib_symbols"))?
+        .find_all("symbol")
+        .into_iter()
+        .find(|s| s.value() == Some(lib_id))
+}
+
+/// [`FieldAnchors`] of a resolved symbol node.
+///
+/// Only direct `(property …)` children count: a unit sub-symbol carries its
+/// own graphics, not the instance's fields.
+pub fn field_anchors_of(symbol: &SexpNode) -> FieldAnchors {
+    let mut anchors = FieldAnchors::default();
+    for prop in symbol.find_all("property") {
+        let Some(name) = prop.value() else { continue };
+        let Some(at) = prop.find("at") else { continue };
+        let s = at.scalar_args();
+        let num = |i: usize| s.get(i).and_then(|v| v.parse::<f64>().ok());
+        let (Some(x), Some(y)) = (num(0), num(1)) else {
+            continue;
+        };
+        let rot = num(2).unwrap_or(0.0);
+        match name {
+            "Reference" => {
+                anchors.reference_at = Some((x, y, rot));
+                anchors.reference_justify = FieldJustify::of_property(prop);
+            }
+            "Value" => {
+                anchors.value_at = Some((x, y, rot));
+                anchors.value_justify = FieldJustify::of_property(prop);
+            }
+            _ => {}
+        }
+    }
+    anchors
+}
+
 /// Number of units of the symbol `lib_id` resolves to, following the
 /// `(extends "Parent")` chain when the symbol has no unit sub-symbols of its
 /// own (#35). The count is the maximum `N >= 1` over `Name_N_M` sub-symbol
@@ -726,5 +882,120 @@ mod suggestion_tests {
             out.contains("(number \"5\""),
             "pins must come with it — a definition-less instance netlists empty (#34):\n{out}"
         );
+    }
+}
+
+#[cfg(test)]
+mod field_anchor_tests {
+    use super::*;
+
+    fn schematic_with(lib_symbols: &str) -> (Schematic, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("anchors.kicad_sch");
+        std::fs::write(
+            &path,
+            format!(
+                "(kicad_sch\n\t(version 20250610)\n\t(generator \"test\")\n\t(lib_symbols\n{}\n\t)\n)\n",
+                lib_symbols
+            ),
+        )
+        .unwrap();
+        // The TempDir rides along: dropping it would delete the file the
+        // Schematic still refers to.
+        (Schematic::load(&path).unwrap(), dir)
+    }
+
+    #[test]
+    fn reads_both_anchors_with_their_text_rotation() {
+        let (sch, _dir) = schematic_with(
+            "(symbol \"Device:R\" (property \"Reference\" \"R\" (at 2.032 0 90)) (property \"Value\" \"R\" (at 0 0 90)))",
+        );
+        let anchors = field_anchors(&sch, "Device:R");
+        assert_eq!(anchors.reference_at, Some((2.032, 0.0, 90.0)));
+        assert_eq!(anchors.value_at, Some((0.0, 0.0, 90.0)));
+    }
+
+    /// The anchor alone is not enough: `Regulator_Linear:AP2112K-3.3` puts
+    /// Reference and Value on the same `y` and keeps them apart with
+    /// `justify left`.
+    #[test]
+    fn reads_the_justify_that_keeps_fields_on_a_shared_row_apart() {
+        let (sch, _dir) = schematic_with(
+            "(symbol \"Regulator_Linear:AP2112K-3.3\" (property \"Reference\" \"U\" (at -5.08 5.715 0) (effects (font (size 1.27 1.27)) (justify left))) (property \"Value\" \"AP2112K-3.3\" (at 0 5.715 0) (effects (font (size 1.27 1.27)) (justify left))))",
+        );
+        let anchors = field_anchors(&sch, "Regulator_Linear:AP2112K-3.3");
+        let left = FieldJustify {
+            horizontal: Some(HorizontalJustify::Left),
+            ..Default::default()
+        };
+        assert_eq!(anchors.reference_justify, left);
+        assert_eq!(anchors.value_justify, left);
+        assert_eq!(anchors.reference_justify.tokens(), vec!["left"]);
+    }
+
+    #[test]
+    fn justify_reads_every_token_and_re_emits_them_in_kicads_order() {
+        let (sch, _dir) = schematic_with(
+            "(symbol \"Device:R\" (property \"Value\" \"R\" (at 0 0 0) (effects (font (size 1.27 1.27)) (justify mirror bottom right nonsense))))",
+        );
+        let justify = field_anchors(&sch, "Device:R").value_justify;
+        assert_eq!(justify.horizontal, Some(HorizontalJustify::Right));
+        assert_eq!(justify.vertical, Some(VerticalJustify::Bottom));
+        assert!(justify.mirror);
+        assert_eq!(justify.tokens(), vec!["right", "bottom", "mirror"]);
+    }
+
+    /// No `(justify …)` is how KiCad spells centred, and centred must stay
+    /// spelled that way rather than becoming an explicit token.
+    #[test]
+    fn a_field_without_justify_is_centred() {
+        let (sch, _dir) = schematic_with(
+            "(symbol \"Device:R\" (property \"Value\" \"R\" (at 0 0 90) (effects (font (size 1.27 1.27)))))",
+        );
+        let justify = field_anchors(&sch, "Device:R").value_justify;
+        assert_eq!(justify, FieldJustify::default());
+        assert!(justify.tokens().is_empty());
+    }
+
+    /// The whole point of #101: one fixed offset cannot serve both, because
+    /// GND anchors Value below the origin and VCC above it.
+    #[test]
+    fn opposite_pointing_power_symbols_anchor_value_opposite_ways() {
+        let (sch, _dir) = schematic_with(
+            "(symbol \"power:GND\" (property \"Value\" \"GND\" (at 0 -3.81 0)))\n(symbol \"power:VCC\" (property \"Value\" \"VCC\" (at 0 3.556 0)))",
+        );
+        assert_eq!(
+            field_anchors(&sch, "power:GND").value_at,
+            Some((0.0, -3.81, 0.0))
+        );
+        assert_eq!(
+            field_anchors(&sch, "power:VCC").value_at,
+            Some((0.0, 3.556, 0.0))
+        );
+    }
+
+    #[test]
+    fn a_symbol_the_schematic_does_not_embed_has_no_anchors() {
+        let (sch, _dir) =
+            schematic_with("(symbol \"Device:R\" (property \"Value\" \"R\" (at 0 0 0)))");
+        assert_eq!(field_anchors(&sch, "Device:C"), FieldAnchors::default());
+    }
+
+    /// Unit sub-symbols carry graphics, not instance fields — a property
+    /// nested in one must not be mistaken for the symbol's own anchor.
+    #[test]
+    fn unit_sub_symbol_properties_are_not_anchors() {
+        let (sch, _dir) = schematic_with(
+            "(symbol \"Device:R\" (property \"Reference\" \"R\" (at 2.032 0 90)) (symbol \"R_0_1\" (property \"Value\" \"nested\" (at 99 99 0))))",
+        );
+        let anchors = field_anchors(&sch, "Device:R");
+        assert_eq!(anchors.reference_at, Some((2.032, 0.0, 90.0)));
+        assert_eq!(anchors.value_at, None, "nested property must not count");
+    }
+
+    #[test]
+    fn a_property_without_an_at_is_skipped() {
+        let (sch, _dir) = schematic_with("(symbol \"Device:R\" (property \"Value\" \"R\"))");
+        assert_eq!(field_anchors(&sch, "Device:R").value_at, None);
     }
 }


### PR DESCRIPTION
Fixes #101.

`positioned_property` put Reference at `y − 3.81` and Value at `y + 3.81` for every
symbol, ignoring the library's own anchors and the instance rotation. That matched
eeschema only for down-pointing symbols: `power:VCC` and every other up-pointing rail
anchors Value *above* the graphic, and `Device:R` anchors both fields beside the body
at 90°.

The anchors are now read from the definition embedded in the schematic's `lib_symbols`
— the copy KiCad actually draws — and put through the placement transform. The old
offsets remain as the fallback for a symbol that defines no anchor.

### Position and angle are stored differently

Easy to get backwards, so it is worth stating:

- **Position is absolute.** The anchor takes the same flip-rotate-translate as a pin.
- **The angle is relative.** KiCad adds the symbol's rotation when it draws, so the
  library value is written through unchanged.

Verified by rendering a 90° `Device:R` with `kicad-cli sch export svg` — storing the
rotated angle draws the reference vertically across the horizontal body.

### The anchor alone is not enough

`(justify …)` comes with it. Fields that share a row rely on it to stay apart:
`Regulator_Linear:AP2112K-3.3` anchors Reference at `(-5.08, 5.715)` and Value at
`(0, 5.715)`, both `justify left`, so centring them prints `U2` on top of
`AP2112K-3.3`. Like the angle, justification is expressed in the text's own frame, so
the library value is written through unchanged, and a centred field keeps writing no
`(justify …)` at all.

### Scope

Applies to new placements — `add_schematic_component` and `add_power_symbol`, which
share `positioned_property`. A sheet placed before this change keeps its old field
positions until each symbol is re-placed; repairing existing sheets is a separate
concern.

### Testing

`cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, the workspace
test suite and the doctests all pass. Nine new unit tests cover anchor extraction,
the text rotation read off each anchor, justify parsing and re-emission in KiCad's
token order, the centred (no-justify) case, opposite-pointing power symbols, and the
three cases with no anchor to read: an unembedded symbol, a unit sub-symbol, and a
property with no `(at …)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
