### PR TITLE
fix(validation): reject malformed nested tool inputs

### DIFF
--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -692,16 +692,21 @@ async fn handle_create_footprint(
         Ok(v) => v.clone(),
         Err(e) => return Ok(e),
     };
+    if let Err(error) = validate_footprint_pad_items(&pads_val) {
+        return Ok(error);
+    }
     let mut pad_geoms: Vec<PadGeom> = Vec::new();
     let mut pad_sexp = String::new();
     for pad in &pads_val {
-        let number = pad["number"].as_str().unwrap_or("1").to_string();
-        let pad_type = pad["type"].as_str().unwrap_or("smd").to_string();
-        let shape = pad["shape"].as_str().unwrap_or("rect");
-        let x = pad["x"].as_f64().unwrap_or(0.0);
-        let y = pad["y"].as_f64().unwrap_or(0.0);
-        let w = pad["width"].as_f64().unwrap_or(1.0);
-        let h = pad["height"].as_f64().unwrap_or(1.0);
+        // Safe after validate_footprint_pad_items: every schema-required field
+        // has the declared type, so no plausible-looking pad is invented.
+        let number = pad["number"].as_str().expect("validated").to_string();
+        let pad_type = pad["type"].as_str().expect("validated").to_string();
+        let shape = pad["shape"].as_str().expect("validated");
+        let x = pad["x"].as_f64().expect("validated");
+        let y = pad["y"].as_f64().expect("validated");
+        let w = pad["width"].as_f64().expect("validated");
+        let h = pad["height"].as_f64().expect("validated");
 
         let layer_names = if let Some(layers) = pad["layers"].as_array() {
             let mut names = Vec::with_capacity(layers.len());
@@ -815,6 +820,37 @@ async fn handle_create_footprint(
         }))
         .unwrap(),
     ))
