### PR TITLE
fix(schematic): respect intentional unconnected pins

### DIFF
--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -15,9 +15,9 @@ use konnect_schematic_editor as cse;
 use konnect_sexp::{
     geometry::{point_on_segment, points_coincident, snap_point},
     schematic::{
-        extract_all_net_labels, extract_labels, extract_lib_pins, extract_symbol_instances,
-        extract_wires, find_lib_symbol, format_net_label, format_wire, pin_endpoint,
-        pin_label_rotation, read_schematic,
+        extract_all_net_labels, extract_labels, extract_lib_pins, extract_lib_pins_for_unit,
+        extract_symbol_instances, extract_wires, find_lib_symbol, format_net_label, format_wire,
+        pin_endpoint, pin_label_rotation, read_schematic,
     },
     writer::{
         apply_edits, find_block_with_leading_whitespace, find_enclosing_direct_child_block,
@@ -278,9 +278,10 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "validate_component_connections",
-            "Check that every non-passive pin on every component has at least one wire \
-             or label connected. Reports unconnected pins with reference, pin number, \
-             and schematic position.",
+            "Check that every connectable pin on every component has at least one wire \
+             or label connected. Symbol pins typed no_connect and pins carrying a \
+             no-connect marker are exempt. Reports unconnected pins with reference, \
+             pin number, electrical type, and schematic position.",
             json!({
                 "type": "object",
                 "properties": {
@@ -1252,6 +1253,7 @@ async fn handle_validate_component_connections(
                 .collect()
         })
         .unwrap_or_default();
+    let ignore_power_pins = args["ignore_power_pins"].as_bool().unwrap_or(false);
     let tol = 0.01_f64;
 
     let (_, tree) = read_schematic(&sch_path)?;
@@ -1311,7 +1313,19 @@ async fn handle_validate_component_connections(
         let lib_sym = find_lib_symbol(&lib_syms, inst);
         if let Some(sym) = lib_sym {
             let t = inst.pin_transform();
-            for pin in extract_lib_pins(sym) {
+            for pin in extract_lib_pins_for_unit(sym, inst.unit) {
+                // A library-declared no-connect pin is intentional by
+                // definition and does not need a placed X marker. This is
+                // distinct from an ordinary pin carrying a schematic
+                // `(no_connect ...)` marker, which is handled below.
+                if pin.electrical_type == "no_connect" {
+                    continue;
+                }
+                if ignore_power_pins
+                    && matches!(pin.electrical_type.as_str(), "power_in" | "power_out")
+                {
+                    continue;
+                }
                 let (px, py) = pin_endpoint(&pin, t);
 
                 // Skip intentional no-connects
@@ -1328,6 +1342,7 @@ async fn handle_validate_component_connections(
                         "value": inst.value,
                         "pin": pin.number,
                         "pin_name": pin.name,
+                        "pin_type": pin.electrical_type,
                         "x": px,
                         "y": py
                     }));
@@ -1684,6 +1699,90 @@ mod midwire_pin_tests {
                 "with_junction={with_junction}: {body}"
             );
         }
+    }
+
+    fn typed_pin_schematic() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("typed-pins.kicad_sch");
+        std::fs::write(
+            &path,
+            r#"(kicad_sch
+  (version 20260306)
+  (generator "eeschema")
+  (uuid "root")
+  (lib_symbols
+    (symbol "Test:Typed"
+      (symbol "Typed_1_1"
+        (pin no_connect line (at 0 0 0) (length 0)
+          (name "NC" (effects (font (size 1.27 1.27))))
+          (number "1" (effects (font (size 1.27 1.27)))))
+        (pin power_in line (at 0 2.54 0) (length 2.54)
+          (name "VDD" (effects (font (size 1.27 1.27))))
+          (number "2" (effects (font (size 1.27 1.27)))))
+        (pin output line (at 0 5.08 0) (length 2.54)
+          (name "OUT" (effects (font (size 1.27 1.27))))
+          (number "3" (effects (font (size 1.27 1.27))))))
+      (symbol "Typed_2_1"
+        (pin input line (at 0 7.62 0) (length 2.54)
+          (name "OTHER_UNIT" (effects (font (size 1.27 1.27))))
+          (number "4" (effects (font (size 1.27 1.27))))))))
+  (symbol
+    (lib_id "Test:Typed")
+    (at 100 80 0)
+    (unit 1)
+    (uuid "u1")
+    (property "Reference" "U1" (at 100 75 0))
+    (property "Value" "Typed" (at 100 77 0)))
+  (sheet_instances (path "/" (page "1"))))
+"#,
+        )
+        .unwrap();
+        (dir, path)
+    }
+
+    async fn validate_components_json(
+        schematic: &std::path::Path,
+        ignore_power_pins: bool,
+    ) -> serde_json::Value {
+        let result = handle_validate_component_connections(
+            &json!({
+                "schematic": schematic.display().to_string(),
+                "ignore_power_pins": ignore_power_pins
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text content");
+        };
+        serde_json::from_str(text).unwrap()
+    }
+
+    #[tokio::test]
+    async fn declared_no_connect_and_other_unit_pins_are_not_reported() {
+        let (_dir, path) = typed_pin_schematic();
+        let body = validate_components_json(&path, false).await;
+        let pins = body["unconnected_pins"].as_array().unwrap();
+
+        assert_eq!(body["unconnected_count"], 2);
+        assert_eq!(pins[0]["pin"], "2");
+        assert_eq!(pins[0]["pin_type"], "power_in");
+        assert_eq!(pins[1]["pin"], "3");
+        assert_eq!(pins[1]["pin_type"], "output");
+        assert!(pins.iter().all(|pin| pin["pin"] != "1"));
+        assert!(pins.iter().all(|pin| pin["pin"] != "4"));
+    }
+
+    #[tokio::test]
+    async fn ignore_power_pins_option_is_effective() {
+        let (_dir, path) = typed_pin_schematic();
+        let body = validate_components_json(&path, true).await;
+        let pins = body["unconnected_pins"].as_array().unwrap();
+
+        assert_eq!(body["unconnected_count"], 1);
+        assert_eq!(pins[0]["pin"], "3");
+        assert_eq!(pins[0]["pin_type"], "output");
     }
 }
 

--- a/crates/konnect-sexp/src/schematic.rs
+++ b/crates/konnect-sexp/src/schematic.rs
@@ -937,6 +937,24 @@ mod unit_pin_tests {
     }
 
     #[test]
+    fn extraction_preserves_the_electrical_pin_type() {
+        let root = parse_sexp(
+            r#"(kicad_symbol_lib
+  (symbol "TEST"
+    (pin no_connect line (at 0 0 0) (length 0)
+      (name "NC" (effects (font (size 1.27 1.27))))
+      (number "1" (effects (font (size 1.27 1.27)))))))"#,
+        )
+        .unwrap();
+        let pin = extract_lib_pins(root.find("symbol").unwrap())
+            .into_iter()
+            .next()
+            .unwrap();
+
+        assert_eq!(pin.electrical_type, "no_connect");
+    }
+
+    #[test]
     fn underscored_base_names_parse_their_unit_suffix() {
         assert_eq!(parse_subsymbol_unit("R_Small_1_1"), Some(1));
         assert_eq!(parse_subsymbol_unit("OP_DUAL_2_1"), Some(2));


### PR DESCRIPTION
## Summary

Stop `validate_component_connections` from reporting intentionally unconnected symbol pins and pins belonging to other units, and make its existing `ignore_power_pins` option effective.

Refs #182

## Root cause and approach

The validator used the unit-agnostic pin extractor, discarded each library pin's electrical type, and never read `ignore_power_pins`. As a result it superimposed pins from other units and treated declared no-connect and optionally ignored power pins as missing connections.

- Preserve each embedded library pin's KiCad electrical type.
- Exempt pins typed `no_connect` and ordinary pins carrying a schematic no-connect marker.
- Honor `ignore_power_pins` for `power_in` and `power_out` pins.
- Use the existing unit-aware extractor so a placed unit does not inherit another unit's pins.
- Add `pin_type` to each finding and clarify the public tool description.

This keeps the smaller #267 framing selected by the maintainer. #280 is now closed as its duplicate. #272 continues to cover the other analysis/export/review paths.

## Compatibility and safety

The request schema is unchanged. Findings gain an additive `pin_type` field. Results intentionally stop containing library-declared NC pins, ignored power pins, and pins from unplaced units.

The validator is read-only and does not alter the schematic.

## Validation

After rebasing this one-commit PR onto current `main` (`2183267`), all commands required by `CONTRIBUTING.md` pass on this exact branch:

- `cargo test --workspace --locked --lib --tests`
- `cargo test --workspace --locked --doc`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Live-GUI tests remain intentionally ignored by the upstream suite unless a running KiCad GUI/socket is supplied.

## Risk and rollback

The main behavioral risk is filtering a pin that should still be reported. Regression tests cover declared NC pins, schematic no-connect markers, power filtering, selected units, and mid-wire junction behavior. Rollback is a single focused commit.