### PR TITLE
feat: edit and place footprints safely

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -65,7 +65,7 @@ Konnect/
 │   │           ├── sch_export.rs     # 6 tools (SVG/PDF/netlist/ERC)
 │   │           ├── sch_hierarchy.rs  # 12 tools (typed Sheet model, sheet CRUD + hierarchy/page queries + pin lifecycle)
 │   │           ├── pcb_board.rs      # 11 tools (S-expr file editing, IPC fallback, SVG logo import)
-│   │           ├── pcb_components.rs # 13 tools (IPC real-time via NNG+protobuf)
+│   │           ├── pcb_components.rs # 13 tools (IPC real-time + safe headless single-placement fallback)
 │   │           ├── pcb_routing.rs    # 12 tools (traces, vias, nets, netclasses)
 │   │           ├── pcb_export.rs     # 13 tools (Gerber, PDF, 3D, DRC, DXF/GenCAD/IPC-2581/ODB++)
 │   │           ├── library.rs        # 17 tools (symbol/footprint library management)

--- a/DEV.md
+++ b/DEV.md
@@ -68,9 +68,10 @@ Konnect/
 │   │           ├── pcb_components.rs # 13 tools (IPC real-time via NNG+protobuf)
 │   │           ├── pcb_routing.rs    # 12 tools (traces, vias, nets, netclasses)
 │   │           ├── pcb_export.rs     # 13 tools (Gerber, PDF, 3D, DRC, DXF/GenCAD/IPC-2581/ODB++)
-│   │           ├── library.rs        # 16 tools (symbol/footprint library management)
+│   │           ├── library.rs        # 17 tools (symbol/footprint library management)
 │   │           ├── footprint_graphics.rs # footprint primitive validation, inspection, and atomic edits
 │   │           ├── footprint_metadata.rs # footprint description, tags, and attribute edits
+│   │           ├── footprint_models.rs # footprint 3D model validation and atomic edits
 │   │           ├── integration.rs    # 9 tools (JLCPCB SQLite, Freerouting, datasheets)
 │   │           ├── verification.rs   # 8 tools (DRC, design rules, KiCAD UI)
 │   │           ├── config.rs         # 7 tools (user/project config, design rules)
