### PR TITLE
feat(netclass): add `get_netclasses`, the read path net classes never had

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -298,7 +298,7 @@ Source: [`crates/konnect-core/src/observability.rs`](crates/konnect-core/src/obs
 
 ## Tool Routing (Starter Kit + On-Demand Loading)
 
-The server does NOT expose all 203 tools (209 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
+The server does NOT expose all 204 tools (210 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
 
 - **Startup**: only `STARTER_KIT` toolsets are pre-loaded (see `router/registry.rs::STARTER_KIT`). Currently: `project`, `config`. Combined with the 6 meta-tools, baseline `tools/list` is 20 tools ≈ 2K tokens.
 - **On demand**: the LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose a toolset's tools in subsequent `tools/list` responses. `unload_toolset(name)` prunes them when the task shifts.
@@ -373,9 +373,9 @@ convention for other `kicad-cli`-calling code.
 
 ## Current Stats
 
-- **19 toolsets, 203 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
+- **19 toolsets, 204 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
 - Baseline `tools/list`: 20 tools / ~2K tokens (starter kit + meta-tools)
-- Full-catalog `tools/list` (all loaded): 209 tools (203 registered + 6 meta) / ~25K tokens
+- Full-catalog `tools/list` (all loaded): 210 tools (204 registered + 6 meta) / ~25K tokens
 - **0 IPC stubs** (all protobuf methods implemented)
 - **0 unimplemented tools**
 - **3 operations `kicad-cli` has never exposed** (specctra DSN/SES, pcb sync — return clear

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Rust binary — that lets Claude and other AI assistants design schematics and PCBs
 through the [Model Context Protocol](https://modelcontextprotocol.io) (MCP).
 
-**203 tools across 19 on-demand toolsets.** Schematic capture, PCB layout and
+**204 tools across 19 on-demand toolsets.** Schematic capture, PCB layout and
 routing, ERC/DRC, design-review audits, JLCPCB part search, Freerouting, reference
 circuits, and a full manufacturing export pipeline — with bundled skills and agents
 that teach Claude KiCAD conventions out of the box.
@@ -70,7 +70,7 @@ through its own S-expression engine with atomic writes (write, fsync, rename), U
 preservation, and round-trip tests — no third-party schematic library with known
 gaps, no text-manipulation workarounds.
 
-**Context economy is a feature.** Exposing all 203 tools to an LLM costs roughly 23K
+**Context economy is a feature.** Exposing all 204 tools to an LLM costs roughly 23K
 tokens of context on every listing. Konnect's router loads a starter kit (~2K
 tokens) and lets the model pull in toolsets on demand — plus built-in observability
 (`get_recent_calls`, `server_stats`, JSONL call logs) so the model can diagnose its

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -82,7 +82,7 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         name: "pcb_routing",
         description: "Traces, vias, copper pours, net classes, differential pairs",
         category: "pcb",
-        tool_count: 12,
+        tool_count: 13,
     },
     ToolsetMeta {
         name: "pcb_export",

--- a/crates/konnect-core/src/tools/pcb_routing.rs
+++ b/crates/konnect-core/src/tools/pcb_routing.rs
@@ -251,6 +251,25 @@ pub fn tools() -> Vec<ToolDef> {
             |args, ctx| async move { handle_create_netclass(args, ctx).await }
         ),
         tool!(
+            "get_netclasses",
+            "Read every netclass in the project's design rules, with its settings, \
+             its netclass_patterns and the board nets those patterns match. Reads \
+             the sibling .kicad_pro and the board file; KiCad need not be running. \
+             Call before create_netclass to see what a class holds — an update \
+             changes only the values you name, and this is the only way to see the \
+             rest. A net can match several classes: KiCad takes each property from \
+             the highest-priority class that sets it (lower number = higher \
+             priority) and falls back to Default.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "board": { "type": "string", "description": "Path to .kicad_pcb file; the sibling .kicad_pro is read" }
+                },
+                "required": ["board"]
+            }),
+            |args, ctx| async move { handle_get_netclasses(args, ctx).await }
+        ),
+        tool!(
             "assign_net_to_class",
             "Assign a net to an existing netclass, as a netclass_patterns entry in \
              the sibling .kicad_pro. The class must already exist (create_netclass). \
@@ -804,6 +823,169 @@ async fn handle_create_netclass(
     })))
 }
 
