### PR TITLE
fix(installer): scope guidance by client

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,33 @@ Verify: open the **PCB Editor** → **Tools → External Plugins** → you shoul
 cargo build --release -p konnect
 ```
 
+### Install guidance for your AI client
+
+Konnect bundles shared KiCad skills for Claude and Codex. Select the client when
+installing, checking, or removing that guidance:
+
+```bash
+# Existing behavior remains the default: Claude skills, agents, and hooks
+konnect init
+
+# Codex installs only the shared skills under ~/.agents/skills
+konnect init --client codex
+konnect status --client codex
+konnect uninstall --client codex
+```
+
+Keep `--client codex` in the MCP server command so first-launch setup also stays
+inside Codex's directories. For example, register a standalone binary with the
+Codex CLI using:
+
+```bash
+codex mcp add konnect -- /path/to/konnect --client codex
+```
+
+Claude remains the default when `--client` is omitted. The installer tracks the
+two clients independently, and a Codex install does not create or modify
+`~/.claude`.
+
 ### macOS
 
 The [Releases](https://github.com/mixelpixx/Konnect/releases) page ships

--- a/crates/konnect/src/install.rs
+++ b/crates/konnect/src/install.rs
@@ -1,269 +1,123 @@
-//! First-run installer for Konnect.
+//! Client-aware installer for Konnect's bundled guidance.
 //!
-//! Handles:
-//! - `init` — full install with console output
-//! - `uninstall` — remove all installed files and hook entries
-//! - `status` — show install state with [+]/[-] markers
-//! - `skill <name>` — print a skill's markdown to stdout (for hook integration)
-//! - Silent install on first MCP launch (no stdout, stderr logging only)
-//! - KiCAD auto-detection on Windows
+//! Handles client-scoped install, uninstall, status, first-launch setup, and
+//! Claude hook integration without writing into another client's directories.
 
 use crate::manifest::{AGENTS, HOOK_SKILLS, SKILLS};
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
+use std::fmt;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
-// ─── Public API ──────────────────────────────────────────────────────────────
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum InstallClient {
+    #[default]
+    Claude,
+    Codex,
+}
 
-/// Full install with console output. Called by `init` subcommand or double-click.
-pub fn run_install() -> Result<()> {
-    println!("Installing Konnect skills, agents, and hooks...\n");
+impl InstallClient {
+    fn marker_name(self) -> &'static str {
+        match self {
+            Self::Claude => ".installed-claude",
+            Self::Codex => ".installed-codex",
+        }
+    }
+}
 
-    // Skills
-    let skills_dir = claude_skills_dir()?;
-    let mut skill_count = 0;
-    for skill in SKILLS {
-        let dest = skills_dir.join(skill.name);
-        fs::create_dir_all(&dest)?;
-        fs::write(dest.join("SKILL.md"), skill.content)?;
+impl fmt::Display for InstallClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Claude => write!(f, "Claude"),
+            Self::Codex => write!(f, "Codex"),
+        }
+    }
+}
 
-        // Reference files
-        if !skill.references.is_empty() {
-            let refs_dir = dest.join("references");
-            fs::create_dir_all(&refs_dir)?;
-            for (filename, content) in skill.references {
-                fs::write(refs_dir.join(filename), content)?;
+impl FromStr for InstallClient {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "claude" => Ok(Self::Claude),
+            "codex" => Ok(Self::Codex),
+            _ => bail!("unsupported client '{value}'; expected 'claude' or 'codex'"),
+        }
+    }
+}
+
+/// Parse `--client <claude|codex>`. Claude remains the default for compatibility.
+pub fn client_from_args(args: &[String]) -> Result<InstallClient> {
+    let mut selected = None;
+    let mut index = 0;
+    while index < args.len() {
+        if args[index] == "--client" {
+            if selected.is_some() {
+                bail!("--client may only be specified once");
             }
+            let value = args
+                .get(index + 1)
+                .context("--client requires 'claude' or 'codex'")?;
+            selected = Some(value.parse()?);
+            index += 2;
+        } else {
+            index += 1;
         }
-        skill_count += 1;
-        println!("  [+] Skill: {}", skill.name);
     }
-
-    // Agents
-    let agents_dir = claude_agents_dir()?;
-    fs::create_dir_all(&agents_dir)?;
-    let mut agent_count = 0;
-    for agent in AGENTS {
-        fs::write(agents_dir.join(agent.filename), agent.content)?;
-        agent_count += 1;
-        println!("  [+] Agent: {}", agent.filename);
-    }
-
-    // Hooks
-    let exe = std::env::current_exe()?;
-    let exe_str = exe.to_string_lossy().to_string();
-    let hook_count = patch_claude_settings(&exe_str)?;
-    if hook_count > 0 {
-        println!(
-            "  [+] Hooks: {} entries patched into settings.json",
-            hook_count
-        );
-    } else {
-        println!("  [=] Hooks: already installed (no changes)");
-    }
-
-    // KiCAD detection
-    if let Some(kicad_path) = detect_kicad() {
-        println!("\n  [+] Found KiCAD at: {}", kicad_path.display());
-    } else {
-        println!("\n  [-] KiCAD not found in standard locations");
-        println!("      Set kicad_cli path in your config file manually");
-    }
-
-    // Write marker
-    let data = data_dir()?;
-    fs::create_dir_all(&data)?;
-    fs::write(data.join(".installed"), env!("CARGO_PKG_VERSION"))?;
-
-    println!(
-        "\nDone: {} skills, {} agents, {} hooks installed.",
-        skill_count, agent_count, hook_count
-    );
-    Ok(())
+    Ok(selected.unwrap_or_default())
 }
 
-/// Silent install — no stdout output (safe for MCP pipe mode).
-/// Logs to stderr via tracing.
-pub fn run_install_silent() -> Result<()> {
-    // Skills
-    let skills_dir = claude_skills_dir()?;
-    for skill in SKILLS {
-        let dest = skills_dir.join(skill.name);
-        fs::create_dir_all(&dest)?;
-        fs::write(dest.join("SKILL.md"), skill.content)?;
-        if !skill.references.is_empty() {
-            let refs_dir = dest.join("references");
-            fs::create_dir_all(&refs_dir)?;
-            for (filename, content) in skill.references {
-                fs::write(refs_dir.join(filename), content)?;
-            }
-        }
-    }
-
-    // Agents
-    let agents_dir = claude_agents_dir()?;
-    fs::create_dir_all(&agents_dir)?;
-    for agent in AGENTS {
-        fs::write(agents_dir.join(agent.filename), agent.content)?;
-    }
-
-    // Hooks
-    let exe = std::env::current_exe()?;
-    let exe_str = exe.to_string_lossy().to_string();
-    let _ = patch_claude_settings(&exe_str);
-
-    // Marker
-    let data = data_dir()?;
-    fs::create_dir_all(&data)?;
-    fs::write(data.join(".installed"), env!("CARGO_PKG_VERSION"))?;
-
-    eprintln!(
-        "[konnect] Silent install complete: {} skills, {} agents",
-        SKILLS.len(),
-        AGENTS.len()
-    );
-    Ok(())
+pub fn run_install(client: InstallClient) -> Result<()> {
+    run_install_at(client, &InstallPaths::for_current_user()?, true)
 }
 
-/// Remove all installed files and hook entries.
-pub fn run_uninstall() -> Result<()> {
-    println!("Uninstalling Konnect skills, agents, and hooks...\n");
-
-    // Skills
-    let skills_dir = claude_skills_dir()?;
-    for skill in SKILLS {
-        let dest = skills_dir.join(skill.name);
-        if dest.exists() {
-            fs::remove_dir_all(&dest)?;
-            println!("  [-] Removed skill: {}", skill.name);
-        }
-    }
-
-    // Agents
-    let agents_dir = claude_agents_dir()?;
-    for agent in AGENTS {
-        let dest = agents_dir.join(agent.filename);
-        if dest.exists() {
-            fs::remove_file(&dest)?;
-            println!("  [-] Removed agent: {}", agent.filename);
-        }
-    }
-
-    // Hooks — remove our entries from settings.json
-    remove_hooks_from_settings()?;
-    println!("  [-] Removed hook entries from settings.json");
-
-    // Marker
-    let data = data_dir()?;
-    let marker = data.join(".installed");
-    if marker.exists() {
-        fs::remove_file(&marker)?;
-    }
-
-    println!("\nDone.");
-    Ok(())
+pub fn run_install_silent(client: InstallClient) -> Result<()> {
+    run_install_at(client, &InstallPaths::for_current_user()?, false)
 }
 
-/// Print install status with [+]/[-] markers.
-pub fn print_status() -> Result<()> {
-    println!("Konnect v{} — Install Status\n", env!("CARGO_PKG_VERSION"));
-
-    let skills_dir = claude_skills_dir()?;
-    println!("Skills (~/.claude/skills/):");
-    for skill in SKILLS {
-        let exists = skills_dir.join(skill.name).join("SKILL.md").exists();
-        let marker = if exists { "+" } else { "-" };
-        println!("  [{}] {}", marker, skill.name);
-    }
-
-    let agents_dir = claude_agents_dir()?;
-    println!("\nAgents (~/.claude/agents/):");
-    for agent in AGENTS {
-        let exists = agents_dir.join(agent.filename).exists();
-        let marker = if exists { "+" } else { "-" };
-        println!("  [{}] {}", marker, agent.filename);
-    }
-
-    println!("\nHooks (~/.claude/settings.json):");
-    let settings_path = claude_settings_path();
-    if settings_path.exists() {
-        let raw = fs::read_to_string(&settings_path).unwrap_or_default();
-        for hook in HOOK_SKILLS {
-            let exists = raw.contains(hook.name);
-            let marker = if exists { "+" } else { "-" };
-            println!("  [{}] {} ({})", marker, hook.name, hook.event);
-        }
-    } else {
-        for hook in HOOK_SKILLS {
-            println!("  [-] {} ({})", hook.name, hook.event);
-        }
-    }
-
-    // KiCAD detection
-    println!("\nKiCAD:");
-    if let Some(path) = detect_kicad() {
-        println!("  [+] Found: {}", path.display());
-    } else {
-        println!("  [-] Not found in standard locations");
-    }
-
-    let data = data_dir()?;
-    let marker = data.join(".installed");
-    if marker.exists() {
-        let ver = fs::read_to_string(&marker).unwrap_or_default();
-        println!("\nInstall marker: v{}", ver.trim());
-    } else {
-        println!("\nInstall marker: not present (never installed)");
-    }
-
-    Ok(())
+pub fn run_uninstall(client: InstallClient) -> Result<()> {
+    run_uninstall_at(client, &InstallPaths::for_current_user()?, true)
 }
 
-/// Print a skill's content to stdout. Used by hooks:
-/// `konnect.exe skill <name>` outputs markdown that Claude Code
-/// injects before/after a tool call.
+pub fn print_status(client: InstallClient) -> Result<()> {
+    print_status_at(client, &InstallPaths::for_current_user()?)
+}
+
+/// Print bundled guidance for Claude hook integration.
 pub fn print_skill_content(name: &str) -> Result<()> {
-    // Check hook skills first (they have short inline content)
     for hook in HOOK_SKILLS {
         if hook.name == name {
             print!("{}", hook.content);
             return Ok(());
         }
     }
-
-    // Check regular skills
     for skill in SKILLS {
         if skill.name == name {
             print!("{}", skill.content);
             return Ok(());
         }
     }
-
     eprintln!("Unknown skill: {}", name);
     std::process::exit(1);
 }
 
-/// Check if install has been completed.
-pub fn needs_install() -> bool {
-    match data_dir() {
-        Ok(d) => !d.join(".installed").exists(),
-        Err(_) => false,
-    }
+pub fn needs_install(client: InstallClient) -> bool {
+    InstallPaths::for_current_user()
+        .map(|paths| !has_install_marker(client, &paths))
+        .unwrap_or(false)
 }
 
-/// Friendly double-click install: shows banner, runs install, prints config snippet.
+/// Double-click behavior remains Claude-focused for backward compatibility.
 pub fn run_double_click_install() -> Result<()> {
     println!("===========================================");
     println!("  Konnect v{}", env!("CARGO_PKG_VERSION"));
     println!("  First-time Setup");
     println!("===========================================\n");
+    run_install(InstallClient::Claude)?;
 
-    run_install()?;
-
-    // Print MCP config snippet
     let exe = std::env::current_exe()?;
     let exe_str = exe.to_string_lossy().replace('\\', "\\\\");
-
     println!("\n-------------------------------------------");
     println!("Add this to your Claude MCP config:");
     println!("-------------------------------------------\n");
@@ -271,136 +125,360 @@ pub fn run_double_click_install() -> Result<()> {
     println!(r#"    "command": "{}","#, exe_str);
     println!(r#"    "env": {{ "RUST_LOG": "info" }}"#);
     println!(r#"  }}"#);
-
     println!("\nConfig locations:");
     println!("  Claude Desktop: %APPDATA%\\Claude\\claude_desktop_config.json");
     println!("  Claude Code:    .mcp.json in your project root");
     println!("\nAfter editing the config, restart Claude.\n");
-
     println!("Press Enter to close...");
     let mut buf = String::new();
     let _ = std::io::stdin().read_line(&mut buf);
     Ok(())
 }
 
-// ─── Internal Helpers ────────────────────────────────────────────────────────
-
-fn home_dir() -> Result<PathBuf> {
-    dirs::home_dir().context("could not locate home directory")
+#[derive(Debug)]
+struct InstallPaths {
+    home: PathBuf,
 }
 
-fn data_dir() -> Result<PathBuf> {
-    Ok(home_dir()?.join(".konnect"))
+impl InstallPaths {
+    fn for_current_user() -> Result<Self> {
+        Ok(Self {
+            home: dirs::home_dir().context("could not locate home directory")?,
+        })
+    }
+
+    fn data_dir(&self) -> PathBuf {
+        self.home.join(".konnect")
+    }
+
+    fn skills_dir(&self, client: InstallClient) -> PathBuf {
+        match client {
+            InstallClient::Claude => self.home.join(".claude").join("skills"),
+            InstallClient::Codex => self.home.join(".agents").join("skills"),
+        }
+    }
+
+    fn claude_agents_dir(&self) -> PathBuf {
+        self.home.join(".claude").join("agents")
+    }
+
+    fn claude_settings_path(&self) -> PathBuf {
+        self.home.join(".claude").join("settings.json")
+    }
+
+    fn marker(&self, client: InstallClient) -> PathBuf {
+        self.data_dir().join(client.marker_name())
+    }
+
+    fn legacy_marker(&self) -> PathBuf {
+        self.data_dir().join(".installed")
+    }
 }
 
-fn claude_skills_dir() -> Result<PathBuf> {
-    Ok(home_dir()?.join(".claude").join("skills"))
+fn run_install_at(client: InstallClient, paths: &InstallPaths, verbose: bool) -> Result<()> {
+    if verbose {
+        match client {
+            InstallClient::Claude => {
+                println!("Installing Konnect skills, agents, and hooks for Claude...\n")
+            }
+            InstallClient::Codex => println!("Installing Konnect skills for Codex...\n"),
+        }
+    }
+
+    let skill_count = install_skills(client, paths, verbose)?;
+    let mut agent_count = 0;
+    let mut hook_count = 0;
+    if client == InstallClient::Claude {
+        let agents_dir = paths.claude_agents_dir();
+        fs::create_dir_all(&agents_dir)?;
+        for agent in AGENTS {
+            fs::write(agents_dir.join(agent.filename), agent.content)?;
+            agent_count += 1;
+            if verbose {
+                println!("  [+] Agent: {}", agent.filename);
+            }
+        }
+
+        let exe = std::env::current_exe()?;
+        let settings_path = paths.claude_settings_path();
+        let exe_str = exe.to_string_lossy();
+        hook_count = if verbose {
+            patch_claude_settings(&settings_path, &exe_str)?
+        } else {
+            patch_claude_settings(&settings_path, &exe_str).unwrap_or_default()
+        };
+        if verbose {
+            if hook_count > 0 {
+                println!("  [+] Hooks: {hook_count} entries patched into settings.json");
+            } else {
+                println!("  [=] Hooks: already installed (no changes)");
+            }
+        }
+    }
+
+    if verbose {
+        if let Some(kicad_path) = detect_kicad() {
+            println!("\n  [+] Found KiCAD at: {}", kicad_path.display());
+        } else {
+            println!("\n  [-] KiCAD not found in standard locations");
+            println!("      Set kicad_cli path in your config file manually");
+        }
+    }
+
+    fs::create_dir_all(paths.data_dir())?;
+    fs::write(paths.marker(client), env!("CARGO_PKG_VERSION"))?;
+
+    if verbose {
+        match client {
+            InstallClient::Claude => println!(
+                "\nDone: {skill_count} skills, {agent_count} agents, {hook_count} hooks installed for Claude."
+            ),
+            InstallClient::Codex => {
+                println!("\nDone: {skill_count} skills installed for Codex.")
+            }
+        }
+    } else {
+        eprintln!(
+            "[konnect] Silent {client} install complete: {skill_count} skills, {agent_count} agents"
+        );
+    }
+    Ok(())
 }
 
-fn claude_agents_dir() -> Result<PathBuf> {
-    Ok(home_dir()?.join(".claude").join("agents"))
+fn install_skills(client: InstallClient, paths: &InstallPaths, verbose: bool) -> Result<usize> {
+    let skills_dir = paths.skills_dir(client);
+    for skill in SKILLS {
+        let dest = skills_dir.join(skill.name);
+        fs::create_dir_all(&dest)?;
+        fs::write(dest.join("SKILL.md"), skill.content)?;
+        if !skill.references.is_empty() {
+            let refs_dir = dest.join("references");
+            fs::create_dir_all(&refs_dir)?;
+            for (filename, content) in skill.references {
+                fs::write(refs_dir.join(filename), content)?;
+            }
+        }
+        if verbose {
+            println!("  [+] Skill: {}", skill.name);
+        }
+    }
+    Ok(SKILLS.len())
 }
 
-fn claude_settings_path() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".claude")
-        .join("settings.json")
+fn run_uninstall_at(client: InstallClient, paths: &InstallPaths, verbose: bool) -> Result<()> {
+    if verbose {
+        println!("Uninstalling Konnect guidance for {client}...\n");
+    }
+
+    let skills_dir = paths.skills_dir(client);
+    for skill in SKILLS {
+        let dest = skills_dir.join(skill.name);
+        if dest.exists() {
+            fs::remove_dir_all(&dest)?;
+            if verbose {
+                println!("  [-] Removed skill: {}", skill.name);
+            }
+        }
+    }
+
+    if client == InstallClient::Claude {
+        let agents_dir = paths.claude_agents_dir();
+        for agent in AGENTS {
+            let dest = agents_dir.join(agent.filename);
+            if dest.exists() {
+                fs::remove_file(&dest)?;
+                if verbose {
+                    println!("  [-] Removed agent: {}", agent.filename);
+                }
+            }
+        }
+        remove_hooks_from_settings(&paths.claude_settings_path())?;
+        if verbose {
+            println!("  [-] Removed hook entries from settings.json");
+        }
+        remove_if_present(&paths.legacy_marker())?;
+    }
+
+    remove_if_present(&paths.marker(client))?;
+    if verbose {
+        println!("\nDone.");
+    }
+    Ok(())
 }
 
-/// Idempotent hook patching: adds hook entries to `~/.claude/settings.json`.
-/// Returns the number of NEW entries added (0 if all already existed).
-fn patch_claude_settings(exe_str: &str) -> Result<usize> {
-    let path = claude_settings_path();
-    fs::create_dir_all(path.parent().unwrap())?;
+fn print_status_at(client: InstallClient, paths: &InstallPaths) -> Result<()> {
+    println!(
+        "Konnect v{} — {client} Install Status\n",
+        env!("CARGO_PKG_VERSION")
+    );
+    let skills_dir = paths.skills_dir(client);
+    println!("Skills ({}):", display_home_path(&skills_dir, &paths.home));
+    for skill in SKILLS {
+        let marker = if skills_dir.join(skill.name).join("SKILL.md").exists() {
+            "+"
+        } else {
+            "-"
+        };
+        println!("  [{marker}] {}", skill.name);
+    }
 
+    if client == InstallClient::Claude {
+        let agents_dir = paths.claude_agents_dir();
+        println!("\nAgents (~/.claude/agents/):");
+        for agent in AGENTS {
+            let marker = if agents_dir.join(agent.filename).exists() {
+                "+"
+            } else {
+                "-"
+            };
+            println!("  [{marker}] {}", agent.filename);
+        }
+        println!("\nHooks (~/.claude/settings.json):");
+        let raw = fs::read_to_string(paths.claude_settings_path()).unwrap_or_default();
+        for hook in HOOK_SKILLS {
+            let marker = if raw.contains(hook.name) { "+" } else { "-" };
+            println!("  [{marker}] {} ({})", hook.name, hook.event);
+        }
+    }
+
+    println!("\nKiCAD:");
+    if let Some(path) = detect_kicad() {
+        println!("  [+] Found: {}", path.display());
+    } else {
+        println!("  [-] Not found in standard locations");
+    }
+
+    if let Some(marker) = install_marker(client, paths) {
+        let version = fs::read_to_string(marker).unwrap_or_default();
+        println!("\nInstall marker: v{}", version.trim());
+    } else {
+        println!("\nInstall marker: not present (never installed)");
+    }
+    Ok(())
+}
+
+fn install_marker(client: InstallClient, paths: &InstallPaths) -> Option<PathBuf> {
+    let marker = paths.marker(client);
+    if marker.exists() {
+        return Some(marker);
+    }
+    if client == InstallClient::Claude && paths.legacy_marker().exists() {
+        return Some(paths.legacy_marker());
+    }
+    None
+}
+
+fn has_install_marker(client: InstallClient, paths: &InstallPaths) -> bool {
+    install_marker(client, paths).is_some()
+}
+
+fn remove_if_present(path: &Path) -> Result<()> {
+    if path.exists() {
+        fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+fn display_home_path(path: &Path, home: &Path) -> String {
+    path.strip_prefix(home)
+        .map(|relative| format!("~/{}", relative.display()))
+        .unwrap_or_else(|_| path.display().to_string())
+}
+
+fn patch_claude_settings(path: &Path, exe_str: &str) -> Result<usize> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
     let raw = if path.exists() {
-        fs::read_to_string(&path)?
+        fs::read_to_string(path)?
     } else {
         "{}".to_string()
     };
     let mut settings: serde_json::Value = serde_json::from_str(&raw)?;
-
     let hooks_obj = settings
         .as_object_mut()
-        .unwrap()
+        .context("Claude settings root is not an object")?
         .entry("hooks")
         .or_insert_with(|| serde_json::json!({}))
         .as_object_mut()
         .context("hooks field is not an object")?;
 
     let mut added = 0;
-
     for hook in HOOK_SKILLS {
         let event_arr = hooks_obj
             .entry(hook.event)
             .or_insert_with(|| serde_json::json!([]))
             .as_array_mut()
             .context("hook event field is not an array")?;
-
-        // Idempotent: skip if a hook with this matcher already exists
-        let already_exists = event_arr.iter().any(|h| {
-            h.get("matcher")
-                .and_then(|m| m.as_str())
-                .map(|m| m.contains(hook.name))
-                .unwrap_or(false)
+        let already_exists = event_arr.iter().any(|entry| {
+            entry
+                .get("hooks")
+                .and_then(|hooks| hooks.as_array())
+                .is_some_and(|hooks| {
+                    hooks.iter().any(|hook_entry| {
+                        hook_entry
+                            .get("command")
+                            .and_then(|command| command.as_str())
+                            .is_some_and(|command| {
+                                command.contains("konnect") && command.contains(hook.name)
+                            })
+                    })
+                })
         });
-
         if !already_exists {
-            // Use the exe path with escaped backslashes for the command
+            // Preserve the established Claude hook command representation.
             let exe_escaped = exe_str.replace('\\', "\\\\");
-            let entry = serde_json::json!({
+            event_arr.push(serde_json::json!({
                 "matcher": hook.tool_matcher,
                 "hooks": [{
                     "type": "command",
                     "command": format!("{} skill {}", exe_escaped, hook.name)
                 }]
-            });
-            event_arr.push(entry);
+            }));
             added += 1;
         }
     }
-
-    fs::write(&path, serde_json::to_string_pretty(&settings)?)?;
+    fs::write(path, serde_json::to_string_pretty(&settings)?)?;
     Ok(added)
 }
 
-/// Remove only our hook entries from settings.json (leave other hooks intact).
-fn remove_hooks_from_settings() -> Result<()> {
-    let path = claude_settings_path();
+fn remove_hooks_from_settings(path: &Path) -> Result<()> {
     if !path.exists() {
         return Ok(());
     }
-
-    let raw = fs::read_to_string(&path)?;
+    let raw = fs::read_to_string(path)?;
     let mut settings: serde_json::Value = serde_json::from_str(&raw)?;
-
-    if let Some(hooks_obj) = settings.get_mut("hooks").and_then(|h| h.as_object_mut()) {
+    if let Some(hooks_obj) = settings
+        .get_mut("hooks")
+        .and_then(|hooks| hooks.as_object_mut())
+    {
         for hook in HOOK_SKILLS {
-            if let Some(event_arr) = hooks_obj.get_mut(hook.event).and_then(|a| a.as_array_mut()) {
-                event_arr.retain(|h| {
-                    let is_ours = h
+            if let Some(event_arr) = hooks_obj
+                .get_mut(hook.event)
+                .and_then(|event| event.as_array_mut())
+            {
+                event_arr.retain(|entry| {
+                    !entry
                         .get("hooks")
                         .and_then(|hooks| hooks.as_array())
-                        .and_then(|arr| arr.first())
-                        .and_then(|h| h.get("command"))
-                        .and_then(|c| c.as_str())
-                        .map(|c| c.contains("konnect"))
-                        .unwrap_or(false);
-                    !is_ours
+                        .is_some_and(|hooks| {
+                            hooks.iter().any(|hook_entry| {
+                                hook_entry
+                                    .get("command")
+                                    .and_then(|command| command.as_str())
+                                    .is_some_and(|command| command.contains("konnect"))
+                            })
+                        })
                 });
             }
         }
     }
-
-    fs::write(&path, serde_json::to_string_pretty(&settings)?)?;
+    fs::write(path, serde_json::to_string_pretty(&settings)?)?;
     Ok(())
 }
 
-/// Auto-detect a KiCAD installation.
-/// Checks standard per-platform paths for kicad-cli (plus the registry on Windows).
+/// Auto-detect a KiCad installation.
 pub fn detect_kicad() -> Option<PathBuf> {
-    // Standard paths (check these first — faster than registry)
     #[cfg(target_os = "windows")]
     let standard_paths: Vec<PathBuf> = [
         r"C:\KiCad\10.0\bin\kicad-cli.exe",
@@ -421,7 +499,6 @@ pub fn detect_kicad() -> Option<PathBuf> {
             PathBuf::from("/usr/local/bin/kicad-cli"),
         ];
         if let Ok(home) = std::env::var("HOME") {
-            // Per-user install (KiCad.app dragged into ~/Applications)
             paths.push(
                 PathBuf::from(home).join("Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli"),
             );
@@ -440,43 +517,180 @@ pub fn detect_kicad() -> Option<PathBuf> {
             return Some(path.clone());
         }
     }
-
-    // Try registry on Windows
     #[cfg(target_os = "windows")]
-    {
-        if let Some(path) = detect_kicad_from_registry() {
-            return Some(path);
-        }
+    if let Some(path) = detect_kicad_from_registry() {
+        return Some(path);
     }
-
     None
 }
 
 #[cfg(target_os = "windows")]
 fn detect_kicad_from_registry() -> Option<PathBuf> {
     use std::process::Command;
-
-    // Use reg.exe to query the registry (avoids winreg dependency)
     let output = Command::new("reg")
         .args(["query", r"HKLM\SOFTWARE\KiCad\10.0", "/ve"])
         .output()
         .ok()?;
-
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
-        // Parse the default value which contains the install path
         for line in stdout.lines() {
             if line.contains("REG_SZ") {
                 let path_str = line.split("REG_SZ").last()?.trim();
-                let cli_path = std::path::Path::new(path_str)
-                    .join("bin")
-                    .join("kicad-cli.exe");
+                let cli_path = Path::new(path_str).join("bin").join("kicad-cli.exe");
                 if cli_path.exists() {
                     return Some(cli_path);
                 }
             }
         }
     }
-
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn test_paths(temp: &TempDir) -> InstallPaths {
+        InstallPaths {
+            home: temp.path().to_path_buf(),
+        }
+    }
+
+    #[test]
+    fn client_argument_defaults_to_claude() {
+        assert_eq!(client_from_args(&[]).unwrap(), InstallClient::Claude);
+    }
+
+    #[test]
+    fn client_argument_selects_codex() {
+        let args = vec!["--client".into(), "codex".into()];
+        assert_eq!(client_from_args(&args).unwrap(), InstallClient::Codex);
+    }
+
+    #[test]
+    fn client_argument_rejects_bad_values() {
+        assert!(client_from_args(&["--client".into()]).is_err());
+        assert!(client_from_args(&["--client".into(), "other".into()]).is_err());
+        assert!(client_from_args(&[
+            "--client".into(),
+            "codex".into(),
+            "--client".into(),
+            "claude".into(),
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn codex_install_writes_skills_without_touching_claude() {
+        let temp = TempDir::new().unwrap();
+        let paths = test_paths(&temp);
+        run_install_at(InstallClient::Codex, &paths, false).unwrap();
+
+        for skill in SKILLS {
+            let skill_dir = paths.skills_dir(InstallClient::Codex).join(skill.name);
+            assert_eq!(
+                fs::read_to_string(skill_dir.join("SKILL.md")).unwrap(),
+                skill.content
+            );
+            for (filename, content) in skill.references {
+                assert_eq!(
+                    fs::read_to_string(skill_dir.join("references").join(filename)).unwrap(),
+                    *content
+                );
+            }
+        }
+        assert!(!temp.path().join(".claude").exists());
+        assert!(paths.marker(InstallClient::Codex).exists());
+        assert!(!paths.marker(InstallClient::Claude).exists());
+    }
+
+    #[test]
+    fn claude_install_is_idempotent_and_preserves_settings() {
+        let temp = TempDir::new().unwrap();
+        let paths = test_paths(&temp);
+        let settings_path = paths.claude_settings_path();
+        fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        fs::write(&settings_path, r#"{"theme":"dark"}"#).unwrap();
+
+        run_install_at(InstallClient::Claude, &paths, false).unwrap();
+        run_install_at(InstallClient::Claude, &paths, false).unwrap();
+
+        for skill in SKILLS {
+            assert!(paths
+                .skills_dir(InstallClient::Claude)
+                .join(skill.name)
+                .join("SKILL.md")
+                .exists());
+        }
+        for agent in AGENTS {
+            assert!(paths.claude_agents_dir().join(agent.filename).exists());
+        }
+        let settings: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(settings_path).unwrap()).unwrap();
+        assert_eq!(settings["theme"], "dark");
+        for hook in HOOK_SKILLS {
+            assert_eq!(settings["hooks"][hook.event].as_array().unwrap().len(), 1);
+        }
+    }
+
+    #[test]
+    fn legacy_marker_applies_to_claude_only() {
+        let temp = TempDir::new().unwrap();
+        let paths = test_paths(&temp);
+        fs::create_dir_all(paths.data_dir()).unwrap();
+        fs::write(paths.legacy_marker(), "0.4.0").unwrap();
+        assert!(has_install_marker(InstallClient::Claude, &paths));
+        assert!(!has_install_marker(InstallClient::Codex, &paths));
+    }
+
+    #[test]
+    fn codex_uninstall_is_scoped() {
+        let temp = TempDir::new().unwrap();
+        let paths = test_paths(&temp);
+        run_install_at(InstallClient::Claude, &paths, false).unwrap();
+        run_install_at(InstallClient::Codex, &paths, false).unwrap();
+        let unrelated = paths.skills_dir(InstallClient::Codex).join("my-skill");
+        fs::create_dir_all(&unrelated).unwrap();
+        fs::write(unrelated.join("SKILL.md"), "keep me").unwrap();
+
+        run_uninstall_at(InstallClient::Codex, &paths, false).unwrap();
+        assert!(unrelated.join("SKILL.md").exists());
+        assert!(paths.marker(InstallClient::Claude).exists());
+        assert!(!paths.marker(InstallClient::Codex).exists());
+        assert!(paths.claude_settings_path().exists());
+    }
+
+    #[test]
+    fn claude_uninstall_preserves_other_hooks() {
+        let temp = TempDir::new().unwrap();
+        let paths = test_paths(&temp);
+        run_install_at(InstallClient::Claude, &paths, false).unwrap();
+        fs::write(paths.legacy_marker(), "0.3.0").unwrap();
+
+        let settings_path = paths.claude_settings_path();
+        let mut settings: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&settings_path).unwrap()).unwrap();
+        settings["hooks"][HOOK_SKILLS[0].event]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!({
+                "matcher": "Write",
+                "hooks": [{"type": "command", "command": "other-tool"}]
+            }));
+        fs::write(
+            &settings_path,
+            serde_json::to_string_pretty(&settings).unwrap(),
+        )
+        .unwrap();
+
+        run_uninstall_at(InstallClient::Claude, &paths, false).unwrap();
+        assert!(!paths.marker(InstallClient::Claude).exists());
+        assert!(!paths.legacy_marker().exists());
+        let remaining: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(settings_path).unwrap()).unwrap();
+        let entries = remaining["hooks"][HOOK_SKILLS[0].event].as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["hooks"][0]["command"], "other-tool");
+    }
 }

--- a/crates/konnect/src/main.rs
+++ b/crates/konnect/src/main.rs
@@ -18,9 +18,18 @@ async fn main() -> Result<()> {
 
     // ─── Subcommand dispatch (install, uninstall, status, skill) ────
     match args.get(1).map(String::as_str) {
-        Some("init") => return install::run_install(),
-        Some("uninstall") => return install::run_uninstall(),
-        Some("status") => return install::print_status(),
+        Some("init") => {
+            let client = install::client_from_args(&args[2..])?;
+            return install::run_install(client);
+        }
+        Some("uninstall") => {
+            let client = install::client_from_args(&args[2..])?;
+            return install::run_uninstall(client);
+        }
+        Some("status") => {
+            let client = install::client_from_args(&args[2..])?;
+            return install::print_status(client);
+        }
         Some("skill") => {
             let name = args.get(2).map(String::as_str).unwrap_or("");
             return install::print_skill_content(name);
@@ -44,9 +53,11 @@ async fn main() -> Result<()> {
         return install::run_double_click_install();
     }
 
+    let client = install::client_from_args(&args[1..])?;
+
     // ─── Auto-install on first MCP launch (safety net) ──────────────
-    if install::needs_install() {
-        let _ = install::run_install_silent();
+    if install::needs_install(client) {
+        let _ = install::run_install_silent(client);
     }
 
     // --config <path>: load config from specified file
@@ -120,17 +131,20 @@ async fn main() -> Result<()> {
 
 fn print_help() {
     println!("Konnect v{}", env!("CARGO_PKG_VERSION"));
-    println!("MCP server for KiCAD EDA with embedded skills and agents.\n");
+    println!("MCP server for KiCad EDA with embedded guidance.\n");
     println!("USAGE:");
     println!("  konnect                  Start MCP server (pipe) or install (TTY)");
-    println!("  konnect init             Install skills, agents, and hooks");
-    println!("  konnect uninstall        Remove all installed files");
-    println!("  konnect status           Show install state");
+    println!("  konnect [--client <client>] [--config <path>]");
+    println!("  konnect init [--client <client>]");
+    println!("  konnect uninstall [--client <client>]");
+    println!("  konnect status [--client <client>]");
     println!("  konnect skill <name>     Print skill content (for hooks)");
     println!("  konnect transaction status <project-dir>");
     println!("  konnect transaction recover <project-dir>");
     println!("  konnect transaction abandon <project-dir> <id> --force");
-    println!("  konnect --config <path>  Start server with config file");
     println!("  konnect --version        Print version");
     println!("  konnect --help           This message");
+    println!("\nCLIENTS:");
+    println!("  claude (default)         Skills, agents, and hooks under ~/.claude");
+    println!("  codex                    Skills under ~/.agents/skills");
 }

--- a/crates/konnect/src/manifest.rs
+++ b/crates/konnect/src/manifest.rs
@@ -1,6 +1,7 @@
 //! Skill and agent manifests embedded at compile time.
 //!
-//! The `init` subcommand installs these to `~/.claude/skills/` and `~/.claude/agents/`.
+//! The client-aware `init` subcommand installs shared skills for Claude or Codex.
+//! Claude-specific agents and hooks remain scoped to Claude's directories.
 //! Hook skills are also patched into `~/.claude/settings.json`.
 
 /// A skill to install to `~/.claude/skills/<name>/SKILL.md`.

--- a/crates/konnect/tests/transaction_cli.rs
+++ b/crates/konnect/tests/transaction_cli.rs
@@ -16,6 +16,18 @@ fn transaction_help_is_advertised() {
 }
 
 #[test]
+fn client_scoped_installer_help_is_advertised() {
+    let output = konnect().arg("--help").output().unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("init [--client <client>]"));
+    assert!(stdout.contains("claude (default)"));
+    assert!(stdout.contains("codex"));
+    assert!(stdout.contains("~/.agents/skills"));
+}
+
+#[test]
 fn malformed_journal_requires_force_and_can_be_abandoned() {
     let project = tempfile::tempdir().unwrap();
     let active = project


### PR DESCRIPTION
## Summary

A Codex MCP launch currently triggers the Claude-only first-run installer and writes `~/.claude`, while never installing Konnect's shared skills where Codex discovers them. This PR makes installer ownership explicit and client-scoped.

Refs #216 (installer slice only; the remaining runtime profile, Codex agents/hooks, and shared-skill wording work stay in follow-up PRs).

## Approach

- Add `--client <claude|codex>` to `init`, `status`, `uninstall`, and MCP server launch; omitting it keeps Claude as the default.
- Install shared skills for Codex under `$HOME/.agents/skills`, following the official Codex skill location, without creating or modifying `~/.claude`.
- Keep Claude's existing skills, agents, hooks, and double-click behavior.
- Track `.installed-claude` and `.installed-codex` independently; recognize the legacy `.installed` marker only for Claude.
- Route all installer logic through explicit home-relative paths so tests run in isolated temporary homes.
- Document Codex setup, including `codex mcp add konnect -- /path/to/konnect --client codex`.

References: [Codex skills](https://learn.chatgpt.com/docs/build-skills), [Codex MCP configuration](https://learn.chatgpt.com/docs/extend/mcp).

## Compatibility and safety

`--client` is additive. No-flag CLI calls and double-click setup remain Claude-focused. Existing `.installed` markers continue to suppress Claude's silent installer but never suppress a Codex install.

Install/uninstall touches only the selected client's known Konnect asset names and marker. Tests verify that Codex does not touch `~/.claude`, that unrelated Codex skills survive uninstall, that Claude settings survive install, and that unrelated Claude hooks survive uninstall. Rollback is the client-scoped `konnect uninstall --client <client>` command or reverting this commit; no project or KiCad design files are modified.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --locked --lib --tests`
- [x] `cargo test --workspace --locked --doc`
- [x] `cargo clippy --workspace --locked -- -D warnings`
- [x] `cargo test -p konnect --locked --test transaction_cli`
- [x] Installer behavior covered with isolated `tempfile` homes
- [ ] Real-KiCad/live IPC checks (not applicable to installer behavior; environment-dependent tests remained ignored by the workspace run)

## Review checklist

- [x] The diff is focused and contains no generated output, personal data, or unrelated cleanup.
- [x] New names follow `docs/NAMING_CONVENTIONS.md`; the public flag is additive and documented.
- [x] New behavior and failure paths have regression coverage.
- [x] Uninstall preserves unrelated client content; no project/design file or IPC mutation is involved.
- [x] No MCP tools were added or removed, so catalogue counts are unchanged.