### PR TITLE
fix(schematic): measure placed symbol geometry

### DIFF
--- a/crates/konnect-core/src/tools/sch_analysis.rs
+++ b/crates/konnect-core/src/tools/sch_analysis.rs
@@ -12,8 +12,7 @@ use konnect_sexp::{
     geometry::{point_on_segment, points_coincident},
     schematic::{
         extract_all_net_labels, extract_labels, extract_symbol_instances, extract_wires,
-        find_lib_symbol, read_schematic, symbol_bounds_for_instance, LabelKind, SymbolBounds,
-        Wire,
+        find_lib_symbol, read_schematic, symbol_bounds_for_instance, LabelKind, SymbolBounds, Wire,
     },
 };
 use serde_json::json;

--- a/crates/konnect-core/src/tools/sch_analysis.rs
+++ b/crates/konnect-core/src/tools/sch_analysis.rs
@@ -11,8 +11,9 @@ use konnect_schematic_editor as cse;
 use konnect_sexp::{
     geometry::{point_on_segment, points_coincident},
     schematic::{
-        extract_all_net_labels, extract_symbol_instances, extract_wires, find_lib_symbol,
-        read_schematic, LabelKind, Wire,
+        extract_all_net_labels, extract_labels, extract_symbol_instances, extract_wires,
+        find_lib_symbol, read_schematic, symbol_bounds_for_instance, LabelKind, SymbolBounds,
+        Wire,
     },
 };
 use serde_json::json;
@@ -172,11 +173,17 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "check_schematic_overlaps",
-            "Find overlapping symbols or labels that may indicate placement errors.",
+            "Find overlapping symbols from their transformed drawing/pin bounds (excluding \
+             free text), plus conflicting labels at the same location. Reports any symbol whose \
+             embedded geometry could not be resolved and used the origin fallback instead.",
             json!({ "type": "object",
                 "properties": {
                     "schematic": { "type": "string" },
-                    "tolerance": { "type": "number", "default": 0.5 }
+                    "tolerance": {
+                        "type": "number",
+                        "description": "Coordinate tolerance in mm for label collisions and the origin fallback when library geometry is unavailable",
+                        "default": 0.5
+                    }
                 },
                 "required": ["schematic"] }),
             |args, ctx| async move { handle_check_overlaps(args, ctx).await }
