### PR TITLE
fix(manufacturing): apply Gerber and position options

### DIFF
--- a/crates/konnect-core/src/tools/cli.rs
+++ b/crates/konnect-core/src/tools/cli.rs
@@ -486,16 +486,32 @@ pub async fn export_netlist(
 
 // ─── PCB Export ──────────────────────────────────────────────────────────────
 
-/// KiCAD 10: `pcb export gerbers --output <dir> <input>` (PLURAL!)
-pub async fn export_gerber(cli: &str, pcb: &Path, output_dir: &Path) -> Result<()> {
-    let args = [
-        "pcb",
-        "export",
-        "gerbers",
-        "--output",
-        output_dir.to_str().unwrap(),
-        pcb.to_str().unwrap(),
-    ];
+/// Argument vector for Gerber export. KiCad's plural `gerbers` subcommand
+/// accepts the complete selection as one comma-separated `--layers` value.
+fn gerber_args<'a>(output_dir: &'a str, pcb: &'a str, layers_csv: &'a str) -> Vec<&'a str> {
+    let mut args = vec!["pcb", "export", "gerbers", "--output", output_dir];
+    if !layers_csv.is_empty() {
+        args.push("--layers");
+        args.push(layers_csv);
+    }
+    args.push(pcb);
+    args
+}
+
+/// KiCad 10: `pcb export gerbers --output <dir> [--layers <csv>] <input>`
+/// (PLURAL!)
+pub async fn export_gerber(
+    cli: &str,
+    pcb: &Path,
+    output_dir: &Path,
+    layers: &[&str],
+) -> Result<()> {
+    let layers_csv = layers.join(",");
+    let args = gerber_args(
+        output_dir.to_str().unwrap_or(""),
+        pcb.to_str().unwrap_or(""),
+        &layers_csv,
+    );
     run_cli(cli, &args, LONG_TIMEOUT).await?;
     Ok(())
 }
@@ -617,24 +633,49 @@ pub async fn export_3d(cli: &str, pcb: &Path, output: &Path, format: &str) -> Re
     Ok(())
 }
 
-/// KiCAD 10: `pcb export pos --output <path> --format <fmt> <input>`
-/// Formats: ascii (default), csv, gerber
+/// Argument vector for position export, factored out so the public options can
+/// be regression-tested without a kicad-cli installation.
+fn position_args<'a>(
+    output: &'a str,
+    pcb: &'a str,
+    format: &'a str,
+    units: &'a str,
+    side: &'a str,
+) -> Vec<&'a str> {
+    let mut args = vec![
+        "pcb", "export", "pos", "--output", output, "--format", format, "--side", side,
+    ];
+    // Gerber coordinates have format-defined units; KiCad only accepts this
+    // option for its ASCII and CSV position formats.
+    if format != "gerber" {
+        args.push("--units");
+        args.push(units);
+    }
+    args.push(pcb);
+    args
+}
+
+/// KiCad 10: `pcb export pos --output <path> --format <fmt> --side <side>
+/// [--units <units>] <input>`
+///
+/// KiCad itself omits footprints carrying `exclude_from_pos_files`; Konnect
+/// deliberately leaves that source-of-truth filtering to the exporter rather
+/// than trying to post-process CSV and Gerber output differently.
 pub async fn export_position_file(
     cli: &str,
     pcb: &Path,
     output: &Path,
     format: &str,
+    units: &str,
+    side: &str,
 ) -> Result<()> {
-    let args = [
-        "pcb",
-        "export",
-        "pos",
-        "--output",
-        output.to_str().unwrap(),
-        "--format",
+    let args = position_args(
+        output.to_str().unwrap_or(""),
+        pcb.to_str().unwrap_or(""),
         format,
-        pcb.to_str().unwrap(),
-    ];
+        units,
+        side,
+    );
     run_cli(cli, &args, LONG_TIMEOUT).await?;
     Ok(())
 }
@@ -937,6 +978,72 @@ mod erc_parse_tests {
             parse_erc_json(&serde_json::json!({ "violations": [{ "severity": "error" }] }))
                 .is_empty()
         );
