### PR TITLE
test(sch): resolve the stub Device library from the stub project

### DIFF
--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -2911,9 +2911,11 @@ mod tests {
     /// "doesn't match copy in library".
     #[tokio::test]
     async fn update_symbols_from_library_refreshes_a_stale_embedded_copy() {
+        // In the stub project dir, so its sym-lib-table shadows the global
+        // `Device` entry — off a developer's KiCad install, that entry resolves
+        // and the edit below then lands on a library nothing reads.
         let (symdir, _env) = stub_symbol_dir();
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("stale.kicad_sch");
+        let path = symdir.path().join("stale.kicad_sch");
         let ctx = test_ctx();
         handle_create_schematic(&json!({ "path": path.display().to_string() }), &ctx)
             .await
@@ -3006,9 +3008,9 @@ mod tests {
     /// (grafted from #177 by @JYPochez).
     #[tokio::test]
     async fn update_symbols_from_library_refuses_a_moved_pin_unless_allowed() {
+        // In the stub project dir — see the stale-copy test above.
         let (symdir, _env) = stub_symbol_dir();
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("guarded.kicad_sch");
+        let path = symdir.path().join("guarded.kicad_sch");
         let ctx = test_ctx();
         handle_create_schematic(&json!({ "path": path.display().to_string() }), &ctx)
             .await
@@ -3201,9 +3203,9 @@ mod tests {
     /// dangles. Same guard, different message.
     #[tokio::test]
     async fn update_symbols_from_library_refuses_a_removed_pin() {
+        // In the stub project dir — see the stale-copy test above.
         let (symdir, _env) = stub_symbol_dir();
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("shrunk.kicad_sch");
+        let path = symdir.path().join("shrunk.kicad_sch");
         let ctx = test_ctx();
         handle_create_schematic(&json!({ "path": path.display().to_string() }), &ctx)
             .await


### PR DESCRIPTION
Three `update_symbols_from_library` tests fail on `main` on any machine with
KiCad installed:

```
assertion `left == right` failed:
  {"pins_moved":[],"unchanged":["Device:R"],"updated":[],"updated_count":0}
```

They put their schematic in a second tempdir, outside the stub project
`stub_symbol_dir()` builds. With no project `sym-lib-table` beside it,
`Device:R` resolves through the global table, which points at KiCad's own
`Device` library — so the test edits a stub the tool never reads, and the
embedded copy is correctly reported unchanged.

The fixture's doc comment already asks for this ("The returned tempdir doubles
as the project directory — put the test's schematic in it"); these three did
not. Each now creates its schematic in the stub project dir. Test-only change.

CI has no KiCad installed, which is why these pass there and fail only for a
developer running the gate locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)