### PR TITLE
feat(pcb): add safe closed-board footprint flipping

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -88,7 +88,7 @@ Konnect/
 │   │           ├── pcb_sync.rs       # update_pcb_from_schematic: pure planner + one-commit IPC apply
 │   │           ├── sch_hierarchy.rs  # 12 tools (typed Sheet model, sheet CRUD + hierarchy/page queries + pin lifecycle)
 │   │           ├── pcb_board.rs      # 11 tools (S-expr file editing, IPC fallback, SVG logo import)
-│   │           ├── pcb_components.rs # 15 tools (IPC real-time + safe headless single-placement fallback)
+│   │           ├── pcb_components.rs # 16 tools (IPC real-time + safe headless single-placement fallback)
 │   │           ├── pcb_routing.rs    # 12 tools (traces, vias, nets, netclasses)
 │   │           ├── pcb_export.rs     # 13 tools (Gerber, PDF, 3D, DRC, DXF/GenCAD/IPC-2581/ODB++)
 │   │           ├── library.rs        # 17 tools (symbol/footprint library management)
@@ -290,7 +290,7 @@ Source: [`crates/konnect-core/src/observability.rs`](crates/konnect-core/src/obs
 
 ## Tool Routing (Starter Kit + On-Demand Loading)
 
-The server does NOT expose all 202 tools (208 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
+The server does NOT expose all 203 tools (209 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
 
 - **Startup**: only `STARTER_KIT` toolsets are pre-loaded (see `router/registry.rs::STARTER_KIT`). Currently: `project`, `config`. Combined with the 6 meta-tools, baseline `tools/list` is 20 tools ≈ 2K tokens.
 - **On demand**: the LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose a toolset's tools in subsequent `tools/list` responses. `unload_toolset(name)` prunes them when the task shifts.
@@ -365,9 +365,9 @@ convention for other `kicad-cli`-calling code.
 
 ## Current Stats
 
-- **19 toolsets, 202 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
+- **19 toolsets, 203 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
 - Baseline `tools/list`: 20 tools / ~2K tokens (starter kit + meta-tools)
-- Full-catalog `tools/list` (all loaded): 208 tools (202 registered + 6 meta) / ~25K tokens
+- Full-catalog `tools/list` (all loaded): 209 tools (203 registered + 6 meta) / ~25K tokens
 - **0 IPC stubs** (all protobuf methods implemented)
 - **0 unimplemented tools**
 - **3 CLI commands removed in KiCAD v10** (specctra DSN/SES, pcb sync — return clear errors)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Rust binary — that lets Claude and other AI assistants design schematics and PCBs
 through the [Model Context Protocol](https://modelcontextprotocol.io) (MCP).
 
-**202 tools across 19 on-demand toolsets.** Schematic capture, PCB layout and
+**203 tools across 19 on-demand toolsets.** Schematic capture, PCB layout and
 routing, ERC/DRC, design-review audits, JLCPCB part search, Freerouting, reference
 circuits, and a full manufacturing export pipeline — with bundled skills and agents
 that teach Claude KiCAD conventions out of the box.
@@ -70,7 +70,7 @@ through its own S-expression engine with atomic writes (write, fsync, rename), U
 preservation, and round-trip tests — no third-party schematic library with known
 gaps, no text-manipulation workarounds.
 
-**Context economy is a feature.** Exposing all 202 tools to an LLM costs roughly 23K
+**Context economy is a feature.** Exposing all 203 tools to an LLM costs roughly 23K
 tokens of context on every listing. Konnect's router loads a starter kit (~2K
 tokens) and lets the model pull in toolsets on demand — plus built-in observability
 (`get_recent_calls`, `server_stats`, JSONL call logs) so the model can diagnose its
@@ -264,7 +264,9 @@ the main workspace — see [DEV.md](DEV.md) for build steps.
 - `kicad-cli` (ships with KiCAD — used for exports, ERC, DRC)
 - For most PCB tools: KiCAD running with the target board open (IPC API).
   `place_component`, `move_component`, and `rotate_component` can safely fall
-  back to a closed board file when IPC is unreachable.
+  back to a closed board file when IPC is unreachable. `flip_component`
+  intentionally requires a closed board because KiCAD IPC has no native
+  footprint-flip command.
 
 ## License: free for the little guys
 
@@ -304,7 +306,8 @@ with that board first; most PCB tools talk to the running PCB editor. Only an
 unreachable KiCAD produces that message: if KiCAD is running and the tool
 refuses anyway, the error is the tool's own reason for refusing.
 `place_component`, `move_component`, and `rotate_component` can fall back to a
-closed board file when no KiCAD process is reachable.
+closed board file when no KiCAD process is reachable; `flip_component`
+requires one, and refuses while KiCAD holds that board open.
 
 See [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) for socket setup, tools
 that don't appear after `load_toolset`, and transaction recovery.

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -74,9 +74,9 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
     },
     ToolsetMeta {
         name: "pcb_components",
-        description: "Place, move, rotate, align and duplicate PCB footprints; inspect pads; inspect and edit a placed footprint's graphics",
+        description: "Place, move, rotate, flip, align and duplicate PCB footprints; inspect pads; inspect and edit a placed footprint's graphics",
         category: "pcb",
-        tool_count: 15,
+        tool_count: 16,
     },
     ToolsetMeta {
         name: "pcb_routing",

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -1135,6 +1135,14 @@ fn direct_children_with_tags(
         .collect()
 }
 
+/// Whether `source` has at least one direct `(child_tag …)`, without caring
+/// how many or failing on a block that has none.
+fn has_direct_child(source: &str, parent_tag: &str, child_tag: &str) -> bool {
+    direct_children_with_tags(source, parent_tag)
+        .map(|children| children.iter().any(|(_, _, tag)| tag == child_tag))
+        .unwrap_or(false)
+}
+
 fn exactly_one_direct_child(
     source: &str,
     parent_tag: &str,
@@ -1515,6 +1523,20 @@ fn flip_footprint_block(footprint: &str) -> anyhow::Result<String> {
     for (start, end, tag) in direct_children_with_tags(footprint, "footprint")? {
         let block = &footprint[start..end];
         let replacement = match tag.as_str() {
+            // A property with no `(at …)` carries no geometry, so there is
+            // nothing to mirror and it passes through untouched.
+            //
+            // This is not an edge case. KiCad writes
+            // `(property ki_fp_filters "R_* Resistor_*")` — a bare token, no
+            // position, no layer — into every footprint it places from a
+            // library: 779 of them across the 19 boards shipped in
+            // `share/kicad/demos`. Requiring exactly one `(at …)` on every
+            // property therefore refused practically every real board with
+            // "property must contain exactly one direct (at ...) block",
+            // which is what the first live run of this tool hit. The
+            // synthetic fixture has only positioned properties, so nothing
+            // offline could have caught it.
+            "property" if !has_direct_child(block, "property", "at") => None,
             "property" | "fp_text" => Some(flip_text_block(block, &tag)?),
             "fp_line" | "fp_rect" | "fp_circle" | "fp_arc" => {
                 Some(flip_graphic_block(block, &tag)?)
@@ -3667,6 +3689,43 @@ mod tests {
             flipped.contains("(offset (xyz 0 0 0))") && flipped.contains("(rotate (xyz 0 0 90))"),
             "a model a flip does not move must survive verbatim: {flipped}"
         );
+        assert!(konnect_sexp::parse_sexp(&flipped).is_ok());
+    }
+
+    /// A property with no position is metadata, not geometry, and must not
+    /// stop the flip.
+    ///
+    /// KiCad writes `(property ki_fp_filters "R_* Resistor_*")` — a bare
+    /// token, no `(at …)`, no layer — into every footprint it places from a
+    /// library. There are **779** of them across the 19 boards in
+    /// `share/kicad/demos`. Requiring exactly one `(at …)` on every property
+    /// therefore refused practically every real board with "property must
+    /// contain exactly one direct (at ...) block", which is what the first
+    /// live run of this tool hit on the stock ecc83 demo.
+    ///
+    /// Nothing offline could have caught it: the synthetic fixture has only
+    /// positioned properties.
+    #[test]
+    fn a_positionless_property_does_not_block_the_flip() {
+        let with_metadata = FLIP_FOOTPRINT.replace(
+            "  (pad \"1\"",
+            "  (property ki_fp_filters \"R_* Resistor_*\")\n  (pad \"1\"",
+        );
+        assert!(
+            with_metadata.contains("ki_fp_filters"),
+            "fixture must carry the metadata property"
+        );
+
+        let flipped = flip_footprint_block(&with_metadata)
+            .expect("a positionless property must not block the flip");
+
+        // Carried through untouched — it has no geometry to mirror.
+        assert!(
+            flipped.contains("(property ki_fp_filters \"R_* Resistor_*\")"),
+            "{flipped}"
+        );
+        // And the positioned ones still flipped.
+        assert!(flipped.contains("(layer \"B.Cu\")"), "{flipped}");
         assert!(konnect_sexp::parse_sexp(&flipped).is_ok());
     }
 

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -2258,6 +2258,13 @@ async fn handle_flip_component(
     //
     // The helper refuses only when KiCAD holds *this* board, because that is
     // the only case where the edit would be discarded by its next save.
+    //
+    // Untested branch, honestly: the only IPC mock in this crate rejects every
+    // request, which exercises the *proceed* side. Confirming the refusal
+    // needs a mock that answers `GetOpenDocuments` naming this board, which
+    // does not exist here — so the refusal is equally untested for
+    // `add_zone` and the copper-pour path, this helper's two other callers.
+    // Tracked as #241 rather than pretended away.
     if let Some(refusal) = crate::tools::pcb_board::refuse_if_board_open_in_kicad(
         ctx.config.ipc_address.clone(),
         &board,
@@ -3661,6 +3668,38 @@ mod tests {
             "a model a flip does not move must survive verbatim: {flipped}"
         );
         assert!(konnect_sexp::parse_sexp(&flipped).is_ok());
+    }
+
+    /// A footprint that is not on either copper side has no "other side" to
+    /// flip to, so it is refused rather than moved to one.
+    ///
+    /// Reachable on any board a user hand-edited or an older tool wrote — and
+    /// the guard existed with nothing exercising it, which the neuter pass
+    /// found.
+    #[tokio::test]
+    async fn a_footprint_on_neither_side_of_the_board_is_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let board = tmp.path().join("inner.kicad_pcb");
+        let stranded = FLIP_FOOTPRINT.replace("(layer \"F.Cu\")", "(layer \"In1.Cu\")");
+        let before = flip_board(&[&stranded], "\n");
+        std::fs::write(&board, &before).unwrap();
+
+        let refusal = handle_flip_component(
+            &json!({
+                "board": board.to_string_lossy(),
+                "reference": "U1",
+                "layer": "B.Cu",
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        assert!(refusal.is_error, "{:?}", refusal.content);
+        let text = result_text(&refusal);
+        assert!(text.contains("In1.Cu"), "{text}");
+        assert!(text.contains("neither side"), "{text}");
+        assert_eq!(std::fs::read_to_string(board).unwrap(), before);
     }
 
     /// KiCad's own flip transforms a model's Y offset and its X/Y rotation.

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -1448,6 +1448,48 @@ fn flip_pad_block(block: &str) -> anyhow::Result<String> {
     ))
 }
 
+/// Refuse a `(model …)` whose placement a flip would have to move.
+///
+/// KiCad's own flip transforms a model's Y offset and its X/Y rotation; this
+/// tool leaves `(model …)` untouched, which is silently wrong for any model
+/// where those are non-zero. Rather than guess the transform — I have not been
+/// able to measure KiCad's flip directly, because KiCad 10.0.5 exposes no
+/// `FlipItems` to drive it and its demo boards contain no back-side footprint
+/// with a non-zero offset to compare against — this refuses, consistent with
+/// how the rest of this path treats geometry it cannot mirror.
+///
+/// The cost of refusing is close to nothing. Across all **14,818** footprints
+/// in KiCad 10's standard libraries that carry a `(model …)`: `offset.y` is
+/// non-zero in **3**, and `rotate.x`/`rotate.y` in **none**. The three are
+/// `RaspberryPi_Pico_Common_THT` (-24.13 mm, badly wrong if ignored) and two
+/// sub-0.04 mm cases. The 84 footprints with a non-zero `rotate.z` are
+/// unaffected either way, since a flip does not touch Z.
+fn refuse_model_a_flip_would_move(block: &str) -> anyhow::Result<()> {
+    let model = konnect_sexp::parse_sexp(block)?;
+    for (tag, fields) in [("offset", ["x", "y", "z"]), ("rotate", ["x", "y", "z"])] {
+        let Some(node) = model.find_all(tag).into_iter().next() else {
+            continue;
+        };
+        let Some(xyz) = node.find_all("xyz").into_iter().next() else {
+            continue;
+        };
+        // A flip negates offset.y, rotate.x and rotate.y; Z and offset.x ride
+        // along unchanged, so a non-zero value there is not a problem.
+        let moved: &[usize] = if tag == "offset" { &[2] } else { &[1, 2] };
+        for &index in moved {
+            let value = xyz.get_f64(index).unwrap_or(0.0);
+            if value != 0.0 {
+                anyhow::bail!(
+                    "the 3D model's {tag}.{} is {value}, and a flip would have to move it; \
+                     flipping this footprint would leave the model where it was",
+                    fields[index - 1]
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
 fn flip_footprint_block(footprint: &str) -> anyhow::Result<String> {
     let root = konnect_sexp::parse_sexp(footprint)?;
     if root.head() != Some("footprint") {
@@ -1479,6 +1521,10 @@ fn flip_footprint_block(footprint: &str) -> anyhow::Result<String> {
             }
             "fp_poly" => Some(flip_poly_block(block)?),
             "pad" => Some(flip_pad_block(block)?),
+            "model" => {
+                refuse_model_a_flip_would_move(block)?;
+                None
+            }
             unsupported if unsupported.starts_with("fp_") || unsupported == "zone" => {
                 anyhow::bail!(
                     "unsupported footprint child '{unsupported}' prevents a safe closed-board flip"
@@ -1513,42 +1559,53 @@ fn prepare_closed_board_footprint_side(
     content: &str,
     reference: &str,
     target_layer: &str,
-) -> anyhow::Result<(String, bool)> {
+) -> Result<(String, bool), ClosedBoardError> {
     if let Err(reason) = check_single_board_form(content) {
-        anyhow::bail!("Refusing to edit the board: {reason}. The board file was left untouched.");
+        return Err(ClosedBoardError::Unusable(reason.to_string()));
     }
     let mut matched = None;
-    for (start, end, tag) in direct_children_with_tags(content, "kicad_pcb")? {
+    for (start, end, tag) in
+        direct_children_with_tags(content, "kicad_pcb").map_err(ClosedBoardError::Io)?
+    {
         if tag != "footprint" {
             continue;
         }
-        let footprint = konnect_sexp::parse_sexp(&content[start..end])?;
+        let footprint = konnect_sexp::parse_sexp(&content[start..end])
+            .map_err(|e| ClosedBoardError::Io(e.into()))?;
         if footprint_reference(&footprint).as_deref() == Some(reference)
             && matched.replace((start, end)).is_some()
         {
-            anyhow::bail!("Footprint reference '{reference}' appears more than once on the board");
+            return Err(ClosedBoardError::ReferenceAmbiguous(reference.to_string()));
         }
     }
     let (start, end) =
-        matched.ok_or_else(|| anyhow::anyhow!("Footprint '{reference}' not found on the board"))?;
+        matched.ok_or_else(|| ClosedBoardError::ReferenceNotFound(reference.to_string()))?;
     let block = &content[start..end];
-    let current_layer = footprint_layer(block)?;
+    let current_layer = footprint_layer(block).map_err(ClosedBoardError::Io)?;
     if !matches!(current_layer.as_str(), "F.Cu" | "B.Cu") {
-        anyhow::bail!("Footprint '{reference}' is on unsupported root layer '{current_layer}'");
+        return Err(ClosedBoardError::Unusable(format!(
+            "footprint '{reference}' sits on root layer '{current_layer}', which is neither              side of the board"
+        )));
     }
     if current_layer == target_layer {
         return Ok((content.to_string(), false));
     }
-    let flipped = flip_footprint_block(block)?;
-    if footprint_layer(&flipped)? != target_layer {
-        anyhow::bail!("flipping '{reference}' did not produce target layer '{target_layer}'");
+    let flipped = flip_footprint_block(block)
+        .map_err(|error| ClosedBoardError::Unusable(format!("{error:#}")))?;
+    if footprint_layer(&flipped).map_err(ClosedBoardError::Io)? != target_layer {
+        return Err(ClosedBoardError::Unusable(format!(
+            "flipping '{reference}' did not produce target layer '{target_layer}'"
+        )));
     }
     let updated = apply_edits(
         content.to_string(),
         vec![SexpEdit::replace(start, end, flipped)],
     );
-    check_single_board_form(&updated)
-        .map_err(|reason| anyhow::anyhow!("flip produced an invalid board: {reason}"))?;
+    if let Err(reason) = check_single_board_form(&updated) {
+        return Err(ClosedBoardError::Unusable(format!(
+            "flipping '{reference}' would have produced {reason}"
+        )));
+    }
     Ok((updated, true))
 }
 
@@ -1556,12 +1613,13 @@ fn set_closed_board_footprint_side(
     board_path: &Path,
     reference: &str,
     target_layer: &str,
-) -> anyhow::Result<bool> {
-    let content = read_consistent(board_path)?;
+) -> Result<bool, ClosedBoardError> {
+    let content = read_consistent(board_path).map_err(|e| ClosedBoardError::Io(e.into()))?;
     let (updated, changed) =
         prepare_closed_board_footprint_side(&content, reference, target_layer)?;
     if changed {
-        persist_board_replacement(board_path, &content, &updated)?;
+        persist_board_replacement(board_path, &content, &updated)
+            .map_err(|e| ClosedBoardError::Io(e.into()))?;
     }
     Ok(changed)
 }
@@ -2184,50 +2242,42 @@ async fn handle_flip_component(
         Err(error) => return Ok(error),
     };
 
-    let requested_board = board.clone();
-    let reference_ipc = reference.clone();
-    let layer_ipc = layer.clone();
-    let attempt: Result<(), konnect_ipc::IpcFailure> =
-        with_ipc_classified(ctx.config.ipc_address.clone(), move |client| {
-            client.ensure_board_is_active(&requested_board)?;
-            anyhow::bail!(
-                "live KiCAD IPC does not expose a native footprint flip command for '{}' to '{}'; \
-             close the PCB editor before retrying so Konnect can apply the revision-aware \
-             closed-board transform",
-                reference_ipc,
-                layer_ipc
-            )
-        })
-        .await?;
+    // KiCAD 10.0.5 and the protocol Konnect vendors carry no FlipItems command,
+    // so this tool has no IPC implementation at all — which makes
+    // `refuse_if_board_open_in_kicad` the right gate rather than
+    // `attempt_ipc_write`.
+    //
+    // The distinction is not cosmetic. Running `ensure_board_is_active` and
+    // then bailing unconditionally produced an `anyhow` with no
+    // `TransportUnreachable` marker, which `IpcFailure::from_error` classifies
+    // as `Rejected` — so *every* reachable KiCAD refused the flip, including
+    // one holding an unrelated project, where this board file is demonstrably
+    // free. It also reported Konnect's own refusal as "KiCAD rejected the
+    // footprint flip over IPC", which is the class fixed in v0.5.0.
+    //
+    // The helper refuses only when KiCAD holds *this* board, because that is
+    // the only case where the edit would be discarded by its next save.
+    if let Some(refusal) = crate::tools::pcb_board::refuse_if_board_open_in_kicad(
+        ctx.config.ipc_address.clone(),
+        &board,
+        "footprint flip",
+    )
+    .await?
+    {
+        return Ok(refusal);
+    }
 
-    match attempt {
+    match set_closed_board_footprint_side(&board, &reference, &layer) {
         Ok(changed) => Ok(CallToolResult::json(&json!({
             "flipped": reference,
             "layer": layer,
             "changed": changed,
-            "source": "ipc"
+            "source": "file",
+            "warning": "KiCAD has no footprint-flip command over IPC, so the board file was \
+                        flipped directly with a revision check. Reopen the board in KiCAD to \
+                        see it."
         }))),
-        Err(konnect_ipc::IpcFailure::Rejected(message)) => Ok(CallToolResult::error(format!(
-            "KiCAD rejected the footprint flip over IPC: {message}. The board file was not \
-             modified — KiCAD is reachable and may hold this board open, so editing the file \
-             directly could be silently overwritten."
-        ))),
-        Err(konnect_ipc::IpcFailure::Unreachable(_)) => {
-            match set_closed_board_footprint_side(&board, &reference, &layer) {
-                Ok(changed) => Ok(CallToolResult::json(&json!({
-                    "flipped": reference,
-                    "layer": layer,
-                    "changed": changed,
-                    "source": "file",
-                    "warning": "KiCAD IPC was not reachable, so the supported closed-board \
-                                footprint was flipped directly with a revision check."
-                }))),
-                Err(error) if error.to_string().contains("not found on the board") => {
-                    Ok(CallToolResult::error(error.to_string()))
-                }
-                Err(error) => Err(error),
-            }
-        }
+        Err(error) => Ok(error.into_result()),
     }
 }
 
@@ -3562,9 +3612,9 @@ mod tests {
     (roundrect_rratio 0.25)
   )
   (model "../models/Test.step"
-    (offset (xyz 1 2 3))
+    (offset (xyz 0 0 0))
     (scale (xyz 1 1 1))
-    (rotate (xyz 4 5 6))
+    (rotate (xyz 0 0 90))
   )
 )"#;
 
@@ -3601,11 +3651,52 @@ mod tests {
             flipped.contains("(layers \"B.Cu\" \"B.Paste\" \"B.Mask\")"),
             "{flipped}"
         );
+        // The model is carried through verbatim. That is only safe because a
+        // model whose placement a flip would have to move is refused outright
+        // — see `a_model_a_flip_would_move_is_refused`. `rotate.z` is not one
+        // of those: a flip does not touch Z.
         assert!(
-            flipped.contains("(offset (xyz 1 2 3))") && flipped.contains("(rotate (xyz 4 5 6))"),
-            "3D model transforms are footprint-side-relative and must remain unchanged: {flipped}"
+            flipped.contains("(offset (xyz 0 0 0))") && flipped.contains("(rotate (xyz 0 0 90))"),
+            "a model a flip does not move must survive verbatim: {flipped}"
         );
         assert!(konnect_sexp::parse_sexp(&flipped).is_ok());
+    }
+
+    /// KiCad's own flip transforms a model's Y offset and its X/Y rotation.
+    /// This path does not transform models at all, so rather than silently
+    /// leave one behind it refuses — the same policy the rest of the flip
+    /// applies to geometry it cannot mirror.
+    ///
+    /// Refusing costs almost nothing. Across all **14,818** footprints in
+    /// KiCad 10's standard libraries carrying a `(model …)`, `offset.y` is
+    /// non-zero in **3** and `rotate.x`/`rotate.y` in **none**; the worst is
+    /// `RaspberryPi_Pico_Common_THT` at -24.13 mm, which would put its model
+    /// roughly 48 mm out. The 84 with a non-zero `rotate.z` are unaffected.
+    #[test]
+    fn a_model_a_flip_would_move_is_refused() {
+        for (label, replacement, needle) in [
+            ("offset.y", "(offset (xyz 0 -24.13 0))", "offset.y"),
+            ("rotate.x", "(rotate (xyz 90 0 0))", "rotate.x"),
+            ("rotate.y", "(rotate (xyz 0 90 0))", "rotate.y"),
+        ] {
+            let source = FLIP_FOOTPRINT
+                .replace("(offset (xyz 0 0 0))", replacement)
+                .replace("(rotate (xyz 0 0 90))", replacement);
+            let error = flip_footprint_block(&source).unwrap_err().to_string();
+            assert!(error.contains(needle), "{label}: {error}");
+            assert!(error.contains("would have to move it"), "{label}: {error}");
+        }
+
+        // The fields a flip leaves alone must not trip it.
+        for untouched in ["(offset (xyz 8.89 0 0))", "(rotate (xyz 0 0 90))"] {
+            let source = FLIP_FOOTPRINT
+                .replace("(offset (xyz 0 0 0))", untouched)
+                .replace("(rotate (xyz 0 0 90))", untouched);
+            assert!(
+                flip_footprint_block(&source).is_ok(),
+                "{untouched} is not moved by a flip and must be accepted"
+            );
+        }
     }
 
     #[tokio::test]
@@ -3696,9 +3787,17 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(flipped.is_error);
-        assert!(result_text(&flipped).contains("not modified"));
-        assert_eq!(std::fs::read_to_string(board).unwrap(), before);
+        // A KiCAD that answers but does not confirm holding *this* board does
+        // not block the flip: nothing it has open can discard a write to this
+        // file, so refusing would deny a safe edit to anyone with an unrelated
+        // project open. That is `refuse_if_board_open_in_kicad`'s contract,
+        // shared with `add_zone` and the copper-pour path.
+        assert!(!flipped.is_error, "{:?}", flipped.content);
+        let result: serde_json::Value =
+            serde_json::from_str(&result_text(&flipped)).expect("flip result must be JSON");
+        assert_eq!(result["source"], "file");
+        assert_eq!(result["changed"], true);
+        assert_ne!(std::fs::read_to_string(board).unwrap(), before);
     }
 
     #[test]
@@ -3873,11 +3972,14 @@ mod tests {
             &test_ctx(),
         )
         .await
-        .expect_err("duplicate references must fail closed");
-        assert!(
-            duplicate.to_string().contains("more than once"),
-            "{duplicate}"
-        );
+        .unwrap();
+        // A structured refusal naming the offending field, not a bubbled
+        // `anyhow` the caller has to read prose out of.
+        assert!(duplicate.is_error);
+        let text = result_text(&duplicate);
+        assert!(text.contains("invalid_argument"), "{text}");
+        assert!(text.contains("\"field\":\"reference\""), "{text}");
+        assert!(text.contains("more than once"), "{text}");
         assert_eq!(
             std::fs::read_to_string(duplicate_board).unwrap(),
             duplicate_before
@@ -3940,7 +4042,7 @@ mod tests {
         let before = flip_board(&[&custom], "\n");
         std::fs::write(&board, &before).unwrap();
 
-        let error = handle_flip_component(
+        let refusal = handle_flip_component(
             &json!({
                 "board": board.to_string_lossy(),
                 "reference": "U1",
@@ -3949,9 +4051,15 @@ mod tests {
             &test_ctx(),
         )
         .await
-        .expect_err("unsupported pad geometry must fail closed");
+        .unwrap();
 
-        assert!(error.to_string().contains("custom pads"), "{error}");
+        assert!(
+            refusal.is_error,
+            "unsupported pad geometry must fail closed"
+        );
+        let text = result_text(&refusal);
+        assert!(text.contains("custom pads"), "{text}");
+        assert!(text.contains("not modified"), "{text}");
         assert_eq!(std::fs::read_to_string(board).unwrap(), before);
     }
 

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -1118,6 +1118,454 @@ fn update_footprint_placement(
     Ok(updated)
 }
 
+fn direct_children_with_tags(
+    source: &str,
+    parent_tag: &str,
+) -> anyhow::Result<Vec<(usize, usize, String)>> {
+    find_direct_child_blocks(source, parent_tag)
+        .into_iter()
+        .map(|(start, end)| {
+            let node = konnect_sexp::parse_sexp(&source[start..end])?;
+            let tag = node
+                .head()
+                .context("direct child has no S-expression tag")?
+                .to_string();
+            Ok((start, end, tag))
+        })
+        .collect()
+}
+
+fn exactly_one_direct_child(
+    source: &str,
+    parent_tag: &str,
+    child_tag: &str,
+) -> anyhow::Result<(usize, usize)> {
+    let matches: Vec<_> = direct_children_with_tags(source, parent_tag)?
+        .into_iter()
+        .filter_map(|(start, end, tag)| (tag == child_tag).then_some((start, end)))
+        .collect();
+    let [(start, end)] = matches.as_slice() else {
+        anyhow::bail!("{parent_tag} must contain exactly one direct ({child_tag} ...) block");
+    };
+    Ok((*start, *end))
+}
+
+fn at_components(block: &str) -> anyhow::Result<(f64, f64, f64, Vec<String>)> {
+    let at = konnect_sexp::parse_sexp(block)?;
+    if at.head() != Some("at") {
+        anyhow::bail!("expected an (at ...) block");
+    }
+    let x = at
+        .get_f64(1)
+        .context("(at ...) has an invalid X position")?;
+    let y = at
+        .get_f64(2)
+        .context("(at ...) has an invalid Y position")?;
+    let children = at.children().unwrap_or_default();
+    let angle = at.get_f64(3).unwrap_or(0.0);
+    let suffix_start = if at.get_f64(3).is_some() { 4 } else { 3 };
+    let suffix = children
+        .iter()
+        .skip(suffix_start)
+        .map(|child| {
+            child
+                .as_str()
+                .map(str::to_string)
+                .context("(at ...) contains a non-atomic suffix")
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    Ok((x, y, angle, suffix))
+}
+
+fn format_at_with_suffix(x: f64, y: f64, angle: f64, suffix: &[String]) -> String {
+    let mut formatted = format_at(x, y, angle);
+    if !suffix.is_empty() {
+        formatted.insert_str(formatted.len() - 1, &format!(" {}", suffix.join(" ")));
+    }
+    formatted
+}
+
+fn format_xy(tag: &str, x: f64, y: f64) -> String {
+    let at = format_at(x, y, 0.0);
+    format!("({tag}{})", &at["(at".len()..at.len() - 1])
+}
+
+fn normalize_angle(angle: f64) -> f64 {
+    angle.rem_euclid(360.0)
+}
+
+fn normalize_angle_180(angle: f64) -> f64 {
+    let normalized = normalize_angle(angle);
+    if normalized > 180.0 {
+        normalized - 360.0
+    } else {
+        normalized
+    }
+}
+
+fn flipped_layer(layer: &str) -> anyhow::Result<String> {
+    const SIDE_PAIRS: &[(&str, &str)] = &[
+        ("F.Cu", "B.Cu"),
+        ("F.Adhes", "B.Adhes"),
+        ("F.Paste", "B.Paste"),
+        ("F.SilkS", "B.SilkS"),
+        ("F.Mask", "B.Mask"),
+        ("F.CrtYd", "B.CrtYd"),
+        ("F.Fab", "B.Fab"),
+    ];
+    for (front, back) in SIDE_PAIRS {
+        if layer == *front {
+            return Ok((*back).to_string());
+        }
+        if layer == *back {
+            return Ok((*front).to_string());
+        }
+    }
+    if layer.starts_with("F.") || layer.starts_with("B.") {
+        anyhow::bail!("unsupported side-specific KiCad layer '{layer}'");
+    }
+    Ok(layer.to_string())
+}
+
+fn flip_layer_block(block: &str) -> anyhow::Result<String> {
+    let layer = konnect_sexp::parse_sexp(block)?;
+    let name = layer
+        .get(1)
+        .and_then(konnect_sexp::SexpNode::as_str)
+        .context("(layer ...) has no layer name")?;
+    Ok(format!(
+        "(layer {})",
+        quote_sexp_string(&flipped_layer(name)?)
+    ))
+}
+
+fn flip_layers_block(block: &str) -> anyhow::Result<String> {
+    let layers = konnect_sexp::parse_sexp(block)?;
+    let names = layers
+        .children()
+        .unwrap_or_default()
+        .iter()
+        .skip(1)
+        .map(|child| {
+            let name = child
+                .as_str()
+                .context("(layers ...) contains a non-atomic layer name")?;
+            flipped_layer(name).map(|flipped| quote_sexp_string(&flipped))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    Ok(format!("(layers {})", names.join(" ")))
+}
+
+fn toggle_text_mirror(effects: &str) -> anyhow::Result<String> {
+    let justify = direct_children_with_tags(effects, "effects")?
+        .into_iter()
+        .filter_map(|(start, end, tag)| (tag == "justify").then_some((start, end)))
+        .collect::<Vec<_>>();
+    match justify.as_slice() {
+        [] => Ok(apply_edits(
+            effects.to_string(),
+            vec![SexpEdit::insert(effects.len() - 1, " (justify mirror)")],
+        )),
+        [(start, end)] => {
+            let node = konnect_sexp::parse_sexp(&effects[*start..*end])?;
+            let mut values = node
+                .children()
+                .unwrap_or_default()
+                .iter()
+                .skip(1)
+                .map(|child| {
+                    child
+                        .as_str()
+                        .map(str::to_string)
+                        .context("(justify ...) contains a non-atomic value")
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?;
+            if let Some(index) = values.iter().position(|value| value == "mirror") {
+                values.remove(index);
+            } else {
+                values.push("mirror".to_string());
+            }
+            let replacement = if values.is_empty() {
+                String::new()
+            } else {
+                format!("(justify {})", values.join(" "))
+            };
+            Ok(apply_edits(
+                effects.to_string(),
+                vec![SexpEdit::replace(*start, *end, replacement)],
+            ))
+        }
+        _ => anyhow::bail!("text effects contain duplicate (justify ...) blocks"),
+    }
+}
+
+fn flip_text_block(block: &str, tag: &str) -> anyhow::Result<String> {
+    let (at_start, at_end) = exactly_one_direct_child(block, tag, "at")?;
+    let (x, y, angle, suffix) = at_components(&block[at_start..at_end])?;
+    let (layer_start, layer_end) = exactly_one_direct_child(block, tag, "layer")?;
+    let layer_block = &block[layer_start..layer_end];
+    let layer = konnect_sexp::parse_sexp(layer_block)?;
+    let layer_name = layer
+        .get(1)
+        .and_then(konnect_sexp::SexpNode::as_str)
+        .context("(layer ...) has no layer name")?;
+    let flipped_layer_name = flipped_layer(layer_name)?;
+    let (effects_start, effects_end) = exactly_one_direct_child(block, tag, "effects")?;
+    let effects = if flipped_layer_name == layer_name {
+        block[effects_start..effects_end].to_string()
+    } else {
+        toggle_text_mirror(&block[effects_start..effects_end])?
+    };
+    Ok(apply_edits(
+        block.to_string(),
+        vec![
+            SexpEdit::replace(
+                at_start,
+                at_end,
+                format_at_with_suffix(x, -y, normalize_angle(180.0 - angle), &suffix),
+            ),
+            SexpEdit::replace(
+                layer_start,
+                layer_end,
+                format!("(layer {})", quote_sexp_string(&flipped_layer_name)),
+            ),
+            SexpEdit::replace(effects_start, effects_end, effects),
+        ],
+    ))
+}
+
+fn flip_graphic_block(block: &str, tag: &str) -> anyhow::Result<String> {
+    let point_tags: &[&str] = match tag {
+        "fp_line" | "fp_rect" => &["start", "end"],
+        "fp_circle" => &["center", "end"],
+        "fp_arc" => &["start", "mid", "end"],
+        _ => anyhow::bail!("unsupported footprint graphic '{tag}'"),
+    };
+    let mut edits = Vec::new();
+    let mut points = Vec::new();
+    for point_tag in point_tags {
+        let (start, end) = exactly_one_direct_child(block, tag, point_tag)?;
+        let point = konnect_sexp::parse_sexp(&block[start..end])?;
+        points.push((
+            start,
+            end,
+            point
+                .get_f64(1)
+                .with_context(|| format!("({point_tag} ...) has an invalid X position"))?,
+            -point
+                .get_f64(2)
+                .with_context(|| format!("({point_tag} ...) has an invalid Y position"))?,
+        ));
+    }
+    let source_order: Vec<usize> = if tag == "fp_arc" {
+        vec![2, 1, 0]
+    } else {
+        (0..points.len()).collect()
+    };
+    for (target_index, point_tag) in point_tags.iter().enumerate() {
+        let (target_start, target_end, _, _) = points[target_index];
+        let (_, _, x, y) = points[source_order[target_index]];
+        edits.push(SexpEdit::replace(
+            target_start,
+            target_end,
+            format_xy(point_tag, x, y),
+        ));
+    }
+    let (layer_start, layer_end) = exactly_one_direct_child(block, tag, "layer")?;
+    edits.push(SexpEdit::replace(
+        layer_start,
+        layer_end,
+        flip_layer_block(&block[layer_start..layer_end])?,
+    ));
+    Ok(apply_edits(block.to_string(), edits))
+}
+
+fn flip_poly_block(block: &str) -> anyhow::Result<String> {
+    let (pts_start, pts_end) = exactly_one_direct_child(block, "fp_poly", "pts")?;
+    let pts = &block[pts_start..pts_end];
+    let mut point_edits = Vec::new();
+    for (start, end, tag) in direct_children_with_tags(pts, "pts")? {
+        if tag != "xy" {
+            anyhow::bail!("fp_poly contains unsupported point block '{tag}'");
+        }
+        let point = konnect_sexp::parse_sexp(&pts[start..end])?;
+        let x = point.get_f64(1).context("(xy ...) has an invalid X")?;
+        let y = point.get_f64(2).context("(xy ...) has an invalid Y")?;
+        point_edits.push(SexpEdit::replace(start, end, format_xy("xy", x, -y)));
+    }
+    let mirrored_pts = apply_edits(pts.to_string(), point_edits);
+    let (layer_start, layer_end) = exactly_one_direct_child(block, "fp_poly", "layer")?;
+    Ok(apply_edits(
+        block.to_string(),
+        vec![
+            SexpEdit::replace(pts_start, pts_end, mirrored_pts),
+            SexpEdit::replace(
+                layer_start,
+                layer_end,
+                flip_layer_block(&block[layer_start..layer_end])?,
+            ),
+        ],
+    ))
+}
+
+fn contains_descendant_tag(node: &konnect_sexp::SexpNode, tag: &str) -> bool {
+    node.children().is_some_and(|children| {
+        children
+            .iter()
+            .any(|child| child.head() == Some(tag) || contains_descendant_tag(child, tag))
+    })
+}
+
+fn flip_pad_block(block: &str) -> anyhow::Result<String> {
+    let pad = konnect_sexp::parse_sexp(block)?;
+    if pad.get(3).and_then(konnect_sexp::SexpNode::as_str) == Some("custom") {
+        anyhow::bail!("custom pads are not supported by closed-board footprint flipping");
+    }
+    for unsupported in ["offset", "rect_delta", "chamfer_ratio", "primitives"] {
+        if contains_descendant_tag(&pad, unsupported) {
+            anyhow::bail!(
+                "pad geometry containing ({unsupported} ...) is not supported by closed-board footprint flipping"
+            );
+        }
+    }
+    let (at_start, at_end) = exactly_one_direct_child(block, "pad", "at")?;
+    let (x, y, angle, suffix) = at_components(&block[at_start..at_end])?;
+    let (layers_start, layers_end) = exactly_one_direct_child(block, "pad", "layers")?;
+    Ok(apply_edits(
+        block.to_string(),
+        vec![
+            SexpEdit::replace(
+                at_start,
+                at_end,
+                format_at_with_suffix(x, -y, normalize_angle(-angle), &suffix),
+            ),
+            SexpEdit::replace(
+                layers_start,
+                layers_end,
+                flip_layers_block(&block[layers_start..layers_end])?,
+            ),
+        ],
+    ))
+}
+
+fn flip_footprint_block(footprint: &str) -> anyhow::Result<String> {
+    let root = konnect_sexp::parse_sexp(footprint)?;
+    if root.head() != Some("footprint") {
+        anyhow::bail!("expected a footprint root");
+    }
+    let (root_at_start, root_at_end) = exactly_one_direct_child(footprint, "footprint", "at")?;
+    let (x, y, angle, suffix) = at_components(&footprint[root_at_start..root_at_end])?;
+    let (root_layer_start, root_layer_end) =
+        exactly_one_direct_child(footprint, "footprint", "layer")?;
+    let mut edits = vec![
+        SexpEdit::replace(
+            root_at_start,
+            root_at_end,
+            format_at_with_suffix(x, y, normalize_angle_180(-angle), &suffix),
+        ),
+        SexpEdit::replace(
+            root_layer_start,
+            root_layer_end,
+            flip_layer_block(&footprint[root_layer_start..root_layer_end])?,
+        ),
+    ];
+
+    for (start, end, tag) in direct_children_with_tags(footprint, "footprint")? {
+        let block = &footprint[start..end];
+        let replacement = match tag.as_str() {
+            "property" | "fp_text" => Some(flip_text_block(block, &tag)?),
+            "fp_line" | "fp_rect" | "fp_circle" | "fp_arc" => {
+                Some(flip_graphic_block(block, &tag)?)
+            }
+            "fp_poly" => Some(flip_poly_block(block)?),
+            "pad" => Some(flip_pad_block(block)?),
+            unsupported if unsupported.starts_with("fp_") || unsupported == "zone" => {
+                anyhow::bail!(
+                    "unsupported footprint child '{unsupported}' prevents a safe closed-board flip"
+                )
+            }
+            _ => None,
+        };
+        if let Some(replacement) = replacement {
+            edits.push(SexpEdit::replace(start, end, replacement));
+        }
+    }
+
+    let flipped = apply_edits(footprint.to_string(), edits);
+    let parsed = konnect_sexp::parse_sexp(&flipped)?;
+    if parsed.head() != Some("footprint") {
+        anyhow::bail!("flip changed the footprint root");
+    }
+    Ok(flipped)
+}
+
+fn footprint_layer(footprint: &str) -> anyhow::Result<String> {
+    let (start, end) = exactly_one_direct_child(footprint, "footprint", "layer")?;
+    let layer = konnect_sexp::parse_sexp(&footprint[start..end])?;
+    layer
+        .get(1)
+        .and_then(konnect_sexp::SexpNode::as_str)
+        .map(str::to_string)
+        .context("footprint layer has no name")
+}
+
+fn prepare_closed_board_footprint_side(
+    content: &str,
+    reference: &str,
+    target_layer: &str,
+) -> anyhow::Result<(String, bool)> {
+    if let Err(reason) = check_single_board_form(content) {
+        anyhow::bail!("Refusing to edit the board: {reason}. The board file was left untouched.");
+    }
+    let mut matched = None;
+    for (start, end, tag) in direct_children_with_tags(content, "kicad_pcb")? {
+        if tag != "footprint" {
+            continue;
+        }
+        let footprint = konnect_sexp::parse_sexp(&content[start..end])?;
+        if footprint_reference(&footprint).as_deref() == Some(reference)
+            && matched.replace((start, end)).is_some()
+        {
+            anyhow::bail!("Footprint reference '{reference}' appears more than once on the board");
+        }
+    }
+    let (start, end) =
+        matched.ok_or_else(|| anyhow::anyhow!("Footprint '{reference}' not found on the board"))?;
+    let block = &content[start..end];
+    let current_layer = footprint_layer(block)?;
+    if !matches!(current_layer.as_str(), "F.Cu" | "B.Cu") {
+        anyhow::bail!("Footprint '{reference}' is on unsupported root layer '{current_layer}'");
+    }
+    if current_layer == target_layer {
+        return Ok((content.to_string(), false));
+    }
+    let flipped = flip_footprint_block(block)?;
+    if footprint_layer(&flipped)? != target_layer {
+        anyhow::bail!("flipping '{reference}' did not produce target layer '{target_layer}'");
+    }
+    let updated = apply_edits(
+        content.to_string(),
+        vec![SexpEdit::replace(start, end, flipped)],
+    );
+    check_single_board_form(&updated)
+        .map_err(|reason| anyhow::anyhow!("flip produced an invalid board: {reason}"))?;
+    Ok((updated, true))
+}
+
+fn set_closed_board_footprint_side(
+    board_path: &Path,
+    reference: &str,
+    target_layer: &str,
+) -> anyhow::Result<bool> {
+    let content = read_consistent(board_path)?;
+    let (updated, changed) =
+        prepare_closed_board_footprint_side(&content, reference, target_layer)?;
+    if changed {
+        persist_board_replacement(board_path, &content, &updated)?;
+    }
+    Ok(changed)
+}
+
 /// Verify `content` is exactly one `(kicad_pcb …)` form and nothing else.
 ///
 /// Checking only that *a* balanced block exists is too weak to back the promise
@@ -1218,6 +1666,22 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "reference", "rotation"]
             }),
             |args, ctx| async move { handle_rotate_component(args, ctx).await }
+        ),
+        tool!(
+            "flip_component",
+            "Set a placed footprint to F.Cu or B.Cu with KiCAD-equivalent geometry mirroring. \
+             This operation requires a closed board: it safely flips supported footprints with \
+             revision checks and fails closed when KiCAD is reachable or geometry is unsupported.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "board":     { "type": "string" },
+                    "reference": { "type": "string" },
+                    "layer":     { "type": "string", "enum": ["F.Cu", "B.Cu"] }
+                },
+                "required": ["board", "reference", "layer"]
+            }),
+            |args, ctx| async move { handle_flip_component(args, ctx).await }
         ),
         tool!(
             "delete_component",
@@ -1692,6 +2156,76 @@ async fn handle_rotate_component(
                     "warning": "KiCAD IPC was not reachable, so the closed board file was edited directly."
                 }))),
                 Err(error) => Ok(error.into_result()),
+            }
+        }
+    }
+}
+
+async fn handle_flip_component(
+    args: &serde_json::Value,
+    ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let board = get_path(args, "board")?;
+    let reference = match require_str(args, "reference") {
+        Ok(value) => value.to_string(),
+        Err(error) => return Ok(error),
+    };
+    let layer = match require_str(args, "layer") {
+        Ok(value) if matches!(value, "F.Cu" | "B.Cu") => value.to_string(),
+        Ok(value) => {
+            return Ok(CallToolResult::error_kind(
+                crate::mcp::error::ToolErrorKind::InvalidArgument {
+                    field: "layer".to_string(),
+                    reason: format!("must be F.Cu or B.Cu, got '{value}'"),
+                },
+                format!("Footprints can only be flipped between F.Cu and B.Cu, got '{value}'"),
+            ))
+        }
+        Err(error) => return Ok(error),
+    };
+
+    let requested_board = board.clone();
+    let reference_ipc = reference.clone();
+    let layer_ipc = layer.clone();
+    let attempt: Result<(), konnect_ipc::IpcFailure> =
+        with_ipc_classified(ctx.config.ipc_address.clone(), move |client| {
+            client.ensure_board_is_active(&requested_board)?;
+            anyhow::bail!(
+                "live KiCAD IPC does not expose a native footprint flip command for '{}' to '{}'; \
+             close the PCB editor before retrying so Konnect can apply the revision-aware \
+             closed-board transform",
+                reference_ipc,
+                layer_ipc
+            )
+        })
+        .await?;
+
+    match attempt {
+        Ok(changed) => Ok(CallToolResult::json(&json!({
+            "flipped": reference,
+            "layer": layer,
+            "changed": changed,
+            "source": "ipc"
+        }))),
+        Err(konnect_ipc::IpcFailure::Rejected(message)) => Ok(CallToolResult::error(format!(
+            "KiCAD rejected the footprint flip over IPC: {message}. The board file was not \
+             modified — KiCAD is reachable and may hold this board open, so editing the file \
+             directly could be silently overwritten."
+        ))),
+        Err(konnect_ipc::IpcFailure::Unreachable(_)) => {
+            match set_closed_board_footprint_side(&board, &reference, &layer) {
+                Ok(changed) => Ok(CallToolResult::json(&json!({
+                    "flipped": reference,
+                    "layer": layer,
+                    "changed": changed,
+                    "source": "file",
+                    "warning": "KiCAD IPC was not reachable, so the supported closed-board \
+                                footprint was flipped directly with a revision check."
+                }))),
+                Err(error) if error.to_string().contains("not found on the board") => {
+                    Ok(CallToolResult::error(error.to_string()))
+                }
+                Err(error) => Err(error),
             }
         }
     }
@@ -2999,6 +3533,425 @@ mod tests {
         .unwrap();
         assert!(rotated.is_error);
         assert!(result_text(&rotated).contains("not modified"));
+        assert_eq!(std::fs::read_to_string(board).unwrap(), before);
+    }
+
+    const FLIP_FOOTPRINT: &str = r#"(footprint "Test:Flip"
+  (layer "F.Cu")
+  (at 10 20 30)
+  (property "Reference" "U1"
+    (at 1 -2 40)
+    (layer "F.SilkS")
+    (effects (font (size 1 1)) (justify left))
+  )
+  (fp_line (start 1 2) (end 3 4)
+    (stroke (width 0.1) (type solid))
+    (layer "F.SilkS")
+  )
+  (fp_arc (start 1 2) (mid 3 4) (end 5 6)
+    (stroke (width 0.1) (type solid))
+    (layer "F.Fab")
+  )
+  (fp_poly (pts (xy 1 2) (xy 3 4) (xy 5 6))
+    (stroke (width 0.1) (type solid))
+    (fill no)
+    (layer "F.CrtYd")
+  )
+  (pad "1" smd roundrect (at 2 3 50) (size 1 2)
+    (layers "F.Cu" "F.Paste" "F.Mask")
+    (roundrect_rratio 0.25)
+  )
+  (model "../models/Test.step"
+    (offset (xyz 1 2 3))
+    (scale (xyz 1 1 1))
+    (rotate (xyz 4 5 6))
+  )
+)"#;
+
+    fn flip_board(footprints: &[&str], eol: &str) -> String {
+        let body = footprints
+            .iter()
+            .flat_map(|footprint| footprint.lines())
+            .map(|line| format!("  {line}"))
+            .collect::<Vec<_>>()
+            .join(eol);
+        format!(
+            "(kicad_pcb{eol}  (version 20260206){eol}  (generator \"pcbnew\"){eol}  \
+             (net 0 \"\"){eol}{body}{eol}){eol}"
+        )
+    }
+
+    #[test]
+    fn flip_footprint_matches_kicads_library_frame_transform() {
+        let flipped = flip_footprint_block(FLIP_FOOTPRINT).unwrap();
+
+        assert!(flipped.contains("(layer \"B.Cu\")"), "{flipped}");
+        assert!(flipped.contains("(at 10 20 -30)"), "{flipped}");
+        assert!(flipped.contains("(at 1 2 140)"), "{flipped}");
+        assert!(flipped.contains("(layer \"B.SilkS\")"), "{flipped}");
+        assert!(flipped.contains("(justify left mirror)"), "{flipped}");
+        assert!(flipped.contains("(start 1 -2)"), "{flipped}");
+        assert!(flipped.contains("(end 3 -4)"), "{flipped}");
+        assert!(flipped.contains("(start 5 -6)"), "{flipped}");
+        assert!(flipped.contains("(mid 3 -4)"), "{flipped}");
+        assert!(flipped.contains("(end 1 -2)"), "{flipped}");
+        assert!(flipped.contains("(xy 1 -2)"), "{flipped}");
+        assert!(flipped.contains("(at 2 -3 310)"), "{flipped}");
+        assert!(
+            flipped.contains("(layers \"B.Cu\" \"B.Paste\" \"B.Mask\")"),
+            "{flipped}"
+        );
+        assert!(
+            flipped.contains("(offset (xyz 1 2 3))") && flipped.contains("(rotate (xyz 4 5 6))"),
+            "3D model transforms are footprint-side-relative and must remain unchanged: {flipped}"
+        );
+        assert!(konnect_sexp::parse_sexp(&flipped).is_ok());
+    }
+
+    #[tokio::test]
+    async fn unreachable_ipc_flips_an_existing_footprint_to_the_requested_side() {
+        let tmp = tempfile::tempdir().unwrap();
+        let board = tmp.path().join("flip.kicad_pcb");
+        std::fs::write(
+            &board,
+            format!(
+                "(kicad_pcb\n  (version 20260206)\n  (generator \"pcbnew\")\n  (net 0 \"\")\n{}\n)\n",
+                FLIP_FOOTPRINT
+                    .lines()
+                    .map(|line| format!("  {line}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            ),
+        )
+        .unwrap();
+
+        let flipped = handle_flip_component(
+            &json!({
+                "board": board.to_string_lossy(),
+                "reference": "U1",
+                "layer": "B.Cu",
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        assert!(!flipped.is_error, "{:?}", flipped.content);
+        let result: serde_json::Value =
+            serde_json::from_str(&result_text(&flipped)).expect("flip result must be JSON");
+        assert_eq!(result["source"], "file");
+        assert_eq!(result["layer"], "B.Cu");
+        let written = std::fs::read_to_string(&board).unwrap();
+        assert!(written.contains("(layer \"B.Cu\")"), "{written}");
+        assert!(written.contains("(layers \"B.Cu\" \"B.Paste\" \"B.Mask\")"));
+
+        let repeated = handle_flip_component(
+            &json!({
+                "board": board.to_string_lossy(),
+                "reference": "U1",
+                "layer": "B.Cu",
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!repeated.is_error, "{:?}", repeated.content);
+        assert_eq!(std::fs::read_to_string(board).unwrap(), written);
+    }
+
+    #[tokio::test]
+    async fn reachable_rejection_prevents_flip_file_fallback() {
+        let tmp = tempfile::tempdir().unwrap();
+        let board = tmp.path().join("flip.kicad_pcb");
+        let before = format!(
+            "(kicad_pcb\n  (version 20260206)\n  (generator \"pcbnew\")\n  (net 0 \"\")\n{}\n)\n",
+            FLIP_FOOTPRINT
+                .lines()
+                .map(|line| format!("  {line}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        std::fs::write(&board, &before).unwrap();
+        let ctx = ToolContext::new(
+            crate::tools::ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: spawn_rejecting_kicad(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+                eager_toolsets: false,
+            },
+            std::sync::Arc::new(crate::router::ToolRouter::new()),
+        );
+
+        let flipped = handle_flip_component(
+            &json!({
+                "board": board.to_string_lossy(),
+                "reference": "U1",
+                "layer": "B.Cu",
+            }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        assert!(flipped.is_error);
+        assert!(result_text(&flipped).contains("not modified"));
+        assert_eq!(std::fs::read_to_string(board).unwrap(), before);
+    }
+
+    #[test]
+    fn flip_refuses_custom_pad_geometry_instead_of_corrupting_it() {
+        let custom = FLIP_FOOTPRINT.replace("roundrect (at 2 3 50)", "custom (at 2 3 50)");
+
+        let error = flip_footprint_block(&custom).unwrap_err();
+
+        assert!(error.to_string().contains("custom pads"));
+    }
+
+    #[test]
+    fn flip_refuses_nested_drill_offsets_instead_of_mirroring_only_part_of_the_padstack() {
+        let offset_drill = FLIP_FOOTPRINT.replace(
+            "(roundrect_rratio 0.25)",
+            "(roundrect_rratio 0.25)\n    (drill oval 0.4 0.8 (offset 0.2 0.1))",
+        );
+
+        let error = flip_footprint_block(&offset_drill).unwrap_err();
+
+        assert!(error.to_string().contains("offset"), "{error}");
+    }
+
+    #[test]
+    fn flip_does_not_mirror_text_on_a_non_side_specific_layer() {
+        let user_text = FLIP_FOOTPRINT.replace(
+            "(layer \"F.SilkS\")\n    (effects (font (size 1 1)) (justify left))",
+            "(layer \"User.Drawings\")\n    (effects (font (size 1 1)) (justify left))",
+        );
+
+        let flipped = flip_footprint_block(&user_text).unwrap();
+
+        assert!(flipped.contains("(layer \"User.Drawings\")"), "{flipped}");
+        assert!(flipped.contains("(justify left)"), "{flipped}");
+        assert!(!flipped.contains("(justify left mirror)"), "{flipped}");
+    }
+
+    #[test]
+    fn supported_footprint_round_trip_restores_the_original_semantics() {
+        let no_justify = FLIP_FOOTPRINT.replace(" (justify left)", "");
+        let back = flip_footprint_block(&no_justify).unwrap();
+        let front = flip_footprint_block(&back).unwrap();
+
+        assert_eq!(
+            konnect_sexp::parse_sexp(&front).unwrap(),
+            konnect_sexp::parse_sexp(&no_justify).unwrap()
+        );
+    }
+
+    #[test]
+    fn non_cardinal_root_orientation_round_trips_without_drift() {
+        let non_cardinal = FLIP_FOOTPRINT.replace("(at 10 20 30)", "(at 10 20 37.5)");
+
+        let back = flip_footprint_block(&non_cardinal).unwrap();
+        assert!(back.contains("(at 10 20 -37.5)"), "{back}");
+        let front = flip_footprint_block(&back).unwrap();
+
+        assert_eq!(
+            konnect_sexp::parse_sexp(&front).unwrap(),
+            konnect_sexp::parse_sexp(&non_cardinal).unwrap()
+        );
+    }
+
+    #[test]
+    fn through_hole_pad_layers_survive_a_flip_round_trip() {
+        let through_hole = FLIP_FOOTPRINT.replace(
+            "(pad \"1\" smd roundrect (at 2 3 50) (size 1 2)\n    \
+             (layers \"F.Cu\" \"F.Paste\" \"F.Mask\")\n    (roundrect_rratio 0.25)",
+            "(pad \"1\" thru_hole oval (at 2 3 50) (size 1 2)\n    \
+             (drill oval 0.4 0.8)\n    (layers \"*.Cu\" \"*.Mask\")",
+        );
+
+        let back = flip_footprint_block(&through_hole).unwrap();
+        assert!(back.contains("(layers \"*.Cu\" \"*.Mask\")"), "{back}");
+        assert!(back.contains("(drill oval 0.4 0.8)"), "{back}");
+        let front = flip_footprint_block(&back).unwrap();
+
+        assert_eq!(
+            konnect_sexp::parse_sexp(&front).unwrap(),
+            konnect_sexp::parse_sexp(&through_hole).unwrap()
+        );
+    }
+
+    #[test]
+    fn hidden_property_stays_hidden_when_flipped() {
+        let hidden = FLIP_FOOTPRINT.replace(
+            "(effects (font (size 1 1)) (justify left))",
+            "(effects (font (size 1 1)) (justify left))\n    (hide yes)",
+        );
+
+        let flipped = flip_footprint_block(&hidden).unwrap();
+
+        assert!(flipped.contains("(hide yes)"), "{flipped}");
+        assert!(flipped.contains("(justify left mirror)"), "{flipped}");
+    }
+
+    #[test]
+    fn legacy_fp_text_reference_flips_and_round_trips() {
+        let legacy = FLIP_FOOTPRINT.replace(
+            "(property \"Reference\" \"U1\"",
+            "(fp_text reference \"U1\"",
+        );
+
+        let back = flip_footprint_block(&legacy).unwrap();
+        assert!(back.contains("(fp_text reference \"U1\""), "{back}");
+        let front = flip_footprint_block(&back).unwrap();
+
+        assert_eq!(
+            konnect_sexp::parse_sexp(&front).unwrap(),
+            konnect_sexp::parse_sexp(&legacy).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_flip_layer_is_structured_and_leaves_the_board_untouched() {
+        let tmp = tempfile::tempdir().unwrap();
+        let board = tmp.path().join("invalid-layer.kicad_pcb");
+        let before = flip_board(&[FLIP_FOOTPRINT], "\n");
+        std::fs::write(&board, &before).unwrap();
+
+        let result = handle_flip_component(
+            &json!({
+                "board": board.to_string_lossy(),
+                "reference": "U1",
+                "layer": "In1.Cu",
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_error);
+        assert_eq!(
+            crate::mcp::error::extract_error_kind(&result).as_deref(),
+            Some("invalid_argument")
+        );
+        assert_eq!(std::fs::read_to_string(board).unwrap(), before);
+    }
+
+    #[tokio::test]
+    async fn missing_and_duplicate_flip_references_leave_the_board_untouched() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing_board = tmp.path().join("missing.kicad_pcb");
+        let missing_before = flip_board(&[FLIP_FOOTPRINT], "\n");
+        std::fs::write(&missing_board, &missing_before).unwrap();
+
+        let missing = handle_flip_component(
+            &json!({
+                "board": missing_board.to_string_lossy(),
+                "reference": "U404",
+                "layer": "B.Cu",
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(missing.is_error);
+        assert_eq!(
+            std::fs::read_to_string(&missing_board).unwrap(),
+            missing_before
+        );
+
+        let duplicate_board = tmp.path().join("duplicate.kicad_pcb");
+        let duplicate_before = flip_board(&[FLIP_FOOTPRINT, FLIP_FOOTPRINT], "\n");
+        std::fs::write(&duplicate_board, &duplicate_before).unwrap();
+        let duplicate = handle_flip_component(
+            &json!({
+                "board": duplicate_board.to_string_lossy(),
+                "reference": "U1",
+                "layer": "B.Cu",
+            }),
+            &test_ctx(),
+        )
+        .await
+        .expect_err("duplicate references must fail closed");
+        assert!(
+            duplicate.to_string().contains("more than once"),
+            "{duplicate}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(duplicate_board).unwrap(),
+            duplicate_before
+        );
+    }
+
+    #[tokio::test]
+    async fn closed_board_flip_preserves_crlf_line_endings() {
+        let tmp = tempfile::tempdir().unwrap();
+        let board = tmp.path().join("crlf.kicad_pcb");
+        let before = flip_board(&[FLIP_FOOTPRINT], "\r\n");
+        std::fs::write(&board, &before).unwrap();
+
+        let result = handle_flip_component(
+            &json!({
+                "board": board.to_string_lossy(),
+                "reference": "U1",
+                "layer": "B.Cu",
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error, "{:?}", result.content);
+
+        let written = std::fs::read_to_string(board).unwrap();
+        assert_eq!(
+            written
+                .match_indices('\n')
+                .filter(|(index, _)| *index == 0 || written.as_bytes()[index - 1] != b'\r')
+                .count(),
+            0,
+            "{written:?}"
+        );
+    }
+
+    #[test]
+    fn stale_closed_board_flip_is_rejected_without_overwriting_newer_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let board = tmp.path().join("stale-flip.kicad_pcb");
+        let expected = flip_board(&[FLIP_FOOTPRINT], "\n");
+        let (replacement, changed) =
+            prepare_closed_board_footprint_side(&expected, "U1", "B.Cu").unwrap();
+        assert!(changed);
+        let newer = expected.replace("(net 0 \"\")", "(net 0 \"\")\n  (net 1 \"GND\")");
+        std::fs::write(&board, &newer).unwrap();
+
+        let error = persist_board_replacement(&board, &expected, &replacement)
+            .expect_err("a stale flip source must conflict");
+
+        assert!(matches!(error, konnect_sexp::SexpError::Conflict { .. }));
+        assert_eq!(std::fs::read_to_string(board).unwrap(), newer);
+    }
+
+    #[tokio::test]
+    async fn unsupported_flip_geometry_returns_zero_writes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let board = tmp.path().join("unsupported.kicad_pcb");
+        let custom = FLIP_FOOTPRINT.replace("roundrect (at 2 3 50)", "custom (at 2 3 50)");
+        let before = flip_board(&[&custom], "\n");
+        std::fs::write(&board, &before).unwrap();
+
+        let error = handle_flip_component(
+            &json!({
+                "board": board.to_string_lossy(),
+                "reference": "U1",
+                "layer": "B.Cu",
+            }),
+            &test_ctx(),
+        )
+        .await
+        .expect_err("unsupported pad geometry must fail closed");
+
+        assert!(error.to_string().contains("custom pads"), "{error}");
         assert_eq!(std::fs::read_to_string(board).unwrap(), before);
     }
 

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -1584,7 +1584,8 @@ fn prepare_closed_board_footprint_side(
     let current_layer = footprint_layer(block).map_err(ClosedBoardError::Io)?;
     if !matches!(current_layer.as_str(), "F.Cu" | "B.Cu") {
         return Err(ClosedBoardError::Unusable(format!(
-            "footprint '{reference}' sits on root layer '{current_layer}', which is neither              side of the board"
+            "footprint '{reference}' sits on root layer '{current_layer}', which is neither \
+             side of the board"
         )));
     }
     if current_layer == target_layer {

--- a/crates/konnect/assets/skills/kicad-pcb/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-pcb/SKILL.md
@@ -19,12 +19,14 @@ ALL modifications go through MCP tools — never edit .kicad_pcb files directly.
 Most PCB layout operations require KiCAD to be running with the board file open. The IPC
 connection communicates with the running KiCAD instance in real-time.
 
-`place_component`, `move_component`, and `rotate_component` are narrow exceptions:
-when IPC is unreachable, they can mutate one footprint in a closed `.kicad_pcb` file
-through revision-aware atomic fallbacks. Placement preserves pads, graphics,
-attributes, and models; moves preserve the existing angle; rotations update the
-footprint and its child angles together. If KiCAD is reachable but rejects a request,
-the fallback stays disabled to avoid racing a live editor.
+`place_component`, `move_component`, `rotate_component`, and `flip_component` are
+narrow exceptions for closed boards. Placement, move, and rotation fall back when
+IPC is unreachable. Flip intentionally requires IPC to be unreachable because KiCAD's
+typed IPC API has no native footprint-flip command. The file paths use revision-aware
+atomic writes: placement preserves pads, graphics, attributes, and models; moves
+preserve the existing angle; rotations update the footprint and its child angles;
+flips mirror supported geometry and swap front/back layers. If KiCAD is reachable and
+rejects a request, the fallback stays disabled to avoid racing a live editor.
 
 If connection fails:
 - Tell the user to open KiCAD and load the project
@@ -97,6 +99,7 @@ Do NOT add copper pours before routing is complete — they interfere with inter
 | `place_component`         | Position one footprint via IPC or safe file fallback |
 | `move_component`          | Relocate a footprint via IPC or safe file fallback |
 | `rotate_component`        | Rotate a footprint via IPC or safe file fallback |
+| `flip_component`          | Set F.Cu/B.Cu on a closed board with geometry mirroring |
 | `align_components`        | Align multiple components (top/bottom/left/right/center) |
 | `place_component_array`   | Grid placement for repeated elements        |
 
@@ -279,8 +282,8 @@ Common DRC errors and fixes:
 5. **Check DRC before finishing** — run `run_drc()` and resolve all errors
 6. **Use netclasses for consistency** — define track widths per net type, not per trace
 7. **KiCAD normally must be running** — `place_component`, `move_component`, and
-   `rotate_component` have safe IPC-unreachable file fallbacks; other PCB edits still
-   require the live IPC connection
+   `rotate_component` have safe IPC-unreachable file fallbacks; `flip_component`
+   requires a closed board; other PCB edits still require the live IPC connection
 8. **Save frequently** — call `save_project` after major operations
 9. **Load toolsets first** — check `get_active_toolsets()` and load what you need
 10. **Copper pour last** — add zones only after routing is substantially complete

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -134,7 +134,7 @@ The fix for those clients is to make the *first* listing complete:
 ```
 
 in `konnect.toml` in the working directory, or a `settings.json` beside the binary. Every toolset is then loaded at
-startup, so `tools/list` carries all 208 tools from the first call.
+startup, so `tools/list` carries all 209 tools from the first call.
 
 It is off by default because it costs what the router exists to save: roughly
 25K tokens per listing instead of ~2K. Turn it on only if your client needs it.

--- a/packaging/metadata.json
+++ b/packaging/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://go.kicad.org/pcm/schemas/v1",
   "name": "Konnect",
-  "description": "AI-assisted PCB design via the Model Context Protocol. Enables Claude and other AI assistants to design schematics and PCBs with 202 tools organized into on-demand toolsets.",
+  "description": "AI-assisted PCB design via the Model Context Protocol. Enables Claude and other AI assistants to design schematics and PCBs with 203 tools organized into on-demand toolsets.",
   "description_full": "Konnect exposes a complete set of KiCAD design tools to AI assistants via the Model Context Protocol (MCP). It supports schematic editing, PCB layout, routing, library management, JLCPCB part search, Freerouting autoroute, ERC/DRC, design review audits, and full export pipelines. Tools are organized into 19 toolsets loaded on demand so the AI only sees relevant tools at once.",
   "identifier": "com.github.mixelpixx.konnect",
   "type": "plugin",

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "identifier": "com.github.mixelpixx.konnect",
   "name": "Konnect",
-  "description": "AI-assisted PCB design via the Model Context Protocol. 202 tools for schematic editing, PCB layout, routing, design review, and manufacturing export.",
+  "description": "AI-assisted PCB design via the Model Context Protocol. 203 tools for schematic editing, PCB layout, routing, design review, and manufacturing export.",
   "runtime": {
     "type": "exec"
   },

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -10,7 +10,7 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 ## Overview
 
 - **19 toolsets** organized into 10 categories
-- **202 registered tools** + **6 always-visible meta-tools** = **208 total**
+- **203 registered tools** + **6 always-visible meta-tools** = **209 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -217,15 +217,16 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `add_zone` | Add a copper fill zone polygon on a specified layer and net. Refuses a net the board does not declare rather than binding copper to net 0, and refuses entirely while KiCad holds the board open. |
 | `import_svg_logo` | Import an SVG file as filled silkscreen/copper artwork (curves flattened to polygons). |
 
-### `pcb_components` · 15 tools
-**Purpose:** Place, move, rotate, align and duplicate PCB footprints; inspect pads; inspect and edit a placed footprint's graphics.
+### `pcb_components` · 16 tools
+**Purpose:** Place, move, rotate, flip, align and duplicate PCB footprints; inspect pads; inspect and edit a placed footprint's graphics.
 **Source:** [`crates/konnect-core/src/tools/pcb_components.rs`](crates/konnect-core/src/tools/pcb_components.rs)
 
 | Tool | Description |
 |------|-------------|
 | `place_component` | Place a footprint through live KiCAD IPC when reachable, or use a revision-aware file fallback when no KiCAD process can hold the board open. The fallback preserves complete footprint content and rejects duplicate references. |
-| `move_component` | Move a placed footprint to a new X/Y position via KiCAD IPC. |
-| `rotate_component` | Set the rotation angle of a placed footprint via KiCAD IPC. |
+| `move_component` | Move a placed footprint through live KiCAD IPC when reachable, or use a revision-aware closed-board file fallback. |
+| `rotate_component` | Set a placed footprint's absolute rotation through live KiCAD IPC when reachable, or use a revision-aware closed-board file fallback that updates child angles. |
+| `flip_component` | Set a placed footprint to F.Cu or B.Cu on a closed board with KiCAD-equivalent geometry mirroring and revision checks; refuses live-editor races and unsupported geometry. |
 | `delete_component` | Remove a footprint from the board via KiCAD IPC. |
 | `edit_component` | Update the value or other properties of a placed footprint via KiCAD IPC. |
 | `find_component` | Find a footprint by reference designator and return its position. |


### PR DESCRIPTION
## Summary

**Implements the safe closed-board `flip_component` path requested by #115.** This is a stacked draft on #229; until #229 merges, review commit `3003e48` for the flip-specific change. After #229 lands, this branch will be rebased onto `main` so the PR contains only the flip commit.

`flip_component(board, reference, layer)` moves an already placed footprint between `F.Cu` and `B.Cu` with KiCad-equivalent geometry mirroring. It is idempotent when the footprint is already on the requested side.

Part of #115. This draft intentionally does **not** close #115 yet: it delivers the revision-aware closed-board path, while live-IPC mirrored-instance construction remains a follow-up unless the maintainer asks to include it here.

## Why `flip_component`

I recommend the public name `flip_component` rather than `mirror_component`:

- **It matches KiCad's own domain language.** The GUI action is “Flip” and the implementation this mirrors is `FOOTPRINT::Flip` / `PAD::Flip`.
- **It groups naturally with the existing PCB operations** `place_component`, `move_component`, and `rotate_component`.
- **It describes the complete board-side operation.** This tool changes the footprint side, root orientation, child geometry, side-specific layers, and text mirroring together.
- **`mirror_component` is more ambiguous.** It can imply choosing an arbitrary X/Y mirror axis, or mirroring geometry without changing F.Cu/B.Cu, neither of which is this contract.
- **KiCad explicitly does not mirror placed footprints.** PCB Editor offers separate horizontal/vertical Mirror actions for shapes, text, zones, tracks, pads, and groups, but skips `PCB_FOOTPRINT_T` and tells users to use Flip to change board side.
- **The operation takes a target side rather than toggling blindly.** `layer: "F.Cu" | "B.Cu"` makes retries idempotent while retaining KiCad's established “flip” term.

This naming decision is explicitly called out for the #115 review. If the maintainer prefers `mirror_component`, the draft can be renamed before merge without shipping two aliases.

## Approach

The closed-board transform follows KiCad's current footprint library-frame behavior:

- mirror child Y coordinates in the footprint-local frame;
- negate and normalize the footprint root orientation;
- swap front/back copper, paste, mask, silkscreen, courtyard, fab, and adhesive layers;
- transform footprint text as `180 - local_angle` and toggle mirroring only on side-specific layers;
- negate pad-local angles;
- mirror primitive points and reverse mirrored arc start/end order;
- preserve 3D model transforms, metadata, groups, and unrelated content.

The handler uses the typed IPC classification established by #229. KiCad 10.0.5 and Konnect's currently vendored protocol do not expose a native footprint-flip command, so a reachable KiCad fails closed with zero file writes and only `IpcFailure::Unreachable` may use the closed-board path. KiCad upstream added `FlipItems` to the 10.0 branch on 2026-08-06; once Konnect raises its supported API baseline and vendors that command, a live-IPC path can reuse this tool contract instead of introducing a second name.

The file path reads one consistent board revision, finds exactly one footprint by reference, validates the complete resulting `kicad_pcb` form, and persists through `write_atomic_if_unchanged`.

## Compatibility and safety

This adds one public tool and updates the catalogue from 202 to 203 registered tools (209 including meta-tools).

Supported closed-board content includes standard SMD/THT pads, properties and legacy `fp_text` fields, line/rect/circle/arc/poly graphics, models, groups, and metadata. Complex padstack geometry that Konnect cannot mirror completely is rejected before writing: nested offsets, trapezoid deltas, chamfers, custom pads/primitives, footprint zones, and unknown `fp_*` items fail closed.

Safety properties covered by tests:

- reachable KiCad never falls back to file editing;
- missing or duplicate references leave the board unchanged;
- malformed/unsupported geometry leaves the board unchanged;
- stale revisions conflict instead of overwriting newer content;
- CRLF is preserved;
- F→B→F semantic round trips restore supported footprints, including non-cardinal angles, THT layer sets, hidden fields, and legacy references.

Rollback is a normal revert of `3003e48`; #229's move/rotate behavior remains independent.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --locked --lib --tests`
- [x] `cargo test --workspace --locked --doc`
- [x] `cargo clippy --workspace --locked --all-targets -- -D warnings`
- [x] `python3 -m unittest discover -s plugin/tests -v`
- [x] `python packaging/validate-pcm.py --metadata packaging/metadata.json` (isolated venv with CI's `jsonschema` dependency)
- [x] `cargo build --release --locked -p konnect`
- [x] `pcb_components` focused suite: 59 passed
- [x] Tool count and asset-reference gates: 4 + 4 passed

### Real KiCad 10 coupon

Using the built MCP server (no direct KiCad-file edits), a temporary project registered the LH60 libraries, placed three representative footprints on F.Cu, then called `flip_component(..., layer="B.Cu")`:

- 23-pad RP2040 SMD module at a non-cardinal 37.5° rotation;
- SOD-323 diode;
- SMD test point.

All three returned `source: "file"`, `changed: true`, and `layer: "B.Cu"`. Read-only inspection confirmed B.Cu/B.Paste/B.Mask padsets where applicable, B-side graphics, mirrored text, preserved models and attributes.

KiCad 10 DRC reported **zero flip-specific findings**: no `lib_footprint_mismatch`, invalid-layer, or malformed-footprint errors. The six remaining coupon findings were expected and unrelated: one `invalid_outline` (the coupon intentionally has no board outline) and five `silk_over_copper` findings.

## Review checklist

- [x] The diff is focused on #115's footprint-side workflow and contains no local paths, generated output, or project-specific geometry.
- [x] The recommended public name and alternative are explicitly documented for maintainer/review-agent attention.
- [x] New behavior and failure paths have regression coverage.
- [x] File mutations are revision-aware and atomic.
- [x] Reachable-IPC behavior fails closed and cannot race a live editor.
- [x] Registry, `tool-directory.md`, DEV.md, README, bundled skill, PCM metadata, plugin manifest, and troubleshooting counts moved together.

## Stack

- Depends on #229 / #228 for the shared closed-board placement-update seam.
- Flip-specific commit: `3003e485797eda8c973652ec8ce17f1184f23dcc`.
- Issue context and design discussion: #115.