+/// KiCad's netclass patterns are wildcard expressions: `*` stands for any run
+/// of characters including none, `?` for exactly one. A pattern carrying
+/// neither is an exact name — which is the shape `assign_net_to_class` writes.
+///
+/// Iterative rather than recursive: a pattern is user data, and `*`-heavy input
+/// makes the naive recursion blow the stack on names a real board can carry.
+fn wildcard_matches(pattern: &str, name: &str) -> bool {
+    let pat: Vec<char> = pattern.chars().collect();
+    let txt: Vec<char> = name.chars().collect();
+    let (mut p, mut t) = (0usize, 0usize);
+    // Where to resume if the current `*` turns out to have consumed too little.
+    let (mut star, mut retry) = (None, 0usize);
+
+    while t < txt.len() {
+        if p < pat.len() && (pat[p] == '?' || pat[p] == txt[t]) {
+            p += 1;
+            t += 1;
+        } else if p < pat.len() && pat[p] == '*' {
+            star = Some(p);
+            retry = t;
+            p += 1;
+        } else if let Some(s) = star {
+            // Backtrack: let the last `*` swallow one more character.
+            p = s + 1;
+            retry += 1;
+            t = retry;
+        } else {
+            return false;
+        }
+    }
+    // Trailing `*`s may still match the empty rest.
+    while p < pat.len() && pat[p] == '*' {
+        p += 1;
+    }
+    p == pat.len()
+}
+
+/// The four settings `create_netclass` writes, as (KiCad's key, this API's
+/// name). Reported per class so a caller can see what a class holds before
+/// overwriting it — the gap that made #220 hard to review.
+const NETCLASS_FIELDS: [(&str, &str); 4] = [
+    ("clearance", "clearance"),
+    ("track_width", "trace_width"),
+    ("via_drill", "via_drill"),
+    ("via_diameter", "via_diameter"),
+];
+
+async fn handle_get_netclasses(
+    args: &serde_json::Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let board_path = get_path(args, "board")?;
+    let (pro, settings) = match load_project_settings(&board_path)? {
+        Ok(v) => v,
+        Err(refusal) => return Ok(refusal),
+    };
+
+    let classes = settings["net_settings"]["classes"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let patterns = settings["net_settings"]["netclass_patterns"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+
+    // The nets come from the board file rather than IPC: this is a read-only
+    // query that must answer with KiCad closed. They are read with
+    // `collect_net_keys`, not `find_all("net")` — KiCad 10 writes no top-level
+    // net table at all, so a direct-children scan finds zero nets on every
+    // current board and every pattern would match nothing. A board held open
+    // with unsaved edits reads as last saved, which the payload says out loud.
+    let (net_names, nets_note): (Vec<String>, String) = match std::fs::read_to_string(&board_path) {
+        Ok(text) => match konnect_sexp::parse_sexp(&text) {
+            Ok(tree) => {
+                let mut names: Vec<String> = konnect_sexp::net::collect_net_keys(&tree)
+                    .into_iter()
+                    .collect();
+                names.sort();
+                (
+                    names,
+                    "board file as last saved; unsaved edits in a running KiCad are not visible"
+                        .to_string(),
+                )
+            }
+            Err(e) => (
+                Vec::new(),
+                format!("board could not be parsed ({e}); nets unavailable"),
+            ),
+        },
+        Err(e) => (
+            Vec::new(),
+            format!("board could not be read ({e}); nets unavailable"),
+        ),
+    };
+
+    let mut out = Vec::new();
+    for class in &classes {
+        let name = class["name"].as_str().unwrap_or_default().to_string();
+        // KiCad's own fallback class. Its clearance explains DRC results that
+        // no explicit class accounts for, so it is reported, not filtered.
+        let is_default = name == "Default";
+
+        let mine: Vec<&serde_json::Value> = patterns
+            .iter()
+            .filter(|p| p["netclass"].as_str() == Some(name.as_str()))
+            .collect();
+        let pattern_strings: Vec<String> = mine
+            .iter()
+            .filter_map(|p| p["pattern"].as_str().map(String::from))
+            .collect();
+
+        let mut matched: Vec<String> = net_names
+            .iter()
+            .filter(|net| pattern_strings.iter().any(|pat| wildcard_matches(pat, net)))
+            .cloned()
+            .collect();
+        matched.sort();
+        matched.dedup();
+
+        let mut entry = json!({
+            "name": name,
+            "is_default": is_default,
+            "priority": class["priority"],
+            "patterns": pattern_strings,
+            "matched_nets": matched,
+        });
+        for (key, api) in NETCLASS_FIELDS {
+            entry[api] = class[key].clone();
+        }
+        out.push(entry);
+    }
+
+    // A pattern naming a class that does not exist does nothing in KiCad, and
+    // is invisible in its dialog. Surfacing it here is the whole point of a
+    // read tool: it is the state assign_net_to_class refuses to create but a
+    // hand-edited or third-party project file can still hold.
+    let orphan_patterns: Vec<serde_json::Value> = patterns
+        .iter()
+        .filter(|p| {
+            let target = p["netclass"].as_str().unwrap_or_default();
+            !classes.iter().any(|c| c["name"] == json!(target))
+        })
+        .cloned()
+        .collect();
+
+    // Netclass membership is many-to-many: KiCad forms an aggregate class per
+    // net, taking each property from the highest-priority class that sets it,
+    // with Default filling what is left. Naming one winning class per net
+    // would be a fiction, so the mapping is reported as it is.
+    Ok(CallToolResult::json(&json!({
+        "file": pro.display().to_string(),
+        "count": out.len(),
+        "netclasses": out,
+        "nets_on_board": net_names.len(),
+        "nets_source": nets_note,
+        "orphan_patterns": orphan_patterns,
+        "note": "A net can match several classes; KiCad then takes each property from the \
+                 highest-priority class that sets it and falls back to Default. Lower \
+                 priority numbers rank higher.",
+    })))
+}
+
 async fn handle_assign_net_to_class(
     args: &serde_json::Value,
     _ctx: &ToolContext,
@@ -1323,6 +1505,267 @@ mod netclass_tests {
         assert_eq!(patterns[0]["netclass"], json!("LV"));
 
         assert_eq!(std::fs::read_to_string(&board).unwrap(), BOARD);
+    }
+
+    /// A board whose nets are named the way KiCad 10 writes them: in place, on
+    /// the items themselves, with no top-level net table anywhere.
+    ///
+    /// This shape is the whole point of the fixture. A board carrying the
+    /// pre-10 `(net 1 "GND")` table would pass even a collector that only
+    /// scans direct children of `(kicad_pcb …)` — and that collector reports
+    /// zero nets on every board KiCad 10 saves.
+    fn fixture_with_nets(nets: &[&str]) -> (tempfile::TempDir, std::path::PathBuf) {
+        let (dir, board) = fixture(true);
+        let mut text = String::from("(kicad_pcb\n\t(version 20260206)\n\t(generator \"pcbnew\")\n");
+        text.push_str("\t(footprint \"R_0402\"\n\t\t(layer \"F.Cu\")\n");
+        for (i, n) in nets.iter().enumerate() {
+            text.push_str(&format!(
+                "\t\t(pad \"{}\" smd roundrect\n\t\t\t(at {} 0)\n\t\t\t(net \"{}\")\n\t\t)\n",
+                i + 1,
+                i,
+                n
+            ));
+        }
+        text.push_str("\t)\n");
+        // The same nets appear again on copper — KiCad repeats the reference on
+        // every item, and a collector that counts occurrences over-reports.
+        for n in nets {
+            text.push_str(&format!(
+                "\t(segment (start 0 0) (end 1 0) (width 0.2) (layer \"F.Cu\") (net \"{n}\"))\n"
+            ));
+        }
+        text.push_str(")\n");
+        std::fs::write(&board, text).unwrap();
+        (dir, board)
+    }
+
+    async fn get_classes(board: &std::path::Path) -> serde_json::Value {
+        let result =
+            handle_get_netclasses(&json!({ "board": board.to_str().unwrap() }), &test_ctx())
+                .await
+                .unwrap();
+        assert!(!result.is_error, "{}", text_of(&result));
+        serde_json::from_str(&text_of(&result)).unwrap()
+    }
+
+    #[test]
+    fn wildcards_match_the_way_kicad_documents_them() {
+        // An exact pattern — what assign_net_to_class writes.
+        assert!(wildcard_matches("GND", "GND"));
+        assert!(!wildcard_matches("GND", "GNDA"));
+        // `*` spans any run, including none.
+        assert!(wildcard_matches("HV_*", "HV_IN"));
+        assert!(wildcard_matches("HV_*", "HV_"));
+        assert!(!wildcard_matches("HV_*", "LV_IN"));
+        assert!(wildcard_matches("*", "anything"));
+        assert!(wildcard_matches("/Power/*", "/Power/VBUS"));
+        // `?` is exactly one character.
+        assert!(wildcard_matches("D?", "D0"));
+        assert!(!wildcard_matches("D?", "D"));
+        assert!(!wildcard_matches("D?", "D12"));
+        // Backtracking: the first `*` must give characters back.
+        assert!(wildcard_matches("*_P", "USB_D_P"));
+        assert!(!wildcard_matches("*_P", "USB_D_N"));
+        // A run of stars must not blow up or mis-answer.
+        assert!(wildcard_matches("**a**", "xxaxx"));
+    }
+
+    /// The read path is the whole point of #222: what a class holds must be
+    /// visible before create_netclass overwrites part of it.
+    #[tokio::test]
+    async fn get_netclasses_reports_settings_patterns_and_matching_nets() {
+        let (_dir, board) = fixture_with_nets(&["GND", "HV_IN", "HV_OUT"]);
+        create(&board, json!({ "name": "HV", "clearance": 0.5 })).await;
+        assign(&board, "GND", "HV").await;
+
+        let body = get_classes(&board).await;
+        assert_eq!(body["count"], json!(1));
+        let hv = &body["netclasses"][0];
+        assert_eq!(hv["name"], json!("HV"));
+        assert_eq!(hv["clearance"], json!(0.5));
+        // Values the caller never named are reported from the file, not echoed
+        // back from the arguments — the gap that made #220 unreviewable.
+        assert_eq!(hv["trace_width"], json!(0.25));
+        assert_eq!(hv["patterns"], json!(["GND"]));
+        assert_eq!(hv["matched_nets"], json!(["GND"]));
+        assert_eq!(hv["is_default"], json!(false));
+        // Each net is named on a pad *and* on a segment; they are one net each.
+        assert_eq!(body["nets_on_board"], json!(3));
+    }
+
+    /// The regression this tool would otherwise ship with: KiCad 10 writes no
+    /// top-level net table, so reading nets as direct children of
+    /// `(kicad_pcb …)` finds nothing and every pattern silently matches
+    /// nothing — a plausible-looking empty answer on every current board.
+    #[tokio::test]
+    async fn nets_named_in_place_are_found_on_a_kicad_10_board() {
+        let (_dir, board) = fixture_with_nets(&["GND", "HV_IN"]);
+        // No net table at all, the way KiCad 10 saves.
+        let text = std::fs::read_to_string(&board).unwrap();
+        let tree = konnect_sexp::parse_sexp(&text).unwrap();
+        assert_eq!(
+            tree.find_all("net").len(),
+            0,
+            "fixture must not carry a top-level net table"
+        );
+
+        create(&board, json!({ "name": "HV" })).await;
+        assign(&board, "HV_IN", "HV").await;
+
+        let body = get_classes(&board).await;
+        assert_eq!(body["nets_on_board"], json!(2));
+        assert_eq!(body["netclasses"][0]["matched_nets"], json!(["HV_IN"]));
+    }
+
+    /// The pre-10 shape must keep working: there the name follows a numeric id,
+    /// and the same net is repeated as a bare `(net 1)` on every item.
+    #[tokio::test]
+    async fn the_pre_kicad_10_net_table_still_resolves() {
+        let (_dir, board) = fixture(true);
+        std::fs::write(
+            &board,
+            "(kicad_pcb\n\t(version 20250610)\n\t(generator \"pcbnew\")\n\
+             \t(net 0 \"\")\n\t(net 1 \"GND\")\n\t(net 2 \"HV_IN\")\n\
+             \t(segment (start 0 0) (end 1 0) (net 1))\n)\n",
+        )
+        .unwrap();
+        create(&board, json!({ "name": "HV" })).await;
+        assign(&board, "HV_IN", "HV").await;
+
+        let body = get_classes(&board).await;
+        // Net 0 is the unconnected pseudo-net and is not a net a user has.
+        assert_eq!(body["nets_on_board"], json!(2));
+        assert_eq!(body["netclasses"][0]["matched_nets"], json!(["HV_IN"]));
+    }
+
+    /// A wildcard pattern is the case a per-net lookup cannot answer: one
+    /// class matches many nets, and nothing in the project file lists them.
+    #[tokio::test]
+    async fn a_wildcard_pattern_resolves_against_the_board_nets() {
+        let (_dir, board) = fixture_with_nets(&["HV_IN", "HV_OUT", "GND"]);
+        create(&board, json!({ "name": "HV" })).await;
+        // assign_net_to_class only writes exact names, so write the wildcard
+        // the way a user's KiCad dialog would.
+        let pro = board.with_extension("kicad_pro");
+        let mut settings: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&pro).unwrap()).unwrap();
+        settings["net_settings"]["netclass_patterns"] =
+            json!([{ "pattern": "HV_*", "netclass": "HV" }]);
+        std::fs::write(&pro, serde_json::to_string_pretty(&settings).unwrap()).unwrap();
+
+        let body = get_classes(&board).await;
+        assert_eq!(
+            body["netclasses"][0]["matched_nets"],
+            json!(["HV_IN", "HV_OUT"])
+        );
+    }
+
+    /// A net may sit in several classes at once — KiCad aggregates them by
+    /// priority. Reporting a single winning class per net would be a fiction.
+    #[tokio::test]
+    async fn one_net_can_belong_to_several_classes() {
+        let (_dir, board) = fixture_with_nets(&["USB_DP"]);
+        create(&board, json!({ "name": "HighSpeed" })).await;
+        create(&board, json!({ "name": "Wide" })).await;
+        let pro = board.with_extension("kicad_pro");
+        let mut settings: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&pro).unwrap()).unwrap();
+        settings["net_settings"]["netclass_patterns"] = json!([
+            { "pattern": "USB_*", "netclass": "HighSpeed" },
+            { "pattern": "*_DP",  "netclass": "Wide" },
+        ]);
+        std::fs::write(&pro, serde_json::to_string_pretty(&settings).unwrap()).unwrap();
+
+        let body = get_classes(&board).await;
+        for class in body["netclasses"].as_array().unwrap() {
+            assert_eq!(
+                class["matched_nets"],
+                json!(["USB_DP"]),
+                "both classes claim the net: {class}"
+            );
+        }
+    }
+
+    /// A pattern naming a class that does not exist does nothing in KiCad and
+    /// is invisible in its dialog. It is exactly what a read tool is for.
+    #[tokio::test]
+    async fn a_pattern_naming_no_class_is_reported_as_an_orphan() {
+        let (_dir, board) = fixture_with_nets(&["GND"]);
+        create(&board, json!({ "name": "HV" })).await;
+        let pro = board.with_extension("kicad_pro");
+        let mut settings: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&pro).unwrap()).unwrap();
+        settings["net_settings"]["netclass_patterns"] =
+            json!([{ "pattern": "GND", "netclass": "Vanished" }]);
+        std::fs::write(&pro, serde_json::to_string_pretty(&settings).unwrap()).unwrap();
+
+        let body = get_classes(&board).await;
+        assert_eq!(body["orphan_patterns"][0]["netclass"], json!("Vanished"));
+        assert_eq!(body["netclasses"][0]["matched_nets"], json!([]));
+    }
+
+    /// Default is KiCad's fallback and its clearance explains DRC results no
+    /// explicit class accounts for, so it is reported and marked.
+    #[tokio::test]
+    async fn the_default_class_is_reported_and_marked() {
+        let (_dir, board) = fixture_with_nets(&["GND"]);
+        let pro = board.with_extension("kicad_pro");
+        let mut settings: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&pro).unwrap()).unwrap();
+        settings["net_settings"] = json!({
+            "classes": [{ "name": "Default", "clearance": 0.2, "track_width": 0.25,
+                          "priority": 2147483647i64 }],
+            "netclass_patterns": []
+        });
+        std::fs::write(&pro, serde_json::to_string_pretty(&settings).unwrap()).unwrap();
+
+        let body = get_classes(&board).await;
+        assert_eq!(body["netclasses"][0]["is_default"], json!(true));
+        assert_eq!(body["netclasses"][0]["priority"], json!(2147483647i64));
+    }
+
+    /// Reading must not write. The project file is byte-identical afterwards —
+    /// #220's second half was create_netclass rewriting it for a no-op call.
+    #[tokio::test]
+    async fn reading_leaves_both_files_untouched() {
+        let (_dir, board) = fixture_with_nets(&["GND"]);
+        create(&board, json!({ "name": "HV" })).await;
+        let pro = board.with_extension("kicad_pro");
+        let before_pro = std::fs::read_to_string(&pro).unwrap();
+        let before_board = std::fs::read_to_string(&board).unwrap();
+
+        get_classes(&board).await;
+
+        assert_eq!(std::fs::read_to_string(&pro).unwrap(), before_pro);
+        assert_eq!(std::fs::read_to_string(&board).unwrap(), before_board);
+    }
+
+    /// Without a project file there are no netclasses to read, and the refusal
+    /// must say where they actually live.
+    #[tokio::test]
+    async fn reading_without_a_project_file_refuses_with_the_reason() {
+        let (_dir, board) = fixture(false);
+        let result =
+            handle_get_netclasses(&json!({ "board": board.to_str().unwrap() }), &test_ctx())
+                .await
+                .unwrap();
+        assert!(result.is_error);
+        assert!(
+            text_of(&result).contains("kicad_pro"),
+            "{}",
+            text_of(&result)
+        );
+    }
+
+    /// A project with no net_settings at all is a normal new project, not an
+    /// error — it simply has no classes yet.
+    #[tokio::test]
+    async fn a_project_without_net_settings_reads_as_empty() {
+        let (_dir, board) = fixture_with_nets(&["GND"]);
+        let body = get_classes(&board).await;
+        assert_eq!(body["count"], json!(0));
+        assert_eq!(body["netclasses"], json!([]));
+        assert_eq!(body["nets_on_board"], json!(1));
     }
 
     /// Assigning to a class that doesn't exist names the ones that do.

