### PR TITLE
fix(schematic): preserve custom paper dimensions and portrait flag

### DIFF
--- a/crates/konnect-schematic-editor/src/schematic/mod.rs
+++ b/crates/konnect-schematic-editor/src/schematic/mod.rs
@@ -96,7 +96,18 @@ pub struct Schematic {
     pub generator: Option<String>,
     pub generator_version: Option<String>,
     pub uuid: Option<String>,
+    /// Page size name only — `A4`, `USLetter`, `User`, …
     pub paper: Option<String>,
+    /// Tokens that follow the page size name inside `(paper …)`, preserved
+    /// verbatim.
+    ///
+    /// KiCAD writes `(paper "User" 292.1 205.105)` for a custom page — the two
+    /// dimensions are REQUIRED there — and `(paper "A4" portrait)` for a
+    /// portrait named page. Both were dropped when only `paper` was
+    /// round-tripped, and a `(paper "User")` with no dimensions makes KiCAD
+    /// refuse to load the schematic at all ("Failed to load schematic", no
+    /// further diagnostic).
+    pub paper_args: Vec<SexpNode>,
 
     pub symbols: SymbolCollection,
     pub wires: WireCollection,
@@ -386,6 +397,7 @@ impl Schematic {
         let mut generator_version = None;
         let mut uuid = None;
         let mut paper = None;
+        let mut paper_args: Vec<SexpNode> = vec![];
 
         let mut symbols: Vec<Symbol> = vec![];
         let mut wires: Vec<Wire> = vec![];
@@ -414,6 +426,9 @@ impl Schematic {
                 }
                 Some("paper") => {
                     paper = child.value().map(str::to_owned);
+                    // Everything after the size name: `292.1 205.105` for a
+                    // custom page, `portrait` for a portrait named page.
+                    paper_args = child.args().iter().skip(1).cloned().collect();
                 }
                 Some("symbol") => match Symbol::from_sexp(child) {
                     Ok(s) => symbols.push(s),
@@ -467,6 +482,7 @@ impl Schematic {
             generator_version,
             uuid,
             paper,
+            paper_args,
             symbols: SymbolCollection::new(symbols),
             wires: WireCollection::new(wires),
             labels: LabelCollection::new(labels),
@@ -499,8 +515,15 @@ impl Schematic {
         if let Some(u) = &self.uuid {
             c.push(tagged("uuid", vec![qstr(u.clone())]));
         }
+        // The page size name alone is not always a complete `(paper …)` node:
+        // `User` requires its width and height, and a portrait named size
+        // carries a `portrait` token. KiCAD rejects the whole file if either is
+        // missing, so re-emit whatever followed the name.
         if let Some(p) = &self.paper {
-            c.push(tagged("paper", vec![qstr(p.clone())]));
+            let mut args = Vec::with_capacity(1 + self.paper_args.len());
+            args.push(qstr(p.clone()));
+            args.extend(self.paper_args.iter().cloned());
+            c.push(tagged("paper", args));
         }
 
         // Preserved nodes — emit in order:

--- a/crates/konnect-schematic-editor/tests/integration.rs
+++ b/crates/konnect-schematic-editor/tests/integration.rs
@@ -676,3 +676,75 @@ fn raw_and_typed_symbol_children_survive_interleaving() {
     assert_eq!(r2.unit, 1);
     assert_eq!(r2.value_str(), Some("22k"));
 }
+
+// ---- (paper …) round-trip ---------------------------------------------------
+
+/// Load a one-off schematic whose only interesting content is its paper node.
+fn sch_with_paper(paper_line: &str) -> Schematic {
+    let src = format!(
+        "(kicad_sch\n  (version 20250114)\n  (generator \"eeschema\")\n  \
+         (generator_version \"10.0\")\n  \
+         (uuid \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\")\n  {paper_line}\n  \
+         (lib_symbols\n  )\n)"
+    );
+    let tmp = tempfile::Builder::new()
+        .suffix(".kicad_sch")
+        .tempfile()
+        .expect("create tempfile");
+    std::fs::write(tmp.path(), src).unwrap();
+    Schematic::load(tmp.path()).unwrap()
+}
+
+#[test]
+fn custom_paper_keeps_its_dimensions() {
+    // `User` is the one page size whose width and height are mandatory. Writing
+    // a bare `(paper "User")` produces a file KiCAD refuses to load, with no
+    // diagnostic beyond "Failed to load schematic" — and KiCAD's own EasyEDA
+    // importer lands every imported sheet on `User`.
+    let sch = sch_with_paper(r#"(paper "User" 292.1 205.105)"#);
+    assert_eq!(sch.paper.as_deref(), Some("User"));
+
+    let out = sch.to_source();
+    assert!(
+        out.contains(r#"(paper "User" 292.1 205.105)"#),
+        "custom page dimensions must survive a parse -> write cycle:\n{out}"
+    );
+}
+
+#[test]
+fn custom_paper_survives_repeated_round_trips() {
+    let mut sch = sch_with_paper(r#"(paper "User" 292.1 205.105)"#);
+    for _ in 0..3 {
+        let tmp = tempfile::Builder::new()
+            .suffix(".kicad_sch")
+            .tempfile()
+            .expect("create tempfile");
+        std::fs::write(tmp.path(), sch.to_source()).unwrap();
+        sch = Schematic::load(tmp.path()).unwrap();
+    }
+    assert!(
+        sch.to_source().contains(r#"(paper "User" 292.1 205.105)"#),
+        "dimensions must not erode across successive edits"
+    );
+}
+
+#[test]
+fn portrait_paper_keeps_its_orientation() {
+    let sch = sch_with_paper(r#"(paper "A4" portrait)"#);
+    assert_eq!(sch.paper.as_deref(), Some("A4"));
+
+    let out = sch.to_source();
+    assert!(
+        out.contains(r#"(paper "A4" portrait)"#),
+        "the portrait flag must survive a parse -> write cycle:\n{out}"
+    );
+}
+
+#[test]
+fn named_paper_gains_no_extra_tokens() {
+    let out = sch_with_paper(r#"(paper "A4")"#).to_source();
+    assert!(
+        out.contains(r#"(paper "A4")"#),
+        "a plain named page must round-trip unchanged:\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary

Any tool that writes a `.kicad_sch` through the typed model destroyed the sheet's page
setup when the page size was `User`, producing a schematic **KiCad flatly refuses to
open**.

```lisp
(paper "User" 292.1 205.105)   ->   (paper "User")
(paper "A4" portrait)          ->   (paper "A4")
```

For the `User` page size the width and height are mandatory — KiCad's own writer emits
them unconditionally for a custom page — so `(paper "User")` is not a valid page node and
the parse of the whole file fails.

This matters more than it looks: **KiCad's EasyEDA importer lands every imported sheet on
`User` paper**, so a freshly imported schematic is destroyed by the very first Konnect
write tool anyone points at it. Named sizes (`A4`, `USLetter`, …) carry no dimensions,
which is why it stayed hidden.

The failure is silent and gives nothing to go on:

- `kicad-cli sch erc -o /tmp/x.rpt file.kicad_sch` prints only `Failed to load schematic`
- `eeschema file.kicad_sch` opens **no window at all** and writes nothing to stdout/stderr
- The s-expression stays well-formed and paren-balanced, so generic validators pass
- Konnect itself reports success — the tool call returns `isError: false`

Closes #208

## Approach

**Root cause** — `crates/konnect-schematic-editor/src/schematic/mod.rs`.
`Schematic::from_sexp` kept only the *first* scalar of the `(paper …)` node via
`child.value()`, and `Schematic::to_sexp` re-emitted exactly that one token:

```rust
Some("paper") => {
    paper = child.value().map(str::to_owned);   // "User" — 292.1 and 205.105 are gone
}
...
if let Some(p) = &self.paper {
    c.push(tagged("paper", vec![qstr(p.clone())]));   // (paper "User")
}
```

This is the header-level twin of #143: the typed model re-serializes and silently drops
what it never parsed.

**Fix** — keep `paper` as the page size name and preserve the trailing tokens verbatim in
a new `paper_args: Vec<SexpNode>`, mirroring how `raw_other` already preserves unmodelled
nodes. Whatever KiCad wrote after the size name comes back unchanged, so the portrait flag
is covered by the same change without having to model KiCad's page grammar (custom
dimensions and `portrait` are mutually exclusive there, and encoding that rule would be a
second thing to get wrong).

Every tool routed through `Schematic::load` → mutate → `save()`/`to_source()` is fixed at
once: `add_wire`, `batch_add_wire`, `add_power_symbol`, `add_junction`,
`batch_add_junction`, `connect_to_net`, `add_net_label`, `add_no_connect`,
`add_schematic_component`, `delete_schematic_component`, `move_schematic_component`,
`rotate_schematic_component`, `move_region`, `batch_place_components`,
`renumber_sheet_pages`, `validate_sheet_pins`.

## Compatibility and safety

- No MCP tool, schema field, CLI flag, env var, or config key changes. No tools added or
  removed, so no count updates.
- One new public field on `Schematic` (`paper_args`). Additive: existing readers of
  `paper` see the unchanged page size name. The struct is only ever constructed inside
  `from_sexp`, so there is no external struct-literal breakage.
- File mutation path is untouched — writes still go through the existing atomic,
  revision-checked `save()`.
- Behaviour change is strictly additive on output: files that previously round-tripped
  correctly (plain named sizes) emit byte-identical `(paper …)` nodes, which
  `named_paper_gains_no_extra_tokens` pins.

## Validation

```
cargo fmt --all -- --check                              clean
cargo test -p konnect-schematic-editor --locked --lib --tests
                                                        41 passed / 0 failed
cargo test --workspace --locked --lib --tests           354 passed / 3 failed
cargo clippy --workspace --locked -- -D warnings        clean
cargo build --release -p konnect                        ok
```

The 3 workspace failures are pre-existing on unmodified `main` @ `17226f0` and untouched
by this change — all three are `tools::sch_components::tests::update_symbols_from_library_*`
(from #150), which race on the process-wide env vars set by `stub_symbol_dir()`. The
schematic-editor suite, which is what this PR touches, is fully green.

### Regression tests

`crates/konnect-schematic-editor/tests/integration.rs`:

- `custom_paper_keeps_its_dimensions` — `(paper "User" 292.1 205.105)` survives
  parse → write
- `custom_paper_survives_repeated_round_trips` — and does not erode over three successive
  load/save cycles
- `portrait_paper_keeps_its_orientation` — `(paper "A4" portrait)` survives
- `named_paper_gains_no_extra_tokens` — a plain `(paper "A4")` gains nothing

All three of the first three fail on `main` and pass with the fix, so the coverage
discriminates.

### End-to-end against real KiCad 10.0.5 (macOS arm64)

A fixture on `(paper "User" 292.1 205.105)`, driven through a hand-written stdio MCP
handshake (`initialize` → `load_toolset sch_wiring` → `tools/call add_wire`), then loaded
with `kicad-cli`:

| binary | paper line after the write | `kicad-cli sch erc` |
|---|---|---|
| — (baseline, no write) | `(paper "User" 292.1 205.105)` | `Found 3 violations` |
| v0.3.2 release | `(paper "User")` | `Failed to load schematic` |
| this branch | `(paper "User" 292.1 205.105)` | `Found 6 violations` |

In both write cases Konnect reported `isError: false`. The violation count rises from 3 to
6 on the fixed run because the added wire is itself unconnected — i.e. the edit really
landed; the file just remains loadable.

Same fixture on `(paper "A4" portrait)`:

| binary | paper line after the write |
|---|---|
| v0.3.2 release | `(paper "A4")` |
| this branch | `(paper "A4" portrait)` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