+}
+
+/// Enforce the nested `pads.items.required` schema before any output file is
+/// created or replaced. Top-level MCP validation is deliberately shallow, so
+/// handlers that own nested objects must preserve this invariant themselves.
+fn validate_footprint_pad_items(pads: &[serde_json::Value]) -> Result<(), CallToolResult> {
+    for (index, pad) in pads.iter().enumerate() {
+        if !pad.is_object() {
+            return Err(invalid_library_argument(
+                &format!("pads[{index}]"),
+                "must be an object",
+            ));
+        }
+        for field in ["number", "type", "shape"] {
+            if pad[field].as_str().is_none() {
+                return Err(invalid_library_argument(
+                    &format!("pads[{index}].{field}"),
+                    "missing or not a string",
+                ));
+            }
+        }
+        for field in ["x", "y", "width", "height"] {
+            if pad[field].as_f64().is_none() {
+                return Err(invalid_library_argument(
+                    &format!("pads[{index}].{field}"),
+                    "missing or not a number",
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 async fn handle_edit_footprint_pad(
@@ -2376,6 +2412,86 @@ fn validate_pin_types(pins_val: &[serde_json::Value]) -> anyhow::Result<()> {
     Ok(())
 }
 
+struct SymbolItems {
+    pins: Vec<serde_json::Value>,
+    units: Vec<serde_json::Value>,
+    power_pins: Vec<serde_json::Value>,
+}
+
+/// Read and validate every array that contributes pins to a generated symbol.
+/// This runs before library content is read or written, making a malformed
+/// nested item an atomic, indexed `invalid_argument` rejection (#234).
+fn parse_symbol_items(args: &serde_json::Value) -> Result<SymbolItems, CallToolResult> {
+    fn optional_array(
+        args: &serde_json::Value,
+        field: &str,
+    ) -> Result<Vec<serde_json::Value>, CallToolResult> {
+        match args.get(field) {
+            None => Ok(Vec::new()),
+            Some(value) => value
+                .as_array()
+                .cloned()
+                .ok_or_else(|| invalid_library_argument(field, "must be an array when provided")),
+        }
+    }
+
+    fn validate_pins(
+        pins: &[serde_json::Value],
+        path: &str,
+        require_xy: bool,
+    ) -> Result<(), CallToolResult> {
+        for (index, pin) in pins.iter().enumerate() {
+            let pin_path = format!("{path}[{index}]");
+            if !pin.is_object() {
+                return Err(invalid_library_argument(&pin_path, "must be an object"));
+            }
+            for field in ["number", "name", "type"] {
+                if pin[field].as_str().is_none() {
+                    return Err(invalid_library_argument(
+                        &format!("{pin_path}.{field}"),
+                        "missing or not a string",
+                    ));
+                }
+            }
+            if require_xy {
+                for field in ["x", "y"] {
+                    if pin[field].as_f64().is_none() {
+                        return Err(invalid_library_argument(
+                            &format!("{pin_path}.{field}"),
+                            "missing or not a number",
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    let pins = optional_array(args, "pins")?;
+    validate_pins(&pins, "pins", false)?;
+
+    let units = optional_array(args, "units")?;
+    for (index, unit) in units.iter().enumerate() {
+        let unit_path = format!("units[{index}]");
+        if !unit.is_object() {
+            return Err(invalid_library_argument(&unit_path, "must be an object"));
+        }
+        let unit_pins = unit["pins"].as_array().ok_or_else(|| {
+            invalid_library_argument(&format!("{unit_path}.pins"), "missing or not an array")
+        })?;
+        validate_pins(unit_pins, &format!("{unit_path}.pins"), false)?;
+    }
+
+    let power_pins = optional_array(args, "power_pins")?;
+    validate_pins(&power_pins, "power_pins", true)?;
+
+    Ok(SymbolItems {
+        pins,
+        units,
+        power_pins,
+    })
+}
+
 /// A conventional body shape for a symbol unit. `Rectangle` is the default (a
 /// derived box around caller-positioned pins); the others draw a fixed op-amp or
 /// logic-gate glyph copied from KiCAD's stock libraries and auto-place the pins.
@@ -3015,6 +3131,15 @@ async fn handle_create_symbol(
     let show_names = args["show_pin_names"].as_bool().unwrap_or(true);
     let show_numbers = args["show_pin_numbers"].as_bool().unwrap_or(true);
 
+    let SymbolItems {
+        pins,
+        units: unit_objs,
+        power_pins,
+    } = match parse_symbol_items(args) {
+        Ok(items) => items,
+        Err(error) => return Ok(error),
+    };
+
     // Optional conventional body shape. `glyph` may be set at the symbol level
     // (a default for every unit) and/or per unit (overriding the default).
     let mut warnings: Vec<String> = Vec::new();
@@ -3032,14 +3157,11 @@ async fn handle_create_symbol(
     // Multi-unit when `units` is a non-empty array; otherwise the single-unit
     // `pins` path. Sub-symbols are named NAME_<unit>_1; units 1..N are the
     // individual units, and shared `power_pins` become a dedicated final unit.
-    let unit_objs: Vec<serde_json::Value> = args["units"].as_array().cloned().unwrap_or_default();
-    let power_pins = args["power_pins"].as_array().cloned().unwrap_or_default();
-
     let mut units_sexp = String::new();
     let unit_count: usize;
     let ref_body: SymbolRect;
     if unit_objs.is_empty() {
-        let pins_val = args["pins"].as_array().cloned().unwrap_or_default();
+        let pins_val = pins;
         // A single-unit triangular glyph (op-amp/buffer/inverter/schmitt) has no
         // room for power-pin names on its narrow apex, so if it carries power
         // pins, split them onto a dedicated rectangular power unit (like KiCAD's
@@ -6805,6 +6927,32 @@ mod required_argument_tests {
     }
 
     #[tokio::test]
+    async fn create_footprint_rejects_a_malformed_pad_without_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("existing.kicad_mod");
+        let original = b"(footprint \"Existing\"\r\n\t(layer \"F.Cu\")\r\n)\r\n";
+        std::fs::write(&path, original).unwrap();
+
+        let result = call(
+            "create_footprint",
+            json!({
+                "output": path.display().to_string(),
+                "name": "Replacement",
+                "pads": [{}]
+            }),
+        )
+        .await;
+
+        assert!(result.is_error, "an invented origin pad must be refused");
+        assert_eq!(error_field(&result), "pads[0].number");
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            original,
+            "the existing footprint must remain byte-identical"
+        );
+    }
+
+    #[tokio::test]
     async fn create_symbol_refuses_a_missing_name_or_reference_prefix() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("lib.kicad_sym");
@@ -6826,5 +6974,55 @@ mod required_argument_tests {
             before,
             "no symbol should have been appended"
         );
+    }
+
+    #[tokio::test]
+    async fn create_symbol_rejects_a_unit_without_pins_before_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("lib.kicad_sym");
+        let original = b"(kicad_symbol_lib\r\n\t(version 20240108)\r\n)\r\n";
+        std::fs::write(&path, original).unwrap();
+
+        let result = call(
+            "create_symbol",
+            json!({
+                "library_path": path.display().to_string(),
+                "name": "BrokenMulti",
+                "reference_prefix": "U",
+                "units": [{}]
+            }),
+        )
+        .await;
+
+        assert!(result.is_error, "a pin-less invented unit must be refused");
+        assert_eq!(error_field(&result), "units[0].pins");
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            original,
+            "the existing symbol library must remain byte-identical"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_symbol_names_the_malformed_nested_pin() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("lib.kicad_sym");
+        let result = call(
+            "create_symbol",
+            json!({
+                "library_path": path.display().to_string(),
+                "name": "BrokenPin",
+                "reference_prefix": "U",
+                "units": [{ "pins": [
+                    { "number": "1", "name": "A", "type": "input" },
+                    { "number": "2", "type": "output" }
+                ] }]
+            }),
+        )
+        .await;
+
+        assert!(result.is_error);
+        assert_eq!(error_field(&result), "units[0].pins[1].name");
+        assert!(!path.exists(), "no library may be created on rejection");
     }
 }

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -614,9 +614,46 @@ async fn handle_batch_add_wire(
 ) -> anyhow::Result<CallToolResult> {
     let sch_path = get_path(args, "schematic")?;
     let wires = match require_array(args, "wires") {
-        Ok(a) => a.clone(),
+        Ok(a) => a,
         Err(e) => return Ok(e),
     };
+
+    // Validate the complete batch before loading or changing the schematic.
+    // The tool schema requires every coordinate, so substituting 0.0 for a
+    // missing field silently created a (0,0)-(0,0) wire (#234). Refusing the
+    // whole batch preserves the same atomic contract as a missing top-level
+    // argument and tells the caller exactly which item needs fixing.
+    let mut parsed_wires = Vec::with_capacity(wires.len());
+    for (index, wire) in wires.iter().enumerate() {
+        if !wire.is_object() {
+            return Ok(invalid_wire_argument(
+                format!("wires[{index}]"),
+                "must be an object",
+            ));
+        }
+        let coordinate = |field: &str| {
+            wire[field].as_f64().ok_or_else(|| {
+                invalid_wire_argument(format!("wires[{index}].{field}"), "missing or not a number")
+            })
+        };
+        let x1 = match coordinate("x1") {
+            Ok(value) => value,
+            Err(error) => return Ok(error),
+        };
+        let y1 = match coordinate("y1") {
+            Ok(value) => value,
+            Err(error) => return Ok(error),
+        };
+        let x2 = match coordinate("x2") {
+            Ok(value) => value,
+            Err(error) => return Ok(error),
+        };
+        let y2 = match coordinate("y2") {
+            Ok(value) => value,
+            Err(error) => return Ok(error),
+        };
+        parsed_wires.push((x1, y1, x2, y2));
+    }
 
     let mut sch = cse::Schematic::load(&sch_path)?;
     let mut added = 0usize;
@@ -626,11 +663,7 @@ async fn handle_batch_add_wire(
         .map(|(_, tree)| crate::tools::all_pin_endpoints(&tree))
         .unwrap_or_default();
 
-    for w in &wires {
-        let x1 = w["x1"].as_f64().unwrap_or(0.0);
-        let y1 = w["y1"].as_f64().unwrap_or(0.0);
-        let x2 = w["x2"].as_f64().unwrap_or(0.0);
-        let y2 = w["y2"].as_f64().unwrap_or(0.0);
+    for (x1, y1, x2, y2) in parsed_wires {
         let (x1, y1) = snap_point(x1, y1, 1.27);
         let (x2, y2) = snap_point(x2, y2, 1.27);
 
@@ -654,6 +687,16 @@ async fn handle_batch_add_wire(
 
     sch.overwrite()?;
     Ok(CallToolResult::json(&json!({ "added_wires": added })))
+}
+
+fn invalid_wire_argument(field: String, reason: &str) -> CallToolResult {
+    CallToolResult::error_kind(
+        crate::mcp::error::ToolErrorKind::InvalidArgument {
+            field: field.clone(),
+            reason: reason.to_string(),
+        },
+        format!("Argument '{field}' is invalid: {reason}"),
+    )
 }
 
 async fn handle_delete_wire(
@@ -2190,6 +2233,38 @@ mod unit_aware_wiring_tests {
         for (x, y) in tees {
             assert_eq!(junctions_at(&path, x, y), 1, "T at ({x}, {y})");
         }
+    }
+
+    #[tokio::test]
+    async fn batch_add_wire_rejects_a_malformed_item_without_writing() {
+        let (_d, path) = bare_schematic();
+        let before = std::fs::read(&path).unwrap();
+        let result = handle_batch_add_wire(
+            &json!({
+                "schematic": path.display().to_string(),
+                "wires": [
+                    { "x1": 10.16, "y1": 10.16, "x2": 20.32, "y2": 10.16 },
+                    { "x1": 20.32, "y1": 10.16, "y2": 20.32 }
+                ]
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_error, "the complete batch must be refused");
+        let text = match result.content.first() {
+            Some(crate::mcp::protocol::ToolContent::Text { text }) => text,
+            other => panic!("expected text error, got {other:?}"),
+        };
+        let error: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(error["error"]["kind"], "invalid_argument");
+        assert_eq!(error["error"]["field"], "wires[1].x2");
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            before,
+            "an earlier valid item must not be applied before rejection"
+        );
     }
 
     // ─── connect_to_net stub orientation ───────────────────────────────────


### PR DESCRIPTION
## Summary

Reject malformed nested items instead of silently inventing data:

- `batch_add_wire` no longer turns missing coordinates into a `(0,0)-(0,0)` wire.
- `create_footprint` no longer turns an incomplete pad object into a plausible origin pad.
- `create_symbol` no longer turns an incomplete unit into a pin-less unit, and also validates the required fields of nested pin items.

Closes #234

## Approach

Each handler validates every nested item before it loads, creates, or replaces its target file. Errors are structured `invalid_argument` results whose field includes the precise array index, for example `wires[1].x2` or `units[0].pins[1].name`.

For wire batches this deliberately refuses the entire call rather than applying the valid prefix and reporting a partial result. That keeps the operation atomic and matches the failure behavior of missing top-level required arguments.

## Compatibility and safety

Valid payloads and schemas are unchanged. Payloads that violate the existing nested `required` declarations now fail instead of receiving hidden defaults.

Regression tests verify that a malformed item leaves an existing schematic, footprint, or symbol library byte-identical and does not create a new target file.

Risk is limited to callers that relied on the undocumented fallback values for malformed items. Rollback is a single commit revert; no generated data or migration is involved.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo test --workspace --locked --lib --tests` (left to CI; local full `konnect-core` run described below)
- [ ] `cargo test --workspace --locked --doc` (left to CI)
- [ ] `cargo clippy --workspace --locked -- -D warnings` (left to CI; package-level clippy passed)
- [x] `cargo test -p konnect-core batch_add_wire`
- [x] `cargo test -p konnect-core create_footprint`
- [x] `cargo test -p konnect-core create_symbol`
- [x] `cargo test -p konnect-core required_argument_tests`
- [x] `cargo clippy -p konnect-core --all-targets -- -D warnings`
- [x] `cargo test -p konnect-core`: 546 passed; the same three environment-dependent `update_symbols_from_library_*` tests already fail on unmodified `main` because the locally installed KiCad library shadows their fixture.

## Review checklist

- [x] The diff is focused and contains no generated output, personal data, or unrelated cleanup.
- [x] New names follow `docs/NAMING_CONVENTIONS.md`; no public names were changed.
- [x] New behavior and failure paths have regression coverage.
- [x] File mutations are atomic and preserve unrelated content.
- [x] IPC mutations verify the requested board and do not leave partial batches (no IPC mutations in this change).
- [x] If tools were added/removed: counts and docs updated per CONTRIBUTING.md (no tools added or removed).
