### PR TITLE
fix(library): project resolution escaping into an unrelated project, and downgraded argument errors

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -206,7 +206,7 @@ if !path.exists() {
 
 Adding a new kind: edit `mcp/error.rs`, add the variant, add the match arm in `short_code()`, use it from the handler. The `short_code_matches_serialized_kind_field` test will fail loudly if they drift.
 
-The dispatch-level errors (not-loaded/unknown/handler-panic) are fully structured. So are **all missing-argument errors** across all 187 tools — `tools/mod.rs::require_str` / `require_f64` emit `ToolErrorKind::InvalidArgument { field, reason }` automatically. Most in-handler errors still use `CallToolResult::error("free text")` or bubble `anyhow::Error`; migrating them is incremental. `project.rs::handle_get_project_info` demonstrates the structured `FileNotFound` pattern.
+The dispatch-level errors (not-loaded/unknown/handler-panic) are fully structured. So are **all missing-argument errors** across all 189 tools — `tools/mod.rs::require_str` / `require_f64` emit `ToolErrorKind::InvalidArgument { field, reason }` automatically. Most in-handler errors still use `CallToolResult::error("free text")` or bubble `anyhow::Error`; migrating them is incremental. `project.rs::handle_get_project_info` demonstrates the structured `FileNotFound` pattern.
 
 ## Observability
 
@@ -227,7 +227,7 @@ Source: [`crates/konnect-core/src/observability.rs`](crates/konnect-core/src/obs
 
 ## Tool Routing (Starter Kit + On-Demand Loading)
 
-The server does NOT expose all 187 tools (193 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
+The server does NOT expose all 189 tools (195 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
 
 - **Startup**: only `STARTER_KIT` toolsets are pre-loaded (see `router/registry.rs::STARTER_KIT`). Currently: `project`, `config`. Combined with the 6 meta-tools, baseline `tools/list` is ~19 tools ≈ 2K tokens.
 - **On demand**: the LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose a toolset's tools in subsequent `tools/list` responses. `unload_toolset(name)` prunes them when the task shifts.
@@ -299,9 +299,9 @@ convention for other `kicad-cli`-calling code.
 
 ## Current Stats
 
-- **18 toolsets, 187 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
+- **18 toolsets, 189 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
 - Baseline `tools/list`: ~19 tools / ~2K tokens (starter kit + meta-tools)
-- Full-catalog `tools/list` (all loaded): 193 tools (187 registered + 6 meta) / ~25K tokens
+- Full-catalog `tools/list` (all loaded): 195 tools (189 registered + 6 meta) / ~25K tokens
 - **0 IPC stubs** (all protobuf methods implemented)
 - **0 unimplemented tools**
 - **3 CLI commands removed in KiCAD v10** (specctra DSN/SES, pcb sync — return clear errors)

--- a/DEV.md
+++ b/DEV.md
@@ -206,7 +206,7 @@ if !path.exists() {
 
 Adding a new kind: edit `mcp/error.rs`, add the variant, add the match arm in `short_code()`, use it from the handler. The `short_code_matches_serialized_kind_field` test will fail loudly if they drift.
 
-The dispatch-level errors (not-loaded/unknown/handler-panic) are fully structured. So are **all missing-argument errors** across all 189 tools — `tools/mod.rs::require_str` / `require_f64` emit `ToolErrorKind::InvalidArgument { field, reason }` automatically. Most in-handler errors still use `CallToolResult::error("free text")` or bubble `anyhow::Error`; migrating them is incremental. `project.rs::handle_get_project_info` demonstrates the structured `FileNotFound` pattern.
+The dispatch-level errors (not-loaded/unknown/handler-panic) are fully structured. So are **all missing-argument errors** across all 191 tools — `tools/mod.rs::require_str` / `require_f64` emit `ToolErrorKind::InvalidArgument { field, reason }` automatically. Most in-handler errors still use `CallToolResult::error("free text")` or bubble `anyhow::Error`; migrating them is incremental. `project.rs::handle_get_project_info` demonstrates the structured `FileNotFound` pattern.
 
 ## Observability
 
@@ -227,7 +227,7 @@ Source: [`crates/konnect-core/src/observability.rs`](crates/konnect-core/src/obs
 
 ## Tool Routing (Starter Kit + On-Demand Loading)
 
-The server does NOT expose all 189 tools (195 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
+The server does NOT expose all 191 tools (197 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
 
 - **Startup**: only `STARTER_KIT` toolsets are pre-loaded (see `router/registry.rs::STARTER_KIT`). Currently: `project`, `config`. Combined with the 6 meta-tools, baseline `tools/list` is ~19 tools ≈ 2K tokens.
 - **On demand**: the LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose a toolset's tools in subsequent `tools/list` responses. `unload_toolset(name)` prunes them when the task shifts.
@@ -299,9 +299,9 @@ convention for other `kicad-cli`-calling code.
 
 ## Current Stats
 
-- **18 toolsets, 189 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
+- **18 toolsets, 191 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
 - Baseline `tools/list`: ~19 tools / ~2K tokens (starter kit + meta-tools)
-- Full-catalog `tools/list` (all loaded): 195 tools (189 registered + 6 meta) / ~25K tokens
+- Full-catalog `tools/list` (all loaded): 197 tools (191 registered + 6 meta) / ~25K tokens
 - **0 IPC stubs** (all protobuf methods implemented)
 - **0 unimplemented tools**
 - **3 CLI commands removed in KiCAD v10** (specctra DSN/SES, pcb sync — return clear errors)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Rust binary — that lets Claude and other AI assistants design schematics and PCBs
 through the [Model Context Protocol](https://modelcontextprotocol.io) (MCP).
 
-**189 tools across 18 on-demand toolsets.** Schematic capture, PCB layout and
+**191 tools across 18 on-demand toolsets.** Schematic capture, PCB layout and
 routing, ERC/DRC, design-review audits, JLCPCB part search, Freerouting, reference
 circuits, and a full manufacturing export pipeline — with bundled skills and agents
 that teach Claude KiCAD conventions out of the box.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Rust binary — that lets Claude and other AI assistants design schematics and PCBs
 through the [Model Context Protocol](https://modelcontextprotocol.io) (MCP).
 
-**187 tools across 18 on-demand toolsets.** Schematic capture, PCB layout and
+**189 tools across 18 on-demand toolsets.** Schematic capture, PCB layout and
 routing, ERC/DRC, design-review audits, JLCPCB part search, Freerouting, reference
 circuits, and a full manufacturing export pipeline — with bundled skills and agents
 that teach Claude KiCAD conventions out of the box.

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -70,7 +70,7 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         name: "pcb_components",
         description: "Place, move, rotate, align, and duplicate PCB footprints",
         category: "pcb",
-        tool_count: 13,
+        tool_count: 15,
     },
     ToolsetMeta {
         name: "pcb_routing",

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -88,7 +88,7 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         name: "library",
         description: "Symbol libraries, footprint libraries, search and registration",
         category: "library",
-        tool_count: 14,
+        tool_count: 16,
     },
     ToolsetMeta {
         name: "integration",

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -1169,13 +1169,29 @@ fn global_sym_lib_table() -> PathBuf {
 ///
 /// The project file is found by scanning for the extension rather than by name:
 /// a sheet's filename says nothing about what the project is called.
+///
+/// A library table sitting beside `file` ends the search before it starts. The
+/// ancestor walk is unbounded, so without that it can leave the file's own
+/// directory and latch onto an unrelated `.kicad_pro` further up — a project
+/// nested inside another project's folder, or a stray file in a shared parent —
+/// and then resolve every library against the wrong `KIPRJMOD`. A directory
+/// carrying its own `sym-lib-table` or `fp-lib-table` is stating where its
+/// libraries come from, and that is the more specific answer.
 fn project_root_for(file: &Path) -> Option<PathBuf> {
     let start = file.parent()?;
+    if holds_lib_table(start) {
+        return Some(start.to_path_buf());
+    }
     start
         .ancestors()
         .find(|dir| holds_kicad_pro(dir))
         .map(Path::to_path_buf)
         .or_else(|| Some(start.to_path_buf()))
+}
+
+/// Whether `dir` carries a library table of its own.
+fn holds_lib_table(dir: &Path) -> bool {
+    dir.join("sym-lib-table").is_file() || dir.join("fp-lib-table").is_file()
 }
 
 /// Whether `dir` contains a `.kicad_pro`. An unreadable directory holds none.
@@ -5822,6 +5838,49 @@ mod symbol_source_tests {
         assert!(
             candidates.contains(&file),
             "a projectless schematic must still use the table beside it, got {candidates:?}"
+        );
+    }
+
+    /// The walk is unbounded, so an unrelated `.kicad_pro` in any ancestor used
+    /// to capture the search and send every lookup to the wrong `KIPRJMOD`. A
+    /// project nested inside another project's folder is the realistic case;
+    /// the one that actually bit was a stray `.kicad_pro` in the system temp
+    /// directory, which quietly defeated the hermetic fixtures of two tests —
+    /// they passed on CI, where temp is clean, and failed on any machine that
+    /// had accumulated one.
+    ///
+    /// A table beside the file is the more specific statement and must win.
+    #[test]
+    fn a_table_beside_the_file_beats_an_unrelated_project_further_up() {
+        let outer = tempfile::tempdir().unwrap();
+        // An unrelated project sitting above — the interloper.
+        std::fs::write(outer.path().join("Unrelated.kicad_pro"), "{}\n").unwrap();
+        std::fs::write(
+            outer.path().join("sym-lib-table"),
+            "(sym_lib_table\n  (version 7)\n  (lib (name \"Shared\") (type \"KiCad\") (uri \"${KIPRJMOD}/wrong.kicad_sym\") (options \"\") (descr \"\"))\n)\n",
+        )
+        .unwrap();
+
+        let inner = outer.path().join("nested");
+        std::fs::create_dir(&inner).unwrap();
+        let want = inner.join("right.kicad_sym");
+        std::fs::write(&want, "(kicad_symbol_lib)\n").unwrap();
+        std::fs::write(
+            inner.join("sym-lib-table"),
+            "(sym_lib_table\n  (version 7)\n  (lib (name \"Shared\") (type \"KiCad\") (uri \"${KIPRJMOD}/right.kicad_sym\") (options \"\") (descr \"\"))\n)\n",
+        )
+        .unwrap();
+        let sch = inner.join("nested.kicad_sch");
+        std::fs::write(&sch, "(kicad_sch)\n").unwrap();
+
+        let candidates = KiCadSymbolSource::for_file(&sch).candidates("Shared");
+        assert!(
+            candidates.contains(&want),
+            "the table beside the schematic must win, got {candidates:?}"
+        );
+        assert!(
+            !candidates.contains(&outer.path().join("wrong.kicad_sym")),
+            "the outer project's table must not be consulted, got {candidates:?}"
         );
     }
 

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -745,7 +745,10 @@ async fn handle_edit_footprint_pad(
     _ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
     let path = get_path(args, "footprint_path")?;
-    let pad_number = require_str(args, "pad_number").map_err(|e| anyhow::anyhow!("{:?}", e))?;
+    let pad_number = match require_str(args, "pad_number") {
+        Ok(v) => v,
+        Err(e) => return Ok(e),
+    };
 
     let content = tokio::fs::read_to_string(&path).await?;
 
@@ -1660,7 +1663,10 @@ async fn handle_register_footprint_library(
     _ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
     let lib_path = get_path(args, "library_path")?;
-    let nickname = require_str(args, "nickname").map_err(|e| anyhow::anyhow!("{:?}", e))?;
+    let nickname = match require_str(args, "nickname") {
+        Ok(v) => v,
+        Err(e) => return Ok(e),
+    };
     let scope = args["scope"].as_str().unwrap_or("project");
 
     let (table_path, uri) = match lib_table_target(
@@ -1817,7 +1823,10 @@ async fn handle_register_symbol_library(
     _ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
     let lib_path = get_path(args, "library_path")?;
-    let nickname = require_str(args, "nickname").map_err(|e| anyhow::anyhow!("{:?}", e))?;
+    let nickname = match require_str(args, "nickname") {
+        Ok(v) => v,
+        Err(e) => return Ok(e),
+    };
     let scope = args["scope"].as_str().unwrap_or("project");
 
     let (table_path, uri) = match lib_table_target(
@@ -3056,7 +3065,10 @@ async fn handle_delete_symbol(
     _ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
     let lib_path = get_path(args, "library_path")?;
-    let symbol_name = require_str(args, "symbol_name").map_err(|e| anyhow::anyhow!("{:?}", e))?;
+    let symbol_name = match require_str(args, "symbol_name") {
+        Ok(v) => v,
+        Err(e) => return Ok(e),
+    };
 
     let content = tokio::fs::read_to_string(&lib_path).await?;
 
@@ -3312,8 +3324,10 @@ async fn handle_list_library_footprints(
     args: &serde_json::Value,
     _ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
-    let library_path_str =
-        require_str(args, "library_path").map_err(|e| anyhow::anyhow!("{:?}", e))?;
+    let library_path_str = match require_str(args, "library_path") {
+        Ok(v) => v,
+        Err(e) => return Ok(e),
+    };
     let lib_dir = PathBuf::from(library_path_str);
 
     if !lib_dir.is_dir() {
@@ -3348,8 +3362,10 @@ async fn handle_get_footprint_info(
     args: &serde_json::Value,
     _ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
-    let fp_path_str =
-        require_str(args, "footprint_path").map_err(|e| anyhow::anyhow!("{:?}", e))?;
+    let fp_path_str = match require_str(args, "footprint_path") {
+        Ok(v) => v,
+        Err(e) => return Ok(e),
+    };
 
     // Resolve "Library:Footprint" against the project's fp-lib-table as well
     // as the global one, when the caller says which project they mean.
@@ -3450,7 +3466,10 @@ async fn handle_get_symbol_info(
     args: &serde_json::Value,
     ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
-    let lib_id = require_str(args, "lib_id").map_err(|e| anyhow::anyhow!("{:?}", e))?;
+    let lib_id = match require_str(args, "lib_id") {
+        Ok(v) => v,
+        Err(e) => return Ok(e),
+    };
 
     let parts: Vec<&str> = lib_id.splitn(2, ':').collect();
     if parts.len() != 2 {

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -118,6 +118,46 @@ pub fn tools() -> Vec<ToolDef> {
             |args, ctx| async move { handle_edit_footprint_pad(args, ctx).await }
         ),
         tool!(
+            "list_footprint_graphics",
+            "List the graphic items in a .kicad_mod footprint — silkscreen, fabrication, and courtyard outlines — with the UUID needed to edit one. An item carrying no UUID is reported with uuid null and editable false: it exists in the file but cannot be addressed by edit_footprint_graphic.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "footprint_path": { "type": "string", "description": "Path to .kicad_mod file" },
+                    "layer": { "type": "string", "description": "Only list items on this layer, e.g. 'F.SilkS' (optional)" }
+                },
+                "required": ["footprint_path"]
+            }),
+            |args, ctx| async move { handle_list_footprint_graphics(args, ctx).await }
+        ),
+        tool!(
+            "edit_footprint_graphic",
+            "Edit the geometry, layer, or stroke width of one graphic item in an existing .kicad_mod footprint, selected by UUID. Covers fp_line, fp_rect, fp_circle, fp_arc, and fp_poly; pads are edited with edit_footprint_pad.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "footprint_path": { "type": "string", "description": "Path to .kicad_mod file" },
+                    "uuid": { "type": "string", "description": "UUID of the graphic item, as reported by list_footprint_graphics" },
+                    "points": {
+                        "type": "array",
+                        "description": "Replacement vertices in millimetres, in the order KiCad stores them: 2 for fp_line and fp_rect (start, end), 2 for fp_circle (center, then a point on the circumference), 3 for fp_arc (start, mid, end), 3 or more for fp_poly. Omit to leave the geometry unchanged.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "x": { "type": "number" },
+                                "y": { "type": "number" }
+                            },
+                            "required": ["x", "y"]
+                        }
+                    },
+                    "layer": { "type": "string", "description": "New layer, e.g. 'F.SilkS' (optional)" },
+                    "width_mm": { "type": "number", "description": "New stroke width in mm (optional)" }
+                },
+                "required": ["footprint_path", "uuid"]
+            }),
+            |args, ctx| async move { handle_edit_footprint_graphic(args, ctx).await }
+        ),
+        tool!(
             "register_footprint_library",
             "Register a local footprint library directory in the KiCAD global or project library table.",
             json!({
@@ -822,6 +862,290 @@ async fn handle_edit_footprint_pad(
         serde_json::to_string(&json!({
             "success": true,
             "pad": pad_number
+        }))
+        .unwrap(),
+    ))
+}
+
+// ─── Footprint graphics ───────────────────────────────────────────────────────
+
+/// The graphic item tags a footprint can carry, and the sub-blocks that hold
+/// each one's vertices, in the order KiCad writes them.
+///
+/// `fp_text` is deliberately absent: its position is a single `(at x y angle)`
+/// carrying a rotation these tools have no way to express, and its size lives
+/// in `(effects (font …))` rather than in a stroke.
+const GRAPHIC_KINDS: [(&str, &[&str]); 5] = [
+    ("fp_line", &["start", "end"]),
+    ("fp_rect", &["start", "end"]),
+    ("fp_circle", &["center", "end"]),
+    ("fp_arc", &["start", "mid", "end"]),
+    ("fp_poly", &[]), // vertices live in (pts (xy …) …) instead
+];
+
+/// Byte range of the first direct `(tag …)` block inside `block`.
+fn find_child_block(block: &str, tag: &str) -> Option<(usize, usize)> {
+    find_block_starts(block, tag)
+        .into_iter()
+        .find_map(|s| find_balanced_block(block, s))
+}
+
+/// Every graphic item in `content`, as (kind, block_start, block_end).
+///
+/// Sorted by position so that callers see them in file order, which is the
+/// order KiCad's own editor lists them in.
+fn graphic_blocks(content: &str) -> Vec<(&'static str, usize, usize)> {
+    let mut out = Vec::new();
+    for (kind, _) in GRAPHIC_KINDS {
+        for start in find_block_starts(content, kind) {
+            if let Some((s, e)) = find_balanced_block(content, start) {
+                out.push((kind, s, e));
+            }
+        }
+    }
+    out.sort_by_key(|&(_, s, _)| s);
+    out
+}
+
+/// The vertices of one graphic block, in KiCad's storage order.
+fn graphic_points(kind: &str, block: &str) -> Vec<(f64, f64)> {
+    let node = match parse_sexp(block) {
+        Ok(n) => n,
+        Err(_) => return Vec::new(),
+    };
+    if kind == "fp_poly" {
+        return node
+            .find("pts")
+            .map(|pts| {
+                pts.find_all("xy")
+                    .into_iter()
+                    .filter_map(|xy| Some((xy.get_f64(1)?, xy.get_f64(2)?)))
+                    .collect()
+            })
+            .unwrap_or_default();
+    }
+    GRAPHIC_KINDS
+        .iter()
+        .find(|(k, _)| *k == kind)
+        .map(|(_, tags)| {
+            tags.iter()
+                .filter_map(|tag| {
+                    let n = node.find(tag)?;
+                    Some((n.get_f64(1)?, n.get_f64(2)?))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Formats a millimetre coordinate the way KiCad does: no trailing zeros, and
+/// no `-0`, which KiCad never writes and a reviewer would flag as a diff.
+fn fmt_mm(v: f64) -> String {
+    // Fixed precision then trim, as pcb_components::format_at does. Plain `{}`
+    // prints the shortest decimal that round-trips the f64, so an accumulated
+    // coordinate reaches the file as 0.30000000000000004 and a denormal as
+    // several hundred digits. Six decimal places is a nanometre.
+    let s = format!("{v:.6}");
+    let s = s.trim_end_matches('0').trim_end_matches('.').to_string();
+    if s == "-0" {
+        "0".to_string()
+    } else {
+        s
+    }
+}
+
+async fn handle_list_footprint_graphics(
+    args: &serde_json::Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let path = get_path(args, "footprint_path")?;
+    let layer_filter = args["layer"].as_str();
+
+    let content = tokio::fs::read_to_string(&path).await?;
+
+    let mut graphics = Vec::new();
+    for (kind, s, e) in graphic_blocks(&content) {
+        let block = &content[s..e];
+        let node = match parse_sexp(block) {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+        let layer = node.find_str("layer").unwrap_or("").to_string();
+        if let Some(want) = layer_filter {
+            if layer != want {
+                continue;
+            }
+        }
+        let width_mm = node.find("stroke").and_then(|s| s.find_f64("width"));
+        // A hand-written or pre-6.0 footprint can carry a graphic with no
+        // (uuid …), and edit_footprint_graphic addresses items by UUID alone —
+        // so there is no way to edit one. Report it as `uuid: null` and
+        // `editable: false` rather than dropping it: the listing is meant to be
+        // a faithful picture of the file, and an item that silently vanishes
+        // from it is harder to account for than one that says why it cannot be
+        // touched.
+        let uuid = node.find_str("uuid");
+        graphics.push(json!({
+            "uuid": uuid,
+            "editable": uuid.is_some(),
+            "kind": kind,
+            "layer": layer,
+            "width_mm": width_mm,
+            "points": graphic_points(kind, block)
+                .into_iter()
+                .map(|(x, y)| json!({ "x": x, "y": y }))
+                .collect::<Vec<_>>(),
+        }));
+    }
+
+    Ok(CallToolResult::text(
+        serde_json::to_string(&json!({
+            "count": graphics.len(),
+            "graphics": graphics,
+            "path": path.to_str().unwrap_or(""),
+        }))
+        .unwrap(),
+    ))
+}
+
+async fn handle_edit_footprint_graphic(
+    args: &serde_json::Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let path = get_path(args, "footprint_path")?;
+    // Return the structured InvalidArgument result rather than folding it into
+    // an anyhow::Error, which reaches the client as a generic handler error.
+    // Matches pcb_components; several older sites in this file still take the
+    // lossy route.
+    let uuid = match require_str(args, "uuid") {
+        Ok(v) => v,
+        Err(e) => return Ok(e),
+    };
+
+    let content = tokio::fs::read_to_string(&path).await?;
+
+    // Locate the item by UUID rather than by index: a footprint's graphics are
+    // reordered whenever KiCad rewrites the file, so an index would address a
+    // different outline after any unrelated edit.
+    let (kind, block_start, block_end) = graphic_blocks(&content)
+        .into_iter()
+        .find(|&(_, s, e)| {
+            parse_sexp(&content[s..e])
+                .ok()
+                .and_then(|n| n.find_str("uuid").map(|u| u == uuid))
+                .unwrap_or(false)
+        })
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "graphic item '{}' not found in footprint '{}' — call \
+                 list_footprint_graphics for the UUIDs it does have",
+                uuid,
+                path.display()
+            )
+        })?;
+
+    let block = &content[block_start..block_end];
+    let mut edits: Vec<konnect_sexp::writer::SexpEdit> = Vec::new();
+
+    if let Some(points) = args["points"].as_array() {
+        let pts: Vec<(f64, f64)> = points
+            .iter()
+            .map(|p| {
+                let x = p["x"]
+                    .as_f64()
+                    .ok_or_else(|| anyhow::anyhow!("each point needs a numeric 'x'"))?;
+                let y = p["y"]
+                    .as_f64()
+                    .ok_or_else(|| anyhow::anyhow!("each point needs a numeric 'y'"))?;
+                Ok::<_, anyhow::Error>((x, y))
+            })
+            .collect::<Result<_, _>>()?;
+
+        if kind == "fp_poly" {
+            if pts.len() < 3 {
+                anyhow::bail!(
+                    "an fp_poly needs at least 3 points, got {} — a 2-point \
+                     outline is an fp_line",
+                    pts.len()
+                );
+            }
+            let (ps, pe) = find_child_block(block, "pts")
+                .ok_or_else(|| anyhow::anyhow!("fp_poly '{}' has no (pts …) block", uuid))?;
+            let body = pts
+                .iter()
+                .map(|&(x, y)| format!("(xy {} {})", fmt_mm(x), fmt_mm(y)))
+                .collect::<Vec<_>>()
+                .join(" ");
+            edits.push(konnect_sexp::writer::SexpEdit::replace(
+                block_start + ps,
+                block_start + pe,
+                format!("(pts {})", body),
+            ));
+        } else {
+            let tags = GRAPHIC_KINDS
+                .iter()
+                .find(|(k, _)| *k == kind)
+                .map(|(_, t)| *t)
+                .unwrap_or(&[]);
+            if pts.len() != tags.len() {
+                anyhow::bail!(
+                    "an {} needs exactly {} points ({}), got {}",
+                    kind,
+                    tags.len(),
+                    tags.join(", "),
+                    pts.len()
+                );
+            }
+            for (tag, &(x, y)) in tags.iter().zip(pts.iter()) {
+                let (ts, te) = find_child_block(block, tag).ok_or_else(|| {
+                    anyhow::anyhow!("{} '{}' has no ({} …) block", kind, uuid, tag)
+                })?;
+                edits.push(konnect_sexp::writer::SexpEdit::replace(
+                    block_start + ts,
+                    block_start + te,
+                    format!("({} {} {})", tag, fmt_mm(x), fmt_mm(y)),
+                ));
+            }
+        }
+    }
+
+    if let Some(layer) = args["layer"].as_str() {
+        let (ls, le) = find_child_block(block, "layer")
+            .ok_or_else(|| anyhow::anyhow!("{} '{}' has no (layer …) block", kind, uuid))?;
+        edits.push(konnect_sexp::writer::SexpEdit::replace(
+            block_start + ls,
+            block_start + le,
+            format!("(layer \"{}\")", layer),
+        ));
+    }
+
+    if let Some(width) = args["width_mm"].as_f64() {
+        // The width lives inside (stroke …); a bare search would also match a
+        // (width …) that a future format revision puts elsewhere in the item.
+        let (ss, se) = find_child_block(block, "stroke")
+            .ok_or_else(|| anyhow::anyhow!("{} '{}' has no (stroke …) block", kind, uuid))?;
+        let stroke = &block[ss..se];
+        let (ws, we) = find_child_block(stroke, "width")
+            .ok_or_else(|| anyhow::anyhow!("{} '{}' has no stroke width", kind, uuid))?;
+        edits.push(konnect_sexp::writer::SexpEdit::replace(
+            block_start + ss + ws,
+            block_start + ss + we,
+            format!("(width {})", fmt_mm(width)),
+        ));
+    }
+
+    if edits.is_empty() {
+        anyhow::bail!("nothing to change — pass points, layer, or width_mm");
+    }
+
+    let edited = konnect_sexp::writer::apply_edits(content, edits);
+    write_atomic(&path, &edited)?;
+
+    Ok(CallToolResult::text(
+        serde_json::to_string(&json!({
+            "success": true,
+            "uuid": uuid,
+            "kind": kind,
         }))
         .unwrap(),
     ))
@@ -5024,6 +5348,350 @@ mod tests {
             rc.contains("(name \"IN\" (effects (font (size 1.27 1.27))))"),
             "rectangle pin names keep the default 1.27 font:\n{rc}"
         );
+    }
+
+    // ─── Footprint graphics ───────────────────────────────────────────────
+
+    /// A footprint in the shape KiCad 10 writes one: tab-indented, each graphic
+    /// carrying a stroke and a uuid. The polygon is a pin-1 marker sitting hard
+    /// against the part's right edge, which is the case these tools were added
+    /// for.
+    fn footprint_with_graphics() -> String {
+        [
+            "(footprint \"Marked_Part\"",
+            "\t(version 20260206)",
+            "\t(generator \"pcbnew\")",
+            "\t(layer \"F.Cu\")",
+            "\t(fp_poly",
+            "\t\t(pts",
+            "\t\t\t(xy 13.9 -0.5) (xy 13.9 0.5) (xy 13 0)",
+            "\t\t)",
+            "\t\t(stroke",
+            "\t\t\t(width 0.1)",
+            "\t\t\t(type default)",
+            "\t\t)",
+            "\t\t(fill yes)",
+            "\t\t(layer \"F.SilkS\")",
+            "\t\t(uuid \"11111111-1111-1111-1111-111111111111\")",
+            "\t)",
+            "\t(fp_line",
+            "\t\t(start -19 0)",
+            "\t\t(end -17 0)",
+            "\t\t(stroke",
+            "\t\t\t(width 0.08)",
+            "\t\t\t(type default)",
+            "\t\t)",
+            "\t\t(layer \"Dwgs.User\")",
+            "\t\t(uuid \"22222222-2222-2222-2222-222222222222\")",
+            "\t)",
+            "\t(fp_circle",
+            "\t\t(center 0 0)",
+            "\t\t(end 2 0)",
+            "\t\t(stroke",
+            "\t\t\t(width 0.05)",
+            "\t\t\t(type default)",
+            "\t\t)",
+            "\t\t(fill none)",
+            "\t\t(layer \"F.CrtYd\")",
+            "\t\t(uuid \"33333333-3333-3333-3333-333333333333\")",
+            "\t)",
+            ")",
+        ]
+        .join("\n")
+    }
+
+    fn write_footprint(dir: &Path) -> PathBuf {
+        let path = dir.join("Marked_Part.kicad_mod");
+        std::fs::write(&path, footprint_with_graphics()).unwrap();
+        path
+    }
+
+    /// The JSON body of a tool result, which these tools return as text.
+    fn result_json(result: &CallToolResult) -> serde_json::Value {
+        match &result.content[0] {
+            crate::mcp::protocol::ToolContent::Text { text } => serde_json::from_str(text).unwrap(),
+            other => panic!("expected a text result, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_footprint_graphics_reports_uuid_layer_and_points() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_footprint(tmp.path());
+
+        let out = handle_list_footprint_graphics(
+            &json!({ "footprint_path": path.to_string_lossy() }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        let v = result_json(&out);
+
+        assert_eq!(v["count"], 3, "one entry per graphic item: {v}");
+        // File order, not tag order: the polygon is written first.
+        assert_eq!(v["graphics"][0]["kind"], "fp_poly");
+        assert_eq!(
+            v["graphics"][0]["uuid"],
+            "11111111-1111-1111-1111-111111111111"
+        );
+        assert_eq!(v["graphics"][0]["layer"], "F.SilkS");
+        assert_eq!(v["graphics"][0]["width_mm"], 0.1);
+        assert_eq!(v["graphics"][0]["points"][0]["x"], 13.9);
+        assert_eq!(v["graphics"][0]["points"][2]["y"], 0.0);
+        // An fp_circle reports (center, circumference point), in that order.
+        assert_eq!(v["graphics"][2]["kind"], "fp_circle");
+        assert_eq!(v["graphics"][2]["points"][1]["x"], 2.0);
+    }
+
+    #[tokio::test]
+    async fn list_footprint_graphics_filters_by_layer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_footprint(tmp.path());
+
+        let out = handle_list_footprint_graphics(
+            &json!({ "footprint_path": path.to_string_lossy(), "layer": "F.SilkS" }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        let v = result_json(&out);
+
+        assert_eq!(v["count"], 1, "only the silkscreen item: {v}");
+        assert_eq!(v["graphics"][0]["kind"], "fp_poly");
+    }
+
+    #[tokio::test]
+    async fn edit_footprint_graphic_moves_a_polygon_and_leaves_the_rest_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_footprint(tmp.path());
+
+        handle_edit_footprint_graphic(
+            &json!({
+                "footprint_path": path.to_string_lossy(),
+                "uuid": "11111111-1111-1111-1111-111111111111",
+                "points": [{"x": 13.5, "y": -0.5}, {"x": 13.5, "y": 0.5}, {"x": 12.7, "y": 0}]
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            after.contains("(pts (xy 13.5 -0.5) (xy 13.5 0.5) (xy 12.7 0))"),
+            "the polygon takes the new vertices:\n{after}"
+        );
+        assert!(
+            after.contains("(fill yes)") && after.contains("(width 0.1)"),
+            "fill and stroke survive a geometry-only edit:\n{after}"
+        );
+        assert!(
+            after.contains("(start -19 0)") && after.contains("(center 0 0)"),
+            "the other two items are untouched:\n{after}"
+        );
+        assert!(
+            after.contains("(uuid \"11111111-1111-1111-1111-111111111111\")"),
+            "the item keeps its identity:\n{after}"
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_footprint_graphic_sets_the_width_inside_the_stroke() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_footprint(tmp.path());
+
+        handle_edit_footprint_graphic(
+            &json!({
+                "footprint_path": path.to_string_lossy(),
+                "uuid": "22222222-2222-2222-2222-222222222222",
+                "width_mm": 0.12
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            after.contains("(width 0.12)"),
+            "the line's stroke width is updated:\n{after}"
+        );
+        assert!(
+            after.contains("(width 0.1)") && after.contains("(width 0.05)"),
+            "the polygon's and circle's widths are untouched:\n{after}"
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_footprint_graphic_rejects_a_polygon_of_two_points() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_footprint(tmp.path());
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        let err = handle_edit_footprint_graphic(
+            &json!({
+                "footprint_path": path.to_string_lossy(),
+                "uuid": "11111111-1111-1111-1111-111111111111",
+                "points": [{"x": 0, "y": 0}, {"x": 1, "y": 1}]
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("at least 3 points"),
+            "explains the arity: {err}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            before,
+            "a rejected edit leaves the footprint byte-identical"
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_footprint_graphic_rejects_an_arc_of_two_points() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("Arced.kicad_mod");
+        std::fs::write(
+            &path,
+            "(footprint \"Arced\"\n\t(fp_arc\n\t\t(start 0 0)\n\t\t(mid 1 1)\n\t\t(end 2 0)\n\t\t(stroke\n\t\t\t(width 0.1)\n\t\t\t(type default)\n\t\t)\n\t\t(layer \"F.SilkS\")\n\t\t(uuid \"44444444-4444-4444-4444-444444444444\")\n\t)\n)",
+        )
+        .unwrap();
+
+        let err = handle_edit_footprint_graphic(
+            &json!({
+                "footprint_path": path.to_string_lossy(),
+                "uuid": "44444444-4444-4444-4444-444444444444",
+                "points": [{"x": 0, "y": 0}, {"x": 2, "y": 0}]
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("exactly 3 points") && err.contains("start, mid, end"),
+            "names the vertices an arc needs: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_footprint_graphic_reports_an_unknown_uuid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_footprint(tmp.path());
+
+        let err = handle_edit_footprint_graphic(
+            &json!({
+                "footprint_path": path.to_string_lossy(),
+                "uuid": "99999999-9999-9999-9999-999999999999",
+                "layer": "F.SilkS"
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("not found") && err.contains("list_footprint_graphics"),
+            "points at the tool that lists the real UUIDs: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_footprint_graphic_needs_something_to_change() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_footprint(tmp.path());
+
+        let err = handle_edit_footprint_graphic(
+            &json!({
+                "footprint_path": path.to_string_lossy(),
+                "uuid": "11111111-1111-1111-1111-111111111111"
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("nothing to change"),
+            "says what is missing: {err}"
+        );
+    }
+
+    /// A graphic with no `(uuid …)` — a hand-written or pre-6.0 footprint — is
+    /// still reported, but marked as something `edit_footprint_graphic` cannot
+    /// address. Dropping it from the listing would make the file and the tool's
+    /// picture of it disagree with nothing to say why.
+    #[tokio::test]
+    async fn list_footprint_graphics_marks_an_item_without_a_uuid_uneditable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("Unmarked.kicad_mod");
+        std::fs::write(
+            &path,
+            [
+                "(footprint \"Unmarked\"",
+                "\t(fp_line",
+                "\t\t(start 0 0)",
+                "\t\t(end 1 0)",
+                "\t\t(stroke",
+                "\t\t\t(width 0.1)",
+                "\t\t\t(type default)",
+                "\t\t)",
+                "\t\t(layer \"F.SilkS\")",
+                "\t)",
+                ")",
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let out = handle_list_footprint_graphics(
+            &json!({ "footprint_path": path.to_string_lossy() }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        let v = result_json(&out);
+
+        assert_eq!(v["count"], 1, "the item is reported, not skipped: {v}");
+        assert!(v["graphics"][0]["uuid"].is_null(), "uuid is null, not \"\"");
+        assert_eq!(v["graphics"][0]["editable"], false);
+
+        // And the edit path still refuses it rather than matching on "".
+        let err = handle_edit_footprint_graphic(
+            &json!({
+                "footprint_path": path.to_string_lossy(),
+                "uuid": "",
+                "layer": "F.Fab"
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("not found"),
+            "empty uuid matches nothing: {err}"
+        );
+    }
+
+    /// `{}` on an f64 prints the shortest decimal that round-trips it, which is
+    /// how accumulated arithmetic reaches a .kicad_mod as 0.30000000000000004.
+    #[test]
+    fn fmt_mm_writes_a_clean_decimal() {
+        assert_eq!(fmt_mm(0.1 + 0.2), "0.3");
+        assert_eq!(fmt_mm(1.0 / 3.0), "0.333333");
+        assert_eq!(fmt_mm(13.9), "13.9");
+        assert_eq!(fmt_mm(100.0), "100");
+        assert_eq!(fmt_mm(0.0), "0");
+        assert_eq!(fmt_mm(-0.0), "0", "KiCad never writes -0");
+        assert_eq!(fmt_mm(-2.54), "-2.54");
     }
 }
 

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -949,6 +949,46 @@ pub fn tools() -> Vec<ToolDef> {
             |args, ctx| async move { handle_find_component(args, ctx).await }
         ),
         tool!(
+            "list_board_footprint_graphics",
+            "List the graphic items inside a footprint placed on the board — silkscreen, fabrication, and courtyard artwork — with the UUID needed to edit one. Points are footprint-local millimetres, as the .kicad_mod shows them. Each item reports 'editable', plus 'outlines' and 'holes' for polygons: 'points' covers the first outline only, so an item with more than one outline or any holes is reported but cannot be edited here. Requires KiCAD running with the board open.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "board":     { "type": "string" },
+                    "reference": { "type": "string", "description": "Reference designator, e.g. 'J2'" },
+                    "layer":     { "type": "string", "description": "Only list items on this layer, e.g. 'F.SilkS' (optional)" }
+                },
+                "required": ["board", "reference"]
+            }),
+            |args, ctx| async move { handle_list_board_footprint_graphics(args, ctx).await }
+        ),
+        tool!(
+            "edit_board_footprint_graphic",
+            "Replace the vertices of a polygon inside a footprint placed on the board, selected by UUID. Points are footprint-local millimetres, as the .kicad_mod shows them. Use this to bring one placed instance in line with a library change without re-placing the part. Only a single-outline polygon with no holes can be replaced; anything else is refused by name rather than flattened. Requires KiCAD running with the board open.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "board":     { "type": "string" },
+                    "reference": { "type": "string", "description": "Reference designator, e.g. 'J2'" },
+                    "uuid":      { "type": "string", "description": "UUID of the graphic item, from list_board_footprint_graphics" },
+                    "points": {
+                        "type": "array",
+                        "description": "Replacement vertices in footprint-local millimetres; at least 3.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "x": { "type": "number" },
+                                "y": { "type": "number" }
+                            },
+                            "required": ["x", "y"]
+                        }
+                    }
+                },
+                "required": ["board", "reference", "uuid", "points"]
+            }),
+            |args, ctx| async move { handle_edit_board_footprint_graphic(args, ctx).await }
+        ),
+        tool!(
             "get_component_pads",
             "Return the pad positions and net assignments for a footprint. \
              A pad's 'net' is its net name, \"\" if the pad carries no net node \
@@ -1204,6 +1244,71 @@ async fn handle_move_component(
     Ok(CallToolResult::json(
         &json!({ "moved": reference, "x": x, "y": y }),
     ))
+}
+
+async fn handle_list_board_footprint_graphics(
+    args: &serde_json::Value,
+    ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let reference = match require_str(args, "reference") {
+        Ok(v) => v.to_string(),
+        Err(e) => return Ok(e),
+    };
+    let layer_filter = args["layer"].as_str().map(|s| s.to_string());
+
+    let ref_ipc = reference.clone();
+    let graphics: Vec<konnect_ipc::types::IpcFootprintGraphic> =
+        ipc!(ctx, args, |c| c.list_footprint_graphics(&ref_ipc));
+
+    let graphics: Vec<_> = graphics
+        .into_iter()
+        .filter(|g| layer_filter.as_deref().is_none_or(|l| g.layer == l))
+        .collect();
+
+    Ok(CallToolResult::json(&json!({
+        "count": graphics.len(),
+        "reference": reference,
+        "graphics": graphics,
+    })))
+}
+
+async fn handle_edit_board_footprint_graphic(
+    args: &serde_json::Value,
+    ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let reference = match require_str(args, "reference") {
+        Ok(v) => v.to_string(),
+        Err(e) => return Ok(e),
+    };
+    let uuid = match require_str(args, "uuid") {
+        Ok(v) => v.to_string(),
+        Err(e) => return Ok(e),
+    };
+    let points: Vec<(f64, f64)> = args["points"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("'points' must be an array of {{x, y}}"))?
+        .iter()
+        .map(|p| {
+            let x = p["x"]
+                .as_f64()
+                .ok_or_else(|| anyhow::anyhow!("each point needs a numeric 'x'"))?;
+            let y = p["y"]
+                .as_f64()
+                .ok_or_else(|| anyhow::anyhow!("each point needs a numeric 'y'"))?;
+            Ok::<_, anyhow::Error>((x, y))
+        })
+        .collect::<Result<_, _>>()?;
+
+    let (ref_ipc, uuid_ipc, pts) = (reference.clone(), uuid.clone(), points.clone());
+    let kind: String = ipc!(ctx, args, |c| c
+        .set_footprint_graphic_points(&ref_ipc, &uuid_ipc, &pts));
+
+    Ok(CallToolResult::json(&json!({
+        "edited": reference,
+        "uuid": uuid,
+        "kind": kind,
+        "points": points.len(),
+    })))
 }
 
 async fn handle_rotate_component(

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -46,6 +46,89 @@ fn layer_enum_to_name(layer: i32) -> &'static str {
     }
 }
 
+/// A placed footprint's anchor in board nanometres, and its orientation in
+/// degrees.
+///
+/// KiCad keeps a footprint's children in absolute board coordinates, so this
+/// is the frame that turns them back into the footprint-local numbers a
+/// `.kicad_mod` shows, and back again.
+fn footprint_frame(fp: &kiapi::board::types::FootprintInstance) -> ((i64, i64), f64) {
+    let pos = fp.position.unwrap_or_default();
+    let angle = fp
+        .orientation
+        .as_ref()
+        .map(|a| a.value_degrees)
+        .unwrap_or(0.0);
+    ((pos.x_nm, pos.y_nm), angle)
+}
+
+/// The shape family of a graphic geometry, named as the tool schemas name it.
+fn geometry_kind(geometry: &kiapi::common::types::graphic_shape::Geometry) -> &'static str {
+    use kiapi::common::types::graphic_shape::Geometry;
+    match geometry {
+        Geometry::Segment(_) => "segment",
+        Geometry::Rectangle(_) => "rectangle",
+        Geometry::Arc(_) => "arc",
+        Geometry::Circle(_) => "circle",
+        Geometry::Polygon(_) => "polygon",
+        Geometry::Bezier(_) => "bezier",
+    }
+}
+
+/// How many outlines a polygon's `PolySet` carries and how many holes across
+/// them. `(0, 0)` for any other geometry.
+///
+/// `geometry_points` reports the first outline only, and the edit path rebuilds
+/// the shape from a single outline — so a footprint carrying a cutout would read
+/// back looking correct and be flattened on the next write. Counting them is
+/// what lets both ends say so.
+fn polygon_extent(geometry: &kiapi::common::types::graphic_shape::Geometry) -> (usize, usize) {
+    use kiapi::common::types::graphic_shape::Geometry;
+    match geometry {
+        Geometry::Polygon(ps) => (
+            ps.polygons.len(),
+            ps.polygons.iter().map(|p| p.holes.len()).sum(),
+        ),
+        _ => (0, 0),
+    }
+}
+
+/// The defining vertices of a graphic geometry, in absolute board nanometres.
+fn geometry_points(geometry: &kiapi::common::types::graphic_shape::Geometry) -> Vec<(i64, i64)> {
+    use kiapi::common::types::graphic_shape::Geometry;
+    // An absent vertex yields nothing rather than the origin. Substituting
+    // (0, 0) would report a shape that looks well-formed and is silently in the
+    // wrong place; a short list is visibly wrong at the point of use.
+    let pt = |v: &Option<kiapi::common::types::Vector2>| v.map(|p| (p.x_nm, p.y_nm));
+    let pts = |vs: [&Option<kiapi::common::types::Vector2>; 4], n: usize| {
+        vs[..n].iter().filter_map(|v| pt(v)).collect::<Vec<_>>()
+    };
+    let none = &None;
+    match geometry {
+        Geometry::Segment(s) => pts([&s.start, &s.end, none, none], 2),
+        Geometry::Rectangle(r) => pts([&r.top_left, &r.bottom_right, none, none], 2),
+        Geometry::Arc(a) => pts([&a.start, &a.mid, &a.end, none], 3),
+        Geometry::Circle(c) => pts([&c.center, &c.radius_point, none, none], 2),
+        Geometry::Bezier(b) => pts([&b.start, &b.control1, &b.control2, &b.end], 4),
+        Geometry::Polygon(ps) => ps
+            .polygons
+            .first()
+            .and_then(|p| p.outline.as_ref())
+            .map(|o| {
+                o.nodes
+                    .iter()
+                    .filter_map(|n| match n.geometry.as_ref() {
+                        Some(kiapi::common::types::poly_line_node::Geometry::Point(p)) => {
+                            Some((p.x_nm, p.y_nm))
+                        }
+                        _ => None,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+    }
+}
+
 /// Wrap a protobuf message into a prost_types::Any with the correct type_url.
 fn pack_any<M: Message>(msg: &M, type_name: &str) -> prost_types::Any {
     let mut buf = Vec::new();
@@ -946,6 +1029,205 @@ impl KiCadIpcClient {
                     let any = crate::builders::pack_any(&fp, "kiapi.board.types.FootprintInstance");
                     self.update_items(vec![any])?;
                     return Ok(());
+                }
+            }
+        }
+        anyhow::bail!("Footprint '{}' not found", reference)
+    }
+
+    /// List the graphic items inside a placed footprint.
+    ///
+    /// Points come back in footprint-local millimetres — the coordinates the
+    /// `.kicad_mod` shows — not the absolute board coordinates KiCad carries
+    /// them in over IPC. See `set_footprint_graphic_points` for why.
+    pub fn list_footprint_graphics(&self, reference: &str) -> Result<Vec<IpcFootprintGraphic>> {
+        let (fp, _) = self.find_footprint_instance(reference)?;
+        let (anchor, angle) = footprint_frame(&fp);
+        let to_local = crate::transform::Xform::Rotate {
+            cx_nm: anchor.0,
+            cy_nm: anchor.1,
+            delta_deg: -angle,
+        };
+
+        let mut out = Vec::new();
+        for any in &fp
+            .definition
+            .as_ref()
+            .map(|d| d.items.clone())
+            .unwrap_or_default()
+        {
+            let Ok(shape) = kiapi::board::types::BoardGraphicShape::decode(any.value.as_slice())
+            else {
+                continue;
+            };
+            let Some(geometry) = shape.shape.as_ref().and_then(|s| s.geometry.as_ref()) else {
+                continue;
+            };
+            let uuid = shape
+                .id
+                .as_ref()
+                .map(|k| k.value.clone())
+                .unwrap_or_default();
+            let kind = geometry_kind(geometry).to_string();
+            let (outlines, holes) = polygon_extent(geometry);
+            out.push(IpcFootprintGraphic {
+                editable: kind == "polygon" && outlines == 1 && holes == 0 && !uuid.is_empty(),
+                uuid,
+                kind,
+                outlines,
+                holes,
+                layer: layer_enum_to_name(shape.layer).to_string(),
+                points: geometry_points(geometry)
+                    .into_iter()
+                    .map(|(x, y)| {
+                        let (lx, ly) = to_local.point(x, y);
+                        IpcVector2 {
+                            x: nm_to_mm(lx - anchor.0),
+                            y: nm_to_mm(ly - anchor.1),
+                        }
+                    })
+                    .collect(),
+            });
+        }
+        Ok(out)
+    }
+
+    /// Replace the vertices of one graphic item inside a placed footprint.
+    ///
+    /// `points_mm` are footprint-local, matching what the `.kicad_mod` shows.
+    /// KiCad carries a footprint's children in absolute board coordinates over
+    /// IPC and re-creates them verbatim on update (the same reason
+    /// `move_footprint` has to shift them), so they are rotated by the
+    /// instance's orientation and translated onto its position here rather
+    /// than making every caller redo that arithmetic against the wrong frame.
+    pub fn set_footprint_graphic_points(
+        &self,
+        reference: &str,
+        uuid: &str,
+        points_mm: &[(f64, f64)],
+    ) -> Result<String> {
+        let (mut fp, _) = self.find_footprint_instance(reference)?;
+        let (anchor, angle) = footprint_frame(&fp);
+        let to_board = crate::transform::Xform::Rotate {
+            cx_nm: 0,
+            cy_nm: 0,
+            delta_deg: angle,
+        };
+
+        let definition = fp
+            .definition
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("footprint '{}' carries no definition", reference))?;
+
+        for any in definition.items.iter_mut() {
+            let Ok(mut shape) =
+                kiapi::board::types::BoardGraphicShape::decode(any.value.as_slice())
+            else {
+                continue;
+            };
+            if shape.id.as_ref().map(|k| k.value.as_str()) != Some(uuid) {
+                continue;
+            }
+
+            let kind = shape
+                .shape
+                .as_ref()
+                .and_then(|s| s.geometry.as_ref())
+                .map(geometry_kind)
+                .unwrap_or("unknown");
+            if kind != "polygon" {
+                anyhow::bail!(
+                    "graphic '{}' on '{}' is a {}; only polygons take a vertex list",
+                    uuid,
+                    reference,
+                    kind
+                );
+            }
+            if points_mm.len() < 3 {
+                anyhow::bail!("a polygon needs at least 3 points, got {}", points_mm.len());
+            }
+            // The rebuild below emits one outline with no holes. Rejecting a
+            // shape that carries more is the difference between refusing the
+            // edit and silently deleting a cutout the caller never mentioned.
+            let (outlines, holes) = shape
+                .shape
+                .as_ref()
+                .and_then(|s| s.geometry.as_ref())
+                .map(polygon_extent)
+                .unwrap_or((0, 0));
+            if outlines > 1 || holes > 0 {
+                anyhow::bail!(
+                    "polygon '{}' on '{}' carries {} outline(s) and {} hole(s); this tool \
+                     replaces a single outline and would discard the rest, so it will not \
+                     write it — edit this one in KiCad",
+                    uuid,
+                    reference,
+                    outlines,
+                    holes
+                );
+            }
+
+            let nodes = points_mm
+                .iter()
+                .map(|&(x, y)| {
+                    let (rx, ry) =
+                        to_board.point(crate::builders::mm_to_nm(x), crate::builders::mm_to_nm(y));
+                    kiapi::common::types::PolyLineNode {
+                        geometry: Some(kiapi::common::types::poly_line_node::Geometry::Point(
+                            kiapi::common::types::Vector2 {
+                                x_nm: anchor.0 + rx,
+                                y_nm: anchor.1 + ry,
+                            },
+                        )),
+                    }
+                })
+                .collect();
+
+            if let Some(s) = shape.shape.as_mut() {
+                s.geometry = Some(kiapi::common::types::graphic_shape::Geometry::Polygon(
+                    kiapi::common::types::PolySet {
+                        polygons: vec![kiapi::common::types::PolygonWithHoles {
+                            outline: Some(kiapi::common::types::PolyLine {
+                                nodes,
+                                closed: true,
+                            }),
+                            holes: vec![],
+                        }],
+                    },
+                ));
+            }
+
+            *any = pack_any(&shape, "kiapi.board.types.BoardGraphicShape");
+            let packed = pack_any(&fp, "kiapi.board.types.FootprintInstance");
+            self.update_items(vec![packed])?;
+            return Ok(kind.to_string());
+        }
+
+        anyhow::bail!(
+            "graphic '{}' not found on footprint '{}' — call list_board_footprint_graphics \
+             for the UUIDs it does have",
+            uuid,
+            reference
+        )
+    }
+
+    /// The placed footprint carrying `reference`, and its index among items.
+    fn find_footprint_instance(
+        &self,
+        reference: &str,
+    ) -> Result<(kiapi::board::types::FootprintInstance, usize)> {
+        let items = self.get_items(kiapi::common::types::KiCadObjectType::KotPcbFootprint)?;
+        for (i, item) in items.iter().enumerate() {
+            if let Ok(fp) = kiapi::board::types::FootprintInstance::decode(item.value.as_slice()) {
+                let ref_text = fp
+                    .reference_field
+                    .as_ref()
+                    .and_then(|f| f.text.as_ref())
+                    .and_then(|bt| bt.text.as_ref())
+                    .map(|t| t.text.as_str())
+                    .unwrap_or("");
+                if ref_text == reference {
+                    return Ok((fp, i));
                 }
             }
         }
@@ -1892,6 +2174,197 @@ mod footprint_graphics_tests {
             assert_normal_padstack_is_unpackable(
                 decoded.pad_stack.as_ref().expect("pad_stack"),
                 &format!("build_footprint_item pad on {layer}"),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod footprint_graphic_tests {
+    use super::*;
+    use crate::builders;
+    use crate::transform::Xform;
+
+    /// A footprint at (100, 100) rotated `angle` degrees, carrying `items`.
+    fn instance(
+        angle: f64,
+        items: Vec<prost_types::Any>,
+    ) -> kiapi::board::types::FootprintInstance {
+        kiapi::board::types::FootprintInstance {
+            position: Some(builders::vec2(100.0, 100.0)),
+            orientation: Some(kiapi::common::types::Angle {
+                value_degrees: angle,
+            }),
+            definition: Some(kiapi::board::types::Footprint {
+                items,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn frame_reports_anchor_and_orientation() {
+        let ((x, y), angle) = footprint_frame(&instance(90.0, vec![]));
+        assert_eq!(
+            (x, y),
+            (builders::mm_to_nm(100.0), builders::mm_to_nm(100.0))
+        );
+        assert_eq!(angle, 90.0);
+    }
+
+    #[test]
+    fn frame_defaults_to_the_origin_unrotated() {
+        let fp = kiapi::board::types::FootprintInstance::default();
+        assert_eq!(footprint_frame(&fp), ((0, 0), 0.0));
+    }
+
+    #[test]
+    fn geometry_kind_names_each_shape() {
+        use kiapi::common::types::graphic_shape::Geometry;
+        let poly = builders::board_polygon("F.SilkS", 0.1, true, &[vec![(0.0, 0.0)]]);
+        let seg = builders::board_segment("F.SilkS", 0.1, 0.0, 0.0, 1.0, 0.0);
+        let of = |s: &kiapi::board::types::BoardGraphicShape| -> &'static str {
+            geometry_kind(s.shape.as_ref().unwrap().geometry.as_ref().unwrap())
+        };
+        assert_eq!(of(&poly), "polygon");
+        assert_eq!(of(&seg), "segment");
+        // Exhaustiveness is enforced by the match, not by listing every arm here.
+        let _ = |g: &Geometry| geometry_kind(g);
+    }
+
+    #[test]
+    fn geometry_points_reads_a_polygon_outline_in_order() {
+        let poly = builders::board_polygon(
+            "F.SilkS",
+            0.1,
+            true,
+            &[vec![(13.9, -0.5), (13.9, 0.5), (13.0, 0.0)]],
+        );
+        let pts = geometry_points(poly.shape.as_ref().unwrap().geometry.as_ref().unwrap());
+        assert_eq!(
+            pts,
+            vec![
+                (builders::mm_to_nm(13.9), builders::mm_to_nm(-0.5)),
+                (builders::mm_to_nm(13.9), builders::mm_to_nm(0.5)),
+                (builders::mm_to_nm(13.0), builders::mm_to_nm(0.0)),
+            ]
+        );
+    }
+
+    #[test]
+    fn geometry_points_reads_a_segment_as_start_then_end() {
+        let seg = builders::board_segment("F.SilkS", 0.1, -19.0, 0.0, -17.0, 0.0);
+        let pts = geometry_points(seg.shape.as_ref().unwrap().geometry.as_ref().unwrap());
+        assert_eq!(
+            pts,
+            vec![
+                (builders::mm_to_nm(-19.0), builders::mm_to_nm(0.0)),
+                (builders::mm_to_nm(-17.0), builders::mm_to_nm(0.0)),
+            ]
+        );
+    }
+
+    /// A vertex KiCad did not populate is dropped, not reported as the origin.
+    /// (0, 0) is a plausible-looking coordinate, so substituting it turns a
+    /// malformed shape into a well-formed one in the wrong place.
+    #[test]
+    fn geometry_points_omits_a_missing_vertex() {
+        let mut seg = builders::board_segment("F.SilkS", 0.1, -19.0, 0.0, -17.0, 0.0);
+        match seg
+            .shape
+            .as_mut()
+            .and_then(|s| s.geometry.as_mut())
+            .unwrap()
+        {
+            kiapi::common::types::graphic_shape::Geometry::Segment(s) => s.end = None,
+            other => panic!("expected a segment, got {other:?}"),
+        }
+
+        let pts = geometry_points(seg.shape.as_ref().unwrap().geometry.as_ref().unwrap());
+        assert_eq!(
+            pts,
+            vec![(builders::mm_to_nm(-19.0), builders::mm_to_nm(0.0))],
+            "the absent end is missing from the list, not reported as (0, 0)"
+        );
+    }
+
+    /// A polygon carrying a cutout or a second outline must be countable, since
+    /// both the read and the write path only handle the first outline.
+    #[test]
+    fn polygon_extent_counts_outlines_and_holes() {
+        let simple = builders::board_polygon(
+            "F.SilkS",
+            0.1,
+            true,
+            &[vec![(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)]],
+        );
+        let geom = |s: &kiapi::board::types::BoardGraphicShape| {
+            s.shape.as_ref().unwrap().geometry.as_ref().unwrap().clone()
+        };
+        assert_eq!(polygon_extent(&geom(&simple)), (1, 0));
+
+        let two = builders::board_polygon(
+            "F.SilkS",
+            0.1,
+            true,
+            &[
+                vec![(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)],
+                vec![(5.0, 5.0), (6.0, 5.0), (6.0, 6.0)],
+            ],
+        );
+        assert_eq!(polygon_extent(&geom(&two)), (2, 0));
+
+        // A hole on the first outline — what board_polygon never builds.
+        let mut holed = simple.clone();
+        if let kiapi::common::types::graphic_shape::Geometry::Polygon(ps) = holed
+            .shape
+            .as_mut()
+            .and_then(|s| s.geometry.as_mut())
+            .unwrap()
+        {
+            ps.polygons[0].holes.push(kiapi::common::types::PolyLine {
+                nodes: vec![],
+                closed: true,
+            });
+        }
+        assert_eq!(polygon_extent(&geom(&holed)), (1, 1));
+
+        // Every other kind reports nothing rather than a misleading 1.
+        let seg = builders::board_segment("F.SilkS", 0.1, 0.0, 0.0, 1.0, 0.0);
+        assert_eq!(polygon_extent(&geom(&seg)), (0, 0));
+    }
+
+    /// The arithmetic both new methods stand on: a footprint-local point
+    /// pushed into board space and read back must land where it started, at a
+    /// rotation where getting the sign wrong is visible.
+    #[test]
+    fn local_to_board_and_back_round_trips_under_rotation() {
+        let fp = instance(90.0, vec![]);
+        let (anchor, angle) = footprint_frame(&fp);
+
+        let to_board = Xform::Rotate {
+            cx_nm: 0,
+            cy_nm: 0,
+            delta_deg: angle,
+        };
+        let to_local = Xform::Rotate {
+            cx_nm: anchor.0,
+            cy_nm: anchor.1,
+            delta_deg: -angle,
+        };
+
+        for &(x_mm, y_mm) in &[(13.5, -0.5), (13.5, 0.5), (12.7, 0.0), (-19.0, 3.25)] {
+            let (rx, ry) = to_board.point(builders::mm_to_nm(x_mm), builders::mm_to_nm(y_mm));
+            let (bx, by) = (anchor.0 + rx, anchor.1 + ry);
+            let (lx, ly) = to_local.point(bx, by);
+            assert_eq!(
+                (
+                    builders::nm_to_mm(lx - anchor.0),
+                    builders::nm_to_mm(ly - anchor.1)
+                ),
+                (x_mm, y_mm),
+                "round trip lost ({x_mm}, {y_mm})"
             );
         }
     }

--- a/crates/konnect-ipc/src/transform.rs
+++ b/crates/konnect-ipc/src/transform.rs
@@ -31,7 +31,7 @@ pub enum Xform {
 }
 
 impl Xform {
-    fn point(&self, x: i64, y: i64) -> (i64, i64) {
+    pub(crate) fn point(&self, x: i64, y: i64) -> (i64, i64) {
         match *self {
             Xform::Translate { dx_nm, dy_nm } => (x + dx_nm, y + dy_nm),
             Xform::Rotate {

--- a/crates/konnect-ipc/src/types.rs
+++ b/crates/konnect-ipc/src/types.rs
@@ -104,6 +104,29 @@ pub struct IpcTrack {
     pub end: IpcVector2,
 }
 
+/// A graphic item inside a placed footprint — silkscreen, fabrication, or
+/// courtyard artwork, not a pad.
+///
+/// `points` are footprint-local millimetres, matching what the `.kicad_mod`
+/// shows, even though KiCad carries them in absolute board coordinates.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IpcFootprintGraphic {
+    pub uuid: String,
+    pub kind: String,
+    pub layer: String,
+    pub points: Vec<IpcVector2>,
+    /// How many outlines a polygon's `PolySet` carries, and how many holes
+    /// across them; `0` for every other kind. `points` reports the first
+    /// outline only, so anything above `1` outline or above `0` holes means
+    /// this listing is not the whole shape — hence stating it rather than
+    /// letting the caller infer a simple triangle from three points.
+    pub outlines: usize,
+    pub holes: usize,
+    /// Whether `edit_board_footprint_graphic` can address this item: a
+    /// single-outline polygon with no holes, carrying a UUID.
+    pub editable: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IpcNet {
     pub name: String,

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -10,7 +10,7 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 ## Overview
 
 - **18 toolsets** organized into 10 categories
-- **187 registered tools** + **6 always-visible meta-tools** = **193 total**
+- **189 registered tools** + **6 always-visible meta-tools** = **195 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -263,7 +263,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 
 ## Library
 
-### `library` · 14 tools
+### `library` · 16 tools
 **Purpose:** Symbol libraries, footprint libraries, search and registration.
 **Source:** [`crates/konnect-core/src/tools/library.rs`](crates/konnect-core/src/tools/library.rs)
 
@@ -271,6 +271,8 @@ Six tools, grouped into *discovery/routing* and *observability*.
 |------|-------------|
 | `create_footprint` | Create a new footprint (`.kicad_mod`) file from a pad layout description. |
 | `edit_footprint_pad` | Edit the size, shape, or position of a pad in an existing `.kicad_mod`. |
+| `list_footprint_graphics` | List the graphic items in a `.kicad_mod` — silkscreen, fabrication, and courtyard outlines — with the UUID needed to edit one. |
+| `edit_footprint_graphic` | Edit the geometry, layer, or stroke width of one graphic item in an existing `.kicad_mod`, selected by UUID. |
 | `register_footprint_library` | Register a local footprint library directory in the KiCAD global or project library table. |
 | `list_footprint_libraries` | List all registered footprint libraries (global and/or project). |
 | `create_symbol` | Create a new KiCAD schematic symbol and append it to a `.kicad_sym` library. |

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -10,7 +10,7 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 ## Overview
 
 - **18 toolsets** organized into 10 categories
-- **189 registered tools** + **6 always-visible meta-tools** = **195 total**
+- **191 registered tools** + **6 always-visible meta-tools** = **197 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -200,7 +200,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `add_zone` | Add a copper fill zone polygon on a specified layer and net. |
 | `import_svg_logo` | Import an SVG file as filled silkscreen/copper artwork (curves flattened to polygons). |
 
-### `pcb_components` · 13 tools
+### `pcb_components` · 15 tools
 **Purpose:** Place, move, rotate, align, and duplicate PCB footprints.
 **Source:** [`crates/konnect-core/src/tools/pcb_components.rs`](crates/konnect-core/src/tools/pcb_components.rs)
 
@@ -212,6 +212,8 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `delete_component` | Remove a footprint from the board via KiCAD IPC. |
 | `edit_component` | Update the value or other properties of a placed footprint via KiCAD IPC. |
 | `find_component` | Find a footprint by reference designator and return its position. |
+| `list_board_footprint_graphics` | List the graphic items inside a placed footprint — silkscreen, fabrication, courtyard — with the UUID needed to edit one. Points are footprint-local mm. |
+| `edit_board_footprint_graphic` | Replace the vertices of a polygon inside a placed footprint, selected by UUID, via KiCAD IPC. Brings one instance in line with a library change without re-placing the part. |
 | `get_component_pads` | Return pad positions and net assignments for a footprint. A pad whose net node is present but unreadable reports `null` rather than an empty string, so "no net" stays distinguishable from "could not read it". |
 | `get_pad_position` | Return the schematic-space position of a specific pad number on a footprint. |
 | `get_component_list` | List all footprints on the board with positions, layers, and values. |


### PR DESCRIPTION
> **Stacked on #160.** This branch carries that PR's two commits as well, because a fork branch cannot be a base for an upstream PR. Merge #160 first and this diff reduces to its own two commits, `fix(library): …` and `refactor(library): …`. Neither of them touches the graphics tools; they are here rather than in #160 so that PR's diff stays about one thing.

Two things found while verifying #160 against real KiCAD, both in `library.rs` and both independent of it.

## 1. An unrelated project above you captures library resolution

`project_root_for` walks ancestors for a `.kicad_pro` and takes the first hit. The walk is unbounded, so **any** unrelated project file in **any** ancestor captures the search and every library lookup then resolves against the wrong `KIPRJMOD`. A project nested inside another project's folder is the realistic case, and it fails silently — you get someone else's `Device` library, not an error.

What made me look was duller. Two tests fail on `main` **right now** on a machine with KiCad installed, and pass on CI:

```
tools::library::symbol_source_tests::a_schematic_with_no_project_falls_back_to_its_own_directory
tools::sch_components::tests::add_component_writes_eeschema_style_instance_path
```

Both build a hermetic fixture in a tempdir. `add_component_writes_eeschema_style_instance_path` says so in its own comment — the project `sym-lib-table` "is what makes this hermetic ... the global table's own `Device` entry resolves to whatever KiCad the developer has installed and would shadow the stub". That is exactly what happens: `tempfile::tempdir()` creates a directory whose parent is the system temp directory, something had left twenty `.kicad_pro` files there, and the walk climbed straight out of the fixture and into them. The stub is never consulted. On CI temp is clean, the walk falls through to the file's own directory, and both pass — which is why v0.3.0 shipped green.

The fix ends the search when the file's own directory carries a `sym-lib-table` or an `fp-lib-table`. A directory that states where its libraries come from is a more specific answer than a `.kicad_pro` somewhere above it. A sheet under `<proj>/sheets/` normally carries no table of its own, so hierarchical resolution is untouched and `a_sheet_in_a_subdirectory_resolves_against_the_project_table` still passes.

New test `a_table_beside_the_file_beats_an_unrelated_project_further_up` reproduces the hazard deterministically — nested project under an outer one, no reliance on ambient litter. I checked it fails without the fix rather than assuming it would.

## 2. Missing-argument errors downgraded to handler errors

`require_str` returns a structured `InvalidArgument` `CallToolResult` naming the offending field. Seven handlers in `library.rs` did `map_err(|e| anyhow!("{:?}", e))?` on it, flattening the taxonomy into a debug-formatted string and surfacing as a generic `handler_error`. `pcb_components.rs` already returns the result directly; this makes `library.rs` agree.

Visible at the client — a missing argument now reports:

```json
{"error": {"kind": "invalid_argument", "field": "uuid", "reason": "missing or not a string"}}
```

where it used to be `handler_error`, which is what lets a caller tell "you forgot an argument" from "the tool tried and failed". An unknown-but-present value correctly stays a `handler_error`.

Copilot flagged one instance of this on #159/#160; the pattern was in seven more. No behaviour change beyond the error shape — every affected handler already returned `anyhow::Result<CallToolResult>`.

## Tests

```
cargo test --workspace --lib --tests --no-fail-fast   # all green
cargo fmt --all -- --check                            # clean
cargo clippy -p konnect-core -p konnect-ipc --lib --tests   # no warnings
```

This is the first fully green `--workspace` run I have had on this machine; the two failures above were the only ones outstanding.

## Risk

The resolution change is the one worth a second opinion, since it changes which directory wins for a file that has a table beside it *and* a project above it. My reading is that the table is the more specific statement, and the existing sub-sheet test pins the case where it should still walk. If you would rather it stayed strictly "nearest `.kicad_pro` wins" and the two tests were made hermetic another way — a fixture that plants its own `.kicad_pro` — say so and I will redo it that way; that also fixes the tests but leaves the nested-project hazard in place.