@@ -702,54 +709,87 @@ async fn handle_check_overlaps(
 ) -> anyhow::Result<CallToolResult> {
     let sch_path = get_path(args, "schematic")?;
     let tol = opt_f64(args, "tolerance").unwrap_or(0.5);
-    let sch = cse::Schematic::load(&sch_path)?;
+    if !tol.is_finite() || tol < 0.0 {
+        return Ok(CallToolResult::error_kind(
+            crate::mcp::error::ToolErrorKind::InvalidArgument {
+                field: "tolerance".to_string(),
+                reason: "must be a finite, non-negative number".to_string(),
+            },
+            "Argument 'tolerance' must be a finite, non-negative number.",
+        ));
+    }
+    let (_, tree) = read_schematic(&sch_path)?;
+    let instances = extract_symbol_instances(&tree);
+    let lib_symbols = tree
+        .find("lib_symbols")
+        .map(|node| node.find_all("symbol"))
+        .unwrap_or_default();
 
-    // Component overlap detection using the new crate's spatial query
-    let symbols: Vec<&cse::Symbol> = sch.symbols.iter().collect();
+    // Compare the actual selected-unit graphic/pin envelopes. Distinct origins
+    // can still place two large symbols on top of each other; the old origin
+    // comparison missed that normal collision shape entirely.
+    let placements = instances
+        .iter()
+        .map(|instance| {
+            let bounds = find_lib_symbol(&lib_symbols, instance)
+                .and_then(|symbol| symbol_bounds_for_instance(symbol, instance));
+            (instance, bounds)
+        })
+        .collect::<Vec<_>>();
     let mut comp_overlaps: Vec<serde_json::Value> = Vec::new();
-    for (i, a) in symbols.iter().enumerate() {
-        let (ax, ay) = a.position();
-        for b in &symbols[i + 1..] {
-            let (bx, by) = b.position();
-            if points_coincident(ax, ay, bx, by, tol) {
-                comp_overlaps.push(json!({
-                    "type": "component_overlap",
-                    "a": a.reference().unwrap_or("?"),
-                    "b": b.reference().unwrap_or("?"),
-                    "x": ax, "y": ay
-                }));
+    let bounds_json = |bounds: SymbolBounds| {
+        json!({
+            "x_min": bounds.min_x,
+            "y_min": bounds.min_y,
+            "x_max": bounds.max_x,
+            "y_max": bounds.max_y
+        })
+    };
+    for (index, (a, a_bounds)) in placements.iter().enumerate() {
+        for (b, b_bounds) in &placements[index + 1..] {
+            match (a_bounds, b_bounds) {
+                (Some(a_bounds), Some(b_bounds)) => {
+                    let (overlap_x, overlap_y) = a_bounds.overlap_depth(*b_bounds);
+                    // Edge/pin contact is a normal connection. Positive area
+                    // on both axes means the placed symbol envelopes collide.
+                    if overlap_x > 1e-9 && overlap_y > 1e-9 {
+                        comp_overlaps.push(json!({
+                            "type": "component_overlap",
+                            "a": a.reference,
+                            "unit_a": a.unit,
+                            "b": b.reference,
+                            "unit_b": b.unit,
+                            "overlap_x_mm": overlap_x,
+                            "overlap_y_mm": overlap_y,
+                            "bounds_a": bounds_json(*a_bounds),
+                            "bounds_b": bounds_json(*b_bounds),
+                            "detection": "symbol_geometry"
+                        }));
+                    }
+                }
+                // Preserve a useful conservative check when an old or damaged
+                // schematic lacks the embedded definition. The response names
+                // every such fallback below so it cannot look authoritative.
+                _ if points_coincident(a.x, a.y, b.x, b.y, tol) => {
+                    comp_overlaps.push(json!({
+                        "type": "component_overlap",
+                        "a": a.reference,
+                        "unit_a": a.unit,
+                        "b": b.reference,
+                        "unit_b": b.unit,
+                        "x": a.x,
+                        "y": a.y,
+                        "detection": "origin_fallback"
+                    }));
+                }
+                _ => {}
             }
         }
     }
 
-    // Label overlap detection — collect all label types into a uniform list
-    struct LabelInfo {
-        net: String,
-        x: f64,
-        y: f64,
-    }
-    let mut all_labels: Vec<LabelInfo> = Vec::new();
-    for l in sch.labels.iter() {
-        all_labels.push(LabelInfo {
-            net: l.text.clone(),
-            x: l.at.x,
-            y: l.at.y,
-        });
-    }
-    for g in sch.global_labels.iter() {
-        all_labels.push(LabelInfo {
-            net: g.text.clone(),
-            x: g.at.x,
-            y: g.at.y,
-        });
-    }
-    for h in sch.hierarchical_labels.iter() {
-        all_labels.push(LabelInfo {
-            net: h.text.clone(),
-            x: h.at.x,
-            y: h.at.y,
-        });
-    }
+    // The structural extractor already combines local, global, and
+    // hierarchical labels.
+    let all_labels = extract_labels(&tree);
     let mut label_overlaps: Vec<serde_json::Value> = Vec::new();
     for (i, a) in all_labels.iter().enumerate() {
         for b in &all_labels[i + 1..] {
@@ -761,9 +801,141 @@ async fn handle_check_overlaps(
 
     let mut all = comp_overlaps;
     all.extend(label_overlaps);
-    Ok(CallToolResult::json(
-        &json!({ "overlap_count": all.len(), "overlaps": all }),
-    ))
+    let bounds_unresolved = placements
+        .iter()
+        .filter(|(_, bounds)| bounds.is_none())
+        .map(|(instance, _)| instance.reference.as_str())
+        .collect::<Vec<_>>();
+    Ok(CallToolResult::json(&json!({
+        "overlap_count": all.len(),
+        "overlaps": all,
+        "bounds_resolved": placements.len() - bounds_unresolved.len(),
+        "bounds_unresolved": bounds_unresolved
+    })))
+}
+
+#[cfg(test)]
+mod placement_overlap_tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::{ServerConfig, ToolContext};
+    use std::sync::Arc;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+                eager_toolsets: false,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    /// Retained graphic and pin nodes from KiCad 10's stock Device:R.
+    const DEVICE_R: &str = r#"		(symbol "Device:R"
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke (width 0.254) (type default))
+					(fill (type none))
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name "" (effects (font (size 1.27 1.27))))
+					(number "1" (effects (font (size 1.27 1.27))))
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name "" (effects (font (size 1.27 1.27))))
+					(number "2" (effects (font (size 1.27 1.27))))
+				)
+			)
+		)
+"#;
+
+    fn schematic(placements: &[(&str, f64, f64)]) -> String {
+        let instances = placements
+            .iter()
+            .map(|(reference, x, y)| {
+                format!(
+                    "\t(symbol\n\t\t(lib_id \"Device:R\")\n\t\t(at {x} {y} 0)\n\t\t(unit 1)\n\t\t(uuid \"{reference}\")\n\t\t(property \"Reference\" \"{reference}\")\n\t\t(property \"Value\" \"10k\")\n\t)\n"
+                )
+            })
+            .collect::<String>();
+        format!(
+            "(kicad_sch\n\t(version 20260206)\n\t(generator \"eeschema\")\n\t(lib_symbols\n{DEVICE_R}\t)\n{instances})\n"
+        )
+    }
+
+    fn response_json(result: &CallToolResult) -> serde_json::Value {
+        let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text result");
+        };
+        serde_json::from_str(text).unwrap()
+    }
+
+    async fn overlaps(source: &str) -> serde_json::Value {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("overlap.kicad_sch");
+        std::fs::write(&path, source).unwrap();
+        let result =
+            handle_check_overlaps(&json!({"schematic": path.to_string_lossy()}), &test_ctx())
+                .await
+                .unwrap();
+        response_json(&result)
+    }
+
+    #[tokio::test]
+    async fn distinct_origins_with_intersecting_symbol_bodies_are_reported() {
+        let result = overlaps(&schematic(&[
+            ("R1", 100.0, 50.0),
+            ("R2", 101.0, 50.0),
+            ("R3", 110.0, 50.0),
+        ]))
+        .await;
+
+        assert_eq!(result["bounds_resolved"], 3);
+        assert_eq!(result["bounds_unresolved"], json!([]));
+        assert_eq!(result["overlap_count"], 1);
+        assert_eq!(result["overlaps"][0]["a"], "R1");
+        assert_eq!(result["overlaps"][0]["b"], "R2");
+        assert_eq!(result["overlaps"][0]["detection"], "symbol_geometry");
+        assert!(result["overlaps"][0]["overlap_x_mm"].as_f64().unwrap() > 1.0);
+    }
+
+    #[tokio::test]
+    async fn symbols_whose_bounds_only_touch_are_not_collisions() {
+        let result = overlaps(&schematic(&[("R1", 100.0, 50.0), ("R2", 102.032, 50.0)])).await;
+
+        assert_eq!(result["overlap_count"], 0, "{result}");
+    }
+
+    #[tokio::test]
+    async fn invalid_overlap_tolerance_is_a_named_argument_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("overlap.kicad_sch");
+        std::fs::write(&path, schematic(&[("R1", 100.0, 50.0)])).unwrap();
+        let result = handle_check_overlaps(
+            &json!({"schematic": path.to_string_lossy(), "tolerance": -0.1}),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        let result = response_json(&result);
+
+        assert_eq!(result["error"]["kind"], "invalid_argument");
+        assert_eq!(result["error"]["field"], "tolerance");
+    }
 }
 
 #[cfg(test)]

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -17,6 +17,7 @@ use konnect_sexp::{
     schematic::{
         extract_all_net_labels, extract_labels, extract_symbol_instances, extract_wires,
         format_net_label, format_wire, pin_endpoint, pin_label_rotation, read_schematic,
+        symbol_bounds_for_instance, SymbolBounds,
     },
     writer::{
         apply_edits, find_block_with_leading_whitespace, find_enclosing_direct_child_block,
@@ -256,7 +257,9 @@ pub fn tools() -> Vec<ToolDef> {
         tool!(
             "get_schematic_layout",
             "Return a compact spatial summary of the schematic: component positions, \
-             bounding box, and optionally wire segments and label locations.",
+             transformed drawing/pin bounds (excluding free text), and optionally wire segments \
+             and label locations. Reports any component whose embedded library geometry could \
+             not be resolved.",
             json!({
                 "type": "object",
                 "properties": {
@@ -1203,40 +1206,81 @@ async fn handle_get_layout(
     let (_, tree) = read_schematic(&sch_path)?;
     let instances = extract_symbol_instances(&tree);
 
-    let components: Vec<serde_json::Value> = instances
+    let lib_symbols = tree
+        .find("lib_symbols")
+        .map(|node| node.find_all("symbol"))
+        .unwrap_or_default();
+    let placements = instances
         .iter()
-        .map(|i| {
+        .map(|instance| {
+            let bounds = find_lib_symbol(&lib_symbols, instance)
+                .and_then(|symbol| symbol_bounds_for_instance(symbol, instance));
+            (instance, bounds)
+        })
+        .collect::<Vec<_>>();
+    let bounds_json = |bounds: SymbolBounds| {
+        json!({
+            "x_min": bounds.min_x,
+            "y_min": bounds.min_y,
+            "x_max": bounds.max_x,
+            "y_max": bounds.max_y,
+            "width": bounds.width(),
+            "height": bounds.height()
+        })
+    };
+    let components: Vec<serde_json::Value> = placements
+        .iter()
+        .map(|(instance, bounds)| {
             json!({
-                "reference": i.reference,
-                "value": i.value,
-                "lib_id": i.lib_id,
-                "x": i.x, "y": i.y,
-                "rotation": i.rotation,
-                "mirror_x": i.mirror_x,
-                "mirror_y": i.mirror_y
+                "reference": instance.reference,
+                "value": instance.value,
+                "lib_id": instance.lib_id,
+                "unit": instance.unit,
+                "x": instance.x, "y": instance.y,
+                "rotation": instance.rotation,
+                "mirror_x": instance.mirror_x,
+                "mirror_y": instance.mirror_y,
+                "bounds": bounds.map(&bounds_json)
             })
         })
         .collect();
 
-    // Bounding box over component origins
-    let (mut min_x, mut min_y) = (f64::MAX, f64::MAX);
-    let (mut max_x, mut max_y) = (f64::MIN, f64::MIN);
-    for i in &instances {
-        min_x = min_x.min(i.x);
-        min_y = min_y.min(i.y);
-        max_x = max_x.max(i.x);
-        max_y = max_y.max(i.y);
+    // Enclose actual placed graphics and pin extents. If a library definition
+    // is missing, preserve the old origin coverage for that one instance and
+    // report the unresolved reference instead of silently understating it.
+    let mut overall: Option<SymbolBounds> = None;
+    let mut unresolved_bounds = Vec::new();
+    for (instance, bounds) in &placements {
+        let bounds = bounds.unwrap_or_else(|| {
+            unresolved_bounds.push(instance.reference.clone());
+            SymbolBounds {
+                min_x: instance.x,
+                min_y: instance.y,
+                max_x: instance.x,
+                max_y: instance.y,
+            }
+        });
+        match &mut overall {
+            Some(overall) => {
+                overall.min_x = overall.min_x.min(bounds.min_x);
+                overall.min_y = overall.min_y.min(bounds.min_y);
+                overall.max_x = overall.max_x.max(bounds.max_x);
+                overall.max_y = overall.max_y.max(bounds.max_y);
+            }
+            None => overall = Some(bounds),
+        }
     }
-    let bbox = if instances.is_empty() {
-        json!({ "x_min": 0, "y_min": 0, "x_max": 0, "y_max": 0 })
-    } else {
-        json!({ "x_min": min_x, "y_min": min_y, "x_max": max_x, "y_max": max_y })
-    };
+    let bbox = overall.map_or_else(
+        || json!({ "x_min": 0, "y_min": 0, "x_max": 0, "y_max": 0, "width": 0, "height": 0 }),
+        bounds_json,
+    );
 
     let mut result = json!({
         "component_count": components.len(),
         "components": components,
-        "bounding_box": bbox
+        "bounding_box": bbox,
+        "bounds_resolved": placements.len() - unresolved_bounds.len(),
+        "bounds_unresolved": unresolved_bounds
     });
 
     if include_wires {
@@ -2609,5 +2653,132 @@ mod power_symbol_connection_tests {
             .map(|p| (p["reference"].as_str().unwrap(), p["pin"].as_str().unwrap()))
             .collect();
         assert_eq!(unconnected, vec![("R1", "1")], "only pin 1 floats: {s}");
+    }
+}
+
+#[cfg(test)]
+mod layout_bounds_tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::{ServerConfig, ToolContext};
+    use std::sync::Arc;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+                eager_toolsets: false,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    /// The retained nodes are from KiCad 10's stock Device:R definition; the
+    /// surrounding schematic is reduced to what this read-only query needs.
+    fn schematic() -> &'static str {
+        r#"(kicad_sch
+	(version 20260206)
+	(generator "eeschema")
+	(lib_symbols
+		(symbol "Device:R"
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke (width 0.254) (type default))
+					(fill (type none))
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name "" (effects (font (size 1.27 1.27))))
+					(number "1" (effects (font (size 1.27 1.27))))
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name "" (effects (font (size 1.27 1.27))))
+					(number "2" (effects (font (size 1.27 1.27))))
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 100 50 0)
+		(unit 1)
+		(uuid "r1")
+		(property "Reference" "R1" (at 102 50 90))
+		(property "Value" "10k" (at 100 50 90))
+	)
+)
+"#
+    }
+
+    fn response_json(result: &CallToolResult) -> serde_json::Value {
+        let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text result");
+        };
+        serde_json::from_str(text).unwrap()
+    }
+
+    #[tokio::test]
+    async fn schematic_layout_bounds_enclose_graphics_and_pin_tips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("layout.kicad_sch");
+        std::fs::write(&path, schematic()).unwrap();
+
+        let result = handle_get_layout(
+            &json!({
+                "schematic": path.to_string_lossy(),
+                "include_wires": false,
+                "include_labels": false
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        let result = response_json(&result);
+
+        assert_eq!(result["bounds_resolved"], 1);
+        assert_eq!(result["bounds_unresolved"], json!([]));
+        assert_eq!(result["bounding_box"]["x_min"], 98.984);
+        assert_eq!(result["bounding_box"]["x_max"], 101.016);
+        assert_eq!(result["bounding_box"]["y_min"], 46.19);
+        assert_eq!(result["bounding_box"]["y_max"], 53.81);
+        assert_eq!(result["components"][0]["bounds"], result["bounding_box"]);
+        assert_ne!(
+            result["bounding_box"]["x_min"], 100.0,
+            "an origin-only box reproduces the old false result"
+        );
+    }
+
+    #[tokio::test]
+    async fn unresolved_geometry_is_named_and_its_origin_remains_covered() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("unresolved.kicad_sch");
+        let source = schematic().replace(
+            "\n)\n",
+            "\n\t(symbol\n\t\t(lib_id \"Missing:Part\")\n\t\t(at 120 60 0)\n\t\t(unit 1)\n\t\t(uuid \"u1\")\n\t\t(property \"Reference\" \"U1\")\n\t)\n)\n",
+        );
+        std::fs::write(&path, source).unwrap();
+
+        let result = handle_get_layout(&json!({"schematic": path.to_string_lossy()}), &test_ctx())
+            .await
+            .unwrap();
+        let result = response_json(&result);
+
+        assert_eq!(result["bounds_resolved"], 1);
+        assert_eq!(result["bounds_unresolved"], json!(["U1"]));
+        assert_eq!(result["components"][1]["bounds"], serde_json::Value::Null);
+        assert_eq!(result["bounding_box"]["x_max"], 120.0);
+        assert_eq!(result["bounding_box"]["y_max"], 60.0);
     }
 }

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -16,8 +16,8 @@ use konnect_sexp::{
     geometry::{points_coincident, snap_point},
     schematic::{
         extract_all_net_labels, extract_labels, extract_symbol_instances, extract_wires,
-        format_net_label, format_wire, pin_endpoint, pin_label_rotation, read_schematic,
-        symbol_bounds_for_instance, SymbolBounds,
+        find_lib_symbol, format_net_label, format_wire, pin_endpoint, pin_label_rotation,
+        read_schematic, symbol_bounds_for_instance, SymbolBounds,
     },
     writer::{
         apply_edits, find_block_with_leading_whitespace, find_enclosing_direct_child_block,
@@ -2757,6 +2757,57 @@ mod layout_bounds_tests {
         assert_ne!(
             result["bounding_box"]["x_min"], 100.0,
             "an origin-only box reproduces the old false result"
+        );
+    }
+
+    /// A real eeschema save (KiCad's ecc83 demo): U1 is placed as three units
+    /// of the embedded dual triode — two identical triode units and one
+    /// heater unit with different library geometry. Every placement must get
+    /// its own resolved bounds from its OWN unit's drawing, or a multi-unit
+    /// component reports one unit's box three times.
+    #[tokio::test]
+    async fn every_placed_unit_gets_bounds_from_its_own_geometry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("ecc83.kicad_sch");
+        std::fs::write(
+            &path,
+            include_str!("../../tests/fixtures/ecc83_multiunit.kicad_sch"),
+        )
+        .unwrap();
+
+        let result =
+            handle_get_layout(&json!({ "schematic": path.to_string_lossy() }), &test_ctx())
+                .await
+                .unwrap();
+        let result = response_json(&result);
+
+        assert_eq!(result["bounds_unresolved"], json!([]), "{result}");
+        let u1_boxes: Vec<(f64, f64)> = result["components"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|component| component["reference"] == "U1")
+            .map(|component| {
+                let bounds = &component["bounds"];
+                assert!(
+                    !bounds.is_null(),
+                    "every U1 placement resolves bounds: {component}"
+                );
+                (
+                    bounds["width"].as_f64().unwrap(),
+                    bounds["height"].as_f64().unwrap(),
+                )
+            })
+            .collect();
+        assert_eq!(u1_boxes.len(), 3, "three placed units of U1");
+        let distinct: std::collections::BTreeSet<String> = u1_boxes
+            .iter()
+            .map(|(w, h)| format!("{w:.3}x{h:.3}"))
+            .collect();
+        assert!(
+            distinct.len() >= 2,
+            "the heater unit's geometry differs from the triodes', so one \
+             shared box means unit selection is broken: {u1_boxes:?}"
         );
     }
 

--- a/crates/konnect-sexp/src/schematic.rs
+++ b/crates/konnect-sexp/src/schematic.rs
@@ -269,6 +269,361 @@ impl SymbolInstance {
     }
 }
 
+/// Axis-aligned schematic-space bounds of a placed symbol's non-text drawings
+/// and pins. Property fields and free library text are deliberately excluded:
+/// their font layout is a separate concern, while callers use these bounds for
+/// component placement and body-collision checks. Explicit `text_box` geometry
+/// is included because KiCad gives it exact corners.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SymbolBounds {
+    pub min_x: f64,
+    pub min_y: f64,
+    pub max_x: f64,
+    pub max_y: f64,
+}
+
+impl SymbolBounds {
+    fn point(x: f64, y: f64) -> Self {
+        Self {
+            min_x: x,
+            min_y: y,
+            max_x: x,
+            max_y: y,
+        }
+    }
+
+    fn include(&mut self, x: f64, y: f64) {
+        if !x.is_finite() || !y.is_finite() {
+            return;
+        }
+        self.min_x = self.min_x.min(x);
+        self.min_y = self.min_y.min(y);
+        self.max_x = self.max_x.max(x);
+        self.max_y = self.max_y.max(y);
+    }
+
+    pub fn width(self) -> f64 {
+        self.max_x - self.min_x
+    }
+
+    pub fn height(self) -> f64 {
+        self.max_y - self.min_y
+    }
+
+    /// Intersection depth on each axis. Touching edges return zero; separated
+    /// boxes return a negative value on at least one axis.
+    pub fn overlap_depth(self, other: Self) -> (f64, f64) {
+        (
+            self.max_x.min(other.max_x) - self.min_x.max(other.min_x),
+            self.max_y.min(other.max_y) - self.min_y.max(other.min_y),
+        )
+    }
+}
+
+fn include_point(bounds: &mut Option<SymbolBounds>, x: f64, y: f64) {
+    if !x.is_finite() || !y.is_finite() {
+        return;
+    }
+    match bounds {
+        Some(bounds) => bounds.include(x, y),
+        None => *bounds = Some(SymbolBounds::point(x, y)),
+    }
+}
+
+fn include_xy_children(bounds: &mut Option<SymbolBounds>, node: &SexpNode) {
+    if let Some(points) = node.find("pts") {
+        for point in points.find_all("xy") {
+            if let (Some(x), Some(y)) = (point.get_f64(1), point.get_f64(2)) {
+                include_point(bounds, x, y);
+            }
+        }
+    }
+}
+
+fn ccw_delta(from: f64, to: f64) -> f64 {
+    (to - from).rem_euclid(std::f64::consts::TAU)
+}
+
+/// Include the exact cardinal extrema of the circular arc through three KiCad
+/// points. Collinear or malformed arcs safely fall back to the three points.
+fn include_arc(bounds: &mut Option<SymbolBounds>, arc: &SexpNode) {
+    let point = |tag| {
+        let node = arc.find(tag)?;
+        Some((node.get_f64(1)?, node.get_f64(2)?))
+    };
+    let (Some(start), Some(mid), Some(end)) = (point("start"), point("mid"), point("end")) else {
+        return;
+    };
+    for (x, y) in [start, mid, end] {
+        include_point(bounds, x, y);
+    }
+
+    let (x1, y1) = start;
+    let (x2, y2) = mid;
+    let (x3, y3) = end;
+    let divisor = 2.0 * (x1 * (y2 - y3) + x2 * (y3 - y1) + x3 * (y1 - y2));
+    if divisor.abs() < 1e-12 {
+        return;
+    }
+    let square = |x: f64, y: f64| x * x + y * y;
+    let center_x =
+        (square(x1, y1) * (y2 - y3) + square(x2, y2) * (y3 - y1) + square(x3, y3) * (y1 - y2))
+            / divisor;
+    let center_y =
+        (square(x1, y1) * (x3 - x2) + square(x2, y2) * (x1 - x3) + square(x3, y3) * (x2 - x1))
+            / divisor;
+    let radius = (x1 - center_x).hypot(y1 - center_y);
+    if !center_x.is_finite() || !center_y.is_finite() || !radius.is_finite() {
+        return;
+    }
+
+    let angle = |(x, y): (f64, f64)| (y - center_y).atan2(x - center_x);
+    let start_angle = angle(start);
+    let mid_angle = angle(mid);
+    let end_angle = angle(end);
+    let ccw = ccw_delta(start_angle, mid_angle) <= ccw_delta(start_angle, end_angle) + 1e-12;
+    for candidate in [
+        0.0,
+        std::f64::consts::FRAC_PI_2,
+        std::f64::consts::PI,
+        3.0 * std::f64::consts::FRAC_PI_2,
+    ] {
+        let on_arc = if ccw {
+            ccw_delta(start_angle, candidate) <= ccw_delta(start_angle, end_angle) + 1e-12
+        } else {
+            ccw_delta(end_angle, candidate) <= ccw_delta(end_angle, start_angle) + 1e-12
+        };
+        if on_arc {
+            include_point(
+                bounds,
+                center_x + radius * candidate.cos(),
+                center_y + radius * candidate.sin(),
+            );
+        }
+    }
+}
+
+fn collect_direct_symbol_geometry(node: &SexpNode, bounds: &mut Option<SymbolBounds>) {
+    for rectangle in node
+        .find_all("rectangle")
+        .into_iter()
+        .chain(node.find_all("text_box"))
+    {
+        for tag in ["start", "end"] {
+            if let Some(point) = rectangle.find(tag) {
+                if let (Some(x), Some(y)) = (point.get_f64(1), point.get_f64(2)) {
+                    include_point(bounds, x, y);
+                }
+            }
+        }
+    }
+    for shape in node
+        .find_all("polyline")
+        .into_iter()
+        .chain(node.find_all("bezier"))
+    {
+        // Bezier control points enclose the complete curve, so their box is a
+        // conservative placement bound without flattening the curve.
+        include_xy_children(bounds, shape);
+    }
+    for circle in node.find_all("circle") {
+        let Some(center) = circle.find("center") else {
+            continue;
+        };
+        let (Some(x), Some(y), Some(radius)) = (
+            center.get_f64(1),
+            center.get_f64(2),
+            circle.find_f64("radius"),
+        ) else {
+            continue;
+        };
+        include_point(bounds, x - radius, y - radius);
+        include_point(bounds, x + radius, y + radius);
+    }
+    for arc in node.find_all("arc") {
+        include_arc(bounds, arc);
+    }
+    for pin in node.find_all("pin") {
+        let Some(pin) = parse_lib_pin(pin) else {
+            continue;
+        };
+        include_point(bounds, pin.local_x, pin.local_y);
+        let angle = pin.rotation.to_radians();
+        include_point(
+            bounds,
+            pin.local_x + pin.length * angle.cos(),
+            pin.local_y + pin.length * angle.sin(),
+        );
+    }
+}
+
+fn collect_symbol_geometry_recursive(node: &SexpNode, bounds: &mut Option<SymbolBounds>) {
+    collect_direct_symbol_geometry(node, bounds);
+    for child in node.find_all("symbol") {
+        collect_symbol_geometry_recursive(child, bounds);
+    }
+}
+
+/// Bounds of the selected unit in library-local, Y-up coordinates.
+///
+/// KiCad stores common graphics in `Name_0_M` and unit-specific graphics and
+/// pins in `Name_N_M`. The selection mirrors [`extract_lib_pins_for_unit`]:
+/// common nodes, the requested unit, and un-suffixed nested nodes participate;
+/// other units do not.
+pub fn symbol_local_bounds_for_unit(sym_node: &SexpNode, unit: u32) -> Option<SymbolBounds> {
+    let mut bounds = None;
+    collect_direct_symbol_geometry(sym_node, &mut bounds);
+    for child in sym_node.find_all("symbol") {
+        let child_unit = child
+            .get(1)
+            .and_then(|node| node.as_str())
+            .and_then(parse_subsymbol_unit);
+        if !matches!(child_unit, Some(child_unit) if child_unit != 0 && child_unit != unit) {
+            collect_symbol_geometry_recursive(child, &mut bounds);
+        }
+    }
+    bounds
+}
+
+/// Transform a selected library unit's bounds into schematic coordinates for
+/// one placed instance, including rotation and mirroring.
+pub fn symbol_bounds_for_instance(
+    sym_node: &SexpNode,
+    instance: &SymbolInstance,
+) -> Option<SymbolBounds> {
+    let local = symbol_local_bounds_for_unit(sym_node, instance.unit)?;
+    let transform = instance.pin_transform();
+    let mut placed = None;
+    for (x, y) in [
+        (local.min_x, local.min_y),
+        (local.min_x, local.max_y),
+        (local.max_x, local.min_y),
+        (local.max_x, local.max_y),
+    ] {
+        let (x, y) = transform_pin(x, y, transform);
+        include_point(&mut placed, x, y);
+    }
+    placed
+}
+
+#[cfg(test)]
+mod symbol_bounds_tests {
+    use super::*;
+
+    /// Reduced from KiCad 10's stock `Device:R` definition. KiCad prefixes the
+    /// root name when embedding it in a schematic; retained graphic and pin
+    /// nodes are otherwise the library output.
+    const DEVICE_R: &str = r#"(symbol "Device:R"
+	(symbol "R_0_1"
+		(rectangle
+			(start -1.016 -2.54)
+			(end 1.016 2.54)
+			(stroke (width 0.254) (type default))
+			(fill (type none))
+		)
+	)
+	(symbol "R_1_1"
+		(pin passive line
+			(at 0 3.81 270)
+			(length 1.27)
+			(name "" (effects (font (size 1.27 1.27))))
+			(number "1" (effects (font (size 1.27 1.27))))
+		)
+		(pin passive line
+			(at 0 -3.81 90)
+			(length 1.27)
+			(name "" (effects (font (size 1.27 1.27))))
+			(number "2" (effects (font (size 1.27 1.27))))
+		)
+	)
+)"#;
+
+    fn resistor_instance(rotation: f64) -> SymbolInstance {
+        SymbolInstance {
+            reference: "R1".into(),
+            value: "10k".into(),
+            footprint: String::new(),
+            lib_name: None,
+            lib_id: "Device:R".into(),
+            x: 100.0,
+            y: 50.0,
+            rotation,
+            mirror_x: false,
+            mirror_y: false,
+            uuid: None,
+            unit: 1,
+        }
+    }
+
+    fn assert_close(actual: f64, expected: f64) {
+        assert!((actual - expected).abs() < 1e-9, "{actual} != {expected}");
+    }
+
+    #[test]
+    fn stock_resistor_bounds_include_body_and_pin_tips() {
+        let symbol = parse_sexp(DEVICE_R).unwrap();
+        let bounds = symbol_local_bounds_for_unit(&symbol, 1).unwrap();
+
+        assert_eq!(
+            bounds,
+            SymbolBounds {
+                min_x: -1.016,
+                min_y: -3.81,
+                max_x: 1.016,
+                max_y: 3.81,
+            }
+        );
+    }
+
+    #[test]
+    fn placed_bounds_follow_schematic_rotation_and_y_axis() {
+        let symbol = parse_sexp(DEVICE_R).unwrap();
+        let vertical = symbol_bounds_for_instance(&symbol, &resistor_instance(0.0)).unwrap();
+        assert_close(vertical.min_x, 98.984);
+        assert_close(vertical.max_x, 101.016);
+        assert_close(vertical.min_y, 46.19);
+        assert_close(vertical.max_y, 53.81);
+
+        let horizontal = symbol_bounds_for_instance(&symbol, &resistor_instance(90.0)).unwrap();
+        assert_close(horizontal.min_x, 96.19);
+        assert_close(horizontal.max_x, 103.81);
+        assert_close(horizontal.min_y, 48.984);
+        assert_close(horizontal.max_y, 51.016);
+    }
+
+    #[test]
+    fn another_units_graphics_do_not_expand_the_selected_unit() {
+        let symbol = parse_sexp(
+            r#"(symbol "Amplifier_Operational:DUAL"
+	(symbol "DUAL_0_1" (circle (center 0 0) (radius 1)))
+	(symbol "DUAL_1_1" (rectangle (start -2 -3) (end 2 3)))
+	(symbol "DUAL_2_1" (rectangle (start -20 -30) (end 20 30)))
+)"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            symbol_local_bounds_for_unit(&symbol, 1).unwrap(),
+            SymbolBounds {
+                min_x: -2.0,
+                min_y: -3.0,
+                max_x: 2.0,
+                max_y: 3.0,
+            }
+        );
+    }
+
+    #[test]
+    fn arc_bounds_include_cardinal_extrema_on_the_selected_sweep() {
+        let upper = parse_sexp("(symbol \"Arc\" (arc (start -1 0) (mid 0 1) (end 1 0)))").unwrap();
+        let bounds = symbol_local_bounds_for_unit(&upper, 1).unwrap();
+        assert_close(bounds.min_x, -1.0);
+        assert_close(bounds.max_x, 1.0);
+        assert_close(bounds.min_y, 0.0);
+        assert_close(bounds.max_y, 1.0);
+    }
+}
+
 pub fn extract_symbol_instances(tree: &SexpNode) -> Vec<SymbolInstance> {
     tree.find_all("symbol")
         .iter()

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -144,7 +144,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `find_shorted_nets` | Detect accidentally merged nets — pairs of distinct net names sharing a wire path. |
 | `find_single_pin_nets` | Find nets with only one label/connection — often indicates a missing counterpart. |
 | `get_connected_items` | Get all wires, labels, and components connected to a given component by tracing each of its pins. |
-| `check_schematic_overlaps` | Find overlapping symbols or labels that may indicate placement errors. |
+| `check_schematic_overlaps` | Find collisions using transformed symbol drawings and pins (excluding free text), with a reported origin fallback when geometry is unavailable. |
 
 ### `sch_batch` · 12 tools
 **Purpose:** Bulk add, edit, delete, and move schematic elements in one call.
@@ -159,7 +159,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `batch_delete_schematic_components` | Delete multiple components by reference designator in a single atomic write. |
 | `connect_passthrough` | Add a wire stub and matching net label at a point to route a signal through a region without drawing a full path. Direction defaults to `auto`. |
 | `add_schematic_text` | Add a text annotation (non-net label) to the schematic at a given position. Aligns the text against that position with `justify`, per axis and defaulting to `left bottom` as KiCad does; an omitted axis is centred, and `center` centres both. |
-| `get_schematic_layout` | Return a compact spatial summary of the schematic: component positions, bounding box, optionally wires and labels. |
+| `get_schematic_layout` | Return component positions and transformed drawing/pin bounds (excluding free text), reporting unresolved geometry; optionally include wires and labels. |
 | `validate_wire_connections` | Check all wire endpoints for floating ends not connected to a pin, label, or another wire. |
 | `validate_component_connections` | Check that every non-passive pin has at least one wire or label connected. Reports unconnected pins. |
 | `batch_place_components` | Place multiple symbols from KiCAD libraries in a single file read/write cycle. Pass explicit references -- there is no auto-numbering; an omitted reference becomes '?' like an eeschema-unannotated symbol, same as `add_schematic_component`. |


### PR DESCRIPTION
## Summary

Make schematic placement queries describe the visible symbol geometry they claim to measure:

- `get_schematic_layout.bounding_box` encloses transformed symbol drawings and pin extents instead of component origins;
- `check_schematic_overlaps` detects intersecting symbol envelopes even when their anchors differ.

No linked issue.

## Approach

Add one structural symbol-bounds implementation in `konnect-sexp` and share it between both handlers. It:

- reads rectangles, polylines, Bezier control hulls, circles, exact three-point arc extrema, explicit text boxes, and complete pin segments;
- selects common (`_0_M`) plus the placed unit's (`_N_M`) geometry for multi-unit symbols;
- applies KiCad's schematic Y-axis convention, absolute rotation, and both mirror modes through the existing canonical transform;
- deliberately excludes free library/property text because KiCad does not provide an exact font-layout box there.

`check_schematic_overlaps` reports positive-area intersections and leaves edge/pin contact valid. When an embedded library definition cannot be resolved, both tools preserve an origin fallback and name every affected reference in `bounds_unresolved` rather than presenting partial geometry as complete.

The regression uses retained nodes from KiCad 10's stock `Device:R` output and covers rotation, multi-unit selection, exact arcs, distinct-origin collisions, touching edges, invalid tolerance, and unresolved geometry.

## Compatibility and safety

No tool, argument, or schema removal.

`get_schematic_layout` keeps its existing fields and adds per-component `unit`/`bounds`, aggregate width/height, and resolution coverage. Its existing `bounding_box` values intentionally change from origin extrema to the actual geometry promised by the field name.

`check_schematic_overlaps` keeps its existing overlap list and adds unit, bounds, detection source, intersection depth, and resolution coverage. Conflicting-label detection remains coordinate based.

Both tools are read-only and perform no file or IPC mutation.

## Validation

- [x] `cargo test -p konnect-sexp --lib` — 137 passed
- [x] `cargo test -p konnect-core layout_bounds_tests -- --nocapture` — 2 passed
- [x] `cargo test -p konnect-core placement_overlap_tests -- --nocapture` — 3 passed
- [ ] `cargo test --workspace --locked --lib --tests` — 547 passed, 3 failed; the failures are the same `update_symbols_from_library_*` baseline failures reproduced on unmodified `main`, caused locally by the installed `Device:R` library shadowing the test fixture
- [x] `cargo test --workspace --locked --doc` — passed (7 passed, 2 intentionally ignored)
- [x] `cargo clippy --workspace --locked --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Real KiCad check through MCP — a 102-instance KiCad 10-authored schematic resolved 102/102 unit bounds with no fallback; its collision query completed with no false positives

## Review checklist

- [x] The diff is focused and contains no generated output, personal data, or unrelated cleanup.
- [x] New names follow `docs/NAMING_CONVENTIONS.md`; no public name was removed or renamed.
- [x] New behavior, transformation cases, and fallback paths have regression coverage.
- [x] File mutation requirements are not applicable; both handlers only read.
- [x] IPC mutation requirements are not applicable.
- [x] Tool-count updates are not applicable; no tool was added or removed.