+    }
+}
+
+#[cfg(test)]
+mod gerber_export_tests {
+    use super::*;
+
+    #[test]
+    fn requested_layers_reach_kicad_as_one_csv_argument() {
+        let args = gerber_args(
+            "/out/gerbers",
+            "/tmp/board.kicad_pcb",
+            "F.Cu,In1.Cu,B.Cu,F.Mask,B.Mask,Edge.Cuts",
+        );
+        let layers = args
+            .iter()
+            .position(|argument| *argument == "--layers")
+            .map(|index| args[index + 1]);
+        assert_eq!(layers, Some("F.Cu,In1.Cu,B.Cu,F.Mask,B.Mask,Edge.Cuts"));
+        assert_eq!(args.last().copied(), Some("/tmp/board.kicad_pcb"));
+    }
+
+    #[test]
+    fn empty_layer_selection_keeps_the_flag_absent() {
+        let args = gerber_args("/out", "/tmp/board.kicad_pcb", "");
+        assert!(!args.contains(&"--layers"));
+    }
+}
+
+#[cfg(test)]
+mod position_export_tests {
+    use super::*;
+
+    fn flag<'a>(args: &'a [&str], name: &str) -> Option<&'a str> {
+        args.iter()
+            .position(|argument| *argument == name)
+            .map(|index| args[index + 1])
+    }
+
+    #[test]
+    fn csv_units_and_side_reach_kicad_cli() {
+        let args = position_args(
+            "/out/positions.csv",
+            "/tmp/board.kicad_pcb",
+            "csv",
+            "mm",
+            "back",
+        );
+        assert_eq!(flag(&args, "--format"), Some("csv"));
+        assert_eq!(flag(&args, "--units"), Some("mm"));
+        assert_eq!(flag(&args, "--side"), Some("back"));
+        assert_eq!(args.last().copied(), Some("/tmp/board.kicad_pcb"));
+    }
+
+    #[test]
+    fn gerber_position_export_does_not_claim_a_units_flag() {
+        let args = position_args(
+            "/out/positions.gbr",
+            "/tmp/board.kicad_pcb",
+            "gerber",
+            "mm",
+            "front",
+        );
+        assert_eq!(flag(&args, "--format"), Some("gerber"));
+        assert_eq!(flag(&args, "--side"), Some("front"));
+        assert_eq!(flag(&args, "--units"), None);
     }
 }
 

--- a/crates/konnect-core/src/tools/manufacturing.rs
+++ b/crates/konnect-core/src/tools/manufacturing.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use std::path::PathBuf;
 use tracing::{debug, error, info, warn};
 
-use super::cli;
+use super::{cli, pcb_export};
 
 // ─── Tool definitions ─────────────────────────────────────────────────────────
 
@@ -53,6 +53,23 @@ pub fn tools() -> Vec<ToolDef> {
                     "bom_group_by": {
                         "type": "string",
                         "description": "Comma-separated fields whose matching references collapse into one BOM row, e.g. 'Value,Footprint'."
+                    },
+                    "gerber_layers": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Exact Gerber layers. Omit or pass [] to auto-select enabled copper, F/B.Mask, F/B.SilkS, and Edge.Cuts while excluding documentation layers."
+                    },
+                    "position_side": {
+                        "type": "string",
+                        "enum": ["front", "back", "both"],
+                        "description": "Board side(s) in the assembly position file.",
+                        "default": "both"
+                    },
+                    "position_units": {
+                        "type": "string",
+                        "enum": ["mm", "in"],
+                        "description": "Coordinate units in the assembly position file.",
+                        "default": "mm"
                     }
                 },
                 "required": ["board", "output_dir"]
