### PR TITLE
feat(sch): add reset_schematic_field_positions

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -58,7 +58,7 @@ Konnect/
 │   │           ├── cli.rs            # kicad-cli v10 subprocess wrapper (verified against actual binary)
 │   │           ├── svg_import.rs     # SVG parsing + Bezier flattening for import_svg_logo (usvg-backed)
 │   │           ├── project.rs        # 6 tools (incl. open_schematic_viewer)
-│   │           ├── sch_components.rs # 18 tools (component placement with lib_symbols embedding)
+│   │           ├── sch_components.rs # 19 tools (component placement with lib_symbols embedding)
 │   │           ├── sch_wiring.rs     # 19 tools (incl. connect_pins, power symbol embedding)
 │   │           ├── sch_analysis.rs   # 15 tools (union-find net graph, connectivity)
 │   │           ├── sch_batch.rs      # 12 tools (single-read/single-write atomic operations)
@@ -206,7 +206,7 @@ if !path.exists() {
 
 Adding a new kind: edit `mcp/error.rs`, add the variant, add the match arm in `short_code()`, use it from the handler. The `short_code_matches_serialized_kind_field` test will fail loudly if they drift.
 
-The dispatch-level errors (not-loaded/unknown/handler-panic) are fully structured. So are **all missing-argument errors** across all 188 tools — `tools/mod.rs::require_str` / `require_f64` emit `ToolErrorKind::InvalidArgument { field, reason }` automatically. Most in-handler errors still use `CallToolResult::error("free text")` or bubble `anyhow::Error`; migrating them is incremental. `project.rs::handle_get_project_info` demonstrates the structured `FileNotFound` pattern.
+The dispatch-level errors (not-loaded/unknown/handler-panic) are fully structured. So are **all missing-argument errors** across all 189 tools — `tools/mod.rs::require_str` / `require_f64` emit `ToolErrorKind::InvalidArgument { field, reason }` automatically. Most in-handler errors still use `CallToolResult::error("free text")` or bubble `anyhow::Error`; migrating them is incremental. `project.rs::handle_get_project_info` demonstrates the structured `FileNotFound` pattern.
 
 ## Observability
 
@@ -227,7 +227,7 @@ Source: [`crates/konnect-core/src/observability.rs`](crates/konnect-core/src/obs
 
 ## Tool Routing (Starter Kit + On-Demand Loading)
 
-The server does NOT expose all 188 tools (194 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
+The server does NOT expose all 189 tools (195 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
 
 - **Startup**: only `STARTER_KIT` toolsets are pre-loaded (see `router/registry.rs::STARTER_KIT`). Currently: `project`, `config`. Combined with the 6 meta-tools, baseline `tools/list` is ~19 tools ≈ 2K tokens.
 - **On demand**: the LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose a toolset's tools in subsequent `tools/list` responses. `unload_toolset(name)` prunes them when the task shifts.
@@ -299,9 +299,9 @@ convention for other `kicad-cli`-calling code.
 
 ## Current Stats
 
-- **18 toolsets, 188 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
+- **18 toolsets, 189 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
 - Baseline `tools/list`: ~19 tools / ~2K tokens (starter kit + meta-tools)
-- Full-catalog `tools/list` (all loaded): 194 tools (188 registered + 6 meta) / ~25K tokens
+- Full-catalog `tools/list` (all loaded): 195 tools (189 registered + 6 meta) / ~25K tokens
 - **0 IPC stubs** (all protobuf methods implemented)
 - **0 unimplemented tools**
 - **3 CLI commands removed in KiCAD v10** (specctra DSN/SES, pcb sync — return clear errors)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Rust binary — that lets Claude and other AI assistants design schematics and PCBs
 through the [Model Context Protocol](https://modelcontextprotocol.io) (MCP).
 
-**188 tools across 18 on-demand toolsets.** Schematic capture, PCB layout and
+**189 tools across 18 on-demand toolsets.** Schematic capture, PCB layout and
 routing, ERC/DRC, design-review audits, JLCPCB part search, Freerouting, reference
 circuits, and a full manufacturing export pipeline — with bundled skills and agents
 that teach Claude KiCAD conventions out of the box.

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -28,7 +28,7 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         name: "sch_components",
         description: "Add, edit, move, rotate, and delete schematic symbols",
         category: "schematic",
-        tool_count: 18,
+        tool_count: 19,
     },
     ToolsetMeta {
         name: "sch_wiring",

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -1512,6 +1512,7 @@ async fn handle_reset_schematic_field_positions(
     let mut moved = Vec::new();
     let mut unchanged = Vec::new();
     let mut no_anchor = Vec::new();
+    let mut no_property = Vec::new();
     let mut missing: Vec<String> = only
         .clone()
         .map(|r| r.into_iter().collect())
@@ -1545,7 +1546,11 @@ async fn handle_reset_schematic_field_positions(
                 continue;
             };
             let (x, y, rot) = crate::tools::field_at(Some(anchor), (0.0, 0.0, 0.0), t);
+            // The library anchors this field but the placed symbol carries no
+            // such property. Report it rather than dropping it in silence —
+            // an unreported skip reads as "reset" to the caller.
             let Some(prop) = sym.properties.iter_mut().find(|p| p.name == name) else {
+                no_property.push(format!("{}.{}", reference, name));
                 continue;
             };
             if set_property_at(prop, x, y, rot) {
@@ -1559,12 +1564,17 @@ async fn handle_reset_schematic_field_positions(
     if !moved.is_empty() && !dry_run {
         sch.overwrite()?;
     }
+    // `missing` starts life as a HashSet, whose iteration order varies run to
+    // run; a caller asking about several unknown references would get them
+    // back in a different order each time.
+    missing.sort_unstable();
 
     Ok(CallToolResult::json(&json!({
         "moved": moved,
         "moved_count": moved.len(),
         "unchanged": unchanged,
         "no_library_anchor": no_anchor,
+        "no_property": no_property,
         "not_found": missing,
         "dry_run": dry_run
     })))
@@ -2573,6 +2583,71 @@ mod tests {
         let body: serde_json::Value = serde_json::from_str(text).unwrap();
         assert_eq!(body["not_found"], json!(["R9"]));
         assert_eq!(body["moved"], json!([]));
+    }
+
+    /// `not_found` is built from a HashSet, whose iteration order varies run
+    /// to run — several unknown references would come back in a different
+    /// order each call unless it is sorted.
+    #[tokio::test]
+    async fn reset_field_positions_reports_unknown_references_in_a_stable_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stable.kicad_sch");
+        std::fs::write(
+            &path,
+            "(kicad_sch\n  (version 20250610)\n  (generator \"konnect\")\n  (uuid \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\")\n  (paper \"A4\")\n  (lib_symbols\n    (symbol \"Device:R\"\n      (property \"Reference\" \"R\" (at 2.032 0 90))\n      (property \"Value\" \"R\" (at 0 0 90))\n    )\n  )\n  (symbol\n    (lib_id \"Device:R\")\n    (at 101.6 50.8 0)\n    (unit 1)\n    (uuid \"bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee\")\n    (property \"Reference\" \"R1\" (at 101.6 46.99 0))\n    (property \"Value\" \"10k\" (at 101.6 54.61 0))\n  )\n)\n",
+        )
+        .unwrap();
+
+        // Repeated because a HashSet of this size reorders between runs; an
+        // unsorted list passes once and then does not.
+        for _ in 0..8 {
+            let result = handle_reset_schematic_field_positions(
+                &json!({
+                    "schematic": path.display().to_string(),
+                    "references": ["R9", "R2", "U7", "C3"]
+                }),
+                &test_ctx(),
+            )
+            .await
+            .unwrap();
+            let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+                panic!("expected text")
+            };
+            let body: serde_json::Value = serde_json::from_str(text).unwrap();
+            assert_eq!(body["not_found"], json!(["C3", "R2", "R9", "U7"]));
+        }
+    }
+
+    /// A field the library anchors but the placed symbol does not carry is
+    /// reported, not skipped in silence — an unreported skip reads as "reset".
+    #[tokio::test]
+    async fn reset_field_positions_reports_a_field_the_symbol_does_not_have() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("no-value.kicad_sch");
+        // The library anchors Reference and Value; the instance has only
+        // Reference.
+        std::fs::write(
+            &path,
+            "(kicad_sch\n  (version 20250610)\n  (generator \"konnect\")\n  (uuid \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\")\n  (paper \"A4\")\n  (lib_symbols\n    (symbol \"Device:R\"\n      (property \"Reference\" \"R\" (at 2.032 0 90))\n      (property \"Value\" \"R\" (at 0 0 90))\n    )\n  )\n  (symbol\n    (lib_id \"Device:R\")\n    (at 101.6 50.8 0)\n    (unit 1)\n    (uuid \"bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee\")\n    (property \"Reference\" \"R1\" (at 101.6 46.99 0))\n  )\n)\n",
+        )
+        .unwrap();
+
+        let result = handle_reset_schematic_field_positions(
+            &json!({ "schematic": path.display().to_string() }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text")
+        };
+        let body: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(body["moved"], json!(["R1.Reference"]));
+        assert_eq!(
+            body["no_property"],
+            json!(["R1.Value"]),
+            "the skipped field must be accounted for: {body}"
+        );
     }
 
     #[tokio::test]

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -307,6 +307,30 @@ pub fn tools() -> Vec<ToolDef> {
             |args, ctx| async move { handle_update_symbols_from_library(args, ctx).await }
         ),
         tool!(
+            "reset_schematic_field_positions",
+            "Move each placed symbol's Reference and Value text back to the position its \
+             library definition anchors them at, carried through the symbol's own rotation \
+             — KiCad's 'Reset field text positions'. Use it on a sheet whose fields sit at \
+             a uniform offset instead of where the library puts them (labels inside a \
+             connector body, a rail's name below an up-pointing arrow). Fields a symbol's \
+             definition gives no anchor for are left alone.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "schematic": { "type": "string", "description": "Path to .kicad_sch file" },
+                    "references": {
+                        "type": "array",
+                        "description": "Component references to reset (e.g. ['U1']). Omit to reset every symbol in the schematic.",
+                        "items": { "type": "string" }
+                    },
+                    "dry_run": { "type": "boolean", "default": false,
+                        "description": "Report what would move without writing." }
+                },
+                "required": ["schematic"]
+            }),
+            |args, ctx| async move { handle_reset_schematic_field_positions(args, ctx).await }
+        ),
+        tool!(
             "get_schematic_view",
             "Render the schematic to a PNG image (base64-encoded) via kicad-cli.",
             json!({
@@ -1429,6 +1453,130 @@ async fn handle_update_symbols_from_library(
     Ok(CallToolResult::json(&body))
 }
 
+/// Put every instance field back on its library anchor.
+///
+/// `add_schematic_component` places new symbols there already; this repairs
+/// sheets written before it did, where every field sat at a fixed ±3.81mm
+/// offset regardless of what the symbol's definition asked for (#101).
+async fn handle_reset_schematic_field_positions(
+    args: &serde_json::Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let sch_path = get_path(args, "schematic")?;
+    let only: Option<std::collections::HashSet<String>> = args["references"].as_array().map(|a| {
+        a.iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .collect()
+    });
+    let dry_run = args["dry_run"].as_bool().unwrap_or(false);
+
+    let mut sch = cse::Schematic::load(&sch_path)?;
+
+    // Anchors first: reading them borrows the schematic, mutating the symbols
+    // borrows it again, so the lookup cannot be inlined into the loop.
+    let lib_ids: Vec<String> = {
+        let mut ids: Vec<String> = Vec::new();
+        for sym in sch.symbols.iter() {
+            if !ids.contains(&sym.lib_id) {
+                ids.push(sym.lib_id.clone());
+            }
+        }
+        ids
+    };
+    let anchors: std::collections::HashMap<String, cse::library::FieldAnchors> = lib_ids
+        .into_iter()
+        .map(|id| {
+            let a = cse::library::field_anchors(&sch, &id);
+            (id, a)
+        })
+        .collect();
+
+    let mut moved = Vec::new();
+    let mut unchanged = Vec::new();
+    let mut no_anchor = Vec::new();
+    let mut missing: Vec<String> = only
+        .clone()
+        .map(|r| r.into_iter().collect())
+        .unwrap_or_default();
+
+    for sym in sch.symbols.iter_mut() {
+        let Some(reference) = sym.reference().map(String::from) else {
+            continue;
+        };
+        if only.as_ref().is_some_and(|r| !r.contains(&reference)) {
+            continue;
+        }
+        missing.retain(|r| r != &reference);
+
+        let anchor = anchors.get(&sym.lib_id).copied().unwrap_or_default();
+        let mirror = sym.mirror.as_deref().unwrap_or("");
+        let t = konnect_sexp::geometry::PinTransform {
+            comp_x: sym.at.x,
+            comp_y: sym.at.y,
+            rotation_deg: sym.at.rotation.unwrap_or(0.0),
+            mirror_x: mirror.contains('x'),
+            mirror_y: mirror.contains('y'),
+        };
+
+        for (name, anchor) in [
+            ("Reference", anchor.reference_at),
+            ("Value", anchor.value_at),
+        ] {
+            let Some(anchor) = anchor else {
+                no_anchor.push(format!("{}.{}", reference, name));
+                continue;
+            };
+            let (x, y, rot) = crate::tools::field_at(Some(anchor), (0.0, 0.0, 0.0), t);
+            let Some(prop) = sym.properties.iter_mut().find(|p| p.name == name) else {
+                continue;
+            };
+            if set_property_at(prop, x, y, rot) {
+                moved.push(format!("{}.{}", reference, name));
+            } else {
+                unchanged.push(format!("{}.{}", reference, name));
+            }
+        }
+    }
+
+    if !moved.is_empty() && !dry_run {
+        sch.overwrite()?;
+    }
+
+    Ok(CallToolResult::json(&json!({
+        "moved": moved,
+        "moved_count": moved.len(),
+        "unchanged": unchanged,
+        "no_library_anchor": no_anchor,
+        "not_found": missing,
+        "dry_run": dry_run
+    })))
+}
+
+/// Rewrite a property's `(at …)` in place. Returns whether anything changed,
+/// so an already-correct field is not reported as moved.
+fn set_property_at(prop: &mut cse::types::Property, x: f64, y: f64, rotation: f64) -> bool {
+    use cse::sexp::{atom, SexpNode};
+    use cse::types::fmt_f64;
+
+    let at = SexpNode::List(vec![
+        atom("at"),
+        atom(fmt_f64(x)),
+        atom(fmt_f64(y)),
+        atom(fmt_f64(rotation)),
+    ]);
+    match prop.sub_nodes.iter_mut().find(|n| n.tag() == Some("at")) {
+        Some(existing) => {
+            if *existing == at {
+                return false;
+            }
+            *existing = at;
+        }
+        // A field with no (at) is drawn at the sheet origin — always a move.
+        None => prop.sub_nodes.insert(0, at),
+    }
+    true
+}
+
 async fn handle_replace_component(
     args: &serde_json::Value,
     _ctx: &ToolContext,
@@ -2306,6 +2454,107 @@ mod tests {
             value.contains("(at 101.6 50.8 90)"),
             "Value must follow the rotated body: {value}"
         );
+    }
+
+    /// The repair path for sheets written before fields followed the library
+    /// (#101): an instance whose fields sit at the old fixed offset is put
+    /// back on its anchors, and a second run reports nothing left to move.
+    #[tokio::test]
+    async fn reset_field_positions_puts_stale_fields_back_on_their_anchors() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stale-fields.kicad_sch");
+        // A sheet as the old code wrote it: Reference at y-3.81 and Value at
+        // y+3.81, while the library anchors them beside the body at 90.
+        std::fs::write(
+            &path,
+            "(kicad_sch\n  (version 20250610)\n  (generator \"konnect\")\n  (uuid \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\")\n  (paper \"A4\")\n  (lib_symbols\n    (symbol \"Device:R\"\n      (property \"Reference\" \"R\" (at 2.032 0 90))\n      (property \"Value\" \"R\" (at 0 0 90))\n    )\n  )\n  (symbol\n    (lib_id \"Device:R\")\n    (at 101.6 50.8 0)\n    (unit 1)\n    (uuid \"bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee\")\n    (property \"Reference\" \"R1\" (at 101.6 46.99 0))\n    (property \"Value\" \"10k\" (at 101.6 54.61 0))\n  )\n)\n",
+        )
+        .unwrap();
+
+        let args = json!({ "schematic": path.display().to_string() });
+        let dry = handle_reset_schematic_field_positions(
+            &json!({
+                "schematic": path.display().to_string(), "dry_run": true
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        let crate::mcp::protocol::ToolContent::Text { text } = &dry.content[0] else {
+            panic!("expected text")
+        };
+        let body: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(body["moved"], json!(["R1.Reference", "R1.Value"]));
+        assert!(
+            std::fs::read_to_string(&path).unwrap().contains("46.99"),
+            "dry_run must not write"
+        );
+
+        let done = handle_reset_schematic_field_positions(&args, &test_ctx())
+            .await
+            .unwrap();
+        assert!(!done.is_error, "{done:?}");
+
+        let sch = cse::Schematic::load(&path).unwrap();
+        let sym = sch.symbols.by_reference("R1").expect("R1");
+        let field = |name: &str| {
+            cse::sexp::writer::write(
+                &sym.properties
+                    .iter()
+                    .find(|p| p.name == name)
+                    .unwrap()
+                    .to_sexp(),
+            )
+        };
+        assert!(
+            field("Reference").contains("(at 103.632 50.8 90)"),
+            "{}",
+            field("Reference")
+        );
+        assert!(
+            field("Value").contains("(at 101.6 50.8 90)"),
+            "{}",
+            field("Value")
+        );
+
+        // Idempotent: nothing left to move on a second pass.
+        let again = handle_reset_schematic_field_positions(&args, &test_ctx())
+            .await
+            .unwrap();
+        let crate::mcp::protocol::ToolContent::Text { text } = &again.content[0] else {
+            panic!("expected text")
+        };
+        let body: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(body["moved"], json!([]));
+        assert_eq!(body["unchanged"], json!(["R1.Reference", "R1.Value"]));
+    }
+
+    /// A reference that is not in the sheet is reported rather than silently
+    /// doing nothing.
+    #[tokio::test]
+    async fn reset_field_positions_reports_an_unknown_reference() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("one.kicad_sch");
+        std::fs::write(
+            &path,
+            "(kicad_sch\n  (version 20250610)\n  (generator \"konnect\")\n  (uuid \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\")\n  (paper \"A4\")\n  (lib_symbols\n    (symbol \"Device:R\"\n      (property \"Reference\" \"R\" (at 2.032 0 90))\n      (property \"Value\" \"R\" (at 0 0 90))\n    )\n  )\n  (symbol\n    (lib_id \"Device:R\")\n    (at 101.6 50.8 0)\n    (unit 1)\n    (uuid \"bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee\")\n    (property \"Reference\" \"R1\" (at 101.6 46.99 0))\n    (property \"Value\" \"10k\" (at 101.6 54.61 0))\n  )\n)\n",
+        )
+        .unwrap();
+
+        let result = handle_reset_schematic_field_positions(
+            &json!({
+                "schematic": path.display().to_string(), "references": ["R9"]
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text")
+        };
+        let body: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(body["not_found"], json!(["R9"]));
+        assert_eq!(body["moved"], json!([]));
     }
 
     #[tokio::test]

--- a/crates/konnect/tests/protocol_stdio.rs
+++ b/crates/konnect/tests/protocol_stdio.rs
@@ -295,7 +295,7 @@ fn load_toolset_batch_form_loads_all_and_notifies_once() {
         .expect("expected a tools/call result")["result"]
         .clone();
     let body = McpProcess::tool_body(&r);
-    assert_eq!(body["tools_added"].as_u64(), Some(37));
+    assert_eq!(body["tools_added"].as_u64(), Some(38));
     // tools items are {name, description} objects, matching the legacy
     // single-name result shape -- not bare name strings.
     let tools = body["tools"].as_array().expect("tools array");

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -10,7 +10,7 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 ## Overview
 
 - **18 toolsets** organized into 10 categories
-- **188 registered tools** + **6 always-visible meta-tools** = **194 total**
+- **189 registered tools** + **6 always-visible meta-tools** = **195 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -55,7 +55,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 
 ## Schematic
 
-### `sch_components` · 18 tools
+### `sch_components` · 19 tools
 **Purpose:** Add, edit, move, rotate, and delete schematic symbols.
 **Source:** [`crates/konnect-core/src/tools/sch_components.rs`](crates/konnect-core/src/tools/sch_components.rs)
 
@@ -78,6 +78,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `group_components` | Add a group property to multiple components in the schematic. |
 | `replace_component` | Replace a component's `lib_id` with a new library symbol (swap the component type). |
 | `update_symbols_from_library` | Re-embed placed symbols' definitions from their libraries, like KiCad's "Update Symbols from Library". Refuses a symbol whose pins moved or disappeared (wires attach at pin coordinates) unless `allow_pin_moves` is set. |
+| `reset_schematic_field_positions` | Move each symbol's Reference and Value text back to its library anchor, through the symbol's rotation — KiCad's "Reset field text positions". Repairs sheets whose fields sit at a uniform offset. |
 | `get_schematic_view` | Render the schematic to a PNG image (base64-encoded) via kicad-cli. |
 
 ### `sch_wiring` · 19 tools


### PR DESCRIPTION
#186 made `add_schematic_component` place Reference and Value at the anchors their
library defines, and said outright that repairing sheets written before it was a
separate concern. This is that concern.

Every symbol on an older sheet keeps the old fixed `y ± 3.81` offset: a connector's
reference sits inside its body, a rail's name below an up-pointing arrow. Nothing on
the tool surface could repair them — `move_schematic_component` translates the fields
along with the symbol, `edit_schematic_component` changes a field's value and not its
position, and `update_symbols_from_library` refreshes `lib_symbols` without touching
instances. The only fix was KiCad's own **Edit → Reset field text positions**, by hand.

`reset_schematic_field_positions` is that command as a tool: for each instance, put
Reference and Value back on the library anchor, carried through the symbol's rotation
and mirror — the same placement transform #186 introduced, called on existing symbols
instead of new ones.

### Behaviour

- **`dry_run`** reports what would move without writing.
- **`references`** filters to a subset; omitted, it resets every symbol on the sheet.
- **References it did not find are reported**, rather than the tool silently doing
  nothing and claiming success.
- **Idempotent** — a second call moves nothing.
- A symbol whose library definition declares no anchor is left alone, matching the
  fallback #186 kept.

### Scope of the write

Only each field's `(at …)` is rewritten. Field values, symbol positions, wires and
junctions are untouched: on a 27-symbol sheet the netlist exported before and after is
byte-identical.

### Related

Not a fix for #202 (`bulk_move_schematic_components` leaving field text behind), which
is a bug in the move itself. It does give a way to repair a sheet that has already hit
it.

### Testing

`cargo fmt --all -- --check`, `cargo clippy --workspace --locked -- -D warnings`,
`cargo test --workspace --locked --doc` and the workspace test suite all pass. Three
`update_symbols_from_library` tests fail on my machine both with and without this
branch — pre-existing on `main`, unrelated to this change.

Two new unit tests: stale fields are put back on their anchors and a second run
reports nothing left to move, and an unknown reference comes back in `not_found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
