### PR TITLE
fix(schematic): issue the lowest free #PWR number, not the count plus one

### DIFF
--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -206,7 +206,7 @@ pub fn tools() -> Vec<ToolDef> {
         tool!(
             "add_power_symbol",
             "Add a power symbol (VCC, GND, etc.) to the schematic. Auto-numbers the \
-             internal #PWR reference.",
+             internal #PWR reference to the lowest number free on the sheet.",
             json!({
                 "type": "object",
                 "properties": {
@@ -1238,6 +1238,22 @@ async fn handle_batch_rotate_labels(
     Ok(CallToolResult::json(&json!({ "rotated": rotated })))
 }
 
+/// The lowest `#PWR` number no symbol on the sheet is using.
+///
+/// Counting the power symbols instead re-issues a live designator after a
+/// deletion: drop `#PWR028` from a sheet of 29 and the count is 28, so the
+/// next symbol is handed `#PWR029` — still in use, silently duplicated.
+fn next_pwr_number(sch: &cse::Schematic) -> u32 {
+    let used: std::collections::HashSet<u32> = sch
+        .symbols
+        .iter()
+        .filter_map(|s| s.reference())
+        .filter_map(|r| r.strip_prefix("#PWR"))
+        .filter_map(|n| n.parse::<u32>().ok())
+        .collect();
+    (1u32..).find(|n| !used.contains(n)).unwrap_or(1)
+}
+
 async fn handle_add_power_symbol(
     args: &serde_json::Value,
     _ctx: &ToolContext,
@@ -1259,17 +1275,7 @@ async fn handle_add_power_symbol(
 
     let mut sch = cse::Schematic::load(&sch_path)?;
 
-    // Auto-number the #PWR reference by counting existing power symbols
-    let pwr_count = sch
-        .symbols
-        .iter()
-        .filter(|s| {
-            s.reference()
-                .map(|r| r.starts_with("#PWR"))
-                .unwrap_or(false)
-        })
-        .count();
-    let pwr_ref = format!("#PWR{:03}", pwr_count + 1);
+    let pwr_ref = format!("#PWR{:03}", next_pwr_number(&sch));
 
     // Embed the power symbol definition in lib_symbols
     let lib_id = format!("power:{}", power_net);
@@ -2688,6 +2694,50 @@ mod power_symbol_tests {
         assert!(
             val_sexp.contains("76.444"),
             "VCC's Value belongs above the symbol at y-3.556, not below: {val_sexp}"
+        );
+    }
+
+    /// Numbering by count re-issued a designator that was still on the sheet:
+    /// delete `#PWR002` of three and the next add produced a second `#PWR003`.
+    #[tokio::test]
+    async fn add_power_symbol_fills_a_freed_number_instead_of_duplicating() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gnd.kicad_sch");
+        std::fs::write(
+            &path,
+            "(kicad_sch\n  (version 20250610)\n  (generator \"konnect\")\n  (uuid \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\")\n  (paper \"A4\")\n  (lib_symbols\n    (symbol \"power:GND\"\n      (property \"Reference\" \"#PWR\" (at 0 -6.35 0))\n      (property \"Value\" \"GND\" (at 0 -3.81 0))\n    )\n  )\n)\n",
+        )
+        .unwrap();
+
+        let add = |x: f64| {
+            let args = json!({
+                "schematic": path.display().to_string(),
+                "power_net": "GND",
+                "x": x,
+                "y": 80.0
+            });
+            async move {
+                let result = handle_add_power_symbol(&args, &test_ctx()).await.unwrap();
+                assert!(!result.is_error, "{result:?}");
+            }
+        };
+        add(100.0).await;
+        add(110.0).await;
+        add(120.0).await;
+
+        let mut sch = cse::Schematic::load(&path).unwrap();
+        sch.symbols.retain(|s| s.reference() != Some("#PWR002"));
+        sch.overwrite().unwrap();
+
+        add(130.0).await;
+
+        let sch = cse::Schematic::load(&path).unwrap();
+        let mut refs: Vec<&str> = sch.symbols.iter().filter_map(|s| s.reference()).collect();
+        refs.sort_unstable();
+        assert_eq!(
+            refs,
+            ["#PWR001", "#PWR002", "#PWR003"],
+            "the freed number belongs to the new symbol, and nothing may repeat"
         );
     }
 }

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -96,7 +96,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `rotate_schematic_label` | Rotate a net label to a new angle and update its justify direction. |
 | `move_labels_by_offset` | Move all labels matching a net name by a given X/Y offset. |
 | `batch_rotate_labels` | Rotate multiple labels by net name in a single file read/write cycle. |
-| `add_power_symbol` | Add a power symbol (VCC, GND, etc.). Auto-numbers the internal `#PWR` reference. |
+| `add_power_symbol` | Add a power symbol (VCC, GND, etc.). Auto-numbers the internal `#PWR` reference to the lowest number free on the sheet. |
 | `add_no_connect` | Add a no-connect flag (X marker) to an unconnected pin endpoint. |
 | `delete_no_connect` | Remove a no-connect flag at a given position. |
 | `batch_delete_no_connect` | Delete multiple no-connect flags in a single file read/write cycle. |


### PR DESCRIPTION
`add_power_symbol` numbered its `#PWR` reference by *counting* the power symbols on the
sheet, so a count equals max+1 only while nothing has been deleted. Delete `#PWR028` from
a sheet of 29 and the next call hands back `#PWR029` — still in use. Two symbols, one
reference, no error, and recovery needs a manual `edit_schematic_component` rename first.

Found dogfooding on a real board (27 symbols, 29 power symbols). Not filed as an issue —
#157 and #202 are the neighbouring reference bugs, both about editing an existing
designator rather than issuing a new one.

### The fix

`next_pwr_number` collects the `#PWR` suffixes already on the sheet and returns the lowest
one free, so a freed number is reused and one still on that sheet never is.

Lowest-free rather than max+1: it keeps numbering dense the way eeschema's annotator does,
and it cannot run away from the symbol count over a long editing session. Reuse is visible
to a caller that caches a reference — a stale `#PWR002` used to fail *not found* and now
names a different symbol — so the tool description and its `tool-directory.md` entry say
which number the tool picks.

Two limits it keeps, both pre-existing:

- The scan covers the sheet being edited, as the counting code did. Two sheets of one
  project each start at `#PWR001` while KiCad annotates project-wide. Closing that means
  reading every sheet the root links, which is its own change.
- It reads each symbol's `Reference` property, which is what the counting code read too,
  so an instances-path reference left stale by #157's rename bug is invisible here.

`PWR_FLAG` still gets `#PWR0xx` where eeschema uses `#FLG0x`. Cosmetic, and left alone:
the prefix is in the file KiCad reads back, so changing it is a behaviour change of its
own.

### Testing

`cargo fmt --all -- --check`, `cargo clippy --workspace --locked -- -D warnings`,
`cargo test --workspace --locked --doc` and the workspace test suite all pass. Three
`update_symbols_from_library` tests fail both with and without this branch — pre-existing
on `main`, unrelated.

One new test adds three GND symbols, deletes `#PWR002`, adds a fourth, and asserts the
sheet holds exactly `#PWR001/002/003`. Under the counting code the fourth is a second
`#PWR003`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
