### PR TITLE
fix(pcb): harden live footprint pad readback

### DIFF
--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -1883,8 +1883,9 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "get_component_pads",
-            "Return the pad positions and net assignments for a footprint. \
-             Reads the board open in KiCad when it is reachable, else the file — \
+            "Return live board-space pad positions, layers and net assignments for a footprint. \
+             Reads the board open in KiCad when it is reachable and falls back to the file only \
+             when KiCad IPC is unreachable — \
              'source' says which, so unsaved placements are visible without a save. \
              A pad's 'net' is its net name, \"\" if the pad carries no net \
              (unconnected), or — reading the file — null if the net node is present \
@@ -1901,7 +1902,7 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "get_pad_position",
-            "Return the schematic-space position of a specific pad number on a footprint.",
+            "Return the live board-space position, layers and net of a specific pad number on a footprint.",
             json!({
                 "type": "object",
                 "properties": {
@@ -2977,7 +2978,7 @@ async fn handle_get_component_pads(
     // live one. The file stays the fallback for an offline session.
     let ipc_board = board_path.clone();
     let ipc_reference = reference.clone();
-    let live = with_ipc(ctx.config.ipc_address.clone(), move |c| {
+    let live = with_ipc_classified(ctx.config.ipc_address.clone(), move |c| {
         let document = c.find_open_board(&ipc_board)?;
         c.get_footprint_pads_in(document, &ipc_reference)
     })
@@ -2987,7 +2988,15 @@ async fn handle_get_component_pads(
         Ok(Some(pads)) if !pads.is_empty() => {
             let items: Vec<serde_json::Value> = pads
                 .iter()
-                .map(|pad| json!({ "number": pad.number, "x": pad.x, "y": pad.y, "net": pad.net }))
+                .map(|pad| {
+                    json!({
+                        "number": pad.number,
+                        "x": pad.x,
+                        "y": pad.y,
+                        "net": pad.net,
+                        "layers": pad.layers
+                    })
+                })
                 .collect();
             return Ok(CallToolResult::json(&json!({
                 "reference": reference,
@@ -3030,7 +3039,10 @@ async fn handle_get_component_pads(
                 "Footprint '{reference}' not found on the board open in KiCad"
             )))
         }
-        Err(_) => {}
+        Err(konnect_ipc::IpcFailure::Unreachable(_)) => {}
+        Err(konnect_ipc::IpcFailure::Rejected(message)) => {
+            return Ok(CallToolResult::error(message));
+        }
     }
 
     let content = std::fs::read_to_string(&board_path)?;
@@ -3084,7 +3096,21 @@ async fn handle_get_component_pads(
                     None => serde_json::Value::Null,
                 },
             };
-            Some(json!({ "number": number, "x": board_x, "y": board_y, "net": net }))
+            let layers: Vec<_> = pad
+                .find("layers")
+                .and_then(konnect_sexp::SexpNode::children)
+                .unwrap_or_default()
+                .iter()
+                .skip(1)
+                .filter_map(konnect_sexp::SexpNode::as_str)
+                .collect();
+            Some(json!({
+                "number": number,
+                "x": board_x,
+                "y": board_y,
+                "net": net,
+                "layers": layers
+            }))
         })
         .collect();
 
@@ -5286,7 +5312,7 @@ mod tests {
         \t(footprint \"R_0805\"\n\
         \t\t(at 5 5 0)\n\
         \t\t(property \"Reference\" \"R1\" (at 0 -1 0) (layer \"F.SilkS\"))\n\
-        \t\t(pad \"1\" smd roundrect (at -0.9 0) (net \"SAVED\"))\n\
+        \t\t(pad \"1\" smd roundrect (at -0.9 0) (layers \"F.Cu\" \"F.Paste\" \"F.Mask\") (net \"SAVED\"))\n\
         \t)\n\
         )\n";
 
@@ -5298,6 +5324,14 @@ mod tests {
                 net: Some(konnect_ipc::gen::kiapi::board::types::Net {
                     code: None,
                     name: net.to_string(),
+                }),
+                pad_stack: Some(konnect_ipc::gen::kiapi::board::types::PadStack {
+                    layers: vec![
+                        konnect_ipc::gen::kiapi::board::types::BoardLayer::BlFCu as i32,
+                        konnect_ipc::gen::kiapi::board::types::BoardLayer::BlFPaste as i32,
+                        konnect_ipc::gen::kiapi::board::types::BoardLayer::BlFMask as i32,
+                    ],
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -5442,6 +5476,10 @@ mod tests {
         assert_eq!(body["source"], json!("ipc"));
         assert_eq!(body["pads"][0]["net"], json!("/VBUS"));
         assert_eq!(body["pads"][0]["x"], json!(101.155));
+        assert_eq!(
+            body["pads"][0]["layers"],
+            json!(["F.Cu", "F.Paste", "F.Mask"])
+        );
     }
 
     #[tokio::test]
@@ -5520,6 +5558,30 @@ mod tests {
         let body = parsed(&res);
         assert_eq!(body["source"], json!("file"));
         assert_eq!(body["pads"][0]["net"], json!("SAVED"));
+        assert_eq!(
+            body["pads"][0]["layers"],
+            json!(["F.Cu", "F.Paste", "F.Mask"])
+        );
+    }
+
+    #[tokio::test]
+    async fn pad_reads_do_not_fall_back_when_reachable_kicad_rejects() {
+        let tmp = tempfile::tempdir().unwrap();
+        let board = tmp.path().join("b.kicad_pcb");
+        std::fs::write(&board, SAVED_BOARD_WITH_R1).unwrap();
+
+        let res = handle_get_component_pads(
+            &json!({ "board": board.to_string_lossy(), "reference": "R1" }),
+            &ctx_talking_to(spawn_rejecting_kicad()),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            res.is_error,
+            "a live rejection must not return stale file pads"
+        );
+        assert!(result_text(&res).contains("mock rejects everything"));
     }
 
     #[tokio::test]

--- a/crates/konnect-ipc/src/builders.rs
+++ b/crates/konnect-ipc/src/builders.rs
@@ -107,6 +107,71 @@ pub fn layer_from_name(name: &str) -> kiapi::board::types::BoardLayer {
     }
 }
 
+/// The canonical KiCAD name for a board layer — the exact inverse of
+/// [`layer_from_name`] over every layer it can represent.
+///
+/// `None` for a value with no name (including `BL_UNDEFINED`); callers
+/// rendering a response decide how to say "unknown" rather than this map
+/// quietly inventing one. Kept next to the forward map because #237's fix
+/// widened only the forward direction, and the narrow reverse map surfaced
+/// as 28 `"Unknown"` strings in every through-hole pad's `layers` list.
+pub fn layer_name(layer: kiapi::board::types::BoardLayer) -> Option<&'static str> {
+    use kiapi::board::types::BoardLayer;
+
+    const IN_CU: [&str; 30] = [
+        "In1.Cu", "In2.Cu", "In3.Cu", "In4.Cu", "In5.Cu", "In6.Cu", "In7.Cu", "In8.Cu", "In9.Cu",
+        "In10.Cu", "In11.Cu", "In12.Cu", "In13.Cu", "In14.Cu", "In15.Cu", "In16.Cu", "In17.Cu",
+        "In18.Cu", "In19.Cu", "In20.Cu", "In21.Cu", "In22.Cu", "In23.Cu", "In24.Cu", "In25.Cu",
+        "In26.Cu", "In27.Cu", "In28.Cu", "In29.Cu", "In30.Cu",
+    ];
+    const USER: [&str; 45] = [
+        "User.1", "User.2", "User.3", "User.4", "User.5", "User.6", "User.7", "User.8", "User.9",
+        "User.10", "User.11", "User.12", "User.13", "User.14", "User.15", "User.16", "User.17",
+        "User.18", "User.19", "User.20", "User.21", "User.22", "User.23", "User.24", "User.25",
+        "User.26", "User.27", "User.28", "User.29", "User.30", "User.31", "User.32", "User.33",
+        "User.34", "User.35", "User.36", "User.37", "User.38", "User.39", "User.40", "User.41",
+        "User.42", "User.43", "User.44", "User.45",
+    ];
+
+    let value = layer as i32;
+    // The same contiguous runs the forward map computes over: In1..=In30
+    // directly after BL_F_Cu, and User.1..=User.45 split around BL_Rescue.
+    if value > BoardLayer::BlFCu as i32 && value <= BoardLayer::BlFCu as i32 + 30 {
+        return Some(IN_CU[(value - BoardLayer::BlFCu as i32 - 1) as usize]);
+    }
+    if (BoardLayer::BlUser1 as i32..=BoardLayer::BlUser9 as i32).contains(&value) {
+        return Some(USER[(value - BoardLayer::BlUser1 as i32) as usize]);
+    }
+    if (BoardLayer::BlUser10 as i32..=BoardLayer::BlUser10 as i32 + 35).contains(&value) {
+        return Some(USER[(value - BoardLayer::BlUser10 as i32 + 9) as usize]);
+    }
+
+    match layer {
+        BoardLayer::BlFCu => Some("F.Cu"),
+        BoardLayer::BlBCu => Some("B.Cu"),
+        BoardLayer::BlFAdhes => Some("F.Adhes"),
+        BoardLayer::BlBAdhes => Some("B.Adhes"),
+        BoardLayer::BlFSilkS => Some("F.SilkS"),
+        BoardLayer::BlBSilkS => Some("B.SilkS"),
+        BoardLayer::BlFMask => Some("F.Mask"),
+        BoardLayer::BlBMask => Some("B.Mask"),
+        BoardLayer::BlFPaste => Some("F.Paste"),
+        BoardLayer::BlBPaste => Some("B.Paste"),
+        BoardLayer::BlFCrtYd => Some("F.CrtYd"),
+        BoardLayer::BlBCrtYd => Some("B.CrtYd"),
+        BoardLayer::BlFFab => Some("F.Fab"),
+        BoardLayer::BlBFab => Some("B.Fab"),
+        BoardLayer::BlDwgsUser => Some("Dwgs.User"),
+        BoardLayer::BlCmtsUser => Some("Cmts.User"),
+        BoardLayer::BlEco1User => Some("Eco1.User"),
+        BoardLayer::BlEco2User => Some("Eco2.User"),
+        BoardLayer::BlEdgeCuts => Some("Edge.Cuts"),
+        BoardLayer::BlMargin => Some("Margin"),
+        BoardLayer::BlRescue => Some("Rescue"),
+        _ => None,
+    }
+}
+
 /// As [`layer_from_name`], but refusing a name this build cannot represent.
 ///
 /// Use this on every path that puts a layer into a message bound for KiCAD.
@@ -579,6 +644,52 @@ pub fn board_text(
 pub(crate) mod tests {
     use super::*;
     use kiapi::common::types::graphic_shape::Geometry;
+
+    /// `layer_name` is the exact inverse of `layer_from_name` over every
+    /// representable layer — computed runs included. The forward map was
+    /// widened for #237; a reverse map that lags it turns real layers into
+    /// "Unknown" in pad and track responses.
+    #[test]
+    fn layer_name_round_trips_every_representable_layer() {
+        use kiapi::board::types::BoardLayer;
+        let mut named = 0;
+        for value in 0..=200 {
+            let Ok(layer) = BoardLayer::try_from(value) else {
+                continue;
+            };
+            if layer == BoardLayer::BlUndefined {
+                assert_eq!(layer_name(layer), None, "BL_UNDEFINED has no name");
+                continue;
+            }
+            if let Some(name) = layer_name(layer) {
+                named += 1;
+                assert_eq!(
+                    layer_from_name(name),
+                    layer,
+                    "'{name}' must map back to {layer:?}"
+                );
+            }
+        }
+        // 2 outer + 30 inner copper, 45 user, and the 19 named non-copper
+        // layers the forward map lists.
+        assert_eq!(named, 96, "every representable layer carries a name");
+
+        for (name, expected) in [
+            ("In3.Cu", true),
+            ("In30.Cu", true),
+            ("User.9", true),
+            ("User.10", true),
+            ("User.45", true),
+            ("Rescue", true),
+        ] {
+            let layer = layer_from_name(name);
+            assert_eq!(
+                layer_name(layer) == Some(name),
+                expected,
+                "spot check {name} -> {layer:?}"
+            );
+        }
+    }
 
     /// The builder is the only thing standing between an `add_zone` request
     /// and the board, so every user-visible choice is asserted here: the mock

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -23,27 +23,10 @@ fn nm_to_mm(nm: i64) -> f64 {
 
 /// Map a BoardLayer enum integer back to a KiCAD layer name string.
 fn layer_enum_to_name(layer: i32) -> &'static str {
-    match kiapi::board::types::BoardLayer::try_from(layer) {
-        Ok(l) => match l {
-            kiapi::board::types::BoardLayer::BlFCu => "F.Cu",
-            kiapi::board::types::BoardLayer::BlBCu => "B.Cu",
-            kiapi::board::types::BoardLayer::BlIn1Cu => "In1.Cu",
-            kiapi::board::types::BoardLayer::BlIn2Cu => "In2.Cu",
-            kiapi::board::types::BoardLayer::BlFSilkS => "F.SilkS",
-            kiapi::board::types::BoardLayer::BlBSilkS => "B.SilkS",
-            kiapi::board::types::BoardLayer::BlFMask => "F.Mask",
-            kiapi::board::types::BoardLayer::BlBMask => "B.Mask",
-            kiapi::board::types::BoardLayer::BlFPaste => "F.Paste",
-            kiapi::board::types::BoardLayer::BlBPaste => "B.Paste",
-            kiapi::board::types::BoardLayer::BlFCrtYd => "F.CrtYd",
-            kiapi::board::types::BoardLayer::BlBCrtYd => "B.CrtYd",
-            kiapi::board::types::BoardLayer::BlFFab => "F.Fab",
-            kiapi::board::types::BoardLayer::BlBFab => "B.Fab",
-            kiapi::board::types::BoardLayer::BlEdgeCuts => "Edge.Cuts",
-            _ => "Unknown",
-        },
-        Err(_) => "Unknown",
-    }
+    kiapi::board::types::BoardLayer::try_from(layer)
+        .ok()
+        .and_then(crate::builders::layer_name)
+        .unwrap_or("Unknown")
 }
 
 /// A placed footprint's anchor in board nanometres, and its orientation in

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -1027,30 +1027,62 @@ impl KiCadIpcClient {
             document,
             kiapi::common::types::KiCadObjectType::KotPcbFootprint,
         )?;
+        let mut found = None;
         for item in &items {
-            let Ok(fp) = kiapi::board::types::FootprintInstance::decode(item.value.as_slice())
-            else {
+            if !crate::builders::any_is(item, "kiapi.board.types.FootprintInstance") {
                 continue;
-            };
+            }
+            let fp = kiapi::board::types::FootprintInstance::decode(item.value.as_slice())
+                .context("KiCad returned an unreadable footprint instance")?;
             if footprint_reference(&fp) != reference {
                 continue;
             }
-            let pads = fp
+            if found.is_some() {
+                anyhow::bail!(
+                    "footprint reference '{}' appears more than once on the board",
+                    reference
+                );
+            }
+
+            let definition = fp
                 .definition
-                .iter()
-                .flat_map(|definition| definition.items.iter())
-                .filter(|child| child.type_url.ends_with("kiapi.board.types.Pad"))
-                .filter_map(|child| kiapi::board::types::Pad::decode(child.value.as_slice()).ok())
-                .map(|pad| IpcPad {
+                .as_ref()
+                .with_context(|| format!("footprint '{reference}' has no definition"))?;
+            let mut pads = Vec::new();
+            for child in &definition.items {
+                if !crate::builders::any_is(child, "kiapi.board.types.Pad") {
+                    continue;
+                }
+                let pad = kiapi::board::types::Pad::decode(child.value.as_slice())
+                    .with_context(|| format!("footprint '{reference}' has an unreadable pad"))?;
+                let position = pad.position.with_context(|| {
+                    format!(
+                        "footprint '{reference}' pad '{}' has no position",
+                        pad.number
+                    )
+                })?;
+                let layers = pad
+                    .pad_stack
+                    .as_ref()
+                    .map(|stack| {
+                        stack
+                            .layers
+                            .iter()
+                            .map(|layer| layer_enum_to_name(*layer).to_string())
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                pads.push(IpcPad {
                     number: pad.number,
-                    x: pad.position.map(|p| nm_to_mm(p.x_nm)).unwrap_or(0.0),
-                    y: pad.position.map(|p| nm_to_mm(p.y_nm)).unwrap_or(0.0),
+                    x: nm_to_mm(position.x_nm),
+                    y: nm_to_mm(position.y_nm),
                     net: pad.net.map(|net| net.name).unwrap_or_default(),
-                })
-                .collect();
-            return Ok(Some(pads));
+                    layers,
+                });
+            }
+            found = Some(pads);
         }
-        Ok(None)
+        Ok(found)
     }
 
     /// Read the title block of a specific open document.

--- a/crates/konnect-ipc/src/types.rs
+++ b/crates/konnect-ipc/src/types.rs
@@ -28,6 +28,8 @@ pub struct IpcPad {
     pub y: f64,
     /// Net name, empty when the pad carries no net.
     pub net: String,
+    /// KiCad layer names from the live pad stack.
+    pub layers: Vec<String>,
 }
 
 /// The document's title block, which the board file also carries.

--- a/crates/konnect-ipc/tests/footprint_transform_test.rs
+++ b/crates/konnect-ipc/tests/footprint_transform_test.rs
@@ -144,6 +144,8 @@ type CapturedUpdate = Arc<Mutex<Option<kiapi::common::commands::UpdateItems>>>;
 fn spawn_footprint_mock(fp: kiapi::board::types::FootprintInstance) -> (MockKicad, CapturedUpdate) {
     let captured: CapturedUpdate = Arc::new(Mutex::new(None));
     let captured_in_mock = captured.clone();
+    let current = Arc::new(Mutex::new(fp));
+    let current_in_mock = current.clone();
 
     let mock = spawn_mock(move |req| {
         let msg = req.message.expect("request must pack a command");
@@ -168,7 +170,7 @@ fn spawn_footprint_mock(fp: kiapi::board::types::FootprintInstance) -> (MockKica
                 header: None,
                 status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
                 items: vec![builders::pack_any(
-                    &fp,
+                    &*current_in_mock.lock().unwrap(),
                     "kiapi.board.types.FootprintInstance",
                 )],
             };
@@ -191,6 +193,10 @@ fn spawn_footprint_mock(fp: kiapi::board::types::FootprintInstance) -> (MockKica
                     item: Some(item),
                 })
                 .collect();
+            if let Some(item) = update.items.first() {
+                *current_in_mock.lock().unwrap() =
+                    kiapi::board::types::FootprintInstance::decode(item.value.as_slice()).unwrap();
+            }
             *captured_in_mock.lock().unwrap() = Some(update);
             Some(reply_with(builders::pack_any(
                 &kiapi::common::commands::UpdateItemsResponse {
@@ -299,4 +305,24 @@ fn rotate_footprint_rotates_children_around_anchor() {
     )
     .unwrap();
     assert_eq!(pad.pad_stack.unwrap().angle.unwrap().value_degrees, 90.0);
+}
+
+#[test]
+fn footprint_pad_readback_observes_the_updated_live_state_after_a_move() {
+    let (mock, _) = spawn_footprint_mock(mk_footprint_r1());
+    let client = KiCadIpcClient::new(&mock.url);
+
+    client.move_footprint("R1", 50.0, 50.0).unwrap();
+    let document = client
+        .find_open_board(std::path::Path::new("test.kicad_pcb"))
+        .expect("the mock holds test.kicad_pcb");
+    let pads = client
+        .get_footprint_pads_in(document, "R1")
+        .expect("pad read")
+        .expect("R1 is on the board");
+
+    assert_eq!(
+        pads.iter().map(|pad| (pad.x, pad.y)).collect::<Vec<_>>(),
+        vec![(49.0, 50.0), (51.0, 50.0)]
+    );
 }

--- a/crates/konnect-ipc/tests/mock_server_test.rs
+++ b/crates/konnect-ipc/tests/mock_server_test.rs
@@ -980,6 +980,14 @@ fn pad_at(number: &str, x_mm: f64, y_mm: f64, net: &str) -> prost_types::Any {
                 code: None,
                 name: net.to_string(),
             }),
+            pad_stack: Some(kiapi::board::types::PadStack {
+                layers: vec![
+                    kiapi::board::types::BoardLayer::BlFCu as i32,
+                    kiapi::board::types::BoardLayer::BlFPaste as i32,
+                    kiapi::board::types::BoardLayer::BlFMask as i32,
+                ],
+                ..Default::default()
+            }),
             ..Default::default()
         },
         "kiapi.board.types.Pad",
@@ -1062,8 +1070,50 @@ fn footprint_pads_come_back_in_board_coordinates_with_their_nets() {
     assert_eq!(pads[0].x, 101.155);
     assert_eq!(pads[0].y, 66.11);
     assert_eq!(pads[0].net, "/VBUS");
+    assert_eq!(pads[0].layers, vec!["F.Cu", "F.Paste", "F.Mask"]);
     // KiCad names no net on an unconnected pad; "" is that, not a read failure.
     assert_eq!(pads[1].net, "");
+}
+
+#[test]
+fn an_unreadable_live_pad_is_reported_instead_of_silently_dropped() {
+    let mock = spawn_kicad_with_footprints(vec![footprint_with_pads(
+        "U1",
+        vec![prost_types::Any {
+            type_url: "type.googleapis.com/kiapi.board.types.Pad".to_string(),
+            value: vec![0xff],
+        }],
+    )]);
+    let client = KiCadIpcClient::new(&mock.url);
+    let document = client
+        .find_open_board(std::path::Path::new("test.kicad_pcb"))
+        .expect("the mock holds test.kicad_pcb");
+
+    let error = client
+        .get_footprint_pads_in(document, "U1")
+        .expect_err("malformed pad data must fail the read");
+    assert!(error.to_string().contains("unreadable pad"), "{error:#}");
+}
+
+#[test]
+fn a_live_pad_without_a_position_is_reported_instead_of_fabricated_at_zero() {
+    let pad = builders::pack_any(
+        &kiapi::board::types::Pad {
+            number: "1".to_string(),
+            ..Default::default()
+        },
+        "kiapi.board.types.Pad",
+    );
+    let mock = spawn_kicad_with_footprints(vec![footprint_with_pads("U1", vec![pad])]);
+    let client = KiCadIpcClient::new(&mock.url);
+    let document = client
+        .find_open_board(std::path::Path::new("test.kicad_pcb"))
+        .expect("the mock holds test.kicad_pcb");
+
+    let error = client
+        .get_footprint_pads_in(document, "U1")
+        .expect_err("missing coordinates must fail the read");
+    assert!(error.to_string().contains("has no position"), "{error:#}");
 }
 
 #[test]

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -237,8 +237,8 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `update_footprints_from_library` | Plan or atomically apply KiCad's Update Footprints from Library operation to placed footprints on the live board. Defaults to a non-mutating dry run; apply requires its exact plan revision. Preserves placed-instance state and pad nets while refreshing supported library-owned content. |
 | `list_board_footprint_graphics` | List the graphic items inside a footprint placed on the board — silkscreen, fabrication, and courtyard artwork — with the UUID needed to edit one. Reports `editable`, plus `outlines` and `holes` for polygons. Requires KiCAD running with the board open. |
 | `edit_board_footprint_graphic` | Replace the vertices of a single-outline polygon inside a placed footprint, selected by UUID, without re-placing the part. Anything with multiple outlines or holes is refused by name rather than flattened. Requires KiCAD running with the board open. |
-| `get_component_pads` | Return pad positions and net assignments for a footprint (IPC, falls back to file parse). A pad whose net node is present but unreadable reports `null` rather than an empty string, so "no net" stays distinguishable from "could not read it". |
-| `get_pad_position` | Return the schematic-space position of a specific pad number on a footprint. |
+| `get_component_pads` | Return live board-space pad positions, layers, and net assignments when KiCAD IPC is reachable; fall back to the saved board only when IPC is unreachable. A pad whose saved net node is present but unreadable reports `null` rather than an empty string. |
+| `get_pad_position` | Return the live board-space position, layers, and net assignment of a specific pad number. |
 | `get_component_list` | List all footprints on the board with positions, layers, and values. |
 | `place_component_array` | Place multiple copies of a footprint in a grid or line array via KiCAD IPC. |
 | `align_components` | Align multiple footprints along a common X or Y axis via KiCAD IPC. |


### PR DESCRIPTION
## Summary

This is now a stacked follow-up to #207, not a competing implementation.

The branch contains #207's commit unchanged, followed by `edcc9b4`. Review only the second commit. Once #207 lands, the shared base commit will disappear from this PR's diff.

Depends on #207.

## Approach

Keep #207's broader live-board reader and its explicit document targeting, then add only the remaining hardening:

- require exact protobuf `Any` types before decoding footprints and pads;
- report malformed pads and missing positions instead of silently dropping them or fabricating `0,0`;
- return live pad-stack layer names, with the same `layers` field in the saved-file fallback;
- distinguish transport-unreachable from KiCad-rejected IPC failures, so a reachable KiCad can never trigger a stale-file fallback;
- verify that move → pad readback observes the updated live board.

## Compatibility and safety

The existing tools remain source-compatible. Responses gain the additive `layers` field; `source` remains unchanged.

This is read-only. It keeps #207's named-document selection, absent-footprint handling, and pad-less-footprint consistency guard.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --locked --doc`
- [x] `cargo clippy --workspace --locked --all-targets -- -D warnings`
- [x] `cargo test -p konnect-ipc --locked --test mock_server_test --test footprint_transform_test` — 29 passed, 1 intentionally ignored timeout test
- [x] `cargo test -p konnect-core --locked tools::pcb_components::tests` — 62 passed
- [ ] `cargo test --workspace --locked --lib --tests` — 551 core tests passed; the same three unchanged `update_symbols_from_library_*` / `Device:R` failures reproduced on the local baseline remain
- [x] The retained layer/filtering behavior was previously checked against real KiCad 10 on a 100-contact connector: 100 numbered pads plus 4 real unnamed mechanical pads, no footprint artwork, and the expected B.Cu/B.Mask/B.Paste layers

## Review checklist

- [x] The follow-up diff is limited to behavior not already supplied by #207.
- [x] New failure paths have regression coverage.
- [x] Reachable IPC failures fail closed instead of returning stale file data.
- [x] Tool counts are unchanged.