@@ -123,6 +140,28 @@ async fn handle_export_manufacturing_package(
     let fab_house = args["fab_house"].as_str().unwrap_or("jlcpcb");
     let include_assembly = args["include_assembly"].as_bool().unwrap_or(true);
     let schematic = args["schematic"].as_str().map(PathBuf::from);
+    let requested_gerber_layers = match pcb_export::optional_string_array(args, "gerber_layers") {
+        Ok(layers) => layers,
+        Err(error) => return Ok(error),
+    };
+    let gerber_layers = if requested_gerber_layers.is_empty() {
+        let board_source = tokio::fs::read_to_string(&board).await?;
+        pcb_export::standard_gerber_layers(&board_source)?
+    } else {
+        requested_gerber_layers
+    };
+    let position_side = args["position_side"].as_str().unwrap_or("both");
+    let position_units = args["position_units"].as_str().unwrap_or("mm");
+    if let Err((field, reason)) =
+        pcb_export::validate_position_values("csv", position_side, position_units)
+    {
+        let public_field = match field {
+            "side" => "position_side",
+            "units" => "position_units",
+            other => other,
+        };
+        return Ok(invalid_manufacturing_argument(public_field, reason));
+    }
 
     info!(
         board = %board.display(),
@@ -141,12 +180,14 @@ async fn handle_export_manufacturing_package(
     // 1. Export Gerbers
     let gerber_dir = output_dir.join("gerbers");
     tokio::fs::create_dir_all(&gerber_dir).await?;
-    match cli::export_gerber(cli_path, &board, &gerber_dir).await {
+    let gerber_layer_refs = gerber_layers.iter().map(String::as_str).collect::<Vec<_>>();
+    match cli::export_gerber(cli_path, &board, &gerber_dir, &gerber_layer_refs).await {
         Ok(()) => {
             info!("[BETA] Gerber export succeeded");
             files_generated.push(json!({
                 "type": "gerber",
-                "path": gerber_dir.to_str().unwrap_or("")
+                "path": gerber_dir.to_str().unwrap_or(""),
+                "layers": gerber_layers.clone()
             }));
         }
         Err(e) => {
@@ -190,13 +231,24 @@ async fn handle_export_manufacturing_package(
             _ => "csv",
         };
         let pos_path = output_dir.join(format!("positions.{}", pos_format));
-        match cli::export_position_file(cli_path, &board, &pos_path, pos_format).await {
+        match cli::export_position_file(
+            cli_path,
+            &board,
+            &pos_path,
+            pos_format,
+            position_units,
+            position_side,
+        )
+        .await
+        {
             Ok(()) => {
                 info!("[BETA] Position file export succeeded");
                 files_generated.push(json!({
                     "type": "pick_and_place",
                     "path": pos_path.to_str().unwrap_or(""),
-                    "format": pos_format
+                    "format": pos_format,
+                    "units": position_units,
+                    "side": position_side
                 }));
             }
             Err(e) => {
@@ -275,6 +327,9 @@ async fn handle_export_manufacturing_package(
             "output_dir": output_dir.to_str().unwrap_or(""),
             "files": all_files,
             "files_generated": files_generated,
+            "gerber_layers": gerber_layers,
+            "position_units": if include_assembly { Some(position_units) } else { None },
+            "position_side": if include_assembly { Some(position_side) } else { None },
             "warnings": warnings,
             "summary": summary,
             "next_steps": format!(
@@ -285,6 +340,17 @@ async fn handle_export_manufacturing_package(
         }))
         .unwrap(),
     ))
+}
+
+fn invalid_manufacturing_argument(field: &str, reason: impl Into<String>) -> CallToolResult {
+    let reason = reason.into();
+    CallToolResult::error_kind(
+        crate::mcp::error::ToolErrorKind::InvalidArgument {
+            field: field.to_string(),
+            reason: reason.clone(),
+        },
+        format!("Argument '{field}' is invalid: {reason}"),
+    )
 }
 
 async fn handle_validate_for_manufacturing(
@@ -542,6 +608,26 @@ async fn handle_estimate_cost(
         }))
         .unwrap(),
     ))
+}
+
+#[cfg(test)]
+mod package_export_option_tests {
+    use super::*;
+
+    #[test]
+    fn package_schema_exposes_applied_gerber_and_position_options() {
+        let package = tools()
+            .into_iter()
+            .find(|tool| tool.name == "export_manufacturing_package")
+            .unwrap();
+        let properties = &package.input_schema["properties"];
+        assert_eq!(properties["gerber_layers"]["items"]["type"], "string");
+        assert_eq!(properties["position_units"]["enum"], json!(["mm", "in"]));
+        assert_eq!(
+            properties["position_side"]["enum"],
+            json!(["front", "back", "both"])
+        );
+    }
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/crates/konnect-core/src/tools/pcb_export.rs
+++ b/crates/konnect-core/src/tools/pcb_export.rs
@@ -39,13 +39,98 @@ fn severity_rank(s: &str) -> u8 {
     }
 }
 
+fn invalid_export_argument(field: &str, reason: impl Into<String>) -> CallToolResult {
+    let reason = reason.into();
+    CallToolResult::error_kind(
+        crate::mcp::error::ToolErrorKind::InvalidArgument {
+            field: field.to_string(),
+            reason: reason.clone(),
+        },
+        format!("Argument '{field}' is invalid: {reason}"),
+    )
+}
+
+pub(crate) fn optional_string_array(
+    args: &serde_json::Value,
+    field: &str,
+) -> Result<Vec<String>, CallToolResult> {
+    let Some(value) = args.get(field) else {
+        return Ok(Vec::new());
+    };
+    let Some(values) = value.as_array() else {
+        return Err(invalid_export_argument(field, "must be an array"));
+    };
+    values
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            value.as_str().map(String::from).ok_or_else(|| {
+                invalid_export_argument(&format!("{field}[{index}]"), "must be a layer name string")
+            })
+        })
+        .collect()
+}
+
+/// Default Gerber selection for a fabrication package: every enabled copper
+/// layer plus solder mask, silkscreen, and the board outline. It deliberately
+/// excludes drawings, comments, adhesive, courtyard, fab, and margin layers.
+pub(crate) fn standard_gerber_layers(board_source: &str) -> anyhow::Result<Vec<String>> {
+    let board = konnect_sexp::parser::parse_sexp(board_source)?;
+    let layers = konnect_sexp::layers::layers(&board)
+        .into_iter()
+        .filter(|layer| {
+            layer.is_copper()
+                || matches!(
+                    layer.name.as_str(),
+                    "F.Mask" | "B.Mask" | "F.SilkS" | "B.SilkS" | "Edge.Cuts"
+                )
+        })
+        .map(|layer| layer.name)
+        .collect::<Vec<_>>();
+    if layers.is_empty() {
+        anyhow::bail!("board declares no standard fabrication layers");
+    }
+    Ok(layers)
+}
+
+pub(crate) fn validate_position_values(
+    format: &str,
+    side: &str,
+    units: &str,
+) -> Result<(), (&'static str, String)> {
+    if !matches!(format, "csv" | "gerber") {
+        return Err((
+            "format",
+            format!("must be 'csv' or 'gerber', got '{format}'"),
+        ));
+    }
+    if !matches!(side, "front" | "back" | "both") {
+        return Err((
+            "side",
+            format!("must be 'front', 'back', or 'both', got '{side}'"),
+        ));
+    }
+    if !matches!(units, "mm" | "in") {
+        return Err(("units", format!("must be 'mm' or 'in', got '{units}'")));
+    }
+    if format == "gerber" && side == "both" {
+        return Err((
+            "side",
+            "Gerber position output supports only 'front' or 'back'".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 // ─── Tool definitions ─────────────────────────────────────────────────────────
 
 pub fn tools() -> Vec<ToolDef> {
     vec![
         tool!(
             "export_gerber",
-            "Export Gerber production files for all copper and mask layers using kicad-cli.",
+            "Export Gerber production files using kicad-cli. By default Konnect selects all \
+             enabled copper layers, masks, silkscreens, and Edge.Cuts while excluding \
+             documentation-only layers.",
             json!({
                 "type": "object",
                 "properties": {
@@ -53,7 +138,7 @@ pub fn tools() -> Vec<ToolDef> {
                     "output_dir": { "type": "string", "description": "Directory to write Gerber files into" },
                     "layers": {
                         "type": "array",
-                        "description": "Layer names to export (empty = all fabrication layers)",
+                        "description": "Exact layer names to export. Omit or pass an empty array to auto-select enabled copper, F/B.Mask, F/B.SilkS, and Edge.Cuts.",
                         "items": { "type": "string" }
                     },
                     "drill_file": { "type": "boolean", "description": "Also generate Excellon drill file", "default": true }
@@ -178,7 +263,8 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "export_position_file",
-            "Generate a component placement (pick-and-place) position file for SMT assembly.",
+            "Generate a component placement (pick-and-place) position file for SMT assembly. \
+             KiCad automatically omits footprints marked exclude_from_pos_files.",
             json!({
                 "type": "object",
                 "properties": {
@@ -187,16 +273,19 @@ pub fn tools() -> Vec<ToolDef> {
                     "format": {
                         "type": "string",
                         "description": "File format: 'csv' (default) or 'gerber'",
+                        "enum": ["csv", "gerber"],
                         "default": "csv"
                     },
                     "side": {
                         "type": "string",
                         "description": "Board side: 'front', 'back', or 'both'",
+                        "enum": ["front", "back", "both"],
                         "default": "both"
                     },
                     "units": {
                         "type": "string",
-                        "description": "Coordinate units: 'mm' (default) or 'in'",
+                        "description": "Coordinate units for CSV: 'mm' (default) or 'in'. Gerber position output has format-defined units.",
+                        "enum": ["mm", "in"],
                         "default": "mm"
                     }
                 },
@@ -322,11 +411,23 @@ async fn handle_export_gerber(
     let output_dir = get_path(args, "output_dir")?;
     let drill = args["drill_file"].as_bool().unwrap_or(true);
 
+    let requested_layers = match optional_string_array(args, "layers") {
+        Ok(layers) => layers,
+        Err(error) => return Ok(error),
+    };
+    let layers = if requested_layers.is_empty() {
+        let board_source = tokio::fs::read_to_string(&board).await?;
+        standard_gerber_layers(&board_source)?
+    } else {
+        requested_layers
+    };
+    let layer_refs = layers.iter().map(String::as_str).collect::<Vec<_>>();
+
     // Ensure output dir exists
     tokio::fs::create_dir_all(&output_dir).await?;
 
     let cli = &ctx.config.kicad_cli;
-    cli::export_gerber(cli, &board, &output_dir).await?;
+    cli::export_gerber(cli, &board, &output_dir, &layer_refs).await?;
 
     if drill {
         // kicad-cli also has a dedicated drill export. Its --output is a
@@ -351,6 +452,7 @@ async fn handle_export_gerber(
         serde_json::to_string(&json!({
             "success": true,
             "output_dir": output_dir.to_str().unwrap_or(""),
+            "layers": layers,
             "files": files
         }))
         .unwrap(),
@@ -499,18 +601,24 @@ async fn handle_export_position_file(
     let side = args["side"].as_str().unwrap_or("both");
     let units = args["units"].as_str().unwrap_or("mm");
 
-    let cli = &ctx.config.kicad_cli;
-    cli::export_position_file(cli, &board, &output, format).await?;
+    if let Err((field, reason)) = validate_position_values(format, side, units) {
+        return Ok(invalid_export_argument(field, reason));
+    }
 
+    let cli = &ctx.config.kicad_cli;
+    cli::export_position_file(cli, &board, &output, format, units, side).await?;
+
+    let mut result = json!({
+        "success": true,
+        "format": format,
+        "side": side,
+        "output": output.to_str().unwrap_or("")
+    });
+    if format != "gerber" {
+        result["units"] = json!(units);
+    }
     Ok(CallToolResult::text(
-        serde_json::to_string(&json!({
-            "success": true,
-            "format": format,
-            "side": side,
-            "units": units,
-            "output": output.to_str().unwrap_or("")
-        }))
-        .unwrap(),
+        serde_json::to_string(&result).unwrap(),
     ))
 }
 
@@ -912,5 +1020,109 @@ mod required_layers_tests {
                 "{tool_name} must keep `layers` optional"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod fabrication_option_tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::ServerConfig;
+    use serde_json::json;
+    use std::sync::Arc;
+
+    fn ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+                eager_toolsets: false,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    #[test]
+    fn default_gerbers_include_only_manufacturing_layers() {
+        // KiCad 9 output from the IPC test fixture, including the real layer
+        // table order and every documentation-only layer this filter excludes.
+        let board = include_str!("../../../konnect-ipc/tests/fixtures/live_ipc.kicad_pcb");
+        assert_eq!(
+            standard_gerber_layers(board).unwrap(),
+            [
+                "F.Cu",
+                "B.Cu",
+                "F.SilkS",
+                "B.SilkS",
+                "F.Mask",
+                "B.Mask",
+                "Edge.Cuts"
+            ]
+        );
+    }
+
+    #[test]
+    fn public_schemas_describe_the_options_that_reach_kicad() {
+        let gerber = tools()
+            .into_iter()
+            .find(|tool| tool.name == "export_gerber")
+            .unwrap();
+        assert!(gerber.input_schema["properties"]["layers"]["description"]
+            .as_str()
+            .unwrap()
+            .contains("auto-select"));
+
+        let position = tools()
+            .into_iter()
+            .find(|tool| tool.name == "export_position_file")
+            .unwrap();
+        assert_eq!(
+            position.input_schema["properties"]["units"]["enum"],
+            json!(["mm", "in"])
+        );
+        assert_eq!(
+            position.input_schema["properties"]["side"]["enum"],
+            json!(["front", "back", "both"])
+        );
+        assert!(position.description.contains("exclude_from_pos_files"));
+    }
+
+    #[tokio::test]
+    async fn impossible_gerber_side_is_rejected_before_running_kicad() {
+        let result = handle_export_position_file(
+            &json!({
+                "board": "/tmp/board.kicad_pcb",
+                "output": "/tmp/positions.gbr",
+                "format": "gerber",
+                "side": "both",
+                "units": "mm"
+            }),
+            &ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(result.is_error);
+        let text = match result.content.first() {
+            Some(crate::mcp::protocol::ToolContent::Text { text }) => text,
+            other => panic!("expected text error, got {other:?}"),
+        };
+        let error: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(error["error"]["field"], "side");
+    }
+
+    #[test]
+    fn malformed_layer_items_name_their_index() {
+        let error = optional_string_array(&json!({ "layers": ["F.Cu", 7] }), "layers")
+            .expect_err("numeric layer must be rejected");
+        let text = match error.content.first() {
+            Some(crate::mcp::protocol::ToolContent::Text { text }) => text,
+            other => panic!("expected text error, got {other:?}"),
+        };
+        let error: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(error["error"]["field"], "layers[1]");
     }
 }


### PR DESCRIPTION
## Summary

- Apply `units` and `side` to position-file exports instead of only echoing them in the response.
- Apply the requested Gerber `layers` as KiCad's single comma-separated `--layers` value.
- Give manufacturing packages explicit `gerber_layers`, `position_units`, and `position_side` controls.
- When Gerber layers are omitted, derive a fabrication-only set from the real board layer table: enabled copper, masks, silkscreens, and `Edge.Cuts`.
- Document that KiCad itself honors `exclude_from_pos_files`.

Refs #251

## Approach

The CLI wrappers now have pure argument builders with regression tests. The handlers validate the public values, forward them to `kicad-cli`, and only report values that apply to the selected format. Gerber position output therefore omits `units`, because KiCad does not accept `--units` for that format.

The default Gerber selector parses KiCad's real layer table and filters by canonical layer role. It excludes adhesive, paste, courtyard, fab, margin, comments, and user drawings instead of inheriting an opaque saved plot selection.

The cross-cutting schema/handler guard requested by #251 is intentionally a separate follow-up PR: the first implementation found pre-existing ignored parameters in unrelated schematic, routing, review, and integration tools. Keeping that audit separate follows CONTRIBUTING.md's one-reviewable-outcome rule and avoids hiding those compatibility decisions inside a manufacturing fix.

## Compatibility and safety

The existing standalone `format`, `units`, `side`, and `layers` fields keep their names and now affect the generated files as documented. The manufacturing-package fields are additive.

An omitted/empty Gerber layer list now means the documented fabrication-only selection rather than the board's saved plot settings. Callers can preserve any custom set by passing its exact layer names. `format: "gerber"` with `side: "both"` now returns a structured argument error because KiCad supports only one side per Gerber position file.

Risk is limited to export selection and response metadata; source boards are only read. Rollback is a single commit revert. No project migration or generated artifact is committed.

## Validation

- [ ] `cargo test --workspace --locked --lib --tests`: all changed and unrelated suites passed except the same three local `update_symbols_from_library_*` tests that fail on unmodified `main` because the installed KiCad `Device:R` library shadows their fixture (551/554 `konnect-core` tests passed).
- [x] `cargo test --workspace --locked --doc`
- [x] `cargo clippy --workspace --locked --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p konnect-core gerber_export_tests`
- [x] `cargo test -p konnect-core position_export_tests`
- [x] `cargo test -p konnect-core fabrication_option_tests`
- [x] `cargo test -p konnect-core package_export_option_tests`
- [x] Real KiCad 10 check on a temporary copy of a populated board: `--units mm` and `--units in` differed by exactly 25.4, `--side front` produced only top-side rows, and the explicit Gerber selection produced only the seven requested layers plus the job file.
- [x] Real KiCad 10 check on the repository's saved-board fixture: all four footprints marked `exclude_from_pos_files` were omitted from the CSV.

## Review checklist

- [x] The diff is focused and contains no generated output, personal data, or unrelated cleanup.
- [x] New public fields follow `docs/NAMING_CONVENTIONS.md`; existing names remain compatible.
- [x] New behavior and failure paths have regression coverage.
- [x] Source board files are read-only; exports go only to the requested output directory.
- [x] No IPC mutations are involved.
- [x] No tools were added or removed, so registry and catalogue counts are unchanged.