--- a/crates/konnect-core/src/tools/pcb_routing.rs
+++ b/crates/konnect-core/src/tools/pcb_routing.rs
@@ -235,7 +235,11 @@ pub fn tools() -> Vec<ToolDef> {
             "Create or update a netclass in the project's design rules. Writes \
              net_settings in the sibling .kicad_pro (where KiCad keeps netclasses \
              since v7); the board file is never touched. Requires the project file \
-             to exist.",
+             to exist. An update changes only the settings you name. To see what a \
+             class holds, call get_netclasses rather than this tool: naming a class \
+             that does not exist here creates it with the defaults, so a call meant \
+             as a look writes one instead — and its result is nearly \
+             indistinguishable from a read of an existing class.",
             json!({
                 "type": "object",
                 "properties": {

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -169,7 +169,7 @@ The fix for those clients is to make the *first* listing complete:
 ```
 
 in `konnect.toml` in the working directory, or a `settings.json` beside the binary. Every toolset is then loaded at
-startup, so `tools/list` carries all 209 tools from the first call.
+startup, so `tools/list` carries all 210 tools from the first call.
 
 It is off by default because it costs what the router exists to save: roughly
 25K tokens per listing instead of ~2K. Turn it on only if your client needs it.

--- a/packaging/metadata.json
+++ b/packaging/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://go.kicad.org/pcm/schemas/v1",
   "name": "Konnect",
-  "description": "AI-assisted PCB design via the Model Context Protocol. Enables Claude and other AI assistants to design schematics and PCBs with 203 tools organized into on-demand toolsets.",
+  "description": "AI-assisted PCB design via the Model Context Protocol. Enables Claude and other AI assistants to design schematics and PCBs with 204 tools organized into on-demand toolsets.",
   "description_full": "Konnect exposes a complete set of KiCAD design tools to AI assistants via the Model Context Protocol (MCP). It supports schematic editing, PCB layout, routing, library management, JLCPCB part search, Freerouting autoroute, ERC/DRC, design review audits, and full export pipelines. Tools are organized into 19 toolsets loaded on demand so the AI only sees relevant tools at once.",
   "identifier": "com.github.mixelpixx.konnect",
   "type": "plugin",

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "identifier": "com.github.mixelpixx.konnect",
   "name": "Konnect",
-  "description": "AI-assisted PCB design via the Model Context Protocol. 203 tools for schematic editing, PCB layout, routing, design review, and manufacturing export.",
+  "description": "AI-assisted PCB design via the Model Context Protocol. 204 tools for schematic editing, PCB layout, routing, design review, and manufacturing export.",
   "runtime": {
     "type": "exec"
   },

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -10,7 +10,7 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 ## Overview
 
 - **19 toolsets** organized into 10 categories
-- **203 registered tools** + **6 always-visible meta-tools** = **209 total**
+- **204 registered tools** + **6 always-visible meta-tools** = **210 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -240,7 +240,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `duplicate_component` | Duplicate an existing footprint at a new position via KiCAD IPC. |
 | `get_board_2d_view` | Render the board with kicad-cli and return a base64 PNG. This is the 3-D render viewed from the top, not a layer plot, and takes no layer selection — use `export_svg` for layer-aware output. |
 
-### `pcb_routing` · 12 tools
+### `pcb_routing` · 13 tools
 **Purpose:** Traces, vias, copper pours, net classes, differential pairs.
 **Source:** [`crates/konnect-core/src/tools/pcb_routing.rs`](crates/konnect-core/src/tools/pcb_routing.rs)
 
@@ -256,6 +256,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `get_nets_list` | Return all nets defined on the PCB via KiCAD IPC. |
 | `modify_trace` | Modify a trace segment by deleting and re-adding it with new parameters. |
 | `create_netclass` | Create or update a netclass in the project's `net_settings` (the sibling `.kicad_pro`, where KiCad keeps netclasses since v7). Never touches the board file. |
+| `get_netclasses` | Read every netclass with its settings, its `netclass_patterns` and the board nets those patterns match. Reads the `.kicad_pro` and the board file, so KiCad need not be running. Reports `Default` (marked) and any pattern naming a class that does not exist. |
 | `assign_net_to_class` | Assign a net to an existing netclass via a `netclass_patterns` entry in the `.kicad_pro`; reassigning moves the entry. |
 | `route_differential_pair` | Route a differential pair (two parallel traces with a specified gap). |
 

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -255,7 +255,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `query_traces` | List trace segments on the board, optionally filtered by net and/or layer. |
 | `get_nets_list` | Return all nets defined on the PCB via KiCAD IPC. |
 | `modify_trace` | Modify a trace segment by deleting and re-adding it with new parameters. |
-| `create_netclass` | Create or update a netclass in the project's `net_settings` (the sibling `.kicad_pro`, where KiCad keeps netclasses since v7). Never touches the board file. |
+| `create_netclass` | Create or update a netclass in the project's `net_settings` (the sibling `.kicad_pro`, where KiCad keeps netclasses since v7). Never touches the board file. An update changes only the settings named; use `get_netclasses` to look, since naming an unknown class here creates it. |
 | `get_netclasses` | Read every netclass with its settings, its `netclass_patterns` and the board nets those patterns match. Reads the `.kicad_pro` and the board file, so KiCad need not be running. Reports `Default` (marked) and any pattern naming a class that does not exist. |
 | `assign_net_to_class` | Assign a net to an existing netclass via a `netclass_patterns` entry in the `.kicad_pro`; reassigning moves the entry. |
 | `route_differential_pair` | Route a differential pair (two parallel traces with a specified gap). |


### PR DESCRIPTION
Closes #222.

## Why

`create_netclass` and `assign_net_to_class` are write-only. Nothing can report what a class holds, which classes exist, or which nets a class matches. Reading `.kicad_pro` by hand is the only way — which is what made #220 hard to review: the update path reset settings the caller had not named, and the only feedback available was the tool's own result payload, echoing the arguments back.

## What

`get_netclasses(board)` reads `net_settings.classes` and `net_settings.netclass_patterns` from the sibling `.kicad_pro` through the existing `load_project_settings`, so it inherits that refusal (and its explanation) when the project file is absent. It then reads the board's nets and resolves each class's patterns against them.

```json
{
  "file": "…/demo.kicad_pro",
  "count": 2,
  "netclasses": [
    { "name": "Default", "is_default": true, "priority": 2147483647,
      "clearance": 0.2, "trace_width": 0.25, "via_drill": 0.4, "via_diameter": 0.8,
      "patterns": [], "matched_nets": [] },
    { "name": "HV", "is_default": false, "priority": 0,
      "clearance": 0.5, "trace_width": 0.8, "via_drill": 0.4, "via_diameter": 0.8,
      "patterns": ["HV_*"], "matched_nets": ["HV_IN", "HV_OUT"] }
  ],
  "nets_on_board": 4,
  "nets_source": "board file as last saved; unsaved edits in a running KiCad are not visible",
  "orphan_patterns": [{ "pattern": "USB_*", "netclass": "Ghost" }],
  "note": "A net can match several classes; KiCad then takes each property from the highest-priority class that sets it and falls back to Default. Lower priority numbers rank higher."
}
```

## Three decisions worth reviewing

**Nets come from the board file, not IPC — and through `net::collect_net_keys`.**
A read-only query has to answer with KiCad closed, so IPC is the wrong dependency. Reading them is the part that is easy to get wrong: KiCad 10 writes no top-level net table at all, so a `find_all("net")` scan of the root finds nothing, every pattern matches nothing, and the result is a plausible-looking empty answer on every current board. `net::collect_net_keys` already handles both shapes and de-duplicates, so it is used rather than re-derived.

The cost is that a board held open with unsaved edits reads as last saved. The payload states that in `nets_source` rather than leaving the caller to guess.

**Membership is many-to-many, and is reported that way.**
Per the KiCad manual, more than one net class can be assigned to a net; KiCad then forms an aggregate class, taking each property from the highest-priority class that sets it, with `Default` filling what is left. Naming one winning class per net would therefore be a fiction. Each class reports the nets its patterns match, and no winner is invented. `one_net_can_belong_to_several_classes` pins this down.

**A pattern naming a class that does not exist is surfaced as `orphan_patterns`.**
`assign_net_to_class` refuses to create that state, but a hand-edited or third-party project file can hold it, and it does nothing in KiCad while being invisible in its dialog. Surfacing it is exactly what a read tool is for.

`Default` is included and marked, since its clearance is what explains DRC results no explicit class accounts for.

Pattern matching follows KiCad's documented wildcards — `*` for any run of characters, `?` for exactly one. The matcher is iterative rather than recursive: a pattern is user data, and `*`-heavy input makes the naive recursion blow the stack.

## Tests

11 new tests in `netclass_tests`, covering:

- settings, patterns and matched nets reported together, including values the caller never named
- wildcard resolution against the board's nets
- **`nets_named_in_place_are_found_on_a_kicad_10_board`** — asserts the fixture carries *no* top-level net table, so it cannot quietly regress into testing the pre-10 shape
- **`the_pre_kicad_10_net_table_still_resolves`** — `(net 1 "GND")` declarations plus bare `(net 1)` references
- one net claimed by several classes
- orphan patterns
- `Default` reported and marked
- reading leaves both files byte-identical
- refusal without a project file; a project with no `net_settings` reads as empty, not as an error
- the wildcard matcher itself, including backtracking and a run of stars

## Checklist

- `cargo test --workspace --locked --lib --tests` — passes
- `cargo test --workspace --locked --doc` — passes
- `cargo clippy --workspace --locked --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Tool counts moved together: `router/registry.rs` (`pcb_routing` 12 → 13), `tool-directory.md` (heading + row), DEV.md "Current Stats", README, and the two package descriptions the sweep test also guards (`plugin/plugin.json`, `packaging/metadata.json`)
- Required arguments read through `get_path`; no `unwrap_or` on caller input
- Naming per `docs/NAMING_CONVENTIONS.md`: `get_*` for a fallible read, `handle_get_netclasses` for the handler, `KiCad` in new prose

Verified end-to-end against the built server over stdio, not only in unit tests: `load_toolset("pcb_routing")` then `tools/call get_netclasses` on a KiCad 10 board pair — 13 tools in the toolset, `HV_*` resolving to `HV_IN`/`HV_OUT`, the orphan pattern surfaced, and both files unchanged afterwards.

## Not in this PR

`create_netclass` writes `priority: 0` into every class it creates and offers no way to change it, so precedence cannot be expressed through Konnect at all. Measured against KiCad 10.0.4 by DRC outcome, that is not a neutral default: lower numbers rank higher, an absent `priority` key behaves as `-1` and therefore outranks an explicit `0`, and an exact tie is broken alphabetically by class name — so where two patterns overlap, today's winner is decided by spelling rather than by intent. A follow-up would add an optional `priority` argument to `create_netclass`, written on create and on update with absent meaning unchanged, rather than allocating a "next free" value automatically — overlapping patterns are precisely the case where guessing the caller's intent is the original defect. Happy to take that as the next PR.