@@ -208,7 +209,7 @@ if !path.exists() {
 
 Adding a new kind: edit `mcp/error.rs`, add the variant, add the match arm in `short_code()`, use it from the handler. The `short_code_matches_serialized_kind_field` test will fail loudly if they drift.
 
-The dispatch-level errors (not-loaded/unknown/handler-panic) are fully structured. So are **all missing-argument errors** across all 190 tools — `tools/mod.rs::require_str` / `require_f64` emit `ToolErrorKind::InvalidArgument { field, reason }` automatically. Most in-handler errors still use `CallToolResult::error("free text")` or bubble `anyhow::Error`; migrating them is incremental. `project.rs::handle_get_project_info` demonstrates the structured `FileNotFound` pattern.
+The dispatch-level errors (not-loaded/unknown/handler-panic) are fully structured. So are **all missing-argument errors** across all 191 tools — `tools/mod.rs::require_str` / `require_f64` emit `ToolErrorKind::InvalidArgument { field, reason }` automatically. Most in-handler errors still use `CallToolResult::error("free text")` or bubble `anyhow::Error`; migrating them is incremental. `project.rs::handle_get_project_info` demonstrates the structured `FileNotFound` pattern.
 
 ## Observability
 
@@ -229,7 +230,7 @@ Source: [`crates/konnect-core/src/observability.rs`](crates/konnect-core/src/obs
 
 ## Tool Routing (Starter Kit + On-Demand Loading)
 
-The server does NOT expose all 190 tools (196 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
+The server does NOT expose all 191 tools (197 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
 
 - **Startup**: only `STARTER_KIT` toolsets are pre-loaded (see `router/registry.rs::STARTER_KIT`). Currently: `project`, `config`. Combined with the 6 meta-tools, baseline `tools/list` is ~19 tools ≈ 2K tokens.
 - **On demand**: the LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose a toolset's tools in subsequent `tools/list` responses. `unload_toolset(name)` prunes them when the task shifts.
@@ -301,9 +302,9 @@ convention for other `kicad-cli`-calling code.
 
 ## Current Stats
 
-- **18 toolsets, 190 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
+- **18 toolsets, 191 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
 - Baseline `tools/list`: ~19 tools / ~2K tokens (starter kit + meta-tools)
-- Full-catalog `tools/list` (all loaded): 196 tools (190 registered + 6 meta) / ~25K tokens
+- Full-catalog `tools/list` (all loaded): 197 tools (191 registered + 6 meta) / ~25K tokens
 - **0 IPC stubs** (all protobuf methods implemented)
 - **0 unimplemented tools**
 - **3 CLI commands removed in KiCAD v10** (specctra DSN/SES, pcb sync — return clear errors)

--- a/DEV.md
+++ b/DEV.md
@@ -68,8 +68,9 @@ Konnect/
 │   │           ├── pcb_components.rs # 13 tools (IPC real-time via NNG+protobuf)
 │   │           ├── pcb_routing.rs    # 12 tools (traces, vias, nets, netclasses)
 │   │           ├── pcb_export.rs     # 13 tools (Gerber, PDF, 3D, DRC, DXF/GenCAD/IPC-2581/ODB++)
-│   │           ├── library.rs        # 15 tools (symbol/footprint library management)
+│   │           ├── library.rs        # 16 tools (symbol/footprint library management)
 │   │           ├── footprint_graphics.rs # footprint primitive validation, inspection, and atomic edits
+│   │           ├── footprint_metadata.rs # footprint description, tags, and attribute edits
 │   │           ├── integration.rs    # 9 tools (JLCPCB SQLite, Freerouting, datasheets)
 │   │           ├── verification.rs   # 8 tools (DRC, design rules, KiCAD UI)
 │   │           ├── config.rs         # 7 tools (user/project config, design rules)
@@ -207,7 +208,7 @@ if !path.exists() {
 
 Adding a new kind: edit `mcp/error.rs`, add the variant, add the match arm in `short_code()`, use it from the handler. The `short_code_matches_serialized_kind_field` test will fail loudly if they drift.
 
-The dispatch-level errors (not-loaded/unknown/handler-panic) are fully structured. So are **all missing-argument errors** across all 189 tools — `tools/mod.rs::require_str` / `require_f64` emit `ToolErrorKind::InvalidArgument { field, reason }` automatically. Most in-handler errors still use `CallToolResult::error("free text")` or bubble `anyhow::Error`; migrating them is incremental. `project.rs::handle_get_project_info` demonstrates the structured `FileNotFound` pattern.
+The dispatch-level errors (not-loaded/unknown/handler-panic) are fully structured. So are **all missing-argument errors** across all 190 tools — `tools/mod.rs::require_str` / `require_f64` emit `ToolErrorKind::InvalidArgument { field, reason }` automatically. Most in-handler errors still use `CallToolResult::error("free text")` or bubble `anyhow::Error`; migrating them is incremental. `project.rs::handle_get_project_info` demonstrates the structured `FileNotFound` pattern.
 
 ## Observability
 
@@ -228,7 +229,7 @@ Source: [`crates/konnect-core/src/observability.rs`](crates/konnect-core/src/obs
 
 ## Tool Routing (Starter Kit + On-Demand Loading)
 
-The server does NOT expose all 189 tools (195 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
+The server does NOT expose all 190 tools (196 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
 
 - **Startup**: only `STARTER_KIT` toolsets are pre-loaded (see `router/registry.rs::STARTER_KIT`). Currently: `project`, `config`. Combined with the 6 meta-tools, baseline `tools/list` is ~19 tools ≈ 2K tokens.
 - **On demand**: the LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose a toolset's tools in subsequent `tools/list` responses. `unload_toolset(name)` prunes them when the task shifts.
@@ -300,9 +301,9 @@ convention for other `kicad-cli`-calling code.
 
 ## Current Stats
 
-- **18 toolsets, 189 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
+- **18 toolsets, 190 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
 - Baseline `tools/list`: ~19 tools / ~2K tokens (starter kit + meta-tools)
-- Full-catalog `tools/list` (all loaded): 195 tools (189 registered + 6 meta) / ~25K tokens
+- Full-catalog `tools/list` (all loaded): 196 tools (190 registered + 6 meta) / ~25K tokens
 - **0 IPC stubs** (all protobuf methods implemented)
 - **0 unimplemented tools**
 - **3 CLI commands removed in KiCAD v10** (specctra DSN/SES, pcb sync — return clear errors)

--- a/DEV.md
+++ b/DEV.md
@@ -68,7 +68,8 @@ Konnect/
 │   │           ├── pcb_components.rs # 13 tools (IPC real-time via NNG+protobuf)
 │   │           ├── pcb_routing.rs    # 12 tools (traces, vias, nets, netclasses)
 │   │           ├── pcb_export.rs     # 13 tools (Gerber, PDF, 3D, DRC, DXF/GenCAD/IPC-2581/ODB++)
-│   │           ├── library.rs        # 14 tools (symbol/footprint library management)
+│   │           ├── library.rs        # 15 tools (symbol/footprint library management)
+│   │           ├── footprint_graphics.rs # footprint primitive validation, inspection, and atomic edits
 │   │           ├── integration.rs    # 9 tools (JLCPCB SQLite, Freerouting, datasheets)
 │   │           ├── verification.rs   # 8 tools (DRC, design rules, KiCAD UI)
 │   │           ├── config.rs         # 7 tools (user/project config, design rules)
@@ -206,7 +207,7 @@ if !path.exists() {
 
 Adding a new kind: edit `mcp/error.rs`, add the variant, add the match arm in `short_code()`, use it from the handler. The `short_code_matches_serialized_kind_field` test will fail loudly if they drift.
 
-The dispatch-level errors (not-loaded/unknown/handler-panic) are fully structured. So are **all missing-argument errors** across all 188 tools — `tools/mod.rs::require_str` / `require_f64` emit `ToolErrorKind::InvalidArgument { field, reason }` automatically. Most in-handler errors still use `CallToolResult::error("free text")` or bubble `anyhow::Error`; migrating them is incremental. `project.rs::handle_get_project_info` demonstrates the structured `FileNotFound` pattern.
+The dispatch-level errors (not-loaded/unknown/handler-panic) are fully structured. So are **all missing-argument errors** across all 189 tools — `tools/mod.rs::require_str` / `require_f64` emit `ToolErrorKind::InvalidArgument { field, reason }` automatically. Most in-handler errors still use `CallToolResult::error("free text")` or bubble `anyhow::Error`; migrating them is incremental. `project.rs::handle_get_project_info` demonstrates the structured `FileNotFound` pattern.
 
 ## Observability
 
@@ -227,7 +228,7 @@ Source: [`crates/konnect-core/src/observability.rs`](crates/konnect-core/src/obs
 
 ## Tool Routing (Starter Kit + On-Demand Loading)
 
-The server does NOT expose all 188 tools (194 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
+The server does NOT expose all 189 tools (195 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
 
 - **Startup**: only `STARTER_KIT` toolsets are pre-loaded (see `router/registry.rs::STARTER_KIT`). Currently: `project`, `config`. Combined with the 6 meta-tools, baseline `tools/list` is ~19 tools ≈ 2K tokens.
 - **On demand**: the LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose a toolset's tools in subsequent `tools/list` responses. `unload_toolset(name)` prunes them when the task shifts.
@@ -299,9 +300,9 @@ convention for other `kicad-cli`-calling code.
 
 ## Current Stats
 
-- **18 toolsets, 188 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
+- **18 toolsets, 189 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
 - Baseline `tools/list`: ~19 tools / ~2K tokens (starter kit + meta-tools)
-- Full-catalog `tools/list` (all loaded): 194 tools (188 registered + 6 meta) / ~25K tokens
+- Full-catalog `tools/list` (all loaded): 195 tools (189 registered + 6 meta) / ~25K tokens
 - **0 IPC stubs** (all protobuf methods implemented)
 - **0 unimplemented tools**
 - **3 CLI commands removed in KiCAD v10** (specctra DSN/SES, pcb sync — return clear errors)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Rust binary — that lets Claude and other AI assistants design schematics and PCBs
 through the [Model Context Protocol](https://modelcontextprotocol.io) (MCP).
 
-**189 tools across 18 on-demand toolsets.** Schematic capture, PCB layout and
+**190 tools across 18 on-demand toolsets.** Schematic capture, PCB layout and
 routing, ERC/DRC, design-review audits, JLCPCB part search, Freerouting, reference
 circuits, and a full manufacturing export pipeline — with bundled skills and agents
 that teach Claude KiCAD conventions out of the box.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Rust binary — that lets Claude and other AI assistants design schematics and PCBs
 through the [Model Context Protocol](https://modelcontextprotocol.io) (MCP).
 
-**190 tools across 18 on-demand toolsets.** Schematic capture, PCB layout and
+**191 tools across 18 on-demand toolsets.** Schematic capture, PCB layout and
 routing, ERC/DRC, design-review audits, JLCPCB part search, Freerouting, reference
 circuits, and a full manufacturing export pipeline — with bundled skills and agents
 that teach Claude KiCAD conventions out of the box.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The full tool catalog is documented in [tool-directory.md](tool-directory.md).
 | Layer | Mechanism |
 |-------|-----------|
 | Schematic editing | Direct `.kicad_sch` S-expression editing with atomic writes (no KiCAD required) |
-| PCB editing | KiCAD 10 IPC API (NNG + protobuf) — real-time, undo-aware, requires KiCAD running |
+| PCB editing | KiCAD 10 IPC API (NNG + protobuf) — real-time and undo-aware; single-footprint placement has a safe headless fallback |
 | Exports & checks | `kicad-cli` subprocess (Gerber, PDF, ERC, DRC, …) |
 | Transport | MCP JSON-RPC over stdio (default), or Streamable HTTP (`transport = "http"` / `"both"`) |
 
@@ -235,7 +235,8 @@ the main workspace — see [DEV.md](DEV.md) for build steps.
   compiles and passes tests in CI but hasn't had per-platform QA yet; both are
   tracked on the [roadmap](ROADMAP.md))
 - `kicad-cli` (ships with KiCAD — used for exports, ERC, DRC)
-- For PCB tools: KiCAD running with the target board open (IPC API)
+- For most PCB tools: KiCAD running with the target board open (IPC API).
+  `place_component` can safely fall back to a closed board file when IPC is unreachable.
 
 ## License: free for the little guys
 
@@ -271,7 +272,8 @@ the architecture it proved, rebuilt for production:
 manual copy), then restart KiCAD.
 
 **PCB tools return "IPC connect failed"** — open KiCAD with your board file first;
-PCB tools talk to the running PCB editor.
+most PCB tools talk to the running PCB editor. `place_component` alone can fall
+back to a closed board file when no KiCAD process is reachable.
 
 **"kicad-cli not found"** — common install paths are auto-detected; set the path
 explicitly in the plugin settings dialog or your `konnect-settings.json` if yours

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Rust binary — that lets Claude and other AI assistants design schematics and PCBs
 through the [Model Context Protocol](https://modelcontextprotocol.io) (MCP).
 
-**188 tools across 18 on-demand toolsets.** Schematic capture, PCB layout and
+**189 tools across 18 on-demand toolsets.** Schematic capture, PCB layout and
 routing, ERC/DRC, design-review audits, JLCPCB part search, Freerouting, reference
 circuits, and a full manufacturing export pipeline — with bundled skills and agents
 that teach Claude KiCAD conventions out of the box.

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -88,7 +88,7 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         name: "library",
         description: "Symbol libraries, footprint libraries, search and registration",
         category: "library",
-        tool_count: 15,
+        tool_count: 16,
     },
     ToolsetMeta {
         name: "integration",

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -88,7 +88,7 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         name: "library",
         description: "Symbol libraries, footprint libraries, search and registration",
         category: "library",
-        tool_count: 14,
+        tool_count: 15,
     },
     ToolsetMeta {
         name: "integration",

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -88,7 +88,7 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         name: "library",
         description: "Symbol libraries, footprint libraries, search and registration",
         category: "library",
-        tool_count: 16,
+        tool_count: 17,
     },
     ToolsetMeta {
         name: "integration",

--- a/crates/konnect-core/src/tools/footprint_graphics.rs
+++ b/crates/konnect-core/src/tools/footprint_graphics.rs
@@ -670,6 +670,9 @@ impl FootprintGraphic {
                 if !radius_mm.is_finite() || *radius_mm <= 0.0 {
                     return Err("radius_mm must be finite and positive".to_string());
                 }
+                if !(center.x + *radius_mm).is_finite() {
+                    return Err("circle end point must remain finite".to_string());
+                }
             }
             Self::Poly {
                 points,
@@ -1161,6 +1164,19 @@ mod tests {
         let mut non_finite = non_finite;
         non_finite[0]["center"]["x"] = serde_json::Value::from(f64::INFINITY);
         assert!(parse_graphics(&non_finite).is_err());
+    }
+
+    #[test]
+    fn rejects_a_circle_whose_derived_end_point_overflows() {
+        let value = json!([{
+            "type": "circle",
+            "center": {"x": f64::MAX, "y": 0.0},
+            "radius_mm": f64::MAX,
+            "stroke_width_mm": 0.05,
+            "fill": "none"
+        }]);
+
+        assert!(parse_graphics(&value).is_err());
     }
 
     #[test]

--- a/crates/konnect-core/src/tools/footprint_graphics.rs
+++ b/crates/konnect-core/src/tools/footprint_graphics.rs
@@ -7,7 +7,7 @@ use konnect_sexp::writer::{
     apply_edits, find_balanced_block, find_block_with_leading_whitespace, find_direct_child_blocks,
     read_consistent, write_atomic_if_unchanged, SexpEdit,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 fn point_schema() -> serde_json::Value {
@@ -299,13 +299,185 @@ fn persist_replacement(
     write_atomic_if_unchanged(path, expected, replacement)
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+fn parse_point(node: &konnect_sexp::SexpNode, tag: &str) -> Result<Point, FootprintGraphicsError> {
+    let point = node
+        .find(tag)
+        .ok_or_else(|| invalid("footprint_path", format!("{tag} is missing")))?;
+    let x = point
+        .get_f64(1)
+        .ok_or_else(|| invalid("footprint_path", format!("{tag}.x is invalid")))?;
+    let y = point
+        .get_f64(2)
+        .ok_or_else(|| invalid("footprint_path", format!("{tag}.y is invalid")))?;
+    let point = Point { x, y };
+    point
+        .validate(tag)
+        .map_err(|reason| invalid("footprint_path", reason))?;
+    Ok(point)
+}
+
+fn parse_stroke_width(node: &konnect_sexp::SexpNode) -> Result<f64, FootprintGraphicsError> {
+    let width = node
+        .find("stroke")
+        .and_then(|stroke| stroke.find_f64("width"))
+        .ok_or_else(|| {
+            invalid(
+                "footprint_path",
+                "graphic stroke width is missing or invalid",
+            )
+        })?;
+    if !width.is_finite() || width < 0.0 {
+        return Err(invalid(
+            "footprint_path",
+            "graphic stroke width must be finite and non-negative",
+        ));
+    }
+    Ok(width)
+}
+
+fn parse_fill(node: &konnect_sexp::SexpNode) -> Result<Fill, FootprintGraphicsError> {
+    match node.find("fill").and_then(|fill| fill.get(1)) {
+        Some(fill) if matches!(fill.as_str(), Some("none" | "no")) => Ok(Fill::None),
+        Some(fill) if matches!(fill.as_str(), Some("solid" | "yes")) => Ok(Fill::Solid),
+        _ => Err(invalid(
+            "footprint_path",
+            "graphic fill is missing or unsupported",
+        )),
+    }
+}
+
+fn graphic_info_base(
+    graphic_type: &str,
+    node: &konnect_sexp::SexpNode,
+) -> Result<FootprintGraphicInfo, FootprintGraphicsError> {
+    let layer = node
+        .find_str("layer")
+        .ok_or_else(|| invalid("footprint_path", "graphic layer is missing"))?
+        .to_string();
+    let item_id = node
+        .find_str("uuid")
+        .or_else(|| node.find_str("tstamp"))
+        .map(str::to_string);
+    Ok(FootprintGraphicInfo {
+        graphic_type: graphic_type.to_string(),
+        layer,
+        start: None,
+        mid: None,
+        end: None,
+        center: None,
+        radius_mm: None,
+        points: None,
+        point_count: None,
+        closed: None,
+        stroke_width_mm: parse_stroke_width(node)?,
+        fill: None,
+        item_id,
+    })
+}
+
+fn inspect_graphic(
+    node: &konnect_sexp::SexpNode,
+) -> Result<FootprintGraphicInfo, FootprintGraphicsError> {
+    let tag = node
+        .head()
+        .ok_or_else(|| invalid("footprint_path", "graphic type is missing"))?;
+    let graphic_type = tag
+        .strip_prefix("fp_")
+        .ok_or_else(|| invalid("footprint_path", "unsupported graphic type"))?;
+    let mut info = graphic_info_base(graphic_type, node)?;
+    match tag {
+        "fp_line" => {
+            info.start = Some(parse_point(node, "start")?);
+            info.end = Some(parse_point(node, "end")?);
+        }
+        "fp_arc" => {
+            info.start = Some(parse_point(node, "start")?);
+            info.mid = Some(parse_point(node, "mid")?);
+            info.end = Some(parse_point(node, "end")?);
+        }
+        "fp_rect" => {
+            info.start = Some(parse_point(node, "start")?);
+            info.end = Some(parse_point(node, "end")?);
+            info.fill = Some(parse_fill(node)?);
+        }
+        "fp_circle" => {
+            let center = parse_point(node, "center")?;
+            let end = parse_point(node, "end")?;
+            info.center = Some(center);
+            info.radius_mm = Some((end.x - center.x).hypot(end.y - center.y));
+            info.fill = Some(parse_fill(node)?);
+        }
+        "fp_poly" => {
+            let points = node
+                .find("pts")
+                .ok_or_else(|| invalid("footprint_path", "polygon points are missing"))?
+                .find_all("xy")
+                .into_iter()
+                .map(|point| {
+                    let x = point
+                        .get_f64(1)
+                        .ok_or_else(|| invalid("footprint_path", "polygon point x is invalid"))?;
+                    let y = point
+                        .get_f64(2)
+                        .ok_or_else(|| invalid("footprint_path", "polygon point y is invalid"))?;
+                    let point = Point { x, y };
+                    point
+                        .validate("polygon point")
+                        .map_err(|reason| invalid("footprint_path", reason))?;
+                    Ok(point)
+                })
+                .collect::<Result<Vec<_>, FootprintGraphicsError>>()?;
+            info.point_count = Some(points.len());
+            info.closed = Some(true);
+            info.points = Some(points);
+            info.fill = Some(parse_fill(node)?);
+        }
+        _ => return Err(invalid("footprint_path", "unsupported graphic type")),
+    }
+    Ok(info)
+}
+
+pub(super) fn inspect_graphics(
+    source: &str,
+    layer_filter: Option<&str>,
+) -> Result<Vec<FootprintGraphicInfo>, FootprintGraphicsError> {
+    if let Some(layer) = layer_filter {
+        if !konnect_sexp::layers::is_canonical_name(layer) {
+            return Err(invalid("graphics_layer", "not a canonical KiCad layer"));
+        }
+    }
+    let tree = konnect_sexp::parse_sexp(source)
+        .map_err(|error| invalid("footprint_path", format!("invalid S-expression: {error}")))?;
+    if tree.head() != Some("footprint") {
+        return Err(invalid("footprint_path", "file root must be a footprint"));
+    }
+
+    let mut graphics = Vec::new();
+    for (start, end) in find_direct_child_blocks(source, "footprint") {
+        let block = konnect_sexp::parse_sexp(&source[start..end]).map_err(|error| {
+            invalid("footprint_path", format!("invalid top-level item: {error}"))
+        })?;
+        let Some(tag) = block.head() else {
+            continue;
+        };
+        if !is_supported_graphic(tag) {
+            continue;
+        }
+        let info = inspect_graphic(&block)?;
+        if layer_filter.is_none_or(|layer| info.layer == layer) {
+            graphics.push(info);
+        }
+    }
+    Ok(graphics)
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq)]
 struct Point {
     x: f64,
     y: f64,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 enum Fill {
     None,
@@ -363,7 +535,7 @@ enum GraphicsMode {
 }
 
 #[derive(Debug, thiserror::Error)]
-enum FootprintGraphicsError {
+pub(super) enum FootprintGraphicsError {
     #[error("invalid {field}: {reason}")]
     InvalidArgument { field: String, reason: String },
     #[error("{0}")]
@@ -375,6 +547,33 @@ struct PreparedMutation {
     replacement: String,
     matched_count: usize,
     added_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct FootprintGraphicInfo {
+    #[serde(rename = "type")]
+    graphic_type: String,
+    pub(super) layer: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    start: Option<Point>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mid: Option<Point>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    end: Option<Point>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    center: Option<Point>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    radius_mm: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    points: Option<Vec<Point>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    point_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    closed: Option<bool>,
+    stroke_width_mm: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fill: Option<Fill>,
+    item_id: Option<String>,
 }
 
 fn parse_graphics(value: &serde_json::Value) -> Result<Vec<FootprintGraphic>, String> {
@@ -1220,6 +1419,94 @@ mod tests {
                 json!(["type", "points", "stroke_width_mm", "fill"]),
             ]
         );
+    }
+
+    #[test]
+    fn inspects_old_and_new_footprint_graphic_syntax() {
+        let source = r#"(footprint "Inspect" (version 20240108) (generator "pcbnew")
+  (layer "F.Cu")
+  (fp_line (start 0 1) (end 2 3)
+    (stroke (width 0.05) (type solid)) (layer "F.SilkS")
+    (tstamp 10000000-0000-4000-8000-000000000001))
+  (fp_arc (start 0 0) (mid 1 1) (end 2 0)
+    (stroke (width 0.06) (type solid)) (layer "B.CrtYd")
+    (uuid "20000000-0000-4000-8000-000000000001"))
+  (fp_rect (start -1 -2) (end 3 4)
+    (stroke (width 0.07) (type solid)) (fill no) (layer "B.CrtYd")
+    (uuid "30000000-0000-4000-8000-000000000001"))
+  (fp_circle (center 1 2) (end 2.5 2)
+    (stroke (width 0.08) (type solid)) (fill yes) (layer "B.CrtYd")
+    (tstamp 40000000-0000-4000-8000-000000000001))
+  (fp_poly
+    (pts (xy 0 0) (xy 2 0) (xy 2 1))
+    (stroke (width 0.09) (type solid)) (fill none) (layer "B.CrtYd"))
+  (fp_text user "ignored" (at 0 0) (layer "B.CrtYd")
+    (effects (font (size 1 1))))
+  (pad "1" thru_hole circle (at 0 0) (size 1.8 1.8) (drill 1)
+    (layers "*.Cu" "*.Mask"))
+)
+"#;
+
+        let graphics = inspect_graphics(source, None).unwrap();
+
+        assert_eq!(
+            serde_json::to_value(&graphics).unwrap(),
+            json!([
+                {
+                    "type": "line",
+                    "layer": "F.SilkS",
+                    "start": {"x": 0.0, "y": 1.0},
+                    "end": {"x": 2.0, "y": 3.0},
+                    "stroke_width_mm": 0.05,
+                    "item_id": "10000000-0000-4000-8000-000000000001"
+                },
+                {
+                    "type": "arc",
+                    "layer": "B.CrtYd",
+                    "start": {"x": 0.0, "y": 0.0},
+                    "mid": {"x": 1.0, "y": 1.0},
+                    "end": {"x": 2.0, "y": 0.0},
+                    "stroke_width_mm": 0.06,
+                    "item_id": "20000000-0000-4000-8000-000000000001"
+                },
+                {
+                    "type": "rect",
+                    "layer": "B.CrtYd",
+                    "start": {"x": -1.0, "y": -2.0},
+                    "end": {"x": 3.0, "y": 4.0},
+                    "stroke_width_mm": 0.07,
+                    "fill": "none",
+                    "item_id": "30000000-0000-4000-8000-000000000001"
+                },
+                {
+                    "type": "circle",
+                    "layer": "B.CrtYd",
+                    "center": {"x": 1.0, "y": 2.0},
+                    "radius_mm": 1.5,
+                    "stroke_width_mm": 0.08,
+                    "fill": "solid",
+                    "item_id": "40000000-0000-4000-8000-000000000001"
+                },
+                {
+                    "type": "poly",
+                    "layer": "B.CrtYd",
+                    "points": [
+                        {"x": 0.0, "y": 0.0},
+                        {"x": 2.0, "y": 0.0},
+                        {"x": 2.0, "y": 1.0}
+                    ],
+                    "point_count": 3,
+                    "closed": true,
+                    "stroke_width_mm": 0.09,
+                    "fill": "none",
+                    "item_id": null
+                }
+            ])
+        );
+
+        let courtyard = inspect_graphics(source, Some("B.CrtYd")).unwrap();
+        assert_eq!(courtyard.len(), 4);
+        assert!(courtyard.iter().all(|graphic| graphic.layer == "B.CrtYd"));
     }
 
     #[tokio::test]

--- a/crates/konnect-core/src/tools/footprint_graphics.rs
+++ b/crates/konnect-core/src/tools/footprint_graphics.rs
@@ -1,4 +1,8 @@
 use konnect_schematic_editor::types::fmt_f64;
+use konnect_sexp::writer::{
+    apply_edits, find_balanced_block, find_block_with_leading_whitespace, find_direct_child_blocks,
+    SexpEdit,
+};
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
@@ -54,6 +58,29 @@ enum FootprintGraphic {
         stroke_width_mm: f64,
         fill: Fill,
     },
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum GraphicsMode {
+    Append,
+    Replace,
+    Delete,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum FootprintGraphicsError {
+    #[error("invalid {field}: {reason}")]
+    InvalidArgument { field: String, reason: String },
+    #[error("{0}")]
+    Conflict(String),
+}
+
+#[derive(Debug)]
+struct PreparedMutation {
+    replacement: String,
+    matched_count: usize,
+    added_count: usize,
 }
 
 fn parse_graphics(value: &serde_json::Value) -> Result<Vec<FootprintGraphic>, String> {
@@ -273,10 +300,215 @@ fn serialize_graphics(layer: &str, graphics: &[FootprintGraphic], indent: &str) 
     output
 }
 
+fn invalid(field: &str, reason: impl Into<String>) -> FootprintGraphicsError {
+    FootprintGraphicsError::InvalidArgument {
+        field: field.to_string(),
+        reason: reason.into(),
+    }
+}
+
+fn is_supported_graphic(tag: &str) -> bool {
+    matches!(
+        tag,
+        "fp_line" | "fp_arc" | "fp_rect" | "fp_circle" | "fp_poly"
+    )
+}
+
+fn child_indent(source: &str, start: usize) -> String {
+    let line_start = source[..start].rfind('\n').map_or(0, |index| index + 1);
+    let indent = &source[line_start..start];
+    if !indent.is_empty()
+        && indent
+            .chars()
+            .all(|character| matches!(character, ' ' | '\t'))
+    {
+        indent.to_string()
+    } else {
+        "  ".to_string()
+    }
+}
+
+fn prepare_mutation(
+    source: &str,
+    layer: &str,
+    mode: GraphicsMode,
+    graphics: &[FootprintGraphic],
+) -> Result<PreparedMutation, FootprintGraphicsError> {
+    if !konnect_sexp::layers::is_canonical_name(layer) {
+        return Err(invalid("selector.layer", "not a canonical KiCad layer"));
+    }
+    let tree = konnect_sexp::parse_sexp(source)
+        .map_err(|error| invalid("footprint_path", format!("invalid S-expression: {error}")))?;
+    if tree.head() != Some("footprint") {
+        return Err(invalid("footprint_path", "file root must be a footprint"));
+    }
+
+    let direct_children = find_direct_child_blocks(source, "footprint");
+    let mut selected = Vec::new();
+    let mut group_members = Vec::new();
+    let mut insertion_anchor = None;
+    for (start, end) in direct_children {
+        let block = &source[start..end];
+        let Ok(node) = konnect_sexp::parse_sexp(block) else {
+            return Err(invalid(
+                "footprint_path",
+                "contains an invalid top-level item",
+            ));
+        };
+        let Some(tag) = node.head() else {
+            continue;
+        };
+        if insertion_anchor.is_none() && matches!(tag, "pad" | "group" | "model") {
+            insertion_anchor =
+                find_block_with_leading_whitespace(source, start).map(|range| range.0);
+        }
+        if tag == "group" {
+            if let Some(members) = node.find("members").and_then(|members| members.children()) {
+                group_members.extend(
+                    members
+                        .iter()
+                        .skip(1)
+                        .filter_map(|member| member.as_str())
+                        .map(str::to_string),
+                );
+            }
+        }
+        if is_supported_graphic(tag) && node.find_str("layer") == Some(layer) {
+            let range = find_block_with_leading_whitespace(source, start)
+                .ok_or_else(|| invalid("footprint_path", "contains an unbalanced graphic"))?;
+            let item_id = node
+                .find_str("uuid")
+                .or_else(|| node.find_str("tstamp"))
+                .map(str::to_string);
+            selected.push((range, item_id));
+        }
+    }
+
+    if !matches!(mode, GraphicsMode::Append) {
+        if let Some(item_id) = selected
+            .iter()
+            .filter_map(|(_, item_id)| item_id.as_deref())
+            .find(|item_id| group_members.iter().any(|member| member == item_id))
+        {
+            return Err(FootprintGraphicsError::Conflict(format!(
+                "selected graphic '{item_id}' is referenced by a footprint group"
+            )));
+        }
+    }
+
+    let indent = selected
+        .first()
+        .map(|(range, _)| {
+            let block_start = find_balanced_block(source, range.0)
+                .map(|range| range.0)
+                .unwrap_or(range.0);
+            child_indent(source, block_start)
+        })
+        .or_else(|| {
+            insertion_anchor.map(|anchor| {
+                let block_start = find_balanced_block(source, anchor)
+                    .map(|range| range.0)
+                    .unwrap_or(anchor);
+                child_indent(source, block_start)
+            })
+        })
+        .unwrap_or_else(|| "  ".to_string());
+    let serialized = serialize_graphics(layer, graphics, &indent);
+    let matched_count = selected.len();
+    let added_count = if matches!(mode, GraphicsMode::Delete) {
+        0
+    } else {
+        graphics.len()
+    };
+
+    let mut edits = Vec::new();
+    match mode {
+        GraphicsMode::Replace => {
+            if let Some((first, rest)) = selected.split_first() {
+                let (first_range, _) = first;
+                edits.push(SexpEdit::replace(first_range.0, first_range.1, serialized));
+                edits.extend(
+                    rest.iter()
+                        .map(|(range, _)| SexpEdit::delete(range.0, range.1)),
+                );
+            } else if !serialized.is_empty() {
+                let root_end = find_balanced_block(source, 0)
+                    .map(|range| range.1 - 1)
+                    .ok_or_else(|| invalid("footprint_path", "unbalanced footprint root"))?;
+                edits.push(SexpEdit::insert(
+                    insertion_anchor.unwrap_or(root_end),
+                    serialized,
+                ));
+            }
+        }
+        GraphicsMode::Append => {
+            if !serialized.is_empty() {
+                let root_end = find_balanced_block(source, 0)
+                    .map(|range| range.1 - 1)
+                    .ok_or_else(|| invalid("footprint_path", "unbalanced footprint root"))?;
+                let offset = selected
+                    .last()
+                    .map(|(range, _)| range.1)
+                    .or(insertion_anchor)
+                    .unwrap_or(root_end);
+                edits.push(SexpEdit::insert(offset, serialized));
+            }
+        }
+        GraphicsMode::Delete => {
+            edits.extend(
+                selected
+                    .iter()
+                    .map(|(range, _)| SexpEdit::delete(range.0, range.1)),
+            );
+        }
+    }
+
+    let replacement = apply_edits(source.to_string(), edits);
+    let parsed = konnect_sexp::parse_sexp(&replacement)
+        .map_err(|error| invalid("graphics", format!("replacement does not parse: {error}")))?;
+    if parsed.head() != Some("footprint") {
+        return Err(FootprintGraphicsError::Conflict(
+            "replacement changed the footprint root".to_string(),
+        ));
+    }
+
+    Ok(PreparedMutation {
+        replacement,
+        matched_count,
+        added_count,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+
+    const OLD_FOOTPRINT: &str = r#"(footprint "Fixture" (version 20221018) (generator pcbnew)
+  (layer "F.Cu")
+  (fp_line (start -1 -1) (end 1 -1)
+    (stroke (width 0.1) (type solid)) (layer "F.SilkS")
+    (tstamp 10000000-0000-4000-8000-000000000001))
+  (fp_poly
+    (pts (xy 0 0) (xy 2 0) (xy 2 2))
+    (stroke (width 0.05) (type solid)) (fill none) (layer "B.CrtYd")
+    (tstamp 20000000-0000-4000-8000-000000000001))
+  (fp_text user "KEEP ON B.CrtYd" (at 0 0) (layer "B.CrtYd")
+    (effects (font (size 1 1)))
+    (tstamp 30000000-0000-4000-8000-000000000001))
+  (fp_poly
+    (pts (xy 3 3) (xy 4 3) (xy 4 4))
+    (stroke (width 0.05) (type solid)) (fill none) (layer "B.CrtYd")
+    (tstamp 20000000-0000-4000-8000-000000000002))
+  (pad "1" thru_hole circle (at 0 0) (size 1.8 1.8) (drill 1)
+    (layers "*.Cu" "*.Mask")
+    (tstamp 40000000-0000-4000-8000-000000000001))
+  (model "KEEP.step"
+    (offset (xyz 0 0 0))
+    (scale (xyz 1 1 1))
+    (rotate (xyz 0 0 0)))
+)
+"#;
 
     #[test]
     fn serializes_every_supported_primitive_as_a_footprint_graphic() {
@@ -430,5 +662,194 @@ mod tests {
 
         let output = serialize_graphics("B.CrtYd", &graphics, "  ");
         assert_eq!(output.matches("(xy 0 0)").count(), 1, "{output}");
+    }
+
+    #[test]
+    fn replace_changes_only_supported_graphics_on_the_selected_layer() {
+        let graphics = parse_graphics(&json!([{
+            "type": "poly",
+            "points": [
+                {"x": -8.695, "y": 3.615},
+                {"x": -8.690, "y": 3.566},
+                {"x": -8.650, "y": 3.500}
+            ],
+            "stroke_width_mm": 0.05,
+            "fill": "none"
+        }]))
+        .unwrap();
+
+        let prepared =
+            prepare_mutation(OLD_FOOTPRINT, "B.CrtYd", GraphicsMode::Replace, &graphics).unwrap();
+
+        assert_eq!(prepared.matched_count, 2);
+        assert_eq!(prepared.added_count, 1);
+        assert_eq!(prepared.replacement.matches("(fp_poly").count(), 1);
+        assert!(!prepared
+            .replacement
+            .contains("20000000-0000-4000-8000-000000000001"));
+        assert!(!prepared
+            .replacement
+            .contains("20000000-0000-4000-8000-000000000002"));
+        for unchanged in [
+            r#"(fp_line (start -1 -1) (end 1 -1)
+    (stroke (width 0.1) (type solid)) (layer "F.SilkS")
+    (tstamp 10000000-0000-4000-8000-000000000001))"#,
+            r#"(fp_text user "KEEP ON B.CrtYd" (at 0 0) (layer "B.CrtYd")
+    (effects (font (size 1 1)))
+    (tstamp 30000000-0000-4000-8000-000000000001))"#,
+            r#"(pad "1" thru_hole circle (at 0 0) (size 1.8 1.8) (drill 1)
+    (layers "*.Cu" "*.Mask")
+    (tstamp 40000000-0000-4000-8000-000000000001))"#,
+            r#"(model "KEEP.step"
+    (offset (xyz 0 0 0))
+    (scale (xyz 1 1 1))
+    (rotate (xyz 0 0 0)))"#,
+        ] {
+            assert!(
+                prepared.replacement.contains(unchanged),
+                "changed unrelated block:\n{unchanged}\n---\n{}",
+                prepared.replacement
+            );
+        }
+        assert!(konnect_sexp::parse_sexp(&prepared.replacement).is_ok());
+    }
+
+    #[test]
+    fn append_preserves_existing_graphics_and_accepts_two_polygons() {
+        let graphics = parse_graphics(&json!([
+            {
+                "type": "poly",
+                "points": [
+                    {"x": 10.0, "y": 10.0},
+                    {"x": 12.0, "y": 10.0},
+                    {"x": 12.0, "y": 12.0}
+                ],
+                "stroke_width_mm": 0.05,
+                "fill": "none"
+            },
+            {
+                "type": "poly",
+                "points": [
+                    {"x": -10.0, "y": -10.0},
+                    {"x": -12.0, "y": -10.0},
+                    {"x": -12.0, "y": -12.0}
+                ],
+                "stroke_width_mm": 0.05,
+                "fill": "none"
+            }
+        ]))
+        .unwrap();
+
+        let prepared =
+            prepare_mutation(OLD_FOOTPRINT, "B.CrtYd", GraphicsMode::Append, &graphics).unwrap();
+
+        assert_eq!(prepared.matched_count, 2);
+        assert_eq!(prepared.added_count, 2);
+        assert_eq!(prepared.replacement.matches("(fp_poly").count(), 4);
+        assert!(prepared
+            .replacement
+            .contains("20000000-0000-4000-8000-000000000001"));
+        assert!(prepared
+            .replacement
+            .contains("20000000-0000-4000-8000-000000000002"));
+        assert!(konnect_sexp::parse_sexp(&prepared.replacement).is_ok());
+    }
+
+    #[test]
+    fn delete_removes_only_selected_supported_graphics() {
+        let prepared =
+            prepare_mutation(OLD_FOOTPRINT, "B.CrtYd", GraphicsMode::Delete, &[]).unwrap();
+
+        assert_eq!(prepared.matched_count, 2);
+        assert_eq!(prepared.added_count, 0);
+        assert!(!prepared.replacement.contains("(fp_poly"));
+        assert!(prepared
+            .replacement
+            .contains(r#"(fp_text user "KEEP ON B.CrtYd""#));
+        assert!(prepared.replacement.contains("(pad \"1\""));
+        assert!(prepared.replacement.contains("(model \"KEEP.step\""));
+        assert!(konnect_sexp::parse_sexp(&prepared.replacement).is_ok());
+    }
+
+    #[test]
+    fn replace_without_a_match_inserts_before_pads_and_models() {
+        let source = r#"(footprint "NoGraphics" (version 20221018) (generator pcbnew)
+  (layer "F.Cu")
+  (pad "1" thru_hole circle (at 0 0) (size 1.8 1.8) (drill 1)
+    (layers "*.Cu" "*.Mask"))
+  (model "KEEP.step")
+)
+"#;
+        let graphics = parse_graphics(&json!([{
+            "type": "circle",
+            "center": {"x": 0.0, "y": 0.0},
+            "radius_mm": 2.0,
+            "stroke_width_mm": 0.05,
+            "fill": "none"
+        }]))
+        .unwrap();
+
+        let prepared =
+            prepare_mutation(source, "B.CrtYd", GraphicsMode::Replace, &graphics).unwrap();
+
+        assert_eq!(prepared.matched_count, 0);
+        assert!(
+            prepared.replacement.find("(fp_circle").unwrap()
+                < prepared.replacement.find("(pad \"1\"").unwrap(),
+            "{}",
+            prepared.replacement
+        );
+        assert!(konnect_sexp::parse_sexp(&prepared.replacement).is_ok());
+    }
+
+    #[test]
+    fn grouped_selected_graphics_are_not_deleted_in_old_or_new_syntax() {
+        let old_group = OLD_FOOTPRINT.replace(
+            "  (model \"KEEP.step\"",
+            r#"  (group "owned" (id 50000000-0000-4000-8000-000000000001)
+    (members
+      20000000-0000-4000-8000-000000000001
+    )
+  )
+  (model "KEEP.step""#,
+        );
+        let new_group = OLD_FOOTPRINT.replace(
+            "  (model \"KEEP.step\"",
+            r#"  (group "owned"
+    (uuid "50000000-0000-4000-8000-000000000001")
+    (members "20000000-0000-4000-8000-000000000002")
+  )
+  (model "KEEP.step""#,
+        );
+
+        for source in [old_group, new_group] {
+            let error =
+                prepare_mutation(&source, "B.CrtYd", GraphicsMode::Delete, &[]).unwrap_err();
+            assert!(
+                matches!(error, FootprintGraphicsError::Conflict(_)),
+                "{error}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_non_footprint_roots_and_noncanonical_layers() {
+        let graphics = parse_graphics(&json!([{
+            "type": "line",
+            "start": {"x": 0.0, "y": 0.0},
+            "end": {"x": 1.0, "y": 1.0},
+            "stroke_width_mm": 0.05
+        }]))
+        .unwrap();
+
+        for (source, layer) in [
+            ("(kicad_pcb (version 20240108))", "B.CrtYd"),
+            (OLD_FOOTPRINT, "BottomCourtyard"),
+        ] {
+            assert!(matches!(
+                prepare_mutation(source, layer, GraphicsMode::Replace, &graphics),
+                Err(FootprintGraphicsError::InvalidArgument { .. })
+            ));
+        }
     }
 }

--- a/crates/konnect-core/src/tools/footprint_graphics.rs
+++ b/crates/konnect-core/src/tools/footprint_graphics.rs
@@ -1,0 +1,434 @@
+use konnect_schematic_editor::types::fmt_f64;
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum Fill {
+    None,
+    Solid,
+}
+
+impl Fill {
+    fn as_kicad(&self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Solid => "solid",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "lowercase")]
+enum FootprintGraphic {
+    Line {
+        start: Point,
+        end: Point,
+        stroke_width_mm: f64,
+    },
+    Arc {
+        start: Point,
+        mid: Point,
+        end: Point,
+        stroke_width_mm: f64,
+    },
+    Rect {
+        start: Point,
+        end: Point,
+        stroke_width_mm: f64,
+        fill: Fill,
+    },
+    Circle {
+        center: Point,
+        radius_mm: f64,
+        stroke_width_mm: f64,
+        fill: Fill,
+    },
+    Poly {
+        points: Vec<Point>,
+        stroke_width_mm: f64,
+        fill: Fill,
+    },
+}
+
+fn parse_graphics(value: &serde_json::Value) -> Result<Vec<FootprintGraphic>, String> {
+    let mut graphics: Vec<FootprintGraphic> =
+        serde_json::from_value(value.clone()).map_err(|error| error.to_string())?;
+    for graphic in &mut graphics {
+        graphic.validate_and_normalize()?;
+    }
+    Ok(graphics)
+}
+
+impl Point {
+    fn validate(self, field: &str) -> Result<(), String> {
+        if self.x.is_finite() && self.y.is_finite() {
+            Ok(())
+        } else {
+            Err(format!("{field} coordinates must be finite"))
+        }
+    }
+}
+
+fn validate_stroke(width_mm: f64, fill: Option<&Fill>) -> Result<(), String> {
+    if !width_mm.is_finite() || width_mm < 0.0 {
+        return Err("stroke_width_mm must be finite and non-negative".to_string());
+    }
+    if width_mm == 0.0 && !matches!(fill, Some(Fill::Solid)) {
+        return Err("an unfilled graphic requires a positive stroke_width_mm".to_string());
+    }
+    Ok(())
+}
+
+fn points_differ(a: Point, b: Point) -> bool {
+    a.x != b.x || a.y != b.y
+}
+
+impl FootprintGraphic {
+    fn validate_and_normalize(&mut self) -> Result<(), String> {
+        match self {
+            Self::Line {
+                start,
+                end,
+                stroke_width_mm,
+            } => {
+                start.validate("start")?;
+                end.validate("end")?;
+                validate_stroke(*stroke_width_mm, None)?;
+                if !points_differ(*start, *end) {
+                    return Err("line start and end must differ".to_string());
+                }
+            }
+            Self::Arc {
+                start,
+                mid,
+                end,
+                stroke_width_mm,
+            } => {
+                start.validate("start")?;
+                mid.validate("mid")?;
+                end.validate("end")?;
+                validate_stroke(*stroke_width_mm, None)?;
+                if !points_differ(*start, *mid)
+                    || !points_differ(*mid, *end)
+                    || !points_differ(*start, *end)
+                {
+                    return Err("arc start, mid, and end must be distinct".to_string());
+                }
+                let twice_area =
+                    (mid.x - start.x) * (end.y - start.y) - (mid.y - start.y) * (end.x - start.x);
+                if twice_area.abs() <= f64::EPSILON {
+                    return Err("arc start, mid, and end must not be collinear".to_string());
+                }
+            }
+            Self::Rect {
+                start,
+                end,
+                stroke_width_mm,
+                fill,
+            } => {
+                start.validate("start")?;
+                end.validate("end")?;
+                validate_stroke(*stroke_width_mm, Some(fill))?;
+                if start.x == end.x || start.y == end.y {
+                    return Err("rectangle width and height must be positive".to_string());
+                }
+            }
+            Self::Circle {
+                center,
+                radius_mm,
+                stroke_width_mm,
+                fill,
+            } => {
+                center.validate("center")?;
+                validate_stroke(*stroke_width_mm, Some(fill))?;
+                if !radius_mm.is_finite() || *radius_mm <= 0.0 {
+                    return Err("radius_mm must be finite and positive".to_string());
+                }
+            }
+            Self::Poly {
+                points,
+                stroke_width_mm,
+                fill,
+            } => {
+                validate_stroke(*stroke_width_mm, Some(fill))?;
+                for (index, point) in points.iter().copied().enumerate() {
+                    point.validate(&format!("points[{index}]"))?;
+                }
+                if points.len() > 1 && points.first() == points.last() {
+                    points.pop();
+                }
+                if points.len() < 3 {
+                    return Err("polygon requires at least three points".to_string());
+                }
+                let mut distinct = Vec::new();
+                for point in points.iter().copied() {
+                    if !distinct.contains(&point) {
+                        distinct.push(point);
+                    }
+                }
+                if distinct.len() < 3 {
+                    return Err("polygon requires at least three distinct points".to_string());
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn point_clause(tag: &str, point: Point) -> String {
+    format!("({tag} {} {})", fmt_f64(point.x), fmt_f64(point.y))
+}
+
+fn stroke_clause(width_mm: f64) -> String {
+    format!("(stroke (width {}) (type solid))", fmt_f64(width_mm))
+}
+
+fn serialize_graphics(layer: &str, graphics: &[FootprintGraphic], indent: &str) -> String {
+    let mut output = String::new();
+    for graphic in graphics {
+        output.push('\n');
+        output.push_str(indent);
+        match graphic {
+            FootprintGraphic::Line {
+                start,
+                end,
+                stroke_width_mm,
+            } => output.push_str(&format!(
+                "(fp_line {} {} {} (layer \"{}\"))",
+                point_clause("start", *start),
+                point_clause("end", *end),
+                stroke_clause(*stroke_width_mm),
+                layer
+            )),
+            FootprintGraphic::Arc {
+                start,
+                mid,
+                end,
+                stroke_width_mm,
+            } => output.push_str(&format!(
+                "(fp_arc {} {} {} {} (layer \"{}\"))",
+                point_clause("start", *start),
+                point_clause("mid", *mid),
+                point_clause("end", *end),
+                stroke_clause(*stroke_width_mm),
+                layer
+            )),
+            FootprintGraphic::Rect {
+                start,
+                end,
+                stroke_width_mm,
+                fill,
+            } => output.push_str(&format!(
+                "(fp_rect {} {} {} (fill {}) (layer \"{}\"))",
+                point_clause("start", *start),
+                point_clause("end", *end),
+                stroke_clause(*stroke_width_mm),
+                fill.as_kicad(),
+                layer
+            )),
+            FootprintGraphic::Circle {
+                center,
+                radius_mm,
+                stroke_width_mm,
+                fill,
+            } => {
+                let end = Point {
+                    x: center.x + radius_mm,
+                    y: center.y,
+                };
+                output.push_str(&format!(
+                    "(fp_circle {} {} {} (fill {}) (layer \"{}\"))",
+                    point_clause("center", *center),
+                    point_clause("end", end),
+                    stroke_clause(*stroke_width_mm),
+                    fill.as_kicad(),
+                    layer
+                ));
+            }
+            FootprintGraphic::Poly {
+                points,
+                stroke_width_mm,
+                fill,
+            } => {
+                let points = points
+                    .iter()
+                    .map(|point| point_clause("xy", *point))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                output.push_str(&format!(
+                    "(fp_poly (pts {points}) {} (fill {}) (layer \"{}\"))",
+                    stroke_clause(*stroke_width_mm),
+                    fill.as_kicad(),
+                    layer
+                ));
+            }
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn serializes_every_supported_primitive_as_a_footprint_graphic() {
+        let graphics = parse_graphics(&json!([
+            {
+                "type": "line",
+                "start": {"x": 0.0, "y": 1.0},
+                "end": {"x": 2.0, "y": 3.0},
+                "stroke_width_mm": 0.05
+            },
+            {
+                "type": "arc",
+                "start": {"x": 0.0, "y": 0.0},
+                "mid": {"x": 1.0, "y": 1.0},
+                "end": {"x": 2.0, "y": 0.0},
+                "stroke_width_mm": 0.05
+            },
+            {
+                "type": "rect",
+                "start": {"x": -1.0, "y": -2.0},
+                "end": {"x": 3.0, "y": 4.0},
+                "stroke_width_mm": 0.05,
+                "fill": "none"
+            },
+            {
+                "type": "circle",
+                "center": {"x": 1.0, "y": 2.0},
+                "radius_mm": 1.5,
+                "stroke_width_mm": 0.05,
+                "fill": "solid"
+            },
+            {
+                "type": "poly",
+                "points": [
+                    {"x": 0.0, "y": 0.0},
+                    {"x": 2.0, "y": 0.0},
+                    {"x": 2.0, "y": 1.0}
+                ],
+                "stroke_width_mm": 0.05,
+                "fill": "none"
+            }
+        ]))
+        .expect("valid graphics");
+
+        let output = serialize_graphics("B.CrtYd", &graphics, "  ");
+
+        for tag in ["fp_line", "fp_arc", "fp_rect", "fp_circle", "fp_poly"] {
+            assert!(
+                output.contains(&format!("({tag}")),
+                "missing {tag}:\n{output}"
+            );
+        }
+        assert_eq!(output.matches("(layer \"B.CrtYd\")").count(), 5);
+        assert_eq!(output.matches("(stroke (width 0.05)").count(), 5);
+        assert_eq!(output.matches("(fill none)").count(), 2);
+        assert_eq!(output.matches("(fill solid)").count(), 1);
+        assert!(
+            konnect_sexp::parse_sexp(&format!("(footprint \"T\" (layer \"F.Cu\"){output}\n)"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_or_invisible_geometry() {
+        let invalid = [
+            json!([{
+                "type": "line",
+                "start": {"x": 0.0, "y": 0.0},
+                "end": {"x": 1.0, "y": 1.0},
+                "stroke_width_mm": -0.05
+            }]),
+            json!([{
+                "type": "line",
+                "start": {"x": 0.0, "y": 0.0},
+                "end": {"x": 0.0, "y": 0.0},
+                "stroke_width_mm": 0.05
+            }]),
+            json!([{
+                "type": "rect",
+                "start": {"x": 0.0, "y": 0.0},
+                "end": {"x": 0.0, "y": 1.0},
+                "stroke_width_mm": 0.05,
+                "fill": "none"
+            }]),
+            json!([{
+                "type": "circle",
+                "center": {"x": 0.0, "y": 0.0},
+                "radius_mm": 0.0,
+                "stroke_width_mm": 0.05,
+                "fill": "none"
+            }]),
+            json!([{
+                "type": "arc",
+                "start": {"x": 0.0, "y": 0.0},
+                "mid": {"x": 1.0, "y": 1.0},
+                "end": {"x": 2.0, "y": 2.0},
+                "stroke_width_mm": 0.05
+            }]),
+            json!([{
+                "type": "poly",
+                "points": [
+                    {"x": 0.0, "y": 0.0},
+                    {"x": 1.0, "y": 0.0},
+                    {"x": 0.0, "y": 0.0}
+                ],
+                "stroke_width_mm": 0.05,
+                "fill": "none"
+            }]),
+            json!([{
+                "type": "poly",
+                "points": [
+                    {"x": 0.0, "y": 0.0},
+                    {"x": 1.0, "y": 0.0},
+                    {"x": 1.0, "y": 1.0}
+                ],
+                "stroke_width_mm": 0.0,
+                "fill": "none"
+            }]),
+        ];
+
+        for value in invalid {
+            assert!(parse_graphics(&value).is_err(), "accepted {value}");
+        }
+
+        let non_finite = json!([{
+            "type": "circle",
+            "center": {"x": 0.0, "y": 0.0},
+            "radius_mm": 1.0,
+            "stroke_width_mm": 0.05,
+            "fill": "none"
+        }]);
+        let mut non_finite = non_finite;
+        non_finite[0]["center"]["x"] = serde_json::Value::from(f64::INFINITY);
+        assert!(parse_graphics(&non_finite).is_err());
+    }
+
+    #[test]
+    fn normalizes_a_repeated_polygon_closing_point() {
+        let graphics = parse_graphics(&json!([{
+            "type": "poly",
+            "points": [
+                {"x": 0.0, "y": 0.0},
+                {"x": 2.0, "y": 0.0},
+                {"x": 2.0, "y": 1.0},
+                {"x": 0.0, "y": 0.0}
+            ],
+            "stroke_width_mm": 0.05,
+            "fill": "none"
+        }]))
+        .unwrap();
+
+        let output = serialize_graphics("B.CrtYd", &graphics, "  ");
+        assert_eq!(output.matches("(xy 0 0)").count(), 1, "{output}");
+    }
+}

--- a/crates/konnect-core/src/tools/footprint_graphics.rs
+++ b/crates/konnect-core/src/tools/footprint_graphics.rs
@@ -1,9 +1,303 @@
+use crate::mcp::error::ToolErrorKind;
+use crate::mcp::protocol::CallToolResult;
+use crate::tool;
+use crate::tools::{ToolContext, ToolDef};
 use konnect_schematic_editor::types::fmt_f64;
 use konnect_sexp::writer::{
     apply_edits, find_balanced_block, find_block_with_leading_whitespace, find_direct_child_blocks,
-    SexpEdit,
+    read_consistent, write_atomic_if_unchanged, SexpEdit,
 };
 use serde::Deserialize;
+use serde_json::json;
+
+fn point_schema() -> serde_json::Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "x": { "type": "number" },
+            "y": { "type": "number" }
+        },
+        "required": ["x", "y"],
+        "additionalProperties": false
+    })
+}
+
+fn common_shape_properties() -> serde_json::Map<String, serde_json::Value> {
+    serde_json::Map::from_iter([
+        (
+            "stroke_width_mm".to_string(),
+            json!({
+                "type": "number",
+                "minimum": 0,
+                "description": "Stroke width in millimetres"
+            }),
+        ),
+        (
+            "fill".to_string(),
+            json!({
+                "type": "string",
+                "enum": ["none", "solid"]
+            }),
+        ),
+    ])
+}
+
+fn primitive_schema(
+    primitive_type: &str,
+    mut properties: serde_json::Map<String, serde_json::Value>,
+    required: &[&str],
+) -> serde_json::Value {
+    properties.insert("type".to_string(), json!({ "const": primitive_type }));
+    json!({
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": false
+    })
+}
+
+fn graphics_schema() -> serde_json::Value {
+    let mut line = serde_json::Map::new();
+    line.insert("start".to_string(), point_schema());
+    line.insert("end".to_string(), point_schema());
+    line.insert(
+        "stroke_width_mm".to_string(),
+        common_shape_properties()["stroke_width_mm"].clone(),
+    );
+
+    let mut arc = line.clone();
+    arc.insert("mid".to_string(), point_schema());
+
+    let mut rect = common_shape_properties();
+    rect.insert("start".to_string(), point_schema());
+    rect.insert("end".to_string(), point_schema());
+
+    let mut circle = common_shape_properties();
+    circle.insert("center".to_string(), point_schema());
+    circle.insert(
+        "radius_mm".to_string(),
+        json!({
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Circle radius in millimetres"
+        }),
+    );
+
+    let mut poly = common_shape_properties();
+    poly.insert(
+        "points".to_string(),
+        json!({
+            "type": "array",
+            "minItems": 3,
+            "items": point_schema()
+        }),
+    );
+
+    json!({
+        "type": "array",
+        "items": {
+            "oneOf": [
+                primitive_schema(
+                    "line",
+                    line,
+                    &["type", "start", "end", "stroke_width_mm"]
+                ),
+                primitive_schema(
+                    "arc",
+                    arc,
+                    &["type", "start", "mid", "end", "stroke_width_mm"]
+                ),
+                primitive_schema(
+                    "rect",
+                    rect,
+                    &["type", "start", "end", "stroke_width_mm", "fill"]
+                ),
+                primitive_schema(
+                    "circle",
+                    circle,
+                    &["type", "center", "radius_mm", "stroke_width_mm", "fill"]
+                ),
+                primitive_schema(
+                    "poly",
+                    poly,
+                    &["type", "points", "stroke_width_mm", "fill"]
+                )
+            ]
+        }
+    })
+}
+
+pub(super) fn tool() -> ToolDef {
+    tool!(
+        "set_footprint_graphics",
+        "Atomically append, replace, or delete graphical primitives on one layer of an existing \
+         .kicad_mod footprint. Replacement and deletion refuse graphics referenced by a group.",
+        json!({
+            "type": "object",
+            "properties": {
+                "footprint_path": {
+                    "type": "string",
+                    "description": "Path to an existing .kicad_mod footprint file"
+                },
+                "selector": {
+                    "type": "object",
+                    "properties": {
+                        "layer": {
+                            "type": "string",
+                            "description": "Canonical KiCad layer name, such as B.CrtYd"
+                        }
+                    },
+                    "required": ["layer"],
+                    "additionalProperties": false
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": ["append", "replace", "delete"]
+                },
+                "graphics": graphics_schema()
+            },
+            "required": ["footprint_path", "selector", "mode"],
+            "additionalProperties": false
+        }),
+        |args, ctx| async move { handle_set_footprint_graphics(args, ctx).await }
+    )
+}
+
+async fn handle_set_footprint_graphics(
+    args: &serde_json::Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let Some(path) = args["footprint_path"]
+        .as_str()
+        .map(std::path::PathBuf::from)
+    else {
+        return Ok(invalid_result("footprint_path", "missing or not a string"));
+    };
+    if path.extension().and_then(|extension| extension.to_str()) != Some("kicad_mod") {
+        return Ok(invalid_result("footprint_path", "must end in .kicad_mod"));
+    }
+    let metadata = match std::fs::metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(CallToolResult::error_kind(
+                ToolErrorKind::FileNotFound {
+                    path: path.display().to_string(),
+                },
+                format!("Footprint file not found: {}", path.display()),
+            ));
+        }
+        Err(error) => return Err(error.into()),
+    };
+    if !metadata.is_file() {
+        return Ok(invalid_result("footprint_path", "must name a regular file"));
+    }
+
+    let Some(layer) = args["selector"]["layer"].as_str() else {
+        return Ok(invalid_result("selector.layer", "missing or not a string"));
+    };
+    let mode: GraphicsMode = match serde_json::from_value(args["mode"].clone()) {
+        Ok(mode) => mode,
+        Err(error) => return Ok(invalid_result("mode", error.to_string())),
+    };
+    let graphics = if matches!(mode, GraphicsMode::Delete) {
+        match args.get("graphics") {
+            Some(value) if value.as_array().is_some_and(Vec::is_empty) => Vec::new(),
+            Some(_) => {
+                return Ok(invalid_result(
+                    "graphics",
+                    "must be omitted or empty in delete mode",
+                ));
+            }
+            None => Vec::new(),
+        }
+    } else {
+        let Some(value) = args.get("graphics") else {
+            return Ok(invalid_result(
+                "graphics",
+                "is required for append and replace modes",
+            ));
+        };
+        match parse_graphics(value) {
+            Ok(graphics) if !graphics.is_empty() => graphics,
+            Ok(_) => {
+                return Ok(invalid_result(
+                    "graphics",
+                    "must contain at least one primitive",
+                ));
+            }
+            Err(reason) => return Ok(invalid_result("graphics", reason)),
+        }
+    };
+
+    let source = match read_consistent(&path) {
+        Ok(source) => source,
+        Err(konnect_sexp::SexpError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(CallToolResult::error_kind(
+                ToolErrorKind::FileNotFound {
+                    path: path.display().to_string(),
+                },
+                format!("Footprint file not found: {}", path.display()),
+            ));
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let prepared = match prepare_mutation(&source, layer, mode, &graphics) {
+        Ok(prepared) => prepared,
+        Err(FootprintGraphicsError::InvalidArgument { field, reason }) => {
+            return Ok(invalid_result(&field, reason));
+        }
+        Err(FootprintGraphicsError::Conflict(reason)) => {
+            return Ok(conflict_result(&path, reason));
+        }
+    };
+    if let Err(error) = persist_replacement(&path, &source, &prepared.replacement) {
+        return match error {
+            konnect_sexp::SexpError::Conflict { .. } => Ok(conflict_result(
+                &path,
+                "footprint changed after it was read",
+            )),
+            other => Err(other.into()),
+        };
+    }
+
+    Ok(CallToolResult::json(&json!({
+        "success": true,
+        "footprint_path": path.display().to_string(),
+        "layer": layer,
+        "mode": args["mode"],
+        "matched_count": prepared.matched_count,
+        "added_count": prepared.added_count
+    })))
+}
+
+fn invalid_result(field: &str, reason: impl Into<String>) -> CallToolResult {
+    let reason = reason.into();
+    CallToolResult::error_kind(
+        ToolErrorKind::InvalidArgument {
+            field: field.to_string(),
+            reason: reason.clone(),
+        },
+        format!("Argument '{field}' is invalid: {reason}"),
+    )
+}
+
+fn conflict_result(path: &std::path::Path, reason: impl Into<String>) -> CallToolResult {
+    let reason = reason.into();
+    CallToolResult::error_kind(
+        ToolErrorKind::Conflict {
+            paths: vec![path.display().to_string()],
+        },
+        format!("Footprint graphics were not changed: {reason}"),
+    )
+}
+
+fn persist_replacement(
+    path: &std::path::Path,
+    expected: &str,
+    replacement: &str,
+) -> Result<(), konnect_sexp::SexpError> {
+    write_atomic_if_unchanged(path, expected, replacement)
+}
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
 struct Point {
@@ -482,7 +776,10 @@ fn prepare_mutation(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::ServerConfig;
     use serde_json::json;
+    use std::sync::Arc;
 
     const OLD_FOOTPRINT: &str = r#"(footprint "Fixture" (version 20221018) (generator pcbnew)
   (layer "F.Cu")
@@ -509,6 +806,28 @@ mod tests {
     (rotate (xyz 0 0 0)))
 )
 "#;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+                eager_toolsets: false,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    fn result_body(result: &CallToolResult) -> serde_json::Value {
+        let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text response");
+        };
+        serde_json::from_str(text).unwrap_or_else(|error| panic!("{error}: {text}"))
+    }
 
     #[test]
     fn serializes_every_supported_primitive_as_a_footprint_graphic() {
@@ -851,5 +1170,299 @@ mod tests {
                 Err(FootprintGraphicsError::InvalidArgument { .. })
             ));
         }
+    }
+
+    #[test]
+    fn library_exposes_the_atomic_graphics_schema() {
+        let tool = crate::tools::library::tools()
+            .into_iter()
+            .find(|tool| tool.name == "set_footprint_graphics")
+            .expect("library must expose set_footprint_graphics");
+        let schema = tool.input_schema;
+
+        assert_eq!(
+            schema["required"],
+            json!(["footprint_path", "selector", "mode"])
+        );
+        assert_eq!(
+            schema["properties"]["mode"]["enum"],
+            json!(["append", "replace", "delete"])
+        );
+        assert_eq!(
+            schema["properties"]["selector"]["required"],
+            json!(["layer"])
+        );
+
+        let variants = schema["properties"]["graphics"]["items"]["oneOf"]
+            .as_array()
+            .expect("graphics oneOf variants");
+        let types = variants
+            .iter()
+            .map(|variant| {
+                variant["properties"]["type"]["const"]
+                    .as_str()
+                    .expect("type const")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(types, ["line", "arc", "rect", "circle", "poly"]);
+
+        let required = variants
+            .iter()
+            .map(|variant| variant["required"].clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            required,
+            vec![
+                json!(["type", "start", "end", "stroke_width_mm"]),
+                json!(["type", "start", "mid", "end", "stroke_width_mm"]),
+                json!(["type", "start", "end", "stroke_width_mm", "fill"]),
+                json!(["type", "center", "radius_mm", "stroke_width_mm", "fill"]),
+                json!(["type", "points", "stroke_width_mm", "fill"]),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn handler_replaces_graphics_and_reports_counts() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("Fixture.kicad_mod");
+        std::fs::write(&path, OLD_FOOTPRINT).unwrap();
+        let args = json!({
+            "footprint_path": path,
+            "selector": {"layer": "B.CrtYd"},
+            "mode": "replace",
+            "graphics": [{
+                "type": "poly",
+                "points": [
+                    {"x": -8.695, "y": 3.615},
+                    {"x": -8.690, "y": 3.566},
+                    {"x": -8.650, "y": 3.500}
+                ],
+                "stroke_width_mm": 0.05,
+                "fill": "none"
+            }]
+        });
+
+        let result = handle_set_footprint_graphics(&args, &test_ctx())
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{:?}", result.content);
+        let response = result_body(&result);
+        assert_eq!(response["mode"], "replace");
+        assert_eq!(response["layer"], "B.CrtYd");
+        assert_eq!(response["matched_count"], 2);
+        assert_eq!(response["added_count"], 1);
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(written.matches("(fp_poly").count(), 1);
+        assert!(written.contains("(xy -8.695 3.615)"));
+        assert!(written.contains("(pad \"1\""));
+        assert!(written.contains("(model \"KEEP.step\""));
+        assert!(konnect_sexp::parse_sexp(&written).is_ok());
+    }
+
+    #[tokio::test]
+    async fn handler_append_and_delete_follow_the_public_mode_contract() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("Fixture.kicad_mod");
+        std::fs::write(&path, OLD_FOOTPRINT).unwrap();
+        let append = json!({
+            "footprint_path": path,
+            "selector": {"layer": "B.CrtYd"},
+            "mode": "append",
+            "graphics": [{
+                "type": "circle",
+                "center": {"x": 0.0, "y": 0.0},
+                "radius_mm": 2.0,
+                "stroke_width_mm": 0.05,
+                "fill": "none"
+            }]
+        });
+
+        let result = handle_set_footprint_graphics(&append, &test_ctx())
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{:?}", result.content);
+        assert_eq!(result_body(&result)["matched_count"], 2);
+        assert_eq!(
+            std::fs::read_to_string(&path)
+                .unwrap()
+                .matches("(fp_poly")
+                .count(),
+            2
+        );
+        assert!(std::fs::read_to_string(&path)
+            .unwrap()
+            .contains("(fp_circle"));
+
+        let delete = json!({
+            "footprint_path": path,
+            "selector": {"layer": "B.CrtYd"},
+            "mode": "delete"
+        });
+        let result = handle_set_footprint_graphics(&delete, &test_ctx())
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{:?}", result.content);
+        assert_eq!(result_body(&result)["matched_count"], 3);
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(!written.contains("(fp_poly"));
+        assert!(!written.contains("(fp_circle"));
+        assert!(written.contains(r#"(fp_text user "KEEP ON B.CrtYd""#));
+    }
+
+    #[tokio::test]
+    async fn handler_returns_structured_argument_and_file_errors() {
+        let temp = tempfile::tempdir().unwrap();
+        let valid_path = temp.path().join("Fixture.kicad_mod");
+        std::fs::write(&valid_path, OLD_FOOTPRINT).unwrap();
+        let directory_path = temp.path().join("Directory.kicad_mod");
+        std::fs::create_dir(&directory_path).unwrap();
+        let malformed_path = temp.path().join("Malformed.kicad_mod");
+        std::fs::write(&malformed_path, "(kicad_pcb)").unwrap();
+        let missing_path = temp.path().join("Missing.kicad_mod");
+
+        let cases = [
+            (
+                json!({
+                    "footprint_path": missing_path,
+                    "selector": {"layer": "B.CrtYd"},
+                    "mode": "delete"
+                }),
+                "file_not_found",
+                None,
+            ),
+            (
+                json!({
+                    "footprint_path": temp.path().join("Fixture.txt"),
+                    "selector": {"layer": "B.CrtYd"},
+                    "mode": "delete"
+                }),
+                "invalid_argument",
+                Some("footprint_path"),
+            ),
+            (
+                json!({
+                    "footprint_path": directory_path,
+                    "selector": {"layer": "B.CrtYd"},
+                    "mode": "delete"
+                }),
+                "invalid_argument",
+                Some("footprint_path"),
+            ),
+            (
+                json!({
+                    "footprint_path": valid_path,
+                    "selector": {"layer": "BottomCourtyard"},
+                    "mode": "delete"
+                }),
+                "invalid_argument",
+                Some("selector.layer"),
+            ),
+            (
+                json!({
+                    "footprint_path": valid_path,
+                    "selector": {"layer": "B.CrtYd"},
+                    "mode": "overwrite"
+                }),
+                "invalid_argument",
+                Some("mode"),
+            ),
+            (
+                json!({
+                    "footprint_path": valid_path,
+                    "selector": {"layer": "B.CrtYd"},
+                    "mode": "replace"
+                }),
+                "invalid_argument",
+                Some("graphics"),
+            ),
+            (
+                json!({
+                    "footprint_path": valid_path,
+                    "selector": {"layer": "B.CrtYd"},
+                    "mode": "delete",
+                    "graphics": [{"type": "line"}]
+                }),
+                "invalid_argument",
+                Some("graphics"),
+            ),
+            (
+                json!({
+                    "footprint_path": malformed_path,
+                    "selector": {"layer": "B.CrtYd"},
+                    "mode": "delete"
+                }),
+                "invalid_argument",
+                Some("footprint_path"),
+            ),
+        ];
+
+        for (args, kind, field) in cases {
+            let result = handle_set_footprint_graphics(&args, &test_ctx())
+                .await
+                .unwrap_or_else(|error| panic!("handler bubbled an error for {args}: {error}"));
+            assert!(result.is_error, "expected failure for {args}");
+            let body = result_body(&result);
+            assert_eq!(body["error"]["kind"], kind, "{args}: {body}");
+            if let Some(field) = field {
+                assert_eq!(body["error"]["field"], field, "{args}: {body}");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn handler_reports_group_references_as_a_structured_conflict() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("Fixture.kicad_mod");
+        let grouped = OLD_FOOTPRINT.replace(
+            "  (model \"KEEP.step\"",
+            r#"  (group "owned" (id 50000000-0000-4000-8000-000000000001)
+    (members
+      20000000-0000-4000-8000-000000000001
+    )
+  )
+  (model "KEEP.step""#,
+        );
+        std::fs::write(&path, &grouped).unwrap();
+        let args = json!({
+            "footprint_path": path,
+            "selector": {"layer": "B.CrtYd"},
+            "mode": "delete"
+        });
+
+        let result = handle_set_footprint_graphics(&args, &test_ctx())
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert_eq!(result_body(&result)["error"]["kind"], "conflict");
+        assert_eq!(std::fs::read_to_string(path).unwrap(), grouped);
+    }
+
+    #[test]
+    fn persistence_rejects_a_stale_source_without_overwriting_it() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("Fixture.kicad_mod");
+        std::fs::write(&path, OLD_FOOTPRINT).unwrap();
+        let graphics = parse_graphics(&json!([{
+            "type": "circle",
+            "center": {"x": 0.0, "y": 0.0},
+            "radius_mm": 2.0,
+            "stroke_width_mm": 0.05,
+            "fill": "none"
+        }]))
+        .unwrap();
+        let prepared =
+            prepare_mutation(OLD_FOOTPRINT, "B.CrtYd", GraphicsMode::Replace, &graphics).unwrap();
+
+        let externally_changed = OLD_FOOTPRINT.replace("Fixture", "ExternallyChanged");
+        std::fs::write(&path, &externally_changed).unwrap();
+
+        let error = persist_replacement(&path, OLD_FOOTPRINT, &prepared.replacement).unwrap_err();
+
+        assert!(matches!(error, konnect_sexp::SexpError::Conflict { .. }));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), externally_changed);
     }
 }

--- a/crates/konnect-core/src/tools/footprint_metadata.rs
+++ b/crates/konnect-core/src/tools/footprint_metadata.rs
@@ -1,0 +1,650 @@
+use crate::mcp::error::ToolErrorKind;
+use crate::mcp::protocol::CallToolResult;
+use crate::tool;
+use crate::tools::{ToolContext, ToolDef};
+use konnect_sexp::writer::{
+    apply_edits, find_balanced_block, find_block_with_leading_whitespace, find_direct_child_blocks,
+    read_consistent, write_atomic_if_unchanged, SexpEdit,
+};
+use serde_json::json;
+use std::path::Path;
+
+const SUPPORTED_ATTRIBUTES: &[&str] = &[
+    "smd",
+    "through_hole",
+    "board_only",
+    "exclude_from_pos_files",
+    "exclude_from_bom",
+    "allow_missing_courtyard",
+    "dnp",
+];
+
+pub(super) fn tool() -> ToolDef {
+    tool!(
+        "set_footprint_metadata",
+        "Atomically replace a footprint's description, tags, or supported attributes while \
+         preserving pads, graphics, properties, groups, and models.",
+        json!({
+            "type": "object",
+            "properties": {
+                "footprint_path": {
+                    "type": "string",
+                    "description": "Path to an existing .kicad_mod footprint file"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Replacement footprint description"
+                },
+                "tags": {
+                    "type": "array",
+                    "description": "Replacement search tags; an empty array removes the tags block",
+                    "items": { "type": "string" }
+                },
+                "attributes": {
+                    "type": "array",
+                    "description": "Replacement KiCad footprint attributes; an empty array removes the attr block",
+                    "items": {
+                        "type": "string",
+                        "enum": SUPPORTED_ATTRIBUTES
+                    }
+                }
+            },
+            "required": ["footprint_path"],
+            "additionalProperties": false
+        }),
+        |args, ctx| async move { handle_set_footprint_metadata(args, ctx).await }
+    )
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct MetadataUpdate {
+    description: Option<String>,
+    tags: Option<Vec<String>>,
+    attributes: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct MetadataError {
+    field: String,
+    reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct PreparedMutation {
+    replacement: String,
+    changed_fields: Vec<&'static str>,
+}
+
+async fn handle_set_footprint_metadata(
+    args: &serde_json::Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let Some(path) = args["footprint_path"]
+        .as_str()
+        .map(std::path::PathBuf::from)
+    else {
+        return Ok(invalid_result("footprint_path", "missing or not a string"));
+    };
+    if path.extension().and_then(|extension| extension.to_str()) != Some("kicad_mod") {
+        return Ok(invalid_result("footprint_path", "must end in .kicad_mod"));
+    }
+    let metadata = match std::fs::metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(CallToolResult::error_kind(
+                ToolErrorKind::FileNotFound {
+                    path: path.display().to_string(),
+                },
+                format!("Footprint file not found: {}", path.display()),
+            ));
+        }
+        Err(error) => return Err(error.into()),
+    };
+    if !metadata.is_file() {
+        return Ok(invalid_result("footprint_path", "must name a regular file"));
+    }
+
+    let update = match parse_update(args) {
+        Ok(update) => update,
+        Err(error) => return Ok(invalid_result(&error.field, error.reason)),
+    };
+    let source = match read_consistent(&path) {
+        Ok(source) => source,
+        Err(konnect_sexp::SexpError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(CallToolResult::error_kind(
+                ToolErrorKind::FileNotFound {
+                    path: path.display().to_string(),
+                },
+                format!("Footprint file not found: {}", path.display()),
+            ));
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let prepared = match prepare_mutation(&source, &update) {
+        Ok(prepared) => prepared,
+        Err(error) => return Ok(invalid_result(&error.field, error.reason)),
+    };
+    if let Err(error) = persist_replacement(&path, &source, &prepared.replacement) {
+        return match error {
+            konnect_sexp::SexpError::Conflict { .. } => Ok(conflict_result(&path)),
+            other => Err(other.into()),
+        };
+    }
+
+    Ok(CallToolResult::json(&json!({
+        "success": true,
+        "footprint_path": path.display().to_string(),
+        "changed_fields": prepared.changed_fields
+    })))
+}
+
+fn parse_update(args: &serde_json::Value) -> Result<MetadataUpdate, MetadataError> {
+    let description = optional_string(args, "description")?;
+    let tags = optional_string_array(args, "tags")?;
+    if let Some(tags) = &tags {
+        if tags.iter().any(|tag| tag.is_empty()) {
+            return Err(invalid("tags", "tag strings must not be empty"));
+        }
+    }
+    let attributes = optional_string_array(args, "attributes")?;
+    if let Some(attributes) = &attributes {
+        if let Some(attribute) = attributes
+            .iter()
+            .find(|attribute| !SUPPORTED_ATTRIBUTES.contains(&attribute.as_str()))
+        {
+            return Err(invalid(
+                "attributes",
+                format!("unsupported footprint attribute '{attribute}'"),
+            ));
+        }
+    }
+    if description.is_none() && tags.is_none() && attributes.is_none() {
+        return Err(invalid(
+            "metadata",
+            "at least one of description, tags, or attributes must be supplied",
+        ));
+    }
+    Ok(MetadataUpdate {
+        description,
+        tags,
+        attributes,
+    })
+}
+
+fn optional_string(args: &serde_json::Value, field: &str) -> Result<Option<String>, MetadataError> {
+    match args.get(field) {
+        None => Ok(None),
+        Some(value) => value
+            .as_str()
+            .map(|value| Some(value.to_string()))
+            .ok_or_else(|| invalid(field, "must be a string when supplied")),
+    }
+}
+
+fn optional_string_array(
+    args: &serde_json::Value,
+    field: &str,
+) -> Result<Option<Vec<String>>, MetadataError> {
+    let Some(value) = args.get(field) else {
+        return Ok(None);
+    };
+    let Some(values) = value.as_array() else {
+        return Err(invalid(field, "must be an array of strings when supplied"));
+    };
+    values
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::to_string)
+                .ok_or_else(|| invalid(field, "must contain only strings"))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Some)
+}
+
+fn prepare_mutation(
+    source: &str,
+    update: &MetadataUpdate,
+) -> Result<PreparedMutation, MetadataError> {
+    let root = konnect_sexp::parse_sexp(source)
+        .map_err(|error| invalid("footprint_path", format!("invalid S-expression: {error}")))?;
+    if root.head() != Some("footprint") {
+        return Err(invalid("footprint_path", "file root must be a footprint"));
+    }
+
+    let mut description = None;
+    let mut tags = None;
+    let mut attributes = None;
+    let mut insertion_anchor = None;
+    let mut child_indent = None;
+    for (start, end) in find_direct_child_blocks(source, "footprint") {
+        let node = konnect_sexp::parse_sexp(&source[start..end])
+            .map_err(|_| invalid("footprint_path", "contains an invalid top-level item"))?;
+        let Some(tag) = node.head() else {
+            continue;
+        };
+        child_indent.get_or_insert_with(|| indent_before(source, start));
+        let target = match tag {
+            "descr" => Some(&mut description),
+            "tags" => Some(&mut tags),
+            "attr" => Some(&mut attributes),
+            _ => None,
+        };
+        if let Some(target) = target {
+            if target.replace((start, end)).is_some() {
+                return Err(invalid(
+                    "footprint_path",
+                    format!("contains duplicate top-level {tag} blocks"),
+                ));
+            }
+        } else if insertion_anchor.is_none() && is_footprint_item(tag) {
+            insertion_anchor = Some(start);
+        }
+    }
+
+    let indent = child_indent.unwrap_or_else(|| "  ".to_string());
+    let mut edits = Vec::new();
+    let mut insertions = Vec::new();
+    let mut changed_fields = Vec::new();
+    apply_metadata_field(
+        source,
+        description,
+        update
+            .description
+            .as_ref()
+            .map(|value| format!("(descr {})", quote_string(value))),
+        "description",
+        &mut edits,
+        &mut insertions,
+        &mut changed_fields,
+    )?;
+    apply_metadata_field(
+        source,
+        tags,
+        update.tags.as_ref().map(|values| {
+            values
+                .is_empty()
+                .then(String::new)
+                .unwrap_or_else(|| format!("(tags {})", quote_string(&values.join(" "))))
+        }),
+        "tags",
+        &mut edits,
+        &mut insertions,
+        &mut changed_fields,
+    )?;
+    apply_metadata_field(
+        source,
+        attributes,
+        update.attributes.as_ref().map(|values| {
+            values
+                .is_empty()
+                .then(String::new)
+                .unwrap_or_else(|| format!("(attr {})", values.join(" ")))
+        }),
+        "attributes",
+        &mut edits,
+        &mut insertions,
+        &mut changed_fields,
+    )?;
+
+    if !insertions.is_empty() {
+        let root_end = find_balanced_block(source, 0)
+            .map(|range| range.1 - 1)
+            .ok_or_else(|| invalid("footprint_path", "unbalanced footprint root"))?;
+        let anchor = insertion_anchor.unwrap_or(root_end);
+        let serialized = if insertion_anchor.is_some() {
+            format!("{}\n{indent}", insertions.join(&format!("\n{indent}")))
+        } else {
+            format!("{indent}{}\n", insertions.join(&format!("\n{indent}")))
+        };
+        edits.push(SexpEdit::insert(anchor, serialized));
+    }
+
+    let replacement = apply_edits(source.to_string(), edits);
+    let parsed = konnect_sexp::parse_sexp(&replacement)
+        .map_err(|error| invalid("metadata", format!("replacement does not parse: {error}")))?;
+    if parsed.head() != Some("footprint") {
+        return Err(invalid(
+            "metadata",
+            "replacement changed the footprint root",
+        ));
+    }
+
+    Ok(PreparedMutation {
+        replacement,
+        changed_fields,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_metadata_field(
+    source: &str,
+    existing: Option<(usize, usize)>,
+    replacement: Option<String>,
+    field: &'static str,
+    edits: &mut Vec<SexpEdit>,
+    insertions: &mut Vec<String>,
+    changed_fields: &mut Vec<&'static str>,
+) -> Result<(), MetadataError> {
+    let Some(replacement) = replacement else {
+        return Ok(());
+    };
+    match (existing, replacement.is_empty()) {
+        (Some((start, _)), true) => {
+            let range = find_block_with_leading_whitespace(source, start)
+                .ok_or_else(|| invalid("footprint_path", "contains unbalanced metadata"))?;
+            edits.push(SexpEdit::delete(range.0, range.1));
+            changed_fields.push(field);
+        }
+        (Some((start, end)), false) if source[start..end] != replacement => {
+            edits.push(SexpEdit::replace(start, end, replacement));
+            changed_fields.push(field);
+        }
+        (None, false) => {
+            insertions.push(replacement);
+            changed_fields.push(field);
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn is_footprint_item(tag: &str) -> bool {
+    tag.starts_with("fp_")
+        || matches!(
+            tag,
+            "property" | "pad" | "zone" | "group" | "model" | "embedded_fonts"
+        )
+}
+
+fn indent_before(source: &str, offset: usize) -> String {
+    let line_start = source[..offset]
+        .rfind('\n')
+        .map(|index| index + 1)
+        .unwrap_or(0);
+    source[line_start..offset].to_string()
+}
+
+fn quote_string(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len() + 2);
+    escaped.push('"');
+    for character in value.chars() {
+        match character {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            other => escaped.push(other),
+        }
+    }
+    escaped.push('"');
+    escaped
+}
+
+fn invalid(field: &str, reason: impl Into<String>) -> MetadataError {
+    MetadataError {
+        field: field.to_string(),
+        reason: reason.into(),
+    }
+}
+
+fn invalid_result(field: &str, reason: impl Into<String>) -> CallToolResult {
+    let reason = reason.into();
+    CallToolResult::error_kind(
+        ToolErrorKind::InvalidArgument {
+            field: field.to_string(),
+            reason: reason.clone(),
+        },
+        format!("Argument '{field}' is invalid: {reason}"),
+    )
+}
+
+fn conflict_result(path: &Path) -> CallToolResult {
+    CallToolResult::error_kind(
+        ToolErrorKind::Conflict {
+            paths: vec![path.display().to_string()],
+        },
+        "Footprint metadata was not changed because the file changed after it was read",
+    )
+}
+
+fn persist_replacement(
+    path: &Path,
+    expected: &str,
+    replacement: &str,
+) -> Result<(), konnect_sexp::SexpError> {
+    write_atomic_if_unchanged(path, expected, replacement)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::{ServerConfig, ToolContext};
+    use serde_json::json;
+    use std::sync::Arc;
+
+    const BARE_FOOTPRINT: &str = r#"(footprint "Socket"
+  (version 20240108)
+  (generator "pcbnew")
+  (layer "F.Cu")
+  (pad "1" thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers "*.Cu" "*.Mask"))
+  (model "../models/keep.step"
+    (offset (xyz 0 0 0))
+    (scale (xyz 1 1 1))
+    (rotate (xyz 0 0 0)))
+)
+"#;
+
+    const METADATA_FOOTPRINT: &str = r#"(footprint "Socket"
+  (version 20240108)
+  (generator "pcbnew")
+  (layer "F.Cu")
+  (descr "old description")
+  (tags "old tags")
+  (attr through_hole exclude_from_bom)
+  (fp_line (start 0 0) (end 1 1) (stroke (width 0.1) (type default)) (layer "F.SilkS"))
+  (pad "1" thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers "*.Cu" "*.Mask"))
+  (model "../models/keep.step"
+    (offset (xyz 0 0 0))
+    (scale (xyz 1 1 1))
+    (rotate (xyz 0 0 0)))
+)
+"#;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+                eager_toolsets: false,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    fn result_text(result: &crate::mcp::protocol::CallToolResult) -> String {
+        match result.content.first() {
+            Some(crate::mcp::protocol::ToolContent::Text { text }) => text.clone(),
+            other => panic!("expected text content, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn schema_requires_a_path_and_exposes_all_metadata_fields() {
+        let metadata_tool = tool();
+        assert_eq!(metadata_tool.name, "set_footprint_metadata");
+        assert_eq!(
+            metadata_tool.input_schema["required"],
+            json!(["footprint_path"])
+        );
+        assert_eq!(
+            metadata_tool.input_schema["properties"]["description"]["type"],
+            "string"
+        );
+        assert_eq!(
+            metadata_tool.input_schema["properties"]["tags"]["items"]["type"],
+            "string"
+        );
+        assert_eq!(
+            metadata_tool.input_schema["properties"]["attributes"]["items"]["enum"],
+            json!([
+                "smd",
+                "through_hole",
+                "board_only",
+                "exclude_from_pos_files",
+                "exclude_from_bom",
+                "allow_missing_courtyard",
+                "dnp"
+            ])
+        );
+    }
+
+    #[test]
+    fn inserts_absent_metadata_before_footprint_items_and_escapes_strings() {
+        let update = parse_update(&json!({
+            "description": "socket \"quoted\" \\ path",
+            "tags": ["keyboard", "hot_swap"],
+            "attributes": ["exclude_from_pos_files"]
+        }))
+        .unwrap();
+
+        let prepared = prepare_mutation(BARE_FOOTPRINT, &update).unwrap();
+
+        assert_eq!(
+            prepared.changed_fields,
+            vec!["description", "tags", "attributes"]
+        );
+        assert!(prepared
+            .replacement
+            .contains(r#"(descr "socket \"quoted\" \\ path")"#));
+        assert!(prepared
+            .replacement
+            .contains(r#"(tags "keyboard hot_swap")"#));
+        assert!(prepared
+            .replacement
+            .contains("(attr exclude_from_pos_files)"));
+        assert!(
+            prepared.replacement.find("(attr ").unwrap()
+                < prepared.replacement.find("(pad \"1\"").unwrap()
+        );
+        assert!(prepared
+            .replacement
+            .contains("(model \"../models/keep.step\""));
+        konnect_sexp::parse_sexp(&prepared.replacement).unwrap();
+    }
+
+    #[test]
+    fn replaces_only_supplied_metadata_and_preserves_every_other_block() {
+        let update = parse_update(&json!({
+            "attributes": ["exclude_from_pos_files"]
+        }))
+        .unwrap();
+
+        let prepared = prepare_mutation(METADATA_FOOTPRINT, &update).unwrap();
+
+        assert_eq!(prepared.changed_fields, vec!["attributes"]);
+        assert!(prepared.replacement.contains("(descr \"old description\")"));
+        assert!(prepared.replacement.contains("(tags \"old tags\")"));
+        assert!(prepared
+            .replacement
+            .contains("(attr exclude_from_pos_files)"));
+        assert!(!prepared.replacement.contains("exclude_from_bom"));
+        assert!(prepared
+            .replacement
+            .contains("(fp_line (start 0 0) (end 1 1)"));
+        assert!(prepared.replacement.contains("(pad \"1\" thru_hole circle"));
+        assert!(prepared
+            .replacement
+            .contains("(model \"../models/keep.step\""));
+    }
+
+    #[test]
+    fn empty_tags_and_attributes_remove_only_their_blocks() {
+        let update = parse_update(&json!({
+            "tags": [],
+            "attributes": []
+        }))
+        .unwrap();
+
+        let prepared = prepare_mutation(METADATA_FOOTPRINT, &update).unwrap();
+
+        assert_eq!(prepared.changed_fields, vec!["tags", "attributes"]);
+        assert!(!prepared.replacement.contains("(tags "));
+        assert!(!prepared.replacement.contains("(attr "));
+        assert!(prepared.replacement.contains("(descr \"old description\")"));
+        assert!(prepared.replacement.contains("(pad \"1\" thru_hole circle"));
+    }
+
+    #[test]
+    fn rejects_unsupported_attributes_and_an_all_omitted_update() {
+        let unsupported = parse_update(&json!({
+            "attributes": ["exclude_from_pos_files", "made_up"]
+        }))
+        .unwrap_err();
+        assert_eq!(unsupported.field, "attributes");
+
+        let omitted = parse_update(&json!({})).unwrap_err();
+        assert_eq!(omitted.field, "metadata");
+    }
+
+    #[test]
+    fn accepts_old_and_current_footprint_versions() {
+        let update = parse_update(&json!({"description": "new"})).unwrap();
+        for source in [
+            BARE_FOOTPRINT,
+            &BARE_FOOTPRINT.replace("20240108", "20221018"),
+        ] {
+            let prepared = prepare_mutation(source, &update).unwrap();
+            assert!(prepared.replacement.contains("(descr \"new\")"));
+            konnect_sexp::parse_sexp(&prepared.replacement).unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn handler_updates_metadata_with_a_revision_aware_atomic_write() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("Socket.kicad_mod");
+        std::fs::write(&path, BARE_FOOTPRINT).unwrap();
+
+        let result = handle_set_footprint_metadata(
+            &json!({
+                "footprint_path": path,
+                "attributes": ["exclude_from_pos_files"]
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.is_error, "{:?}", result.content);
+        let body: serde_json::Value = serde_json::from_str(&result_text(&result)).unwrap();
+        assert_eq!(body["changed_fields"], json!(["attributes"]));
+        assert!(std::fs::read_to_string(&path)
+            .unwrap()
+            .contains("(attr exclude_from_pos_files)"));
+    }
+
+    #[test]
+    fn stale_source_is_rejected_without_overwriting_the_newer_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("Socket.kicad_mod");
+        std::fs::write(&path, BARE_FOOTPRINT).unwrap();
+        let update = parse_update(&json!({"description": "prepared"})).unwrap();
+        let prepared = prepare_mutation(BARE_FOOTPRINT, &update).unwrap();
+
+        let newer = BARE_FOOTPRINT.replace("(layer \"F.Cu\")", "(layer \"B.Cu\")");
+        std::fs::write(&path, &newer).unwrap();
+
+        let error = persist_replacement(&path, BARE_FOOTPRINT, &prepared.replacement)
+            .expect_err("a stale expected source must conflict");
+        assert!(matches!(error, konnect_sexp::SexpError::Conflict { .. }));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), newer);
+    }
+}

--- a/crates/konnect-core/src/tools/footprint_metadata.rs
+++ b/crates/konnect-core/src/tools/footprint_metadata.rs
@@ -224,7 +224,9 @@ fn prepare_mutation(
         let Some(tag) = node.head() else {
             continue;
         };
-        child_indent.get_or_insert_with(|| indent_before(source, start));
+        if child_indent.is_none() {
+            child_indent = indent_before(source, start);
+        }
         let target = match tag {
             "descr" => Some(&mut description),
             "tags" => Some(&mut tags),
@@ -358,12 +360,16 @@ fn is_footprint_item(tag: &str) -> bool {
         )
 }
 
-fn indent_before(source: &str, offset: usize) -> String {
+fn indent_before(source: &str, offset: usize) -> Option<String> {
     let line_start = source[..offset]
         .rfind('\n')
         .map(|index| index + 1)
         .unwrap_or(0);
-    source[line_start..offset].to_string()
+    let indent = &source[line_start..offset];
+    indent
+        .chars()
+        .all(|character| matches!(character, ' ' | '\t'))
+        .then(|| indent.to_string())
 }
 
 fn quote_string(value: &str) -> String {
@@ -605,6 +611,32 @@ mod tests {
             assert!(prepared.replacement.contains("(descr \"new\")"));
             konnect_sexp::parse_sexp(&prepared.replacement).unwrap();
         }
+    }
+
+    #[test]
+    fn old_inline_header_accepts_replacements_plus_an_inserted_attribute() {
+        let source = r#"(footprint "Socket" (version 20221018) (generator pcbnew)
+  (layer "F.Cu")
+  (descr "old description")
+  (tags "old tags")
+  (fp_text reference "REF**" (at 0 0) (layer "F.SilkS"))
+  (pad "1" thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers "*.Cu" "*.Mask"))
+)
+"#;
+        let update = parse_update(&json!({
+            "description": "new description",
+            "tags": ["keyboard", "hot_swap"],
+            "attributes": ["exclude_from_pos_files"]
+        }))
+        .unwrap();
+
+        let prepared = prepare_mutation(source, &update).unwrap();
+
+        assert_eq!(prepared.replacement.matches("(footprint ").count(), 1);
+        assert!(prepared
+            .replacement
+            .contains("(attr exclude_from_pos_files)"));
+        konnect_sexp::parse_sexp(&prepared.replacement).unwrap();
     }
 
     #[tokio::test]

--- a/crates/konnect-core/src/tools/footprint_models.rs
+++ b/crates/konnect-core/src/tools/footprint_models.rs
@@ -1,0 +1,662 @@
+use crate::mcp::error::ToolErrorKind;
+use crate::mcp::protocol::CallToolResult;
+use crate::tool;
+use crate::tools::{ToolContext, ToolDef};
+use konnect_schematic_editor::types::fmt_f64;
+use konnect_sexp::writer::{
+    apply_edits, find_balanced_block, find_block_with_leading_whitespace, find_direct_child_blocks,
+    read_consistent, write_atomic_if_unchanged, SexpEdit,
+};
+use serde::Deserialize;
+use serde_json::json;
+use std::path::Path;
+
+fn xyz_schema(default: [f64; 3]) -> serde_json::Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "x": { "type": "number", "default": default[0] },
+            "y": { "type": "number", "default": default[1] },
+            "z": { "type": "number", "default": default[2] }
+        },
+        "required": ["x", "y", "z"],
+        "additionalProperties": false
+    })
+}
+
+pub(super) fn tool() -> ToolDef {
+    tool!(
+        "set_footprint_models",
+        "Atomically append, replace, or delete top-level 3D model blocks in an existing \
+         .kicad_mod footprint while preserving every non-model child.",
+        json!({
+            "type": "object",
+            "properties": {
+                "footprint_path": {
+                    "type": "string",
+                    "description": "Path to an existing .kicad_mod footprint file"
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": ["append", "replace", "delete"]
+                },
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "path": { "type": "string" },
+                            "offset": xyz_schema([0.0, 0.0, 0.0]),
+                            "scale": xyz_schema([1.0, 1.0, 1.0]),
+                            "rotate": xyz_schema([0.0, 0.0, 0.0])
+                        },
+                        "required": ["path"],
+                        "additionalProperties": false
+                    }
+                }
+            },
+            "required": ["footprint_path", "mode"],
+            "additionalProperties": false
+        }),
+        |args, ctx| async move { handle_set_footprint_models(args, ctx).await }
+    )
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum ModelMode {
+    Append,
+    Replace,
+    Delete,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+struct Xyz {
+    x: f64,
+    y: f64,
+    z: f64,
+}
+
+impl Xyz {
+    const ZERO: Self = Self {
+        x: 0.0,
+        y: 0.0,
+        z: 0.0,
+    };
+    const ONE: Self = Self {
+        x: 1.0,
+        y: 1.0,
+        z: 1.0,
+    };
+
+    fn is_finite(self) -> bool {
+        self.x.is_finite() && self.y.is_finite() && self.z.is_finite()
+    }
+}
+
+fn default_zero() -> Xyz {
+    Xyz::ZERO
+}
+
+fn default_one() -> Xyz {
+    Xyz::ONE
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+struct FootprintModel {
+    path: String,
+    #[serde(default = "default_zero")]
+    offset: Xyz,
+    #[serde(default = "default_one")]
+    scale: Xyz,
+    #[serde(default = "default_zero")]
+    rotate: Xyz,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct ModelRequest {
+    mode: ModelMode,
+    models: Vec<FootprintModel>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct ModelError {
+    field: String,
+    reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct PreparedMutation {
+    replacement: String,
+    matched_count: usize,
+    added_count: usize,
+    model_count: usize,
+}
+
+async fn handle_set_footprint_models(
+    args: &serde_json::Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let Some(path) = args["footprint_path"]
+        .as_str()
+        .map(std::path::PathBuf::from)
+    else {
+        return Ok(invalid_result("footprint_path", "missing or not a string"));
+    };
+    if path.extension().and_then(|extension| extension.to_str()) != Some("kicad_mod") {
+        return Ok(invalid_result("footprint_path", "must end in .kicad_mod"));
+    }
+    let metadata = match std::fs::metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(CallToolResult::error_kind(
+                ToolErrorKind::FileNotFound {
+                    path: path.display().to_string(),
+                },
+                format!("Footprint file not found: {}", path.display()),
+            ));
+        }
+        Err(error) => return Err(error.into()),
+    };
+    if !metadata.is_file() {
+        return Ok(invalid_result("footprint_path", "must name a regular file"));
+    }
+
+    let request = match parse_request(args) {
+        Ok(request) => request,
+        Err(error) => return Ok(invalid_result(&error.field, error.reason)),
+    };
+    let source = match read_consistent(&path) {
+        Ok(source) => source,
+        Err(konnect_sexp::SexpError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(CallToolResult::error_kind(
+                ToolErrorKind::FileNotFound {
+                    path: path.display().to_string(),
+                },
+                format!("Footprint file not found: {}", path.display()),
+            ));
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let prepared = match prepare_mutation(&source, &request) {
+        Ok(prepared) => prepared,
+        Err(error) => return Ok(invalid_result(&error.field, error.reason)),
+    };
+    if let Err(error) = persist_replacement(&path, &source, &prepared.replacement) {
+        return match error {
+            konnect_sexp::SexpError::Conflict { .. } => Ok(conflict_result(&path)),
+            other => Err(other.into()),
+        };
+    }
+
+    Ok(CallToolResult::json(&json!({
+        "success": true,
+        "footprint_path": path.display().to_string(),
+        "mode": args["mode"],
+        "matched_count": prepared.matched_count,
+        "added_count": prepared.added_count,
+        "model_count": prepared.model_count
+    })))
+}
+
+fn parse_request(args: &serde_json::Value) -> Result<ModelRequest, ModelError> {
+    let mode: ModelMode = serde_json::from_value(args["mode"].clone())
+        .map_err(|error| invalid("mode", error.to_string()))?;
+    let models = match args.get("models") {
+        None if matches!(mode, ModelMode::Delete) => Vec::new(),
+        None => {
+            return Err(invalid(
+                "models",
+                "is required for append and replace modes",
+            ))
+        }
+        Some(value) => serde_json::from_value::<Vec<FootprintModel>>(value.clone())
+            .map_err(|error| invalid("models", error.to_string()))?,
+    };
+    match mode {
+        ModelMode::Append | ModelMode::Replace if models.is_empty() => {
+            return Err(invalid(
+                "models",
+                "must contain at least one model in append and replace modes",
+            ))
+        }
+        ModelMode::Delete if !models.is_empty() => {
+            return Err(invalid("models", "must be omitted or empty in delete mode"))
+        }
+        _ => {}
+    }
+    validate_models(&models)?;
+    Ok(ModelRequest { mode, models })
+}
+
+fn validate_models(models: &[FootprintModel]) -> Result<(), ModelError> {
+    for (index, model) in models.iter().enumerate() {
+        if model.path.trim().is_empty() {
+            return Err(invalid(
+                "models",
+                format!("models[{index}].path must not be empty"),
+            ));
+        }
+        if model.path.contains('\0') {
+            return Err(invalid(
+                "models",
+                format!("models[{index}].path contains a NUL character"),
+            ));
+        }
+        if !model.offset.is_finite() || !model.scale.is_finite() || !model.rotate.is_finite() {
+            return Err(invalid(
+                "models",
+                format!("models[{index}] transforms must contain only finite numbers"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn prepare_mutation(source: &str, request: &ModelRequest) -> Result<PreparedMutation, ModelError> {
+    validate_models(&request.models)?;
+    let root = konnect_sexp::parse_sexp(source)
+        .map_err(|error| invalid("footprint_path", format!("invalid S-expression: {error}")))?;
+    if root.head() != Some("footprint") {
+        return Err(invalid("footprint_path", "file root must be a footprint"));
+    }
+
+    let mut selected = Vec::new();
+    let mut child_indent = None;
+    for (start, end) in find_direct_child_blocks(source, "footprint") {
+        let node = konnect_sexp::parse_sexp(&source[start..end])
+            .map_err(|_| invalid("footprint_path", "contains an invalid top-level item"))?;
+        child_indent.get_or_insert_with(|| indent_before(source, start));
+        if node.head() == Some("model") {
+            selected.push((start, end));
+        }
+    }
+
+    let indent = selected
+        .first()
+        .map(|(start, _)| indent_before(source, *start))
+        .or(child_indent)
+        .unwrap_or_else(|| "  ".to_string());
+    let serialized = serialize_models(&request.models, &indent);
+    let matched_count = selected.len();
+    let added_count = request.models.len();
+    let model_count = match request.mode {
+        ModelMode::Append => matched_count + added_count,
+        ModelMode::Replace => added_count,
+        ModelMode::Delete => 0,
+    };
+    let mut edits = Vec::new();
+
+    match request.mode {
+        ModelMode::Replace => {
+            if let Some((first, rest)) = selected.split_first() {
+                edits.push(SexpEdit::replace(first.0, first.1, serialized));
+                for (start, _) in rest {
+                    let range = find_block_with_leading_whitespace(source, *start)
+                        .ok_or_else(|| invalid("footprint_path", "contains an unbalanced model"))?;
+                    edits.push(SexpEdit::delete(range.0, range.1));
+                }
+            } else {
+                insert_models_at_root(source, &serialized, &indent, &mut edits)?;
+            }
+        }
+        ModelMode::Append => {
+            if let Some((_, end)) = selected.last() {
+                edits.push(SexpEdit::insert(*end, format!("\n{indent}{serialized}")));
+            } else {
+                insert_models_at_root(source, &serialized, &indent, &mut edits)?;
+            }
+        }
+        ModelMode::Delete => {
+            for (start, _) in &selected {
+                let range = find_block_with_leading_whitespace(source, *start)
+                    .ok_or_else(|| invalid("footprint_path", "contains an unbalanced model"))?;
+                edits.push(SexpEdit::delete(range.0, range.1));
+            }
+        }
+    }
+
+    let replacement = apply_edits(source.to_string(), edits);
+    let parsed = konnect_sexp::parse_sexp(&replacement)
+        .map_err(|error| invalid("models", format!("replacement does not parse: {error}")))?;
+    if parsed.head() != Some("footprint") {
+        return Err(invalid("models", "replacement changed the footprint root"));
+    }
+
+    Ok(PreparedMutation {
+        replacement,
+        matched_count,
+        added_count: if matches!(request.mode, ModelMode::Delete) {
+            0
+        } else {
+            added_count
+        },
+        model_count,
+    })
+}
+
+fn insert_models_at_root(
+    source: &str,
+    serialized: &str,
+    indent: &str,
+    edits: &mut Vec<SexpEdit>,
+) -> Result<(), ModelError> {
+    let root_end = find_balanced_block(source, 0)
+        .map(|range| range.1 - 1)
+        .ok_or_else(|| invalid("footprint_path", "unbalanced footprint root"))?;
+    let insertion = if source[..root_end].ends_with('\n') {
+        format!("{indent}{serialized}\n")
+    } else {
+        format!("\n{indent}{serialized}\n")
+    };
+    edits.push(SexpEdit::insert(root_end, insertion));
+    Ok(())
+}
+
+fn serialize_models(models: &[FootprintModel], indent: &str) -> String {
+    models
+        .iter()
+        .map(serialize_model)
+        .collect::<Vec<_>>()
+        .join(&format!("\n{indent}"))
+}
+
+fn serialize_model(model: &FootprintModel) -> String {
+    format!(
+        "(model {}\n    (offset (xyz {} {} {}))\n    (scale (xyz {} {} {}))\n    (rotate (xyz {} {} {})))",
+        quote_string(&model.path),
+        fmt_f64(model.offset.x),
+        fmt_f64(model.offset.y),
+        fmt_f64(model.offset.z),
+        fmt_f64(model.scale.x),
+        fmt_f64(model.scale.y),
+        fmt_f64(model.scale.z),
+        fmt_f64(model.rotate.x),
+        fmt_f64(model.rotate.y),
+        fmt_f64(model.rotate.z),
+    )
+}
+
+fn indent_before(source: &str, offset: usize) -> String {
+    let line_start = source[..offset]
+        .rfind('\n')
+        .map(|index| index + 1)
+        .unwrap_or(0);
+    source[line_start..offset].to_string()
+}
+
+fn quote_string(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len() + 2);
+    escaped.push('"');
+    for character in value.chars() {
+        match character {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            other => escaped.push(other),
+        }
+    }
+    escaped.push('"');
+    escaped
+}
+
+fn invalid(field: &str, reason: impl Into<String>) -> ModelError {
+    ModelError {
+        field: field.to_string(),
+        reason: reason.into(),
+    }
+}
+
+fn invalid_result(field: &str, reason: impl Into<String>) -> CallToolResult {
+    let reason = reason.into();
+    CallToolResult::error_kind(
+        ToolErrorKind::InvalidArgument {
+            field: field.to_string(),
+            reason: reason.clone(),
+        },
+        format!("Argument '{field}' is invalid: {reason}"),
+    )
+}
+
+fn conflict_result(path: &Path) -> CallToolResult {
+    CallToolResult::error_kind(
+        ToolErrorKind::Conflict {
+            paths: vec![path.display().to_string()],
+        },
+        "Footprint models were not changed because the file changed after it was read",
+    )
+}
+
+fn persist_replacement(
+    path: &Path,
+    expected: &str,
+    replacement: &str,
+) -> Result<(), konnect_sexp::SexpError> {
+    write_atomic_if_unchanged(path, expected, replacement)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::{ServerConfig, ToolContext};
+    use serde_json::json;
+    use std::sync::Arc;
+
+    const ONE_MODEL_FOOTPRINT: &str = r#"(footprint "Socket"
+  (version 20240108)
+  (generator "pcbnew")
+  (layer "F.Cu")
+  (descr "preserve me")
+  (fp_line (start 0 0) (end 1 1) (stroke (width 0.1) (type default)) (layer "F.SilkS"))
+  (pad "1" thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers "*.Cu" "*.Mask"))
+  (model "../models/old.step"
+    (offset (xyz 1 2 3))
+    (scale (xyz 1 1 1))
+    (rotate (xyz 0 0 90)))
+)
+"#;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+                eager_toolsets: false,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    fn result_text(result: &crate::mcp::protocol::CallToolResult) -> String {
+        match result.content.first() {
+            Some(crate::mcp::protocol::ToolContent::Text { text }) => text.clone(),
+            other => panic!("expected text content, got {other:?}"),
+        }
+    }
+
+    fn model(path: &str) -> serde_json::Value {
+        json!({"path": path})
+    }
+
+    #[test]
+    fn schema_exposes_modes_and_xyz_model_fields() {
+        let model_tool = tool();
+        assert_eq!(model_tool.name, "set_footprint_models");
+        assert_eq!(
+            model_tool.input_schema["required"],
+            json!(["footprint_path", "mode"])
+        );
+        assert_eq!(
+            model_tool.input_schema["properties"]["mode"]["enum"],
+            json!(["append", "replace", "delete"])
+        );
+        let item = &model_tool.input_schema["properties"]["models"]["items"];
+        assert_eq!(item["required"], json!(["path"]));
+        for transform in ["offset", "scale", "rotate"] {
+            assert_eq!(
+                item["properties"][transform]["required"],
+                json!(["x", "y", "z"])
+            );
+        }
+    }
+
+    #[test]
+    fn append_adds_a_defaulted_model_after_existing_models() {
+        let request = parse_request(&json!({
+            "mode": "append",
+            "models": [model("../models/new.step")]
+        }))
+        .unwrap();
+
+        let prepared = prepare_mutation(ONE_MODEL_FOOTPRINT, &request).unwrap();
+
+        assert_eq!(prepared.matched_count, 1);
+        assert_eq!(prepared.added_count, 1);
+        assert_eq!(prepared.model_count, 2);
+        assert!(
+            prepared.replacement.find("../models/old.step").unwrap()
+                < prepared.replacement.find("../models/new.step").unwrap()
+        );
+        assert!(prepared.replacement.contains(
+            "(model \"../models/new.step\"\n    (offset (xyz 0 0 0))\n    (scale (xyz 1 1 1))\n    (rotate (xyz 0 0 0)))"
+        ));
+        konnect_sexp::parse_sexp(&prepared.replacement).unwrap();
+    }
+
+    #[test]
+    fn replace_one_model_with_two_explicit_models() {
+        let request = parse_request(&json!({
+            "mode": "replace",
+            "models": [
+                {
+                    "path": "../models/a.step",
+                    "offset": {"x": 5.025, "y": -7.925, "z": -1.838},
+                    "scale": {"x": -1, "y": 1, "z": 1},
+                    "rotate": {"x": -90, "y": 0, "z": 0}
+                },
+                {
+                    "path": "../models/b.step",
+                    "rotate": {"x": 90, "y": 0, "z": 0}
+                }
+            ]
+        }))
+        .unwrap();
+
+        let prepared = prepare_mutation(ONE_MODEL_FOOTPRINT, &request).unwrap();
+
+        assert_eq!(prepared.matched_count, 1);
+        assert_eq!(prepared.added_count, 2);
+        assert_eq!(prepared.model_count, 2);
+        assert!(!prepared.replacement.contains("../models/old.step"));
+        assert!(prepared
+            .replacement
+            .contains("(offset (xyz 5.025 -7.925 -1.838))"));
+        assert!(prepared.replacement.contains("(scale (xyz -1 1 1))"));
+        assert!(prepared.replacement.contains("(rotate (xyz -90 0 0))"));
+        assert!(prepared.replacement.contains("(rotate (xyz 90 0 0))"));
+        assert!(prepared.replacement.contains("(descr \"preserve me\")"));
+        assert!(prepared
+            .replacement
+            .contains("(fp_line (start 0 0) (end 1 1)"));
+        assert!(prepared.replacement.contains("(pad \"1\" thru_hole circle"));
+    }
+
+    #[test]
+    fn delete_removes_all_models_and_preserves_non_model_children() {
+        let source = ONE_MODEL_FOOTPRINT.replace(
+            "\n)",
+            "\n  (model \"../models/second.step\"\n    (offset (xyz 0 0 0))\n    (scale (xyz 1 1 1))\n    (rotate (xyz 0 0 0)))\n)\n",
+        );
+        let request = parse_request(&json!({"mode": "delete", "models": []})).unwrap();
+
+        let prepared = prepare_mutation(&source, &request).unwrap();
+
+        assert_eq!(prepared.matched_count, 2);
+        assert_eq!(prepared.added_count, 0);
+        assert_eq!(prepared.model_count, 0);
+        assert!(!prepared.replacement.contains("(model "));
+        assert!(prepared.replacement.contains("(descr \"preserve me\")"));
+        assert!(prepared.replacement.contains("(pad \"1\" thru_hole circle"));
+        konnect_sexp::parse_sexp(&prepared.replacement).unwrap();
+    }
+
+    #[test]
+    fn rejects_invalid_mode_lists_empty_paths_and_non_finite_transforms() {
+        for value in [
+            json!({"mode": "append", "models": []}),
+            json!({"mode": "replace"}),
+            json!({"mode": "delete", "models": [model("x.step")]}),
+            json!({"mode": "append", "models": [model("")]}),
+        ] {
+            assert!(parse_request(&value).is_err(), "{value}");
+        }
+
+        let mut request = parse_request(&json!({
+            "mode": "append",
+            "models": [model("x.step")]
+        }))
+        .unwrap();
+        request.models[0].offset.x = f64::INFINITY;
+        assert_eq!(
+            prepare_mutation(ONE_MODEL_FOOTPRINT, &request)
+                .unwrap_err()
+                .field,
+            "models"
+        );
+    }
+
+    #[tokio::test]
+    async fn handler_replaces_models_in_one_atomic_operation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("Socket.kicad_mod");
+        std::fs::write(&path, ONE_MODEL_FOOTPRINT).unwrap();
+
+        let result = handle_set_footprint_models(
+            &json!({
+                "footprint_path": path,
+                "mode": "replace",
+                "models": [model("../models/new.step")]
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.is_error, "{:?}", result.content);
+        let body: serde_json::Value = serde_json::from_str(&result_text(&result)).unwrap();
+        assert_eq!(body["matched_count"], 1);
+        assert_eq!(body["added_count"], 1);
+        assert_eq!(body["model_count"], 1);
+        let updated = std::fs::read_to_string(path).unwrap();
+        assert!(!updated.contains("../models/old.step"));
+        assert!(updated.contains("../models/new.step"));
+    }
+
+    #[test]
+    fn stale_source_is_rejected_without_overwriting_the_newer_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("Socket.kicad_mod");
+        std::fs::write(&path, ONE_MODEL_FOOTPRINT).unwrap();
+        let request = parse_request(&json!({
+            "mode": "replace",
+            "models": [model("../models/new.step")]
+        }))
+        .unwrap();
+        let prepared = prepare_mutation(ONE_MODEL_FOOTPRINT, &request).unwrap();
+
+        let newer = ONE_MODEL_FOOTPRINT.replace("(layer \"F.Cu\")", "(layer \"B.Cu\")");
+        std::fs::write(&path, &newer).unwrap();
+
+        let error = persist_replacement(&path, ONE_MODEL_FOOTPRINT, &prepared.replacement)
+            .expect_err("a stale expected source must conflict");
+        assert!(matches!(error, konnect_sexp::SexpError::Conflict { .. }));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), newer);
+    }
+}

--- a/crates/konnect-core/src/tools/footprint_models.rs
+++ b/crates/konnect-core/src/tools/footprint_models.rs
@@ -266,7 +266,9 @@ fn prepare_mutation(source: &str, request: &ModelRequest) -> Result<PreparedMuta
     for (start, end) in find_direct_child_blocks(source, "footprint") {
         let node = konnect_sexp::parse_sexp(&source[start..end])
             .map_err(|_| invalid("footprint_path", "contains an invalid top-level item"))?;
-        child_indent.get_or_insert_with(|| indent_before(source, start));
+        if child_indent.is_none() {
+            child_indent = indent_before(source, start);
+        }
         if node.head() == Some("model") {
             selected.push((start, end));
         }
@@ -274,7 +276,7 @@ fn prepare_mutation(source: &str, request: &ModelRequest) -> Result<PreparedMuta
 
     let indent = selected
         .first()
-        .map(|(start, _)| indent_before(source, *start))
+        .and_then(|(start, _)| indent_before(source, *start))
         .or(child_indent)
         .unwrap_or_else(|| "  ".to_string());
     let serialized = serialize_models(&request.models, &indent);
@@ -377,12 +379,16 @@ fn serialize_model(model: &FootprintModel) -> String {
     )
 }
 
-fn indent_before(source: &str, offset: usize) -> String {
+fn indent_before(source: &str, offset: usize) -> Option<String> {
     let line_start = source[..offset]
         .rfind('\n')
         .map(|index| index + 1)
         .unwrap_or(0);
-    source[line_start..offset].to_string()
+    let indent = &source[line_start..offset];
+    indent
+        .chars()
+        .all(|character| matches!(character, ' ' | '\t'))
+        .then(|| indent.to_string())
 }
 
 fn quote_string(value: &str) -> String {
@@ -566,6 +572,27 @@ mod tests {
             .replacement
             .contains("(fp_line (start 0 0) (end 1 1)"));
         assert!(prepared.replacement.contains("(pad \"1\" thru_hole circle"));
+    }
+
+    #[test]
+    fn old_inline_header_accepts_inserting_the_first_model() {
+        let source = r#"(footprint "Socket" (version 20221018) (generator pcbnew)
+  (layer "F.Cu")
+  (descr "old description")
+  (pad "1" thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers "*.Cu" "*.Mask"))
+)
+"#;
+        let request = parse_request(&json!({
+            "mode": "replace",
+            "models": [model("../models/new.step")]
+        }))
+        .unwrap();
+
+        let prepared = prepare_mutation(source, &request).unwrap();
+
+        assert_eq!(prepared.replacement.matches("(footprint ").count(), 1);
+        assert!(prepared.replacement.contains("../models/new.step"));
+        konnect_sexp::parse_sexp(&prepared.replacement).unwrap();
     }
 
     #[test]

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -3079,27 +3079,67 @@ async fn handle_create_symbol(
         None => (2.54, -2.54),
     };
 
-    let numbers_vis = if show_numbers { "" } else { " hide" };
-    let names_vis = if show_names { "" } else { " hide" };
+    let numbers = if show_numbers {
+        String::new()
+    } else {
+        "\n    (pin_numbers hide)".to_string()
+    };
+    let names = if show_names {
+        format!(
+            "\n    (pin_names\n      (offset {}))",
+            fmt_f64(PIN_NAME_OFFSET)
+        )
+    } else {
+        format!(
+            "\n    (pin_names\n      (offset {})\n      (hide yes))",
+            fmt_f64(PIN_NAME_OFFSET)
+        )
+    };
+    let visible_property = |name: &str, value: &str, y: f64| {
+        format!(
+            "\n    (property \"{name}\" \"{value}\" (at 0 {y:.4} 0) \
+             (show_name no) (do_not_autoplace no) \
+             (effects (font (size 1.27 1.27))))"
+        )
+    };
+    let hidden_property = |name: &str, value: &str| {
+        format!(
+            "\n    (property \"{name}\" \"{value}\" (at 0 0 0) \
+             (show_name no) (do_not_autoplace no) (hide yes) \
+             (effects (font (size 1.27 1.27))))"
+        )
+    };
 
     let symbol_sexp = format!(
-        "\n  (symbol \"{}\"\n    (pin_numbers{})\n    (pin_names (offset {}){})\n    (in_bom yes)\n    (on_board yes)\n    (property \"Reference\" \"{}\" (at 0 {:.4} 0) (effects (font (size 1.27 1.27))))\n    (property \"Value\" \"{}\" (at 0 {:.4} 0) (effects (font (size 1.27 1.27))))\n    (property \"Footprint\" \"\" (at 0 0 0) (effects (font (size 1.27 1.27)) hide))\n    (property \"Datasheet\" \"~\" (at 0 0 0) (effects (font (size 1.27 1.27)) hide)){}\n  )",
+        "\n  (symbol \"{}\"{}{}\n    (exclude_from_sim no)\n    (in_bom yes)\n    (on_board yes)\n    (in_pos_files yes)\n    (duplicate_pin_numbers_are_jumpers no){}{}{}{}{}{}\n    (embedded_fonts no)\n  )",
         name,
-        numbers_vis,
-        fmt_f64(PIN_NAME_OFFSET),
-        names_vis,
-        ref_prefix,
-        ref_y,
-        value_str,
-        value_y,
+        numbers,
+        names,
+        visible_property("Reference", ref_prefix, ref_y),
+        visible_property("Value", value_str, value_y),
+        hidden_property("Footprint", ""),
+        hidden_property("Datasheet", ""),
+        hidden_property("Description", ""),
         units_sexp
     );
 
     // If file doesn't exist, create scaffold
     let content = if lib_path.exists() {
-        tokio::fs::read_to_string(&lib_path).await?
+        let mut content = tokio::fs::read_to_string(&lib_path).await?;
+        content = content.replace("(version 20240108)", "(version 20251024)");
+        if !content.contains("(generator_version ") {
+            if let Some(position) = content.find("(generator \"") {
+                if let Some(end) = content[position..].find(')') {
+                    let insert_at = position + end + 1;
+                    content.insert_str(insert_at, "\n  (generator_version \"10.0\")");
+                }
+            }
+        }
+        content
     } else {
-        "(kicad_symbol_lib\n  (version 20240108)\n  (generator \"konnect\")\n)\n".to_string()
+        "(kicad_symbol_lib\n  (version 20251024)\n  (generator \"konnect\")\n  \
+         (generator_version \"10.0\")\n)\n"
+            .to_string()
     };
 
     // Insert before closing paren of root expression
@@ -5065,12 +5105,49 @@ mod tests {
             c.contains("(generator \"konnect\")"),
             "stale generator string"
         );
-        assert!(c.contains("(pin_numbers)"), "pin numbers should be shown");
-        assert!(!c.contains("(pin_numbers hide)"));
+        assert!(
+            !c.contains("(pin_numbers hide)"),
+            "KiCad 10 shows pin numbers by omitting the hide override"
+        );
         assert!(
             konnect_sexp::parser::parse_sexp(&c).is_ok(),
             "generated symbol doesn't parse"
         );
+    }
+
+    #[tokio::test]
+    async fn create_symbol_emits_kicad10_library_match_defaults() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lib = tmp.path().join("modern.kicad_sym");
+        let args = json!({
+            "library_path": lib.to_string_lossy(),
+            "name": "Modern",
+            "reference_prefix": "U",
+            "pins": [
+                {"number":"1","name":"IN","type":"input","x":-7.62,"y":0.0,"angle":0}
+            ]
+        });
+
+        let result = handle_create_symbol(&args, &test_ctx()).await.unwrap();
+        assert!(!result.is_error);
+        let output = std::fs::read_to_string(&lib).unwrap();
+
+        assert!(output.contains("(version 20251024)"), "{output}");
+        assert!(output.contains("(generator_version \"10.0\")"), "{output}");
+        assert!(output.contains("(exclude_from_sim no)"), "{output}");
+        assert!(output.contains("(in_pos_files yes)"), "{output}");
+        assert!(
+            output.contains("(duplicate_pin_numbers_are_jumpers no)"),
+            "{output}"
+        );
+        assert!(
+            output.contains("(property \"Description\" \"\""),
+            "{output}"
+        );
+        assert!(output.contains("(show_name no)"), "{output}");
+        assert!(output.contains("(do_not_autoplace no)"), "{output}");
+        assert!(output.contains("(hide yes)"), "{output}");
+        assert!(output.contains("(embedded_fonts no)"), "{output}");
     }
 
     #[tokio::test]

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -301,11 +301,15 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "get_footprint_info",
-            "Return detailed information about a footprint: pad layout, courtyard, description.",
+            "Return detailed information about a footprint: pad layout, courtyard, description, \
+             and optionally its supported graphical primitives.",
             json!({
                 "type": "object",
                 "properties": {
-                    "footprint_path": { "type": "string", "description": "Path to .kicad_mod file, OR 'Library:Footprint' identifier" }
+                    "footprint_path": { "type": "string", "description": "Path to .kicad_mod file, OR 'Library:Footprint' identifier" },
+                    "project": { "type": "string", "description": "Path to a .kicad_pro used to resolve project libraries (optional)" },
+                    "include_graphics": { "type": "boolean", "description": "Include supported top-level footprint graphics in the response", "default": false },
+                    "graphics_layer": { "type": "string", "description": "Return graphics only from this canonical KiCad layer; implies include_graphics" }
                 },
                 "required": ["footprint_path"]
             }),
@@ -3074,17 +3078,41 @@ async fn handle_get_footprint_info(
     let has_courtyard = content.contains("B.CrtYd") || content.contains("F.CrtYd");
     let has_3d = content.contains("(model ");
 
-    Ok(CallToolResult::text(
-        serde_json::to_string(&json!({
-            "name": fp_name,
-            "description": description,
-            "pad_count": pad_count,
-            "has_courtyard": has_courtyard,
-            "has_3d_model": has_3d,
-            "path": path.to_str().unwrap_or("")
-        }))
-        .unwrap(),
-    ))
+    let mut response = json!({
+        "name": fp_name,
+        "description": description,
+        "pad_count": pad_count,
+        "has_courtyard": has_courtyard,
+        "has_3d_model": has_3d,
+        "path": path.to_str().unwrap_or("")
+    });
+    let graphics_layer = args["graphics_layer"].as_str();
+    let include_graphics =
+        args["include_graphics"].as_bool().unwrap_or(false) || graphics_layer.is_some();
+    if include_graphics {
+        let graphics = match super::footprint_graphics::inspect_graphics(&content, graphics_layer) {
+            Ok(graphics) => graphics,
+            Err(super::footprint_graphics::FootprintGraphicsError::InvalidArgument {
+                field,
+                reason,
+            }) => {
+                return Ok(CallToolResult::error_kind(
+                    crate::mcp::error::ToolErrorKind::InvalidArgument {
+                        field: field.clone(),
+                        reason: reason.clone(),
+                    },
+                    format!("Argument '{field}' is invalid: {reason}"),
+                ));
+            }
+            Err(super::footprint_graphics::FootprintGraphicsError::Conflict(reason)) => {
+                return Ok(CallToolResult::error(reason));
+            }
+        };
+        response["graphic_count"] = json!(graphics.len());
+        response["graphics"] = serde_json::to_value(graphics)?;
+    }
+
+    Ok(CallToolResult::json(&response))
 }
 
 // ─── search_footprints (moved from verification toolset) ─────────────────────
@@ -4124,6 +4152,93 @@ mod tests {
             konnect_sexp::parser::parse_sexp(&c).is_ok(),
             "generated footprint doesn't parse"
         );
+    }
+
+    #[tokio::test]
+    async fn get_footprint_info_includes_graphics_only_when_requested() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("inspect.kicad_mod");
+        std::fs::write(
+            &path,
+            r#"(footprint "Inspect" (version 20240108) (generator "pcbnew")
+  (layer "F.Cu")
+  (descr "Inspection fixture")
+  (fp_line (start 0 0) (end 1 0)
+    (stroke (width 0.1) (type solid)) (layer "F.SilkS"))
+  (fp_poly
+    (pts (xy 0 0) (xy 2 0) (xy 2 1))
+    (stroke (width 0.05) (type solid)) (fill none) (layer "B.CrtYd"))
+  (pad "1" thru_hole circle (at 0 0) (size 1.8 1.8) (drill 1)
+    (layers "*.Cu" "*.Mask"))
+)
+"#,
+        )
+        .unwrap();
+
+        let default = handle_get_footprint_info(
+            &json!({"footprint_path": path.to_string_lossy()}),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        let crate::mcp::protocol::ToolContent::Text { text } = &default.content[0] else {
+            panic!("expected text");
+        };
+        let default: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(default["name"], "Inspect");
+        assert_eq!(default["pad_count"], 1);
+        assert!(
+            default.get("graphics").is_none(),
+            "default response must stay compact: {default}"
+        );
+        assert!(default.get("graphic_count").is_none());
+
+        let detailed = handle_get_footprint_info(
+            &json!({
+                "footprint_path": path.to_string_lossy(),
+                "include_graphics": true,
+                "graphics_layer": "B.CrtYd"
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        let crate::mcp::protocol::ToolContent::Text { text } = &detailed.content[0] else {
+            panic!("expected text");
+        };
+        let detailed: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(detailed["graphic_count"], 1);
+        assert_eq!(detailed["graphics"][0]["type"], "poly");
+        assert_eq!(detailed["graphics"][0]["layer"], "B.CrtYd");
+        assert_eq!(detailed["graphics"][0]["point_count"], 3);
+        assert_eq!(detailed["graphics"][0]["closed"], true);
+        assert_eq!(detailed["graphics"][0]["stroke_width_mm"], 0.05);
+        assert_eq!(detailed["graphics"][0]["fill"], "none");
+
+        let invalid = handle_get_footprint_info(
+            &json!({
+                "footprint_path": path.to_string_lossy(),
+                "graphics_layer": "BottomCourtyard"
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(invalid.is_error);
+        let crate::mcp::protocol::ToolContent::Text { text } = &invalid.content[0] else {
+            panic!("expected text");
+        };
+        let invalid: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(invalid["error"]["kind"], "invalid_argument");
+        assert_eq!(invalid["error"]["field"], "graphics_layer");
+
+        let schema = tools()
+            .into_iter()
+            .find(|tool| tool.name == "get_footprint_info")
+            .unwrap()
+            .input_schema;
+        assert_eq!(schema["properties"]["include_graphics"]["type"], "boolean");
+        assert_eq!(schema["properties"]["graphics_layer"]["type"], "string");
     }
 
     #[tokio::test]

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -350,6 +350,7 @@ pub fn tools() -> Vec<ToolDef> {
     ];
     tools.insert(2, super::footprint_graphics::tool());
     tools.insert(3, super::footprint_metadata::tool());
+    tools.insert(4, super::footprint_models::tool());
     tools
 }
 

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -77,7 +77,22 @@ pub fn tools() -> Vec<ToolDef> {
                                 "y": { "type": "number" },
                                 "width": { "type": "number" },
                                 "height": { "type": "number" },
-                                "drill": { "type": "number", "description": "Drill diameter for thru-hole pads" }
+                                "drill": { "type": "number", "description": "Drill diameter for thru-hole pads" },
+                                "layers": {
+                                    "type": "array",
+                                    "items": { "type": "string" },
+                                    "description": "Explicit canonical KiCAD pad layers. Defaults to F.Cu/F.Paste/F.Mask for SMD and *.Cu/*.Mask otherwise."
+                                },
+                                "rotation": {
+                                    "type": "number",
+                                    "description": "Pad rotation in degrees (default 0)"
+                                },
+                                "roundrect_rratio": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 0.5,
+                                    "description": "Rounded-rectangle corner radius ratio (0..0.5)"
+                                }
                             },
                             "required": ["number", "type", "shape", "x", "y", "width", "height"]
                         }
@@ -654,10 +669,59 @@ async fn handle_create_footprint(
         let w = pad["width"].as_f64().unwrap_or(1.0);
         let h = pad["height"].as_f64().unwrap_or(1.0);
 
-        let layers = if pad_type == "smd" {
-            r#"(layers "F.Cu" "F.Paste" "F.Mask")"#
+        let layer_names = if let Some(layers) = pad["layers"].as_array() {
+            let mut names = Vec::with_capacity(layers.len());
+            for layer in layers {
+                let layer = layer
+                    .as_str()
+                    .ok_or_else(|| anyhow::anyhow!("pad layers must contain strings"))?;
+                if !matches!(
+                    layer,
+                    "F.Cu"
+                        | "B.Cu"
+                        | "F.Paste"
+                        | "B.Paste"
+                        | "F.Mask"
+                        | "B.Mask"
+                        | "*.Cu"
+                        | "*.Mask"
+                ) {
+                    anyhow::bail!("invalid pad layer: {layer}");
+                }
+                names.push(layer);
+            }
+            if names.is_empty() {
+                anyhow::bail!("pad layers must not be empty");
+            }
+            names
+        } else if pad_type == "smd" {
+            vec!["F.Cu", "F.Paste", "F.Mask"]
         } else {
-            r#"(layers "*.Cu" "*.Mask")"#
+            vec!["*.Cu", "*.Mask"]
+        };
+        let layers = format!(
+            "(layers {})",
+            layer_names
+                .iter()
+                .map(|layer| format!("\"{layer}\""))
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+
+        let rotation = pad["rotation"].as_f64().unwrap_or(0.0);
+        let at = if rotation == 0.0 {
+            format!("(at {x} {y})")
+        } else {
+            format!("(at {x} {y} {rotation})")
+        };
+
+        let roundrect_ratio = if let Some(ratio) = pad["roundrect_rratio"].as_f64() {
+            if !(0.0..=0.5).contains(&ratio) {
+                anyhow::bail!("roundrect_rratio must be between 0 and 0.5");
+            }
+            format!("(roundrect_rratio {ratio})")
+        } else {
+            String::new()
         };
 
         let drill_sexp = if let Some(drill) = pad["drill"].as_f64() {
@@ -667,8 +731,8 @@ async fn handle_create_footprint(
         };
 
         pad_sexp.push_str(&format!(
-            "\n  (pad \"{}\" {} {} (at {} {}) (size {} {}) {} {})",
-            number, pad_type, shape, x, y, w, h, layers, drill_sexp
+            "\n  (pad \"{}\" {} {} {} (size {} {}) {} {} {})",
+            number, pad_type, shape, at, w, h, layers, drill_sexp, roundrect_ratio
         ));
         pad_geoms.push(PadGeom {
             number,
@@ -4756,6 +4820,137 @@ mod tests {
             konnect_sexp::parser::parse_sexp(&c).is_ok(),
             "generated footprint doesn't parse"
         );
+    }
+
+    #[test]
+    fn create_footprint_schema_exposes_pad_layers_rotation_and_roundrect_ratio() {
+        let tool = tools()
+            .into_iter()
+            .find(|tool| tool.name == "create_footprint")
+            .expect("library must expose create_footprint");
+        let pad_properties = &tool.input_schema["properties"]["pads"]["items"]["properties"];
+        assert_eq!(pad_properties["layers"]["items"]["type"], json!("string"));
+        assert_eq!(pad_properties["rotation"]["type"], json!("number"));
+        assert_eq!(pad_properties["roundrect_rratio"]["maximum"], json!(0.5));
+    }
+
+    #[tokio::test]
+    async fn create_footprint_emits_bottom_layer_rotated_roundrect_pad() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = tmp.path().join("BOTTOM.kicad_mod");
+        let args = json!({
+            "output": out.to_string_lossy(),
+            "name": "BOTTOM",
+            "pads": [{
+                "number": "1",
+                "type": "smd",
+                "shape": "roundrect",
+                "x": -8.075,
+                "y": 4.7,
+                "width": 2.5,
+                "height": 2.55,
+                "layers": ["B.Cu", "B.Paste", "B.Mask"],
+                "rotation": 180.0,
+                "roundrect_rratio": 0.2
+            }]
+        });
+
+        let result = handle_create_footprint(&args, &test_ctx()).await.unwrap();
+        assert!(!result.is_error);
+        let content = std::fs::read_to_string(&out).unwrap();
+        assert!(
+            content.contains("(at -8.075 4.7 180)"),
+            "missing pad rotation:\n{content}"
+        );
+        assert!(
+            content.contains("(layers \"B.Cu\" \"B.Paste\" \"B.Mask\")"),
+            "missing bottom pad layers:\n{content}"
+        );
+        assert!(
+            content.contains("(roundrect_rratio 0.2)"),
+            "missing roundrect ratio:\n{content}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_footprint_legacy_pad_payload_remains_front_side() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = tmp.path().join("LEGACY.kicad_mod");
+        let args = json!({
+            "output": out.to_string_lossy(),
+            "name": "LEGACY",
+            "pads": [{
+                "number": "1",
+                "type": "smd",
+                "shape": "roundrect",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 1.0,
+                "height": 1.0
+            }]
+        });
+
+        let result = handle_create_footprint(&args, &test_ctx()).await.unwrap();
+        assert!(!result.is_error);
+        let content = std::fs::read_to_string(&out).unwrap();
+        assert!(content.contains("(at 0 0)"), "{content}");
+        assert!(
+            content.contains("(layers \"F.Cu\" \"F.Paste\" \"F.Mask\")"),
+            "{content}"
+        );
+        assert!(!content.contains("(at 0 0 0)"), "{content}");
+    }
+
+    #[tokio::test]
+    async fn create_footprint_rejects_invalid_pad_layer_without_writing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = tmp.path().join("INVALID_LAYER.kicad_mod");
+        let args = json!({
+            "output": out.to_string_lossy(),
+            "name": "INVALID_LAYER",
+            "pads": [{
+                "number": "1",
+                "type": "smd",
+                "shape": "rect",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 1.0,
+                "height": 1.0,
+                "layers": ["User.MadeUp"]
+            }]
+        });
+
+        let error = handle_create_footprint(&args, &test_ctx())
+            .await
+            .expect_err("invalid layer must be rejected");
+        assert!(error.to_string().contains("invalid pad layer"));
+        assert!(!out.exists());
+    }
+
+    #[tokio::test]
+    async fn create_footprint_rejects_invalid_roundrect_ratio_without_writing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = tmp.path().join("INVALID_RATIO.kicad_mod");
+        let args = json!({
+            "output": out.to_string_lossy(),
+            "name": "INVALID_RATIO",
+            "pads": [{
+                "number": "1",
+                "type": "smd",
+                "shape": "roundrect",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 1.0,
+                "height": 1.0,
+                "roundrect_rratio": 0.75
+            }]
+        });
+
+        let error = handle_create_footprint(&args, &test_ctx())
+            .await
+            .expect_err("invalid roundrect ratio must be rejected");
+        assert!(error.to_string().contains("roundrect_rratio"));
+        assert!(!out.exists());
     }
 
     #[tokio::test]

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -3,12 +3,16 @@
 //! Operations are file-based (S-expression manipulation + directory scanning).
 //! No IPC or kicad-cli is required for most tools.
 
+use crate::mcp::error::ToolErrorKind;
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
 use crate::tools::{get_path, require_str, ToolContext, ToolDef};
 use konnect_schematic_editor::types::fmt_f64;
 use konnect_sexp::parser::{parse_sexp, SexpNode};
-use konnect_sexp::writer::{find_balanced_block, find_block_starts, write_atomic};
+use konnect_sexp::writer::{
+    apply_edits, find_balanced_block, find_block_starts, find_direct_child_blocks, read_consistent,
+    write_atomic, write_atomic_if_unchanged, SexpEdit,
+};
 use serde_json::json;
 use std::path::{Path, PathBuf};
 
@@ -106,6 +110,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "properties": {
                     "footprint_path": { "type": "string", "description": "Path to .kicad_mod file" },
                     "pad_number": { "type": "string", "description": "Pad number to edit" },
+                    "new_number": { "type": "string", "description": "New pad number (optional; duplicate destination numbers are allowed)" },
+                    "match_all": { "type": "boolean", "description": "Edit every direct-child pad with pad_number instead of only the first match", "default": false },
                     "x": { "type": "number", "description": "New X position in mm (optional)" },
                     "y": { "type": "number", "description": "New Y position in mm (optional)" },
                     "width": { "type": "number", "description": "New pad width in mm (optional)" },
@@ -715,49 +721,129 @@ async fn handle_edit_footprint_pad(
         Ok(v) => v,
         Err(e) => return Ok(e),
     };
-
-    let content = tokio::fs::read_to_string(&path).await?;
-
-    // Find the pad block:  (pad "N" ... (at X Y) (size W H) ...)
-    // We search for the at/size/drill atoms and replace them individually.
-    let pad_pat = format!(r#"(pad "{}""#, pad_number);
-    let pad_start = content
-        .find(&pad_pat)
-        .ok_or_else(|| anyhow::anyhow!("Pad '{}' not found in footprint", pad_number))?;
-
-    // Find the closing paren of this pad block (simple depth count)
-    let pad_end = {
-        let mut depth = 0i32;
-        let mut end = pad_start;
-        for (i, ch) in content[pad_start..].char_indices() {
-            match ch {
-                '(' => depth += 1,
-                ')' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        end = pad_start + i + 1;
-                        break;
-                    }
-                }
-                _ => {}
+    let new_number = match args.get("new_number") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(value) => match value.as_str() {
+            Some(number) => Some(number),
+            None => {
+                return Ok(invalid_library_argument(
+                    "new_number",
+                    "must be a string when supplied",
+                ))
             }
-        }
-        end
+        },
     };
-    let pad_block = &content[pad_start..pad_end];
+    let match_all = match args.get("match_all") {
+        None | Some(serde_json::Value::Null) => false,
+        Some(value) => match value.as_bool() {
+            Some(match_all) => match_all,
+            None => {
+                return Ok(invalid_library_argument(
+                    "match_all",
+                    "must be a boolean when supplied",
+                ))
+            }
+        },
+    };
 
-    // Helper: replace or add a sub-expression within the pad block
+    let content = read_consistent(&path)?;
+    match parse_sexp(&content) {
+        Ok(root) if root.head() == Some("footprint") => {}
+        Ok(_) => {
+            return Ok(invalid_library_argument(
+                "footprint_path",
+                "file root must be a footprint",
+            ))
+        }
+        Err(error) => {
+            return Ok(invalid_library_argument(
+                "footprint_path",
+                format!("footprint is malformed: {error}"),
+            ))
+        }
+    }
+
+    let mut edits = Vec::new();
+    let mut matched_count = 0usize;
+    for (start, end) in find_direct_child_blocks(&content, "footprint") {
+        let block = &content[start..end];
+        let Ok(node) = parse_sexp(block) else {
+            return Ok(invalid_library_argument(
+                "footprint_path",
+                "footprint contains a malformed direct child",
+            ));
+        };
+        if node.head() != Some("pad") || node.get(1).and_then(SexpNode::as_str) != Some(pad_number)
+        {
+            continue;
+        }
+
+        matched_count += 1;
+        edits.push(SexpEdit::replace(
+            start,
+            end,
+            edit_footprint_pad_block(block, args, new_number),
+        ));
+        if !match_all {
+            break;
+        }
+    }
+
+    if matched_count == 0 {
+        return Ok(invalid_library_argument(
+            "pad_number",
+            format!("pad '{pad_number}' was not found"),
+        ));
+    }
+
+    let new_content = apply_edits(content.clone(), edits);
+    write_atomic_if_unchanged(&path, &content, &new_content)?;
+
+    Ok(CallToolResult::text(
+        serde_json::to_string(&json!({
+            "success": true,
+            "pad": pad_number,
+            "matched_count": matched_count,
+            "updated_count": matched_count
+        }))
+        .unwrap(),
+    ))
+}
+
+fn invalid_library_argument(field: &str, reason: impl Into<String>) -> CallToolResult {
+    let reason = reason.into();
+    CallToolResult::error_kind(
+        ToolErrorKind::InvalidArgument {
+            field: field.to_string(),
+            reason: reason.clone(),
+        },
+        format!("Argument '{field}' is invalid: {reason}"),
+    )
+}
+
+fn edit_footprint_pad_block(
+    pad_block: &str,
+    args: &serde_json::Value,
+    new_number: Option<&str>,
+) -> String {
     let mut new_pad = pad_block.to_string();
 
+    if let Some(number) = new_number {
+        if let Some(number_start) = new_pad.find('"') {
+            if let Some(number_end) = new_pad[number_start + 1..].find('"') {
+                let number_end = number_start + 1 + number_end;
+                new_pad.replace_range(number_start + 1..number_end, &escape_library_string(number));
+            }
+        }
+    }
+
     if let Some(x) = args["x"].as_f64() {
-        // Replace (at OLD_X OLD_Y [ROT]) → update X
         if let Some(at_pos) = new_pad.find("(at ") {
             let at_end = new_pad[at_pos..]
                 .find(')')
                 .map(|i| at_pos + i + 1)
                 .unwrap_or(new_pad.len());
             let at_block = &new_pad[at_pos..at_end];
-            // Parse existing values
             let parts: Vec<&str> = at_block
                 .trim_start_matches("(at ")
                 .trim_end_matches(')')
@@ -768,8 +854,7 @@ async fn handle_edit_footprint_pad(
                 .and_then(|s| s.parse::<f64>().ok())
                 .unwrap_or(0.0);
             let rot = parts.get(2).map(|s| format!(" {}", s)).unwrap_or_default();
-            let new_at = format!("(at {} {}{})", x, old_y, rot);
-            new_pad.replace_range(at_pos..at_end, &new_at);
+            new_pad.replace_range(at_pos..at_end, &format!("(at {} {}{})", x, old_y, rot));
         }
     }
     if let Some(y) = args["y"].as_f64() {
@@ -789,51 +874,36 @@ async fn handle_edit_footprint_pad(
                 .and_then(|s| s.parse::<f64>().ok())
                 .unwrap_or(0.0);
             let rot = parts.get(2).map(|s| format!(" {}", s)).unwrap_or_default();
-            let new_at = format!("(at {} {}{})", old_x, y, rot);
-            new_pad.replace_range(at_pos..at_end, &new_at);
+            new_pad.replace_range(at_pos..at_end, &format!("(at {} {}{})", old_x, y, rot));
         }
     }
-    if let (Some(w), Some(h)) = (args["width"].as_f64(), args["height"].as_f64()) {
-        if let Some(sz_pos) = new_pad.find("(size ") {
-            let sz_end = new_pad[sz_pos..]
+    if let (Some(width), Some(height)) = (args["width"].as_f64(), args["height"].as_f64()) {
+        if let Some(size_pos) = new_pad.find("(size ") {
+            let size_end = new_pad[size_pos..]
                 .find(')')
-                .map(|i| sz_pos + i + 1)
+                .map(|i| size_pos + i + 1)
                 .unwrap_or(new_pad.len());
-            let new_size = format!("(size {} {})", w, h);
-            new_pad.replace_range(sz_pos..sz_end, &new_size);
+            new_pad.replace_range(size_pos..size_end, &format!("(size {width} {height})"));
         }
     }
     if let Some(drill) = args["drill"].as_f64() {
-        if let Some(dr_pos) = new_pad.find("(drill ") {
-            let dr_end = new_pad[dr_pos..]
+        if let Some(drill_pos) = new_pad.find("(drill ") {
+            let drill_end = new_pad[drill_pos..]
                 .find(')')
-                .map(|i| dr_pos + i + 1)
+                .map(|i| drill_pos + i + 1)
                 .unwrap_or(new_pad.len());
-            let new_drill = format!("(drill {})", drill);
-            new_pad.replace_range(dr_pos..dr_end, &new_drill);
+            new_pad.replace_range(drill_pos..drill_end, &format!("(drill {drill})"));
         } else {
-            // Insert drill before closing paren of pad
             let insert_at = new_pad.rfind(')').unwrap_or(new_pad.len());
-            new_pad.insert_str(insert_at, &format!(" (drill {})", drill));
+            new_pad.insert_str(insert_at, &format!(" (drill {drill})"));
         }
     }
 
-    // Apply the pad block replacement
-    let new_content = format!(
-        "{}{}{}",
-        &content[..pad_start],
-        new_pad,
-        &content[pad_end..]
-    );
-    write_atomic(&path, &new_content)?;
+    new_pad
+}
 
-    Ok(CallToolResult::text(
-        serde_json::to_string(&json!({
-            "success": true,
-            "pad": pad_number
-        }))
-        .unwrap(),
-    ))
+fn escape_library_string(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 // ─── Library table helpers ────────────────────────────────────────────────────
@@ -3813,6 +3883,166 @@ mod tests {
             content.matches("(lib ").count(),
             1,
             "an already-registered nickname must not be duplicated: {content}"
+        );
+    }
+
+    const DUPLICATE_PAD_FOOTPRINT: &str = r#"(footprint "DualSocket"
+  (version 20240108)
+  (generator "pcbnew")
+  (layer "F.Cu")
+  (descr "preserve me")
+  (fp_line (start 0 0) (end 1 1) (stroke (width 0.1) (type default)) (layer "F.SilkS"))
+  (pad "3" thru_hole circle (at 1 2) (size 2 2) (drill 1) (layers "*.Cu" "*.Mask"))
+  (pad "3" thru_hole oval (at 3 4 90) (size 3 2) (drill oval 1 2) (layers "*.Cu" "*.Mask"))
+  (pad "1" thru_hole circle (at 5 6) (size 2 2) (drill 1) (layers "*.Cu" "*.Mask"))
+  (model "../models/keep.step"
+    (offset (xyz 0 0 0))
+    (scale (xyz 1 1 1))
+    (rotate (xyz 0 0 0)))
+)
+"#;
+
+    #[tokio::test]
+    async fn edit_footprint_pad_renumbers_only_the_first_duplicate_by_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("DualSocket.kicad_mod");
+        std::fs::write(&path, DUPLICATE_PAD_FOOTPRINT).unwrap();
+
+        let result = handle_edit_footprint_pad(
+            &json!({
+                "footprint_path": path,
+                "pad_number": "3",
+                "new_number": "1"
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.is_error, "{:?}", result.content);
+        let output: serde_json::Value = serde_json::from_str(&result_text(&result)).unwrap();
+        assert_eq!(output["matched_count"], 1);
+        assert_eq!(output["updated_count"], 1);
+
+        let updated = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(updated.matches("(pad \"3\"").count(), 1);
+        assert_eq!(updated.matches("(pad \"1\"").count(), 2);
+        assert!(
+            updated.contains("(pad \"1\" thru_hole circle (at 1 2) (size 2 2) (drill 1)"),
+            "the first duplicate should be renumbered: {updated}"
+        );
+        assert!(
+            updated.contains("(pad \"3\" thru_hole oval (at 3 4 90) (size 3 2) (drill oval 1 2)"),
+            "the second duplicate should remain unchanged: {updated}"
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_footprint_pad_renumbers_and_resizes_every_duplicate_atomically() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("DualSocket.kicad_mod");
+        std::fs::write(&path, DUPLICATE_PAD_FOOTPRINT).unwrap();
+
+        let result = handle_edit_footprint_pad(
+            &json!({
+                "footprint_path": path,
+                "pad_number": "3",
+                "new_number": "1",
+                "match_all": true,
+                "x": 9.5,
+                "width": 4.0,
+                "height": 5.0
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.is_error, "{:?}", result.content);
+        let output: serde_json::Value = serde_json::from_str(&result_text(&result)).unwrap();
+        assert_eq!(output["matched_count"], 2);
+        assert_eq!(output["updated_count"], 2);
+
+        let updated = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(updated.matches("(pad \"3\"").count(), 0);
+        assert_eq!(updated.matches("(pad \"1\"").count(), 3);
+        assert_eq!(updated.matches("(at 9.5 ").count(), 2);
+        assert_eq!(updated.matches("(size 4 5)").count(), 2);
+        assert!(updated.contains("(descr \"preserve me\")"));
+        assert!(updated.contains("(fp_line (start 0 0) (end 1 1)"));
+        assert!(updated.contains("(model \"../models/keep.step\""));
+        parse_sexp(&updated).expect("the edited footprint must remain parseable");
+    }
+
+    #[tokio::test]
+    async fn edit_footprint_pad_missing_match_returns_structured_error_without_writing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("DualSocket.kicad_mod");
+        std::fs::write(&path, DUPLICATE_PAD_FOOTPRINT).unwrap();
+
+        let result = handle_edit_footprint_pad(
+            &json!({
+                "footprint_path": path,
+                "pad_number": "404",
+                "new_number": "1",
+                "match_all": true
+            }),
+            &test_ctx(),
+        )
+        .await
+        .expect("a missing pad is a tool error, not a transport error");
+
+        assert!(result.is_error);
+        let output: serde_json::Value = serde_json::from_str(&result_text(&result)).unwrap();
+        assert_eq!(output["error"]["kind"], "invalid_argument");
+        assert_eq!(output["error"]["field"], "pad_number");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            DUPLICATE_PAD_FOOTPRINT
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_footprint_pad_rejects_non_string_new_number_without_writing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("DualSocket.kicad_mod");
+        std::fs::write(&path, DUPLICATE_PAD_FOOTPRINT).unwrap();
+
+        let result = handle_edit_footprint_pad(
+            &json!({
+                "footprint_path": path,
+                "pad_number": "3",
+                "new_number": 1
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_error);
+        let output: serde_json::Value = serde_json::from_str(&result_text(&result)).unwrap();
+        assert_eq!(output["error"]["kind"], "invalid_argument");
+        assert_eq!(output["error"]["field"], "new_number");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            DUPLICATE_PAD_FOOTPRINT
+        );
+    }
+
+    #[test]
+    fn edit_footprint_pad_schema_exposes_batch_renumbering_compatibly() {
+        let tool = tools()
+            .into_iter()
+            .find(|tool| tool.name == "edit_footprint_pad")
+            .expect("library must expose edit_footprint_pad");
+        let properties = &tool.input_schema["properties"];
+
+        assert_eq!(properties["new_number"]["type"], "string");
+        assert_eq!(properties["match_all"]["type"], "boolean");
+        assert_eq!(properties["match_all"]["default"], false);
+        assert_eq!(
+            tool.input_schema["required"],
+            json!(["footprint_path", "pad_number"])
         );
     }
 

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -11,7 +11,7 @@ use konnect_schematic_editor::types::fmt_f64;
 use konnect_sexp::parser::{parse_sexp, SexpNode};
 use konnect_sexp::writer::{
     apply_edits, find_balanced_block, find_block_starts, find_direct_child_blocks, read_consistent,
-    write_atomic, write_atomic_if_unchanged, SexpEdit,
+    write_atomic, write_atomic_if_unchanged, write_new_atomic, SexpEdit,
 };
 use serde_json::json;
 use std::path::{Path, PathBuf};
@@ -136,7 +136,12 @@ pub fn tools() -> Vec<ToolDef> {
                         "description": "Scope: 'global' or 'project'",
                         "default": "project"
                     },
-                    "project": { "type": "string", "description": "Path to .kicad_pro file (required for project scope)" }
+                    "project": { "type": "string", "description": "Path to .kicad_pro file (required for project scope)" },
+                    "replace_existing": {
+                        "type": "boolean",
+                        "description": "Replace the URI of an existing nickname instead of leaving it unchanged",
+                        "default": false
+                    }
                 },
                 "required": ["library_path", "nickname"]
             }),
@@ -1422,6 +1427,18 @@ async fn handle_register_footprint_library(
         Err(e) => return Ok(e),
     };
     let scope = args["scope"].as_str().unwrap_or("project");
+    let replace_existing = match args.get("replace_existing") {
+        None | Some(serde_json::Value::Null) => false,
+        Some(value) => match value.as_bool() {
+            Some(value) => value,
+            None => {
+                return Ok(invalid_library_argument(
+                    "replace_existing",
+                    "must be a boolean when supplied",
+                ))
+            }
+        },
+    };
 
     let (table_path, uri) = match lib_table_target(
         scope,
@@ -1434,7 +1451,18 @@ async fn handle_register_footprint_library(
         Err(e) => return Ok(e),
     };
 
-    let repaired_root = register_in_lib_table(&table_path, nickname, &uri, "KiCad").await?;
+    let registration = match register_in_lib_table_with_policy(
+        &table_path,
+        nickname,
+        &uri,
+        "KiCad",
+        replace_existing,
+    )
+    .await?
+    {
+        Ok(registration) => registration,
+        Err(error) => return Ok(invalid_library_argument(&error.field, error.reason)),
+    };
 
     Ok(CallToolResult::text(
         serde_json::to_string(&json!({
@@ -1442,7 +1470,9 @@ async fn handle_register_footprint_library(
             "nickname": nickname,
             "scope": scope,
             "table": table_path.to_str().unwrap_or(""),
-            "repaired_table_root": repaired_root
+            "uri": uri,
+            "state": registration.state.as_str(),
+            "repaired_table_root": registration.repaired_root
         }))
         .unwrap(),
     ))
@@ -1542,6 +1572,61 @@ fn project_relative_uri(lib_path: &Path, table_dir: &Path) -> String {
     }
 }
 
+fn repository_relative_uri(
+    lib_path: &Path,
+    table_dir: &Path,
+    project_path: &Path,
+) -> Option<String> {
+    if !project_path.is_file()
+        || project_path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            != Some("kicad_pro")
+    {
+        return None;
+    }
+    let repository = table_dir
+        .ancestors()
+        .find(|ancestor| ancestor.join(".git").exists())?;
+    let repository = std::fs::canonicalize(repository).ok()?;
+    let table_dir = std::fs::canonicalize(table_dir).ok()?;
+    let library = std::fs::canonicalize(lib_path).ok()?;
+    if !table_dir.starts_with(&repository) || !library.starts_with(&repository) {
+        return None;
+    }
+    let relative = lexical_relative_path(&table_dir, &library)?;
+    Some(format!("${{KIPRJMOD}}/{}", portable_uri(&relative)))
+}
+
+fn lexical_relative_path(from: &Path, to: &Path) -> Option<PathBuf> {
+    use std::path::Component;
+
+    let from_components: Vec<_> = from.components().collect();
+    let to_components: Vec<_> = to.components().collect();
+    if from_components.first() != to_components.first() {
+        return None;
+    }
+    let common = from_components
+        .iter()
+        .zip(&to_components)
+        .take_while(|(left, right)| left == right)
+        .count();
+    if common == 0 {
+        return None;
+    }
+
+    let mut relative = PathBuf::new();
+    for component in &from_components[common..] {
+        if matches!(component, Component::Normal(_)) {
+            relative.push("..");
+        }
+    }
+    for component in &to_components[common..] {
+        relative.push(component.as_os_str());
+    }
+    Some(relative)
+}
+
 /// Which lib-table a `register_*` call writes to, and the URI it records.
 ///
 /// Shared by the symbol and footprint registrars so the two cannot drift: both
@@ -1569,6 +1654,11 @@ fn lib_table_target(
         .unwrap_or(Path::new("."))
         .to_path_buf();
     let uri = project_relative_uri(lib_path, &table_dir);
+    let uri = if uri.starts_with("${KIPRJMOD}") {
+        uri
+    } else {
+        repository_relative_uri(lib_path, &table_dir, Path::new(proj)).unwrap_or(uri)
+    };
     Ok((table_dir.join(table_filename), uri))
 }
 
@@ -1702,57 +1792,216 @@ fn repair_table_root(content: String, expected_root: &str) -> (String, bool) {
     }
 }
 
-/// Insert a new `(lib ...)` entry into a lib-table file (fp-lib-table or sym-lib-table).
-/// Creates the file with minimal scaffolding if it doesn't exist, and repairs a
-/// mismatched root element on an existing one.
-///
-/// Returns whether the root element had to be repaired.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LibTableRegistrationState {
+    Inserted,
+    Unchanged,
+    Updated,
+}
+
+impl LibTableRegistrationState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Inserted => "inserted",
+            Self::Unchanged => "unchanged",
+            Self::Updated => "updated",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LibTableRegistration {
+    state: LibTableRegistrationState,
+    repaired_root: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LibTableRegistrationError {
+    field: String,
+    reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PreparedLibTableRegistration {
+    content: String,
+    registration: LibTableRegistration,
+}
+
 async fn register_in_lib_table(
     table_path: &Path,
     nickname: &str,
     uri: &str,
     lib_type: &str,
 ) -> anyhow::Result<bool> {
-    // The root element must match the table kind: a sym-lib-table with an
-    // (fp_lib_table root is rejected by KiCad. Decide from the filename, which
-    // is fixed by convention.
+    let registration =
+        register_in_lib_table_with_policy(table_path, nickname, uri, lib_type, false)
+            .await?
+            .map_err(|error| anyhow::anyhow!(error.reason))?;
+    Ok(registration.repaired_root)
+}
+
+async fn register_in_lib_table_with_policy(
+    table_path: &Path,
+    nickname: &str,
+    uri: &str,
+    lib_type: &str,
+    replace_existing: bool,
+) -> anyhow::Result<Result<LibTableRegistration, LibTableRegistrationError>> {
     let root = table_root_element(table_path);
-    let (content, repaired_root) = if table_path.exists() {
-        repair_table_root(tokio::fs::read_to_string(table_path).await?, root)
+    let existing = table_path.exists();
+    let source = if existing {
+        read_consistent(table_path)?
     } else {
-        (format!("({root}\n  (version 7)\n)\n"), false)
+        format!("({root}\n  (version 7)\n)\n")
     };
-    if repaired_root {
+    let prepared = match prepare_lib_table_registration(
+        &source,
+        root,
+        nickname,
+        uri,
+        lib_type,
+        replace_existing,
+    ) {
+        Ok(prepared) => prepared,
+        Err(error) => return Ok(Err(error)),
+    };
+    if prepared.registration.repaired_root {
         tracing::warn!(
             "Repaired the root element of {} — it declared the wrong table kind, so KiCad was skipping the whole table",
             table_path.display()
         );
     }
 
-    // Check if nickname already registered
-    if content.contains(&format!("(name \"{}\")", nickname)) {
-        // Idempotent — but a repaired root still has to reach disk, or a table
-        // that already lists this nickname stays rejected forever.
-        if repaired_root {
-            write_atomic(table_path, &content)?;
+    if prepared.content != source {
+        if let Some(parent) = table_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
         }
-        return Ok(repaired_root);
+        if existing {
+            persist_lib_table_registration(table_path, &source, &prepared.content)?;
+        } else {
+            write_new_atomic(table_path, &prepared.content)?;
+        }
+    }
+    Ok(Ok(prepared.registration))
+}
+
+fn prepare_lib_table_registration(
+    source: &str,
+    expected_root: &str,
+    nickname: &str,
+    uri: &str,
+    lib_type: &str,
+    replace_existing: bool,
+) -> Result<PreparedLibTableRegistration, LibTableRegistrationError> {
+    let (content, repaired_root) = repair_table_root(source.to_string(), expected_root);
+    let parsed = parse_sexp(&content).map_err(|error| LibTableRegistrationError {
+        field: "table".to_string(),
+        reason: format!("invalid library table S-expression: {error}"),
+    })?;
+    if parsed.head() != Some(expected_root) {
+        return Err(LibTableRegistrationError {
+            field: "table".to_string(),
+            reason: format!("root must be {expected_root}"),
+        });
     }
 
-    // Find closing paren of the root expression
-    let insert_pos = content.rfind(')').unwrap_or(content.len());
-    let entry = format!(
-        "\n  (lib (name \"{}\") (type \"{}\") (uri \"{}\") (options \"\") (descr \"\"))",
-        nickname, lib_type, uri
-    );
-
-    let new_content = format!("{}{}\n)", &content[..insert_pos], entry);
-
-    if let Some(parent) = table_path.parent() {
-        tokio::fs::create_dir_all(parent).await?;
+    let mut matches = Vec::new();
+    for (start, end) in find_direct_child_blocks(&content, expected_root) {
+        let block = &content[start..end];
+        let node = parse_sexp(block).map_err(|_| LibTableRegistrationError {
+            field: "table".to_string(),
+            reason: "contains a malformed direct child".to_string(),
+        })?;
+        if node.head() == Some("lib") && node.find_str("name") == Some(nickname) {
+            matches.push((start, end));
+        }
     }
-    write_atomic(table_path, &new_content)?;
-    Ok(repaired_root)
+    if matches.len() > 1 {
+        return Err(LibTableRegistrationError {
+            field: "nickname".to_string(),
+            reason: format!("library table contains duplicate nickname '{nickname}'"),
+        });
+    }
+
+    let (content, state) = if let Some((start, end)) = matches.first().copied() {
+        if !replace_existing {
+            (content, LibTableRegistrationState::Unchanged)
+        } else {
+            let block = &content[start..end];
+            let current_uri = parse_sexp(block)
+                .ok()
+                .and_then(|node| node.find_str("uri").map(str::to_string))
+                .ok_or_else(|| LibTableRegistrationError {
+                    field: "table".to_string(),
+                    reason: format!("entry '{nickname}' has no valid uri"),
+                })?;
+            if current_uri == uri {
+                (content, LibTableRegistrationState::Unchanged)
+            } else {
+                let uri_range = find_direct_child_blocks(block, "lib")
+                    .into_iter()
+                    .find(|(child_start, child_end)| {
+                        parse_sexp(&block[*child_start..*child_end])
+                            .is_ok_and(|node| node.head() == Some("uri"))
+                    })
+                    .ok_or_else(|| LibTableRegistrationError {
+                        field: "table".to_string(),
+                        reason: format!("entry '{nickname}' has no uri block"),
+                    })?;
+                let replacement = format!("(uri {})", quote_lib_table_string(uri));
+                let updated = apply_edits(
+                    content,
+                    vec![SexpEdit::replace(
+                        start + uri_range.0,
+                        start + uri_range.1,
+                        replacement,
+                    )],
+                );
+                (updated, LibTableRegistrationState::Updated)
+            }
+        }
+    } else {
+        let root_end = find_balanced_block(&content, 0)
+            .map(|range| range.1 - 1)
+            .ok_or_else(|| LibTableRegistrationError {
+                field: "table".to_string(),
+                reason: "unbalanced library table root".to_string(),
+            })?;
+        let entry = format!(
+            "\n  (lib (name {}) (type {}) (uri {}) (options \"\") (descr \"\"))",
+            quote_lib_table_string(nickname),
+            quote_lib_table_string(lib_type),
+            quote_lib_table_string(uri)
+        );
+        (
+            apply_edits(content, vec![SexpEdit::insert(root_end, entry)]),
+            LibTableRegistrationState::Inserted,
+        )
+    };
+
+    parse_sexp(&content).map_err(|error| LibTableRegistrationError {
+        field: "table".to_string(),
+        reason: format!("updated library table does not parse: {error}"),
+    })?;
+    Ok(PreparedLibTableRegistration {
+        content,
+        registration: LibTableRegistration {
+            state,
+            repaired_root,
+        },
+    })
+}
+
+fn quote_lib_table_string(value: &str) -> String {
+    format!("\"{}\"", escape_library_string(value))
+}
+
+fn persist_lib_table_registration(
+    table_path: &Path,
+    expected: &str,
+    replacement: &str,
+) -> Result<(), konnect_sexp::SexpError> {
+    write_atomic_if_unchanged(table_path, expected, replacement)
 }
 
 // ─── Symbol library tools ─────────────────────────────────────────────────────
@@ -3886,6 +4135,129 @@ mod tests {
             1,
             "an already-registered nickname must not be duplicated: {content}"
         );
+    }
+
+    #[test]
+    fn register_footprint_library_schema_exposes_opt_in_replacement() {
+        let registration = tools()
+            .into_iter()
+            .find(|tool| tool.name == "register_footprint_library")
+            .expect("library must expose register_footprint_library");
+        let replace = &registration.input_schema["properties"]["replace_existing"];
+
+        assert_eq!(replace["type"], "boolean");
+        assert_eq!(replace["default"], false);
+        assert_eq!(
+            registration.input_schema["required"],
+            json!(["library_path", "nickname"])
+        );
+    }
+
+    #[tokio::test]
+    async fn register_footprint_library_keeps_existing_uri_by_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("test").join("board.kicad_pro");
+        std::fs::create_dir_all(project.parent().unwrap()).unwrap();
+        let table = project.parent().unwrap().join("fp-lib-table");
+        let original = "(fp_lib_table\n  (version 7)\n  (lib (name \"Parts\") (type \"KiCad\") (uri \"C:/stale/Parts.pretty\") (options \"keep=1\") (descr \"keep me\"))\n)\n";
+        std::fs::write(&table, original).unwrap();
+
+        let result = handle_register_footprint_library(
+            &json!({
+                "library_path": tmp.path().join("lib").join("Parts.pretty"),
+                "nickname": "Parts",
+                "project": project
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.is_error, "{:?}", result.content);
+        let output: serde_json::Value = serde_json::from_str(&result_text(&result)).unwrap();
+        assert_eq!(output["state"], "unchanged");
+        assert_eq!(std::fs::read_to_string(table).unwrap(), original);
+    }
+
+    #[tokio::test]
+    async fn register_footprint_library_replaces_uri_portably_and_preserves_entry_metadata() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        let project = tmp.path().join("test").join("board.kicad_pro");
+        std::fs::create_dir_all(project.parent().unwrap()).unwrap();
+        std::fs::write(&project, "{}").unwrap();
+        let library = tmp.path().join("lib").join("Parts.pretty");
+        std::fs::create_dir_all(&library).unwrap();
+        let table = project.parent().unwrap().join("fp-lib-table");
+        let original = "(fp_lib_table\n\t(version 7)\n\t(lib (name \"Other\") (type \"KiCad\") (uri \"${KIPRJMOD}/other.pretty\") (options \"\") (descr \"other\"))\n\t(lib (name \"Parts\") (type \"KiCad\") (uri \"C:/stale/Parts.pretty\") (options \"keep=1\") (descr \"keep me\"))\n)\n";
+        std::fs::write(&table, original).unwrap();
+
+        let result = handle_register_footprint_library(
+            &json!({
+                "library_path": library,
+                "nickname": "Parts",
+                "project": project,
+                "replace_existing": true
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.is_error, "{:?}", result.content);
+        let output: serde_json::Value = serde_json::from_str(&result_text(&result)).unwrap();
+        assert_eq!(output["state"], "updated");
+        assert_eq!(output["uri"], "${KIPRJMOD}/../lib/Parts.pretty");
+
+        let updated = std::fs::read_to_string(table).unwrap();
+        assert!(updated.starts_with("(fp_lib_table\n\t(version 7)"));
+        assert!(updated
+            .contains("(name \"Other\") (type \"KiCad\") (uri \"${KIPRJMOD}/other.pretty\")"));
+        assert!(updated.contains("(name \"Parts\") (type \"KiCad\") (uri \"${KIPRJMOD}/../lib/Parts.pretty\") (options \"keep=1\") (descr \"keep me\")"));
+        assert!(!updated.contains("C:/stale"));
+    }
+
+    #[tokio::test]
+    async fn register_footprint_library_rejects_duplicate_nicknames_without_writing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("board.kicad_pro");
+        let table = tmp.path().join("fp-lib-table");
+        let duplicate = "(fp_lib_table\n  (version 7)\n  (lib (name \"Parts\") (type \"KiCad\") (uri \"/one\") (options \"\") (descr \"\"))\n  (lib (name \"Parts\") (type \"KiCad\") (uri \"/two\") (options \"\") (descr \"\"))\n)\n";
+        std::fs::write(&table, duplicate).unwrap();
+
+        let result = handle_register_footprint_library(
+            &json!({
+                "library_path": tmp.path().join("Parts.pretty"),
+                "nickname": "Parts",
+                "project": project,
+                "replace_existing": true
+            }),
+            &test_ctx(),
+        )
+        .await
+        .expect("a malformed table is a tool error, not a transport error");
+
+        assert!(result.is_error);
+        let output: serde_json::Value = serde_json::from_str(&result_text(&result)).unwrap();
+        assert_eq!(output["error"]["kind"], "invalid_argument");
+        assert_eq!(output["error"]["field"], "nickname");
+        assert_eq!(std::fs::read_to_string(table).unwrap(), duplicate);
+    }
+
+    #[test]
+    fn stale_library_table_source_is_rejected_without_overwriting_newer_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let table = tmp.path().join("fp-lib-table");
+        let original = "(fp_lib_table\n  (version 7)\n)\n";
+        std::fs::write(&table, original).unwrap();
+        let prepared = "(fp_lib_table\n  (version 7)\n  (lib (name \"Parts\") (type \"KiCad\") (uri \"/parts\") (options \"\") (descr \"\"))\n)\n";
+        let newer = "(fp_lib_table\n  (version 7)\n  (lib (name \"Other\") (type \"KiCad\") (uri \"/other\") (options \"\") (descr \"\"))\n)\n";
+        std::fs::write(&table, newer).unwrap();
+
+        let error = persist_lib_table_registration(&table, original, prepared)
+            .expect_err("a stale expected table must conflict");
+        assert!(matches!(error, konnect_sexp::SexpError::Conflict { .. }));
+        assert_eq!(std::fs::read_to_string(table).unwrap(), newer);
     }
 
     const DUPLICATE_PAD_FOOTPRINT: &str = r#"(footprint "DualSocket"

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -349,6 +349,7 @@ pub fn tools() -> Vec<ToolDef> {
         ),
     ];
     tools.insert(2, super::footprint_graphics::tool());
+    tools.insert(3, super::footprint_metadata::tool());
     tools
 }
 

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -50,7 +50,7 @@ fn pin_item_schema(type_desc: &str, require_xy: bool) -> serde_json::Value {
 }
 
 pub fn tools() -> Vec<ToolDef> {
-    vec![
+    let mut tools = vec![
         tool!(
             "create_footprint",
             "Create a new footprint (.kicad_mod) file from a pad layout description.",
@@ -337,7 +337,9 @@ pub fn tools() -> Vec<ToolDef> {
             }),
             |args, ctx| async move { handle_get_symbol_info(args, ctx).await }
         ),
-    ]
+    ];
+    tools.insert(2, super::footprint_graphics::tool());
+    tools
 }
 
 // ─── Handlers ─────────────────────────────────────────────────────────────────

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod design_review;
 mod footprint_graphics;
 mod footprint_metadata;
+mod footprint_models;
 pub mod integration;
 pub mod library;
 pub mod manufacturing;

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -3,6 +3,8 @@
 pub mod cli;
 pub mod config;
 pub mod design_review;
+#[allow(dead_code)]
+mod footprint_graphics;
 pub mod integration;
 pub mod library;
 pub mod manufacturing;

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -3,7 +3,6 @@
 pub mod cli;
 pub mod config;
 pub mod design_review;
-#[allow(dead_code)]
 mod footprint_graphics;
 pub mod integration;
 pub mod library;

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -4,6 +4,7 @@ pub mod cli;
 pub mod config;
 pub mod design_review;
 mod footprint_graphics;
+mod footprint_metadata;
 pub mod integration;
 pub mod library;
 pub mod manufacturing;

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -11,7 +11,8 @@ use crate::tools::{get_path, require_f64, require_str, ToolContext, ToolDef};
 use anyhow::Context;
 use konnect_ipc::client::KiCadIpcClient;
 use konnect_sexp::writer::{
-    apply_edits, find_balanced_block, find_block_starts, new_uuid, write_atomic,
+    apply_edits, find_balanced_block, find_block_starts, new_uuid, read_consistent,
+    write_atomic_if_unchanged,
 };
 use konnect_sexp::SexpEdit;
 use serde_json::json;
@@ -147,6 +148,15 @@ fn replace_quoted_after(source: &mut String, marker: &str, value: &str) -> anyho
     Ok(())
 }
 
+fn replace_reference(source: &mut String, reference: &str) -> anyhow::Result<()> {
+    for marker in ["(property \"Reference\" \"", "(fp_text reference \""] {
+        if source.contains(marker) {
+            return replace_quoted_after(source, marker, reference);
+        }
+    }
+    anyhow::bail!("footprint library data has no Reference property or fp_text")
+}
+
 #[allow(clippy::too_many_arguments)]
 fn prepare_footprint_source(
     source: &str,
@@ -170,7 +180,7 @@ fn prepare_footprint_source(
     }
     let mut prepared = source.to_string();
     replace_quoted_after(&mut prepared, "(footprint \"", lib_id)?;
-    replace_quoted_after(&mut prepared, "(property \"Reference\" \"", reference)?;
+    replace_reference(&mut prepared, reference)?;
     if let Some(value) = value {
         replace_quoted_after(&mut prepared, "(property \"Value\" \"", value)?;
     }
@@ -545,7 +555,7 @@ fn board_footprint_sexp(
         out = apply_rotation_to_children(&out, rotation);
     }
     if let Some(reference) = reference {
-        out = replace_property_value(&out, "Reference", reference);
+        replace_reference(&mut out, reference).map_err(|error| error.to_string())?;
     }
     if layer != "F.Cu" {
         out = replace_footprint_layer(&out, layer);
@@ -715,32 +725,6 @@ fn quote_sexp_string(value: &str) -> String {
     format!("\"{}\"", escape_sexp_string(value))
 }
 
-/// Replace the value of the first `(property "<key>" "<value>" …)` entry.
-fn replace_property_value(content: &str, key: &str, value: &str) -> String {
-    let needle = format!("(property \"{key}\"");
-    let Some(prop) = find_block_starts(content, "property")
-        .into_iter()
-        .find(|&i| content[i..].starts_with(&needle))
-    else {
-        return content.to_string();
-    };
-    let after_key = prop + needle.len();
-    let Some(rel) = content[after_key..].find('"') else {
-        return content.to_string();
-    };
-    let vstart = after_key + rel;
-    let Some(rel_end) = content[vstart + 1..].find('"') else {
-        return content.to_string();
-    };
-    let vend = vstart + 1 + rel_end + 1;
-
-    let mut out = String::with_capacity(content.len());
-    out.push_str(&content[..vstart]);
-    out.push_str(&quote_sexp_string(value));
-    out.push_str(&content[vend..]);
-    out
-}
-
 /// Replace the footprint's own `(layer "…")` — the first `layer` block that is a
 /// direct child of the footprint, not one belonging to a pad or graphic.
 ///
@@ -782,7 +766,21 @@ fn replace_footprint_layer(content: &str, layer: &str) -> String {
 /// `.kicad_pcb`, and no reader in this workspace understands them either, so
 /// the assumption is at least consistent.
 fn insert_into_board(board_path: &Path, blocks: &[String]) -> anyhow::Result<()> {
-    let content = std::fs::read_to_string(board_path)?;
+    let content = read_consistent(board_path)?;
+    let existing_references = footprint_references(&content)?;
+    let mut inserted_references = HashSet::new();
+    for block in blocks {
+        for reference in footprint_references(block)? {
+            if existing_references.contains(&reference)
+                || !inserted_references.insert(reference.clone())
+            {
+                anyhow::bail!(
+                    "Footprint reference '{}' already exists on the board",
+                    reference
+                );
+            }
+        }
+    }
     // KiCad writes these files CRLF on Windows — its bundled .kicad_mod
     // libraries are CRLF throughout — so an inserted block joined with bare LF
     // would leave the board with two conventions in it.
@@ -796,7 +794,7 @@ fn insert_into_board(board_path: &Path, blocks: &[String]) -> anyhow::Result<()>
         .iter()
         .map(|b| format!("{eol}{}", indent_block(b.trim_end(), "\t", eol)))
         .collect();
-    let new_content = apply_edits(content, vec![SexpEdit::insert(close_pos, joined)]);
+    let new_content = apply_edits(content.clone(), vec![SexpEdit::insert(close_pos, joined)]);
 
     if let Err(why) = check_single_board_form(&new_content) {
         anyhow::bail!(
@@ -806,8 +804,66 @@ fn insert_into_board(board_path: &Path, blocks: &[String]) -> anyhow::Result<()>
         );
     }
 
-    write_atomic(board_path, &new_content)?;
+    persist_board_replacement(board_path, &content, &new_content)?;
     Ok(())
+}
+
+fn footprint_references(content: &str) -> anyhow::Result<HashSet<String>> {
+    let root = konnect_sexp::parse_sexp(content)?;
+    let footprints: Vec<&konnect_sexp::SexpNode> = if root.head() == Some("footprint") {
+        vec![&root]
+    } else if root.head() == Some("kicad_pcb") {
+        root.find_all("footprint")
+    } else {
+        anyhow::bail!("expected a footprint or kicad_pcb root");
+    };
+
+    Ok(footprints
+        .into_iter()
+        .filter_map(footprint_reference)
+        .collect())
+}
+
+fn board_contains_reference(board_path: &Path, reference: &str) -> anyhow::Result<bool> {
+    let content = read_consistent(board_path)?;
+    if let Err(reason) = check_single_board_form(&content) {
+        anyhow::bail!(
+            "Refusing to read {}: {}. The board file is not balanced and was left untouched.",
+            board_path.display(),
+            reason
+        );
+    }
+    Ok(footprint_references(&content)?.contains(reference))
+}
+
+fn footprint_reference(footprint: &konnect_sexp::SexpNode) -> Option<String> {
+    footprint
+        .find_all("property")
+        .into_iter()
+        .find(|property| {
+            property.get(1).and_then(konnect_sexp::SexpNode::as_str) == Some("Reference")
+        })
+        .and_then(|property| property.get(2))
+        .and_then(konnect_sexp::SexpNode::as_str)
+        .or_else(|| {
+            footprint
+                .find_all("fp_text")
+                .into_iter()
+                .find(|text| {
+                    text.get(1).and_then(konnect_sexp::SexpNode::as_str) == Some("reference")
+                })
+                .and_then(|text| text.get(2))
+                .and_then(konnect_sexp::SexpNode::as_str)
+        })
+        .map(str::to_string)
+}
+
+fn persist_board_replacement(
+    board_path: &Path,
+    expected: &str,
+    replacement: &str,
+) -> Result<(), konnect_sexp::SexpError> {
+    write_atomic_if_unchanged(board_path, expected, replacement)
 }
 
 /// Verify `content` is exactly one `(kicad_pcb …)` form and nothing else.
@@ -863,7 +919,8 @@ pub fn tools() -> Vec<ToolDef> {
     vec![
         tool!(
             "place_component",
-            "Place a footprint on the PCB at the given position and layer via KiCAD IPC.",
+            "Place a footprint on the PCB. Uses live KiCAD IPC when reachable; otherwise safely \
+             edits a closed board file with revision checks.",
             json!({
                 "type": "object",
                 "properties": {
@@ -1156,6 +1213,17 @@ async fn handle_place_component(
         Err(konnect_ipc::IpcFailure::Unreachable(_)) => {
             // No live KiCad on the other end of this transport: fall back to
             // editing the board file directly.
+            if board_contains_reference(&board, &reference)? {
+                return Ok(CallToolResult::error_kind(
+                    crate::mcp::error::ToolErrorKind::InvalidArgument {
+                        field: "reference".to_string(),
+                        reason: format!(
+                            "footprint reference '{reference}' already exists on the board"
+                        ),
+                    },
+                    format!("Footprint reference '{reference}' already exists on the board"),
+                ));
+            }
             let sexp = match board_footprint_sexp(
                 &footprint,
                 x,
@@ -1970,6 +2038,38 @@ mod tests {
         board
     }
 
+    fn legacy_fallback_fixture(dir: &Path) -> std::path::PathBuf {
+        let pretty = dir.join("Legacy.pretty");
+        std::fs::create_dir_all(&pretty).unwrap();
+        std::fs::write(
+            pretty.join("Socket.kicad_mod"),
+            r#"(footprint "Socket" (version 20221018) (generator pcbnew)
+  (layer "F.Cu")
+  (attr exclude_from_pos_files)
+  (fp_text reference "REF**" (at 0 -8.5) (layer "F.SilkS"))
+  (fp_text value "Socket" (at 0 8.5) (layer "F.Fab"))
+  (pad "1" thru_hole circle (at 0 0) (size 4 4) (drill 3) (layers "*.Cu" "*.Mask"))
+  (model "../models/Socket.step"
+    (offset (xyz 0 0 0))
+    (scale (xyz 1 1 1))
+    (rotate (xyz 0 0 0)))
+)
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("fp-lib-table"),
+            format!(
+                "(fp_lib_table\n  (version 7)\n  (lib (name \"Legacy\") (type \"KiCad\") (uri \"{}\") (options \"\") (descr \"\"))\n)\n",
+                pretty.to_string_lossy()
+            ),
+        )
+        .unwrap();
+        let board = dir.join("legacy.kicad_pcb");
+        std::fs::write(&board, EMPTY_BOARD).unwrap();
+        board
+    }
+
     /// Net paren depth, ignoring anything inside quoted strings.
     fn count_parens(s: &str) -> i32 {
         let (mut depth, mut in_str, mut esc) = (0i32, false, false);
@@ -2041,6 +2141,91 @@ mod tests {
             0,
             "board is no longer balanced:\n{written}"
         );
+    }
+
+    #[tokio::test]
+    async fn fallback_replaces_legacy_fp_text_reference_and_preserves_models_and_attributes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let board = legacy_fallback_fixture(tmp.path());
+        let args = json!({
+            "board": board.to_string_lossy(),
+            "footprint": "Legacy:Socket",
+            "reference": "SW1",
+            "x": 20.0,
+            "y": 30.0,
+        });
+
+        let result = handle_place_component(&args, &test_ctx()).await.unwrap();
+
+        assert!(!result.is_error, "{:?}", result.content);
+        let written = std::fs::read_to_string(&board).unwrap();
+        assert!(written.contains("(fp_text reference \"SW1\""), "{written}");
+        assert!(!written.contains("REF**"), "{written}");
+        assert!(
+            written.contains("(attr exclude_from_pos_files)"),
+            "{written}"
+        );
+        assert!(
+            written.contains("(model \"../models/Socket.step\""),
+            "{written}"
+        );
+        assert!(konnect_sexp::parse_sexp(&written).is_ok());
+    }
+
+    #[tokio::test]
+    async fn fallback_rejects_a_duplicate_reference_without_writing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let board = fallback_fixture(tmp.path());
+        let args = json!({
+            "board": board.to_string_lossy(),
+            "footprint": "Resistor_SMD:R_0805_2012Metric",
+            "reference": "R1",
+            "x": 10.0,
+            "y": 20.0,
+        });
+        let first = handle_place_component(&args, &test_ctx()).await.unwrap();
+        assert!(!first.is_error, "{:?}", first.content);
+        let before_duplicate = std::fs::read_to_string(&board).unwrap();
+
+        let duplicate = handle_place_component(
+            &json!({
+                "board": board.to_string_lossy(),
+                "footprint": "Resistor_SMD:R_0805_2012Metric",
+                "reference": "R1",
+                "x": 30.0,
+                "y": 40.0,
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        assert!(duplicate.is_error);
+        assert!(
+            result_text(&duplicate).contains("already exists"),
+            "{:?}",
+            duplicate.content
+        );
+        assert_eq!(std::fs::read_to_string(board).unwrap(), before_duplicate);
+    }
+
+    #[test]
+    fn stale_board_source_is_rejected_without_overwriting_newer_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let board = tmp.path().join("board.kicad_pcb");
+        std::fs::write(&board, EMPTY_BOARD).unwrap();
+        let replacement = EMPTY_BOARD.replace(
+            "\n)\n",
+            "\n\t(footprint \"Legacy:Socket\" (layer \"F.Cu\"))\n)\n",
+        );
+        let newer = EMPTY_BOARD.replace("(net 0 \"\")", "(net 0 \"\")\n\t(net 1 \"GND\")");
+        std::fs::write(&board, &newer).unwrap();
+
+        let error = persist_board_replacement(&board, EMPTY_BOARD, &replacement)
+            .expect_err("a stale expected board must conflict");
+
+        assert!(matches!(error, konnect_sexp::SexpError::Conflict { .. }));
+        assert_eq!(std::fs::read_to_string(board).unwrap(), newer);
     }
 
     #[tokio::test]
@@ -2383,7 +2568,8 @@ mod tests {
 
     #[test]
     fn reference_substitution_targets_the_reference_property_only() {
-        let out = replace_property_value(&library_footprint(), "Reference", "R42");
+        let mut out = library_footprint();
+        replace_reference(&mut out, "R42").unwrap();
         assert!(out.contains("(property \"Reference\" \"R42\""), "{out}");
         assert!(
             out.contains("(property \"Value\" \"R_0805_2012Metric\""),

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -1498,6 +1498,12 @@ mod batch_place_and_connect_tests {
             1,
             "lib_symbols entry must not be duplicated: {after}"
         );
+        assert!(
+            !after
+                .lines()
+                .any(|line| line.ends_with(' ') || line.ends_with('\t')),
+            "batch placement must not leave trailing whitespace: {after:?}"
+        );
     }
 
     #[tokio::test]
@@ -1793,6 +1799,12 @@ mod connect_to_net_orientation_tests {
             ("89.84 100 180".into(), "right bottom".into())
         );
         assert!(konnect_sexp::parse_sexp(&after).is_ok(), "{after}");
+        assert!(
+            !after
+                .lines()
+                .any(|line| line.ends_with(' ') || line.ends_with('\t')),
+            "label insertion must not leave the symbol line's indent behind: {after:?}"
+        );
     }
 
     #[tokio::test]
@@ -2180,6 +2192,15 @@ mod insert_order_tests {
         assert!(
             label < inst,
             "a label after the instances makes the file unloadable:\n{out}"
+        );
+        assert!(
+            !out.contains(")(symbol"),
+            "elements must not be glued: {out}"
+        );
+        assert!(
+            !out.lines()
+                .any(|line| line.ends_with(' ') || line.ends_with('\t')),
+            "insertion must consume the target line's indent: {out:?}"
         );
     }
 

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -1872,6 +1872,11 @@ mod tests {
             sym.has_instance_path("amp", &format!("/{}", root_uuid)),
             "instance path must be /<root-uuid> under the file-stem project name"
         );
+        assert!(
+            !raw.lines()
+                .any(|line| line.ends_with(' ') || line.ends_with('\t')),
+            "component placement must not leave trailing whitespace: {raw:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -379,9 +379,19 @@ pub fn tools() -> Vec<ToolDef> {
 
 pub(crate) fn insert_before_close(content: &str, new_sexp: &str) -> String {
     // Find the first top-level (symbol block — insert before it
-    let insert_pos = find_first_symbol_instance(content)
+    let item_pos = find_first_symbol_instance(content)
         .unwrap_or_else(|| content.rfind(')').unwrap_or(content.len()));
-    let edits = vec![SexpEdit::insert(insert_pos, new_sexp)];
+    let line_start = content[..item_pos].rfind('\n').map_or(0, |pos| pos + 1);
+    let insert_pos = if content[line_start..item_pos]
+        .chars()
+        .all(char::is_whitespace)
+    {
+        line_start
+    } else {
+        item_pos
+    };
+    let insertion = format!("{}\n", new_sexp.trim_matches('\n'));
+    let edits = vec![SexpEdit::insert(insert_pos, insertion)];
     apply_edits(content.to_string(), edits)
 }
 

--- a/crates/konnect-core/src/tools/verification.rs
+++ b/crates/konnect-core/src/tools/verification.rs
@@ -8,6 +8,7 @@ use crate::tool;
 use crate::tools::{get_path, require_str, ToolContext, ToolDef};
 use konnect_sexp::writer::write_atomic;
 use serde_json::json;
+use std::path::{Path, PathBuf};
 use tokio::task;
 
 use super::cli;
@@ -49,7 +50,7 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "set_design_rules",
-            "Set board-level design rules (clearance, trace width, via size) in the PCB file.",
+            "Set board-level design rules (clearance, trace width, via size) in the sibling KiCAD project file.",
             json!({
                 "type": "object",
                 "properties": {
@@ -66,7 +67,7 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "get_design_rules",
-            "Return the current design rule constraints defined in the PCB file.",
+            "Return the current design rule constraints defined in the sibling KiCAD project file.",
             json!({
                 "type": "object",
                 "properties": {
@@ -138,7 +139,7 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "set_layer_constraints",
-            "Set per-layer design constraints (e.g. min trace width, clearance) in the board setup section.",
+            "Set per-layer design constraints (e.g. min trace width, clearance) in the sibling .kicad_dru custom rules file.",
             json!({
                 "type": "object",
                 "properties": {
@@ -225,76 +226,104 @@ async fn handle_run_drc(
     ))
 }
 
-// ─── Design rules S-expression helpers ───────────────────────────────────────
+// ─── Design rules helpers ────────────────────────────────────────────────────
 
-/// Read a rule value from `(setup (rules (rule_severity key val) ...))`.
-/// KiCAD stores rules in: `(setup ... (rules (rule_severity "..." ...) ...))`
-/// But simple constraints are in `(setup (constraints ...))`.
-fn read_constraint(content: &str, key: &str) -> Option<f64> {
-    // Pattern: `(constraint clearance (min VAL))` or `(min_clearance VAL)` in setup
-    // Try legacy format first: `(key VAL)` inside setup section
-    let pat = format!("({} ", key);
-    if let Some(pos) = content.find(&pat) {
-        let after = &content[pos + pat.len()..];
-        if let Some(end) = after.find(')') {
-            return after[..end].trim().parse::<f64>().ok();
+fn sibling_project_path(board: &Path) -> PathBuf {
+    board.with_extension("kicad_pro")
+}
+
+fn sibling_custom_rules_path(board: &Path) -> PathBuf {
+    board.with_extension("kicad_dru")
+}
+
+fn project_rules_mut(
+    project: &mut serde_json::Value,
+) -> anyhow::Result<&mut serde_json::Map<String, serde_json::Value>> {
+    let project = project
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("KiCAD project root must be a JSON object"))?;
+    let board = project
+        .entry("board")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("KiCAD project 'board' must be a JSON object"))?;
+    let design_settings = board
+        .entry("design_settings")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .ok_or_else(|| {
+            anyhow::anyhow!("KiCAD project 'board.design_settings' must be a JSON object")
+        })?;
+    design_settings
+        .entry("rules")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .ok_or_else(|| {
+            anyhow::anyhow!("KiCAD project 'board.design_settings.rules' must be a JSON object")
+        })
+}
+
+fn project_rule_value(project: &serde_json::Value, key: &str) -> Option<f64> {
+    project["board"]["design_settings"]["rules"][key].as_f64()
+}
+
+fn named_rule_range(content: &str, name: &str) -> Option<(usize, usize)> {
+    let needle = format!("(rule \"{name}\"");
+    let start = content.find(&needle)?;
+    let mut depth = 0i32;
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut in_comment = false;
+
+    for (offset, character) in content[start..].char_indices() {
+        if in_comment {
+            if character == '\n' {
+                in_comment = false;
+            }
+            continue;
         }
-    }
-    // Try constraint format: `(constraint min_clearance (min VAL))`
-    let cpat = format!("(constraint {} (min ", key);
-    if let Some(pos) = content.find(&cpat) {
-        let after = &content[pos + cpat.len()..];
-        if let Some(end) = after.find(')') {
-            return after[..end].trim().parse::<f64>().ok();
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match character {
+            '#' => in_comment = true,
+            '"' => in_string = true,
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((start, start + offset + character.len_utf8()));
+                }
+            }
+            _ => {}
         }
     }
     None
 }
 
-/// Set or insert a rule inside the `(setup ...)` section.
-fn set_constraint(content: &str, key: &str, value: f64) -> String {
-    let pat = format!("({} ", key);
-
-    if let Some(pos) = content.find(&pat) {
-        // Replace existing value
-        let end = content[pos..]
-            .find(')')
-            .map(|i| pos + i + 1)
-            .unwrap_or(content.len());
-        let new_entry = format!("({} {})", key, value);
-        format!("{}{}{}", &content[..pos], new_entry, &content[end..])
-    } else {
-        // Insert into setup section before its closing paren
-        if let Some(setup_pos) = content.find("(setup") {
-            let setup_end = {
-                let mut depth = 0i32;
-                let mut end = setup_pos;
-                for (i, ch) in content[setup_pos..].char_indices() {
-                    match ch {
-                        '(' => depth += 1,
-                        ')' => {
-                            depth -= 1;
-                            if depth == 0 {
-                                end = setup_pos + i;
-                                break;
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-                end
-            };
-            let new_entry = format!("\n  ({} {})", key, value);
-            format!(
-                "{}{}{}",
-                &content[..setup_end],
-                new_entry,
-                &content[setup_end..]
-            )
-        } else {
-            content.to_string()
-        }
+fn upsert_named_rule(content: &str, name: &str, rule: &str) -> String {
+    if let Some((start, end)) = named_rule_range(content, name) {
+        return format!("{}{}{}", &content[..start], rule, &content[end..]);
     }
+
+    let mut result = content.trim_end().to_string();
+    if !result.is_empty() {
+        result.push_str("\n\n");
+    }
+    result.push_str(rule);
+    result.push('\n');
+    result
+}
+
+fn layer_rule(name: &str, constraint: &str, value: f64, layer: &str) -> String {
+    format!("(rule \"{name}\"\n  (constraint {constraint} (min {value}mm))\n  (layer \"{layer}\"))")
 }
 
 async fn handle_set_design_rules(
@@ -302,32 +331,43 @@ async fn handle_set_design_rules(
     _ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
     let board = get_path(args, "board")?;
-    let mut content = tokio::fs::read_to_string(&board).await?;
+    let project_path = sibling_project_path(&board);
+    let project_content = tokio::fs::read_to_string(&project_path).await?;
+    let mut project: serde_json::Value = serde_json::from_str(&project_content)?;
 
     let mut changed = Vec::new();
 
     let rules: &[(&str, &str)] = &[
         ("min_clearance", "min_clearance"),
         ("min_track_width", "min_trace_width"),
-        ("min_via_drill", "min_via_drill"),
+        ("min_through_hole_diameter", "min_via_drill"),
         ("min_via_size", "min_via_size"),
         ("min_hole_to_hole", "min_hole_to_hole"),
     ];
 
-    for (sexp_key, arg_key) in rules {
+    let project_rules = project_rules_mut(&mut project)?;
+    for (project_key, arg_key) in rules {
         if let Some(val) = args[arg_key].as_f64() {
-            content = set_constraint(&content, sexp_key, val);
-            changed.push(format!("{} = {}", sexp_key, val));
+            let storage_key = if *project_key == "min_via_size" {
+                "min_via_diameter"
+            } else {
+                project_key
+            };
+            project_rules.insert(storage_key.to_string(), json!(val));
+            changed.push(format!("{} = {}", storage_key, val));
         }
     }
 
     if !changed.is_empty() {
-        write_atomic(&board, &content)?;
+        let mut content = serde_json::to_string_pretty(&project)?;
+        content.push('\n');
+        write_atomic(&project_path, &content)?;
     }
 
     Ok(CallToolResult::text(
         serde_json::to_string(&json!({
             "success": true,
+            "project": project_path,
             "changed": changed
         }))
         .unwrap(),
@@ -339,17 +379,20 @@ async fn handle_get_design_rules(
     _ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
     let board = get_path(args, "board")?;
-    let content = tokio::fs::read_to_string(&board).await?;
+    let project_path = sibling_project_path(&board);
+    let content = tokio::fs::read_to_string(&project_path).await?;
+    let project: serde_json::Value = serde_json::from_str(&content)?;
 
     Ok(CallToolResult::text(
         serde_json::to_string(&json!({
             "board": board.to_str().unwrap_or(""),
+            "project": project_path.to_str().unwrap_or(""),
             "rules": {
-                "min_clearance": read_constraint(&content, "min_clearance"),
-                "min_trace_width": read_constraint(&content, "min_track_width"),
-                "min_via_drill": read_constraint(&content, "min_via_drill"),
-                "min_via_size": read_constraint(&content, "min_via_size"),
-                "min_hole_to_hole": read_constraint(&content, "min_hole_to_hole")
+                "min_clearance": project_rule_value(&project, "min_clearance"),
+                "min_trace_width": project_rule_value(&project, "min_track_width"),
+                "min_via_drill": project_rule_value(&project, "min_through_hole_diameter"),
+                "min_via_size": project_rule_value(&project, "min_via_diameter"),
+                "min_hole_to_hole": project_rule_value(&project, "min_hole_to_hole")
             }
         }))
         .unwrap(),
@@ -737,82 +780,52 @@ async fn handle_set_layer_constraints(
         Ok(v) => v.to_string(),
         Err(e) => return Ok(e),
     };
-    let mut content = tokio::fs::read_to_string(&board).await?;
+    anyhow::ensure!(
+        !layer.is_empty()
+            && layer
+                .chars()
+                .all(|character| character.is_ascii_alphanumeric()
+                    || character == '.'
+                    || character == '_'),
+        "Layer name contains unsupported characters"
+    );
+    let rules_path = sibling_custom_rules_path(&board);
+    let mut content = match tokio::fs::read_to_string(&rules_path).await {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => "(version 1)\n".to_string(),
+        Err(error) => return Err(error.into()),
+    };
     let mut changed = Vec::new();
 
-    // Build a layer constraint rule block to insert into (setup ...)
-    // KiCAD uses `(rule "name" (constraint ...) (condition "A.Layer == 'LAYER'"))` inside setup
-    let rule_name = format!("{}_constraints", layer.replace('.', "_"));
-
     if let Some(clearance) = args["min_clearance"].as_f64() {
-        let rule_sexp = format!(
-            "\n    (rule \"{rule_name}_clearance\"\n      (constraint clearance (min {clearance}))\n      (condition \"A.Layer == '{layer}'\")\n    )"
+        let rule_name = format!("konnect:{layer}:clearance");
+        content = upsert_named_rule(
+            &content,
+            &rule_name,
+            &layer_rule(&rule_name, "clearance", clearance, &layer),
         );
-        // Insert into setup block
-        if let Some(setup_pos) = content.find("(setup") {
-            let mut depth = 0i32;
-            let mut setup_end = setup_pos;
-            for (i, ch) in content[setup_pos..].char_indices() {
-                match ch {
-                    '(' => depth += 1,
-                    ')' => {
-                        depth -= 1;
-                        if depth == 0 {
-                            setup_end = setup_pos + i;
-                            break;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            content = format!(
-                "{}{}{}",
-                &content[..setup_end],
-                rule_sexp,
-                &content[setup_end..]
-            );
-            changed.push(format!("clearance = {} on {}", clearance, layer));
-        }
+        changed.push(format!("clearance = {} on {}", clearance, layer));
     }
 
     if let Some(trace_width) = args["min_trace_width"].as_f64() {
-        let rule_sexp = format!(
-            "\n    (rule \"{rule_name}_trace_width\"\n      (constraint track_width (min {trace_width}))\n      (condition \"A.Layer == '{layer}'\")\n    )"
+        let rule_name = format!("konnect:{layer}:track_width");
+        content = upsert_named_rule(
+            &content,
+            &rule_name,
+            &layer_rule(&rule_name, "track_width", trace_width, &layer),
         );
-        if let Some(setup_pos) = content.find("(setup") {
-            let mut depth = 0i32;
-            let mut setup_end = setup_pos;
-            for (i, ch) in content[setup_pos..].char_indices() {
-                match ch {
-                    '(' => depth += 1,
-                    ')' => {
-                        depth -= 1;
-                        if depth == 0 {
-                            setup_end = setup_pos + i;
-                            break;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            content = format!(
-                "{}{}{}",
-                &content[..setup_end],
-                rule_sexp,
-                &content[setup_end..]
-            );
-            changed.push(format!("min_trace_width = {} on {}", trace_width, layer));
-        }
+        changed.push(format!("min_trace_width = {} on {}", trace_width, layer));
     }
 
     if !changed.is_empty() {
-        write_atomic(&board, &content)?;
+        write_atomic(&rules_path, &content)?;
     }
 
     Ok(CallToolResult::text(
         serde_json::to_string(&json!({
             "success": true,
             "layer": layer,
+            "rules_file": rules_path,
             "changed": changed
         }))
         .unwrap(),
@@ -875,4 +888,101 @@ fn find_footprint_position(
     let fp_y = fp_at.and_then(|a| a.get_f64(2)).unwrap_or(0.0);
 
     Ok((fp_x, fp_y))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::ServerConfig;
+    use std::sync::Arc;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+                eager_toolsets: false,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    fn blank_board() -> &'static str {
+        "(kicad_pcb\n  (version 20250610)\n  (generator \"test\")\n  (general (thickness 1.6))\n  (paper \"A4\")\n  (layers\n    (0 \"F.Cu\" signal)\n    (31 \"B.Cu\" signal)\n    (44 \"Edge.Cuts\" user)\n  )\n  (setup (pad_to_mask_clearance 0))\n  (net 0 \"\")\n)\n"
+    }
+
+    fn blank_project() -> &'static str {
+        "{\n  \"meta\": {\"filename\": \"board.kicad_pro\", \"version\": 1},\n  \"board\": {\"design_settings\": {}},\n  \"schematic\": {}\n}\n"
+    }
+
+    #[tokio::test]
+    async fn set_design_rules_updates_project_json_without_touching_board() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = dir.path().join("board.kicad_pcb");
+        let project = dir.path().join("board.kicad_pro");
+        tokio::fs::write(&board, blank_board()).await.unwrap();
+        tokio::fs::write(&project, blank_project()).await.unwrap();
+        let original_board = tokio::fs::read(&board).await.unwrap();
+
+        let args = json!({
+            "board": board,
+            "min_clearance": 0.25,
+            "min_trace_width": 0.25,
+            "min_via_drill": 0.30,
+            "min_via_size": 0.70,
+            "min_hole_to_hole": 0.45
+        });
+        let result = handle_set_design_rules(&args, &test_ctx()).await.unwrap();
+        assert!(!result.is_error);
+
+        assert_eq!(tokio::fs::read(&board).await.unwrap(), original_board);
+        let project_json: serde_json::Value =
+            serde_json::from_slice(&tokio::fs::read(&project).await.unwrap()).unwrap();
+        let rules = &project_json["board"]["design_settings"]["rules"];
+        assert_eq!(rules["min_clearance"], 0.25);
+        assert_eq!(rules["min_track_width"], 0.25);
+        assert_eq!(rules["min_through_hole_diameter"], 0.30);
+        assert_eq!(rules["min_via_diameter"], 0.70);
+        assert_eq!(rules["min_hole_to_hole"], 0.45);
+    }
+
+    #[tokio::test]
+    async fn set_layer_constraints_writes_idempotent_custom_rules_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = dir.path().join("board.kicad_pcb");
+        tokio::fs::write(&board, blank_board()).await.unwrap();
+        let original_board = tokio::fs::read(&board).await.unwrap();
+        let args = json!({
+            "board": board,
+            "layer": "F.Cu",
+            "min_clearance": 0.25,
+            "min_trace_width": 0.25
+        });
+
+        for _ in 0..2 {
+            let result = handle_set_layer_constraints(&args, &test_ctx())
+                .await
+                .unwrap();
+            assert!(!result.is_error);
+        }
+
+        assert_eq!(tokio::fs::read(&board).await.unwrap(), original_board);
+        let rules = tokio::fs::read_to_string(dir.path().join("board.kicad_dru"))
+            .await
+            .unwrap();
+        assert!(rules.starts_with("(version 1)"));
+        assert_eq!(rules.matches("(rule \"konnect:F.Cu:clearance\"").count(), 1);
+        assert_eq!(
+            rules.matches("(rule \"konnect:F.Cu:track_width\"").count(),
+            1
+        );
+        assert!(rules.contains("(constraint clearance (min 0.25mm))"));
+        assert!(rules.contains("(constraint track_width (min 0.25mm))"));
+        assert!(rules.contains("(layer \"F.Cu\")"));
+    }
 }

--- a/crates/konnect/assets/skills/kicad-library/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-library/SKILL.md
@@ -20,7 +20,8 @@ using Konnect MCP tools. ALL modifications go through MCP tools — never edit
 
 ```
 load_toolset('library')    # search_symbols, search_footprints, create_symbol, create_footprint,
-                           # set_footprint_graphics, get_footprint_info, register_symbol_library,
+                           # edit_footprint_pad, set_footprint_graphics, set_footprint_metadata,
+                           # get_footprint_info, register_symbol_library,
                            # register_footprint_library, get_symbol_info
 ```
 
@@ -184,6 +185,29 @@ set_footprint_graphics(
   first point at the end is optional.
 - Use `get_footprint_info` with graphics inclusion enabled and a layer filter to verify
   the resulting type, geometry, stroke width, fill, and item ID.
+
+### Existing Footprint Metadata
+
+Use `set_footprint_metadata` to replace a footprint description, search tags, or
+KiCad footprint attributes without changing pads, graphics, properties, groups, or
+3D models.
+
+```text
+set_footprint_metadata(
+  footprint_path=".../Part.kicad_mod",
+  description="Optional replacement",
+  tags=["keyboard", "hot_swap"],
+  attributes=["exclude_from_pos_files"]
+)
+```
+
+- Supply at least one metadata field.
+- Only supplied fields change.
+- Empty `tags` or `attributes` removes the corresponding block.
+- `exclude_from_pos_files` omits the footprint from pick-and-place output without
+  implicitly adding `exclude_from_bom`.
+- Use `edit_footprint_pad` with `new_number` and optional `match_all=true` to
+  renumber one or every matching direct-child pad atomically.
 
 ---
 

--- a/crates/konnect/assets/skills/kicad-library/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-library/SKILL.md
@@ -117,6 +117,38 @@ Optional but recommended:
 | `thru_hole`     | Through-hole pads (plated drill)                     |
 | `np_thru_hole`  | Non-plated through hole (mounting holes, slots)      |
 
+### Pad Side and Shape Details
+
+`create_footprint` defaults SMD pads to the front-side layer set
+`["F.Cu", "F.Paste", "F.Mask"]`. For bottom-side SMD pads, set
+`layers=["B.Cu", "B.Paste", "B.Mask"]` explicitly. Through-hole pads default to
+`["*.Cu", "*.Mask"]`.
+
+Each pad may also set:
+
+- `rotation` in degrees; omit it for `0`.
+- `roundrect_rratio` from `0` through `0.5` when `shape="roundrect"`.
+- `layers` using only canonical pad layers: `F.Cu`, `B.Cu`, `F.Paste`, `B.Paste`,
+  `F.Mask`, `B.Mask`, `*.Cu`, and `*.Mask`.
+
+```text
+create_footprint(
+  ...,
+  pads=[{
+    number: "1",
+    type: "smd",
+    shape: "roundrect",
+    x: -8.075,
+    y: 4.7,
+    width: 2.5,
+    height: 2.55,
+    layers: ["B.Cu", "B.Paste", "B.Mask"],
+    rotation: 180,
+    roundrect_rratio: 0.2
+  }]
+)
+```
+
 ### Standard Pad Sizes Reference
 
 | Package   | Pad Size (mm)   | Pitch (mm) | Notes                        |
@@ -148,7 +180,9 @@ Optional but recommended:
 | F.Cu       | Front copper (pads)                                   |
 | B.Cu       | Back copper (pads for bottom-side components)         |
 | F.Mask     | Front solder mask opening (auto-generated from pads)  |
+| B.Mask     | Back solder mask opening                              |
 | F.Paste    | Front solder paste (stencil openings)                 |
+| B.Paste    | Back solder paste (stencil openings)                  |
 | F.SilkS    | Front silkscreen (component outline, pin 1 marker)    |
 | F.CrtYd    | Front courtyard (assembly spacing)                    |
 | F.Fab      | Front fabrication (true component dimensions)         |

--- a/crates/konnect/assets/skills/kicad-library/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-library/SKILL.md
@@ -20,7 +20,8 @@ using Konnect MCP tools. ALL modifications go through MCP tools — never edit
 
 ```
 load_toolset('library')    # search_symbols, search_footprints, create_symbol, create_footprint,
-                           # register_symbol_library, register_footprint_library, get_symbol_info
+                           # set_footprint_graphics, get_footprint_info, register_symbol_library,
+                           # register_footprint_library, get_symbol_info
 ```
 
 Always call `get_active_toolsets()` first to see what is already loaded.
@@ -159,6 +160,31 @@ Optional but recommended:
 - Reference (`%R`) on F.SilkS, readable at 1.0mm text height
 - Value on F.Fab layer
 
+### Existing Footprint Graphics
+
+Use `set_footprint_graphics` to add or change line, arc, rectangle, circle, or polygon
+primitives in an existing `.kicad_mod`. Never patch the file directly.
+
+```text
+set_footprint_graphics(
+  footprint path,
+  selector={layer: "B.CrtYd"},
+  mode="replace",
+  graphics=[...]
+)
+```
+
+- `append` preserves existing supported graphics on the selected layer.
+- `replace` replaces all supported graphics on the selected layer in one atomic write.
+- `delete` removes all supported graphics on the selected layer.
+- Text, pads, properties, models, groups, and graphics on other layers are preserved.
+- Replacement/deletion stops with a conflict if a selected graphic belongs to a group;
+  do not work around this by editing the file.
+- Polygons close automatically. Supply at least three distinct points; repeating the
+  first point at the end is optional.
+- Use `get_footprint_info` with graphics inclusion enabled and a layer filter to verify
+  the resulting type, geometry, stroke width, fill, and item ID.
+
 ---
 
 ## Library Registration
@@ -252,3 +278,5 @@ Dimension format: `LxW` in mm (body dimensions, not pad-to-pad).
 8. **Use project scope by default** — avoid polluting global libraries
 9. **Name footprints per IPC** — consistent naming helps future reuse
 10. **Load toolsets first** — check `get_active_toolsets()` and load `library` before starting
+11. **Use layer-scoped graphic edits deliberately** — `replace` and `delete` affect every
+    supported primitive on the selected layer

--- a/crates/konnect/assets/skills/kicad-library/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-library/SKILL.md
@@ -248,6 +248,11 @@ register_symbol_library(name, path, scope)
 register_footprint_library(name, path, scope)
 ```
 
+- Registration is idempotent by default: an existing nickname is left unchanged.
+- Set `replace_existing=true` to update a stale URI for that nickname in place.
+- Project-local and same-repository sibling libraries are written as portable
+  `${KIPRJMOD}` URIs; existing options, descriptions, and unrelated entries are preserved.
+
 ### Scope
 
 | Scope       | Location                        | Visible To           |

--- a/crates/konnect/assets/skills/kicad-library/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-library/SKILL.md
@@ -21,7 +21,7 @@ using Konnect MCP tools. ALL modifications go through MCP tools — never edit
 ```
 load_toolset('library')    # search_symbols, search_footprints, create_symbol, create_footprint,
                            # edit_footprint_pad, set_footprint_graphics, set_footprint_metadata,
-                           # get_footprint_info, register_symbol_library,
+                           # set_footprint_models, get_footprint_info, register_symbol_library,
                            # register_footprint_library, get_symbol_info
 ```
 
@@ -208,6 +208,29 @@ set_footprint_metadata(
   implicitly adding `exclude_from_bom`.
 - Use `edit_footprint_pad` with `new_number` and optional `match_all=true` to
   renumber one or every matching direct-child pad atomically.
+
+### Existing Footprint 3D Models
+
+Use `set_footprint_models` to append, replace, or delete top-level 3D model
+associations without changing any non-model footprint content.
+
+```text
+set_footprint_models(
+  footprint_path=".../Part.kicad_mod",
+  mode="replace",
+  models=[{
+    path: "../models/Part.step",
+    offset: {x: 0, y: 0, z: 0},
+    scale: {x: 1, y: 1, z: 1},
+    rotate: {x: 0, y: 0, z: 90}
+  }]
+)
+```
+
+- `append` and `replace` require at least one model.
+- `delete` requires models to be omitted or empty and removes every top-level model.
+- Omitted transforms default to offset `0/0/0`, scale `1/1/1`, and rotation `0/0/0`.
+- Multiple model blocks are written in payload order in one atomic operation.
 
 ---
 

--- a/crates/konnect/assets/skills/kicad-pcb/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-pcb/SKILL.md
@@ -16,8 +16,14 @@ ALL modifications go through MCP tools — never edit .kicad_pcb files directly.
 
 ## Prerequisites
 
-PCB layout operations require KiCAD to be running with the board file open. The IPC
+Most PCB layout operations require KiCAD to be running with the board file open. The IPC
 connection communicates with the running KiCAD instance in real-time.
+
+`place_component` is the narrow exception: when IPC is unreachable, it can place one
+front-side footprint into a closed `.kicad_pcb` file through a revision-aware atomic
+fallback. It preserves pads, graphics, attributes, and models, and rejects duplicate
+references. If KiCAD is reachable but rejects the request, the fallback stays disabled
+to avoid racing a live editor.
 
 If connection fails:
 - Tell the user to open KiCAD and load the project
@@ -85,7 +91,7 @@ Do NOT add copper pours before routing is complete — they interfere with inter
 
 | Tool                      | Use Case                                    |
 |---------------------------|---------------------------------------------|
-| `place_component`         | Position a single footprint at x,y          |
+| `place_component`         | Position one footprint via IPC or safe file fallback |
 | `move_component`          | Relocate an existing footprint              |
 | `rotate_component`        | Rotate footprint (0/90/180/270)             |
 | `align_components`        | Align multiple components (top/bottom/left/right/center) |
@@ -258,7 +264,8 @@ Common DRC errors and fixes:
 4. **Refill zones after changes** — stale zone fills cause phantom DRC errors
 5. **Check DRC before finishing** — run `run_drc()` and resolve all errors
 6. **Use netclasses for consistency** — define track widths per net type, not per trace
-7. **KiCAD must be running** — PCB tools require the live IPC connection
+7. **KiCAD normally must be running** — only `place_component` has a safe
+   IPC-unreachable file fallback; other PCB edits still require the live IPC connection
 8. **Save frequently** — call `save_project` after major operations
 9. **Load toolsets first** — check `get_active_toolsets()` and load what you need
 10. **Copper pour last** — add zones only after routing is substantially complete

--- a/crates/konnect/tests/asset_references.rs
+++ b/crates/konnect/tests/asset_references.rs
@@ -234,6 +234,7 @@ fn backticked_tool_names_in_prose_exist_in_the_registry() {
         "new_number",
         "match_all",
         "replace_existing",
+        "roundrect_rratio",
     ];
 
     let mut phantom = Vec::new();

--- a/crates/konnect/tests/asset_references.rs
+++ b/crates/konnect/tests/asset_references.rs
@@ -227,6 +227,13 @@ fn backticked_tool_names_in_prose_exist_in_the_registry() {
         "pin_y",
         "orientation_degrees",
         "tool_name",
+        "footprint_path",
+        "hot_swap",
+        "exclude_from_pos_files",
+        "exclude_from_bom",
+        "new_number",
+        "match_all",
+        "replace_existing",
     ];
 
     let mut phantom = Vec::new();

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -207,7 +207,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 
 | Tool | Description |
 |------|-------------|
-| `place_component` | Place a footprint on the PCB at a given position and layer via KiCAD IPC. |
+| `place_component` | Place a footprint through live KiCAD IPC when reachable, or use a revision-aware file fallback when no KiCAD process can hold the board open. The fallback preserves complete footprint content and rejects duplicate references. |
 | `move_component` | Move a placed footprint to a new X/Y position via KiCAD IPC. |
 | `rotate_component` | Set the rotation angle of a placed footprint via KiCAD IPC. |
 | `delete_component` | Remove a footprint from the board via KiCAD IPC. |

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -10,7 +10,7 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 ## Overview
 
 - **18 toolsets** organized into 10 categories
-- **188 registered tools** + **6 always-visible meta-tools** = **194 total**
+- **189 registered tools** + **6 always-visible meta-tools** = **195 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -264,7 +264,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 
 ## Library
 
-### `library` · 14 tools
+### `library` · 15 tools
 **Purpose:** Symbol libraries, footprint libraries, search and registration.
 **Source:** [`crates/konnect-core/src/tools/library.rs`](crates/konnect-core/src/tools/library.rs)
 
@@ -272,6 +272,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 |------|-------------|
 | `create_footprint` | Create a new footprint (`.kicad_mod`) file from a pad layout description. |
 | `edit_footprint_pad` | Edit the size, shape, or position of a pad in an existing `.kicad_mod`. |
+| `set_footprint_graphics` | Atomically append, replace, or delete line, arc, rectangle, circle, and polygon primitives on one footprint layer. Replacement/deletion preserves unrelated source and rejects graphics referenced by a group. |
 | `register_footprint_library` | Register a local footprint library directory in the KiCAD global or project library table. |
 | `list_footprint_libraries` | List all registered footprint libraries (global and/or project). |
 | `create_symbol` | Create a new KiCAD schematic symbol and append it to a `.kicad_sym` library. |
@@ -281,7 +282,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `list_symbol_libraries` | List all registered symbol libraries (global and/or project). |
 | `search_symbols` | Search for symbols across all registered libraries by name or keyword. |
 | `list_library_footprints` | List all footprints in a specific registered library (`.pretty` directory). |
-| `get_footprint_info` | Return detailed information about a footprint: pad layout, courtyard, description. |
+| `get_footprint_info` | Return detailed information about a footprint. Set `include_graphics` (and optionally `graphics_layer`) to inspect supported top-level primitives, geometry, stroke, fill, and item IDs. |
 | `search_footprints` | Search for footprints across all registered libraries by name or keyword. |
 | `get_symbol_info` | Return detailed information about a schematic symbol: pins, properties, description. |
 

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -10,7 +10,7 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 ## Overview
 
 - **18 toolsets** organized into 10 categories
-- **190 registered tools** + **6 always-visible meta-tools** = **196 total**
+- **191 registered tools** + **6 always-visible meta-tools** = **197 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -264,7 +264,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 
 ## Library
 
-### `library` · 16 tools
+### `library` · 17 tools
 **Purpose:** Symbol libraries, footprint libraries, search and registration.
 **Source:** [`crates/konnect-core/src/tools/library.rs`](crates/konnect-core/src/tools/library.rs)
 
@@ -274,6 +274,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `edit_footprint_pad` | Edit or renumber the first or every matching pad in an existing `.kicad_mod`. |
 | `set_footprint_graphics` | Atomically append, replace, or delete line, arc, rectangle, circle, and polygon primitives on one footprint layer. Replacement/deletion preserves unrelated source and rejects graphics referenced by a group. |
 | `set_footprint_metadata` | Atomically replace a footprint description, tags, or supported attributes while preserving unrelated source. Empty tags or attributes remove their block. |
+| `set_footprint_models` | Atomically append, replace, or delete one or more top-level 3D model blocks with optional offset, scale, and rotation transforms. |
 | `register_footprint_library` | Register a local footprint library directory in the KiCAD global or project library table. |
 | `list_footprint_libraries` | List all registered footprint libraries (global and/or project). |
 | `create_symbol` | Create a new KiCAD schematic symbol and append it to a `.kicad_sym` library. |

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -275,7 +275,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `set_footprint_graphics` | Atomically append, replace, or delete line, arc, rectangle, circle, and polygon primitives on one footprint layer. Replacement/deletion preserves unrelated source and rejects graphics referenced by a group. |
 | `set_footprint_metadata` | Atomically replace a footprint description, tags, or supported attributes while preserving unrelated source. Empty tags or attributes remove their block. |
 | `set_footprint_models` | Atomically append, replace, or delete one or more top-level 3D model blocks with optional offset, scale, and rotation transforms. |
-| `register_footprint_library` | Register a local footprint library directory in the KiCAD global or project library table. |
+| `register_footprint_library` | Register a local footprint library directory in the KiCAD global or project library table. Set `replace_existing` to update a stale URI in place while preserving entry metadata. |
 | `list_footprint_libraries` | List all registered footprint libraries (global and/or project). |
 | `create_symbol` | Create a new KiCAD schematic symbol and append it to a `.kicad_sym` library. |
 | `delete_symbol` | Delete a symbol definition from a `.kicad_sym` library. |

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -10,7 +10,7 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 ## Overview
 
 - **18 toolsets** organized into 10 categories
-- **189 registered tools** + **6 always-visible meta-tools** = **195 total**
+- **190 registered tools** + **6 always-visible meta-tools** = **196 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -264,15 +264,16 @@ Six tools, grouped into *discovery/routing* and *observability*.
 
 ## Library
 
-### `library` · 15 tools
+### `library` · 16 tools
 **Purpose:** Symbol libraries, footprint libraries, search and registration.
 **Source:** [`crates/konnect-core/src/tools/library.rs`](crates/konnect-core/src/tools/library.rs)
 
 | Tool | Description |
 |------|-------------|
 | `create_footprint` | Create a new footprint (`.kicad_mod`) file from a pad layout description. |
-| `edit_footprint_pad` | Edit the size, shape, or position of a pad in an existing `.kicad_mod`. |
+| `edit_footprint_pad` | Edit or renumber the first or every matching pad in an existing `.kicad_mod`. |
 | `set_footprint_graphics` | Atomically append, replace, or delete line, arc, rectangle, circle, and polygon primitives on one footprint layer. Replacement/deletion preserves unrelated source and rejects graphics referenced by a group. |
+| `set_footprint_metadata` | Atomically replace a footprint description, tags, or supported attributes while preserving unrelated source. Empty tags or attributes remove their block. |
 | `register_footprint_library` | Register a local footprint library directory in the KiCAD global or project library table. |
 | `list_footprint_libraries` | List all registered footprint libraries (global and/or project). |
 | `create_symbol` | Create a new KiCAD schematic symbol and append it to a `.kicad_sym` library. |


### PR DESCRIPTION
## Summary

Add safe, atomic editing for graphics, pads, metadata, and 3D models in existing footprints, plus portable library-table upserts and hardened headless placement so the workflow works end to end without direct KiCad source edits.

Closes #200

## Approach

- Add `set_footprint_graphics` with `append`, `replace`, and `delete` modes for top-level `line`, `arc`, `rect`, `circle`, and `poly` primitives on one canonical layer.
- Extend `get_footprint_info` with opt-in graphic inspection so callers can verify geometry, point counts, stroke, fill, and item IDs.
- Preserve unrelated footprint source with targeted edits; reject grouped selected graphics instead of leaving dangling group members.
- Extend `edit_footprint_pad` with opt-in `match_all` and `new_number` for atomic duplicate-pad renumbering.
- Extend `create_footprint` pads with optional canonical `layers`, `rotation`, and `roundrect_rratio`; legacy payloads retain the existing front-side defaults.
- Update the bundled `kicad-library` and `kicad-pcb` skills so agents use the atomic footprint APIs, safe placement fallback, and front/back pad contracts instead of editing KiCad files directly.
- Add atomic `set_footprint_metadata` and `set_footprint_models` tools.
- Add `replace_existing` to `register_footprint_library` so stale project URIs can be updated in place while preserving options, descriptions, and unrelated entries.
- Harden the existing IPC-unreachable `place_component` file fallback for legacy `fp_text reference` footprints, duplicate-reference rejection, and revision-aware board writes.

The keyboard socket geometry used for acceptance remains outside Konnect. The implementation exposes only project-agnostic primitives, metadata, models, library registration, and placement behavior.

## Compatibility and safety

- Existing tool names and default behavior remain compatible. New arguments are optional and default to the previous single-item/idempotent behavior.
- All footprint mutations require a regular `.kicad_mod` file with a `footprint` root, validate the complete replacement, and commit with `write_atomic_if_unchanged`.
- `replace`/`delete` of grouped graphics returns a structured conflict; no group membership is silently changed.
- Invalid layers, non-finite or degenerate geometry, invalid metadata/model payloads, missing files, stale revisions, malformed tables, and duplicate library nicknames are rejected before writes.
- Project library upserts preserve existing entry metadata and convert same-repository project paths to portable `${KIPRJMOD}` URIs.
- Headless placement is used only when IPC is unreachable. A reachable KiCad rejection still fails closed so a live editor cannot be raced.
- Headless placement preserves full pads, graphics, attributes, and models, rejects duplicate references, validates one complete board form, and uses revision-aware atomic persistence.
- Rollback is a normal branch revert. No migration or persistent config change is required; installed tool binaries are not modified by this PR.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --locked --lib --tests` (all non-environment tests passed; real-GUI/e2e tests remained explicitly ignored)
- [x] `cargo test --workspace --locked --doc`
- [x] `cargo clippy --workspace --locked --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p konnect --test protocol_stdio --locked` (9 passed)
- [x] `cargo test -p konnect --test doc_tool_counts --locked` (3 passed)
- [x] `cargo test -p konnect --test asset_references --locked` (3 passed)
- [x] `KICAD_CLI=~/.local/bin/kicad-cli python -m unittest -v test.test_socket_library_update test.test_lh60_sockets` in the external LH60 consumer (18 passed)
- [x] Deployed-binary MCP probe: bottom-side pad layers, 180° rotation, and roundrect ratio serialized exactly as requested
- [x] External LH60 consumer: generated 21 G/K/Dual footprints, exported all 21 to SVG, and passed a clean KiCad 10 coupon DRC with 0 violations / 0 unconnected items
- [x] KiCad 10 DRC on an MCP-generated conflict coupon: one `courtyards_overlap`, 0 unconnected items
- [x] Disposable MCP project probe: create project, set outline, register library, place a legacy footprint through file fallback, then KiCad 10 DRC: 0 violations, 0 unconnected items

## Review checklist

- [x] The diff is focused and contains no generated output, personal data, or keyboard-specific geometry.
- [x] New names follow `docs/NAMING_CONVENTIONS.md`; existing public names are unchanged.
- [x] New behavior and failure paths have regression coverage, including old/current footprint syntax and stale revisions.
- [x] File mutations are atomic and preserve unrelated content.
- [x] IPC mutations verify the requested board and the file fallback remains gated on typed IPC-unreachable failures.
- [x] Tool counts and docs are synchronized: library 17 tools, 191 registered tools, 197 including meta-tools.

