### PR TITLE
fix(export): apply every advertised output option

### DIFF
--- a/crates/konnect-core/src/tools/cli.rs
+++ b/crates/konnect-core/src/tools/cli.rs
@@ -364,35 +364,91 @@ pub async fn annotate_schematic(_cli: &str, schematic: &Path) -> Result<()> {
 
 // ─── Schematic Export ────────────────────────────────────────────────────────
 
-/// KiCAD 10: `sch export svg --output <dir> <input>`
+#[derive(Debug, Default, Clone)]
+pub struct SchematicSvgOptions<'a> {
+    pub black_and_white: bool,
+    pub theme: Option<&'a str>,
+}
+
+fn schematic_svg_args<'a>(
+    output_dir: &'a str,
+    schematic: &'a str,
+    options: &'a SchematicSvgOptions<'a>,
+) -> Vec<&'a str> {
+    let mut args = vec!["sch", "export", "svg", "--output", output_dir];
+    if options.black_and_white {
+        args.push("--black-and-white");
+    }
+    if let Some(theme) = options.theme {
+        args.push("--theme");
+        args.push(theme);
+    }
+    args.push(schematic);
+    args
+}
+
+/// KiCAD 10: `sch export svg --output <dir> [--black-and-white]
+/// [--theme <name>] <input>`
 pub async fn export_schematic_svg(
     cli: &str,
     schematic: &Path,
     output_dir: &Path,
+    options: &SchematicSvgOptions<'_>,
 ) -> Result<PathBuf> {
-    let args = [
-        "sch",
-        "export",
-        "svg",
-        "--output",
+    let args = schematic_svg_args(
         output_dir.to_str().unwrap(),
         schematic.to_str().unwrap(),
-    ];
+        options,
+    );
     run_cli(cli, &args, LONG_TIMEOUT).await?;
     let stem = schematic.file_stem().unwrap_or_default().to_string_lossy();
     Ok(output_dir.join(format!("{}.svg", stem)))
 }
 
-/// KiCAD 10: `sch export pdf --output <path> <input>`
-pub async fn export_schematic_pdf(cli: &str, schematic: &Path, output: &Path) -> Result<()> {
-    let args = [
-        "sch",
-        "export",
-        "pdf",
-        "--output",
+#[derive(Debug, Clone)]
+pub struct SchematicPdfOptions {
+    pub black_and_white: bool,
+    pub all_sheets: bool,
+}
+
+impl Default for SchematicPdfOptions {
+    fn default() -> Self {
+        Self {
+            black_and_white: false,
+            all_sheets: true,
+        }
+    }
+}
+
+fn schematic_pdf_args<'a>(
+    output: &'a str,
+    schematic: &'a str,
+    options: &SchematicPdfOptions,
+) -> Vec<&'a str> {
+    let mut args = vec!["sch", "export", "pdf", "--output", output];
+    if options.black_and_white {
+        args.push("--black-and-white");
+    }
+    if !options.all_sheets {
+        args.extend(["--pages", "1"]);
+    }
+    args.push(schematic);
+    args
+}
+
+/// KiCAD 10: `sch export pdf --output <path> [--black-and-white]
+/// [--pages 1] <input>`
+pub async fn export_schematic_pdf(
+    cli: &str,
+    schematic: &Path,
+    output: &Path,
+    options: &SchematicPdfOptions,
+) -> Result<()> {
+    let args = schematic_pdf_args(
         output.to_str().unwrap(),
         schematic.to_str().unwrap(),
-    ];
+        options,
+    );
     run_cli(cli, &args, LONG_TIMEOUT).await?;
     Ok(())
 }
@@ -579,6 +635,7 @@ fn single_file_pcb_export_args(
     format: &str,
     output: &str,
     layers: &[&str],
+    black_and_white: bool,
     pcb: &str,
 ) -> Vec<String> {
     let mut args = vec![
@@ -593,16 +650,27 @@ fn single_file_pcb_export_args(
         args.push("--layers".to_string());
         args.push(layers.join(","));
     }
+    if black_and_white {
+        args.push("--black-and-white".to_string());
+    }
     args.push(pcb.to_string());
     args
 }
 
-/// KiCAD 10: `pcb export pdf --output <path> --mode-single [--layers <a,b>] <input>`
-pub async fn export_pdf(cli: &str, pcb: &Path, output: &Path, layers: &[&str]) -> Result<()> {
+/// KiCAD 10: `pcb export pdf --output <path> --mode-single [--layers <a,b>]
+/// [--black-and-white] <input>`
+pub async fn export_pdf(
+    cli: &str,
+    pcb: &Path,
+    output: &Path,
+    layers: &[&str],
+    black_and_white: bool,
+) -> Result<()> {
     let args = single_file_pcb_export_args(
         "pdf",
         output.to_str().unwrap(),
         layers,
+        black_and_white,
         pcb.to_str().unwrap(),
     );
     let args: Vec<&str> = args.iter().map(String::as_str).collect();
@@ -610,12 +678,20 @@ pub async fn export_pdf(cli: &str, pcb: &Path, output: &Path, layers: &[&str]) -
     Ok(())
 }
 
-/// KiCAD 10: `pcb export svg --output <path> --mode-single [--layers <a,b>] <input>`
-pub async fn export_svg_pcb(cli: &str, pcb: &Path, output: &Path, layers: &[&str]) -> Result<()> {
+/// KiCAD 10: `pcb export svg --output <path> --mode-single [--layers <a,b>]
+/// [--black-and-white] <input>`
+pub async fn export_svg_pcb(
+    cli: &str,
+    pcb: &Path,
+    output: &Path,
+    layers: &[&str],
+    black_and_white: bool,
+) -> Result<()> {
     let args = single_file_pcb_export_args(
         "svg",
         output.to_str().unwrap(),
         layers,
+        black_and_white,
         pcb.to_str().unwrap(),
     );
     let args: Vec<&str> = args.iter().map(String::as_str).collect();
@@ -623,9 +699,14 @@ pub async fn export_svg_pcb(cli: &str, pcb: &Path, output: &Path, layers: &[&str
     Ok(())
 }
 
-/// KiCAD 10: `pcb export <format> --output <path> <input>`
+/// KiCAD 10: `pcb export <format> --output <path> [--no-unspecified] <input>`
 /// Supported 3D formats: step, vrml, glb, brep, stl, ply, stpz, u3d, xao, 3dpdf
-pub async fn export_3d(cli: &str, pcb: &Path, output: &Path, format: &str) -> Result<()> {
+fn export_3d_args<'a>(
+    pcb: &'a str,
+    output: &'a str,
+    format: &str,
+    include_unspecified: bool,
+) -> Result<Vec<&'a str>> {
     let subcommand = match format.to_lowercase().as_str() {
         "step" | "stp" => "step",
         "vrml" | "wrl" => "vrml",
@@ -642,14 +723,27 @@ pub async fn export_3d(cli: &str, pcb: &Path, output: &Path, format: &str) -> Re
             other
         ),
     };
-    let args = vec![
-        "pcb",
-        "export",
-        subcommand,
-        "--output",
-        output.to_str().unwrap(),
+    let mut args = vec!["pcb", "export", subcommand, "--output", output];
+    if !include_unspecified {
+        args.push("--no-unspecified");
+    }
+    args.push(pcb);
+    Ok(args)
+}
+
+pub async fn export_3d(
+    cli: &str,
+    pcb: &Path,
+    output: &Path,
+    format: &str,
+    include_unspecified: bool,
+) -> Result<()> {
+    let args = export_3d_args(
         pcb.to_str().unwrap(),
-    ];
+        output.to_str().unwrap(),
+        format,
+        include_unspecified,
+    )?;
     run_cli(cli, &args, LONG_TIMEOUT).await?;
     Ok(())
 }
@@ -780,7 +874,7 @@ pub async fn export_odb(
 /// KiCAD 10: `sch export svg --output <dir> <input>`
 pub async fn render_schematic_svg(cli: &str, schematic: &Path, output: &Path) -> Result<PathBuf> {
     let output_dir = output.parent().unwrap_or(Path::new("."));
-    export_schematic_svg(cli, schematic, output_dir).await
+    export_schematic_svg(cli, schematic, output_dir, &SchematicSvgOptions::default()).await
 }
 
 /// KiCAD 10: `pcb render --output <path> --width <w> --height <h> <input>`
@@ -815,6 +909,75 @@ pub async fn render_pcb_png(
 }
 
 #[cfg(test)]
+mod schematic_export_option_tests {
+    use super::*;
+
+    #[test]
+    fn svg_theme_and_monochrome_flags_reach_kicad() {
+        let options = SchematicSvgOptions {
+            black_and_white: true,
+            theme: Some("Solarized Dark"),
+        };
+        let args = schematic_svg_args("/out", "/tmp/design.kicad_sch", &options);
+
+        assert!(args.contains(&"--black-and-white"));
+        let theme = args
+            .iter()
+            .position(|argument| *argument == "--theme")
+            .map(|index| args[index + 1]);
+        assert_eq!(theme, Some("Solarized Dark"));
+        assert_eq!(args.last().copied(), Some("/tmp/design.kicad_sch"));
+    }
+
+    #[test]
+    fn pdf_can_limit_the_export_to_the_root_sheet() {
+        let options = SchematicPdfOptions {
+            black_and_white: true,
+            all_sheets: false,
+        };
+        let args = schematic_pdf_args("/out/design.pdf", "/tmp/design.kicad_sch", &options);
+
+        assert!(args.contains(&"--black-and-white"));
+        let pages = args
+            .iter()
+            .position(|argument| *argument == "--pages")
+            .map(|index| args[index + 1]);
+        assert_eq!(pages, Some("1"));
+    }
+
+    #[test]
+    fn schematic_defaults_leave_kicad_theme_and_page_selection_alone() {
+        let svg_options = SchematicSvgOptions::default();
+        let svg = schematic_svg_args("/out", "/tmp/design.kicad_sch", &svg_options);
+        assert!(!svg.contains(&"--black-and-white"));
+        assert!(!svg.contains(&"--theme"));
+
+        let pdf_options = SchematicPdfOptions::default();
+        let pdf = schematic_pdf_args("/out/design.pdf", "/tmp/design.kicad_sch", &pdf_options);
+        assert!(!pdf.contains(&"--black-and-white"));
+        assert!(!pdf.contains(&"--pages"));
+    }
+}
+
+#[cfg(test)]
+mod three_d_export_option_tests {
+    use super::*;
+
+    #[test]
+    fn unspecified_models_are_excluded_by_default() {
+        let args =
+            export_3d_args("/tmp/board.kicad_pcb", "/out/board.step", "step", false).unwrap();
+        assert!(args.contains(&"--no-unspecified"));
+    }
+
+    #[test]
+    fn including_unspecified_models_omits_the_exclusion_flag() {
+        let args = export_3d_args("/tmp/board.kicad_pcb", "/out/board.wrl", "vrml", true).unwrap();
+        assert!(!args.contains(&"--no-unspecified"));
+    }
+}
+
+#[cfg(test)]
 mod pcb_plot_export_tests {
     use super::*;
 
@@ -824,6 +987,7 @@ mod pcb_plot_export_tests {
             "svg",
             "/out/board.svg",
             &["F.Cu", "F.Paste", "F.SilkS", "Edge.Cuts"],
+            false,
             "/tmp/board.kicad_pcb",
         );
 
@@ -837,8 +1001,13 @@ mod pcb_plot_export_tests {
 
     #[test]
     fn file_output_uses_single_mode_and_empty_layers_are_omitted() {
-        let args =
-            single_file_pcb_export_args("pdf", "/out/board.pdf", &[], "/tmp/board.kicad_pcb");
+        let args = single_file_pcb_export_args(
+            "pdf",
+            "/out/board.pdf",
+            &[],
+            false,
+            "/tmp/board.kicad_pcb",
+        );
 
         assert!(args.iter().any(|arg| arg == "--mode-single"));
         assert!(!args.iter().any(|arg| arg == "--layers"));
@@ -846,6 +1015,20 @@ mod pcb_plot_export_tests {
             args.last().map(String::as_str),
             Some("/tmp/board.kicad_pcb")
         );
+    }
+
+    #[test]
+    fn black_and_white_reaches_both_single_file_plotters() {
+        for format in ["pdf", "svg"] {
+            let args = single_file_pcb_export_args(
+                format,
+                "/out/board.plot",
+                &["F.Cu"],
+                true,
+                "/tmp/board.kicad_pcb",
+            );
+            assert!(args.iter().any(|argument| argument == "--black-and-white"));
+        }
     }
 
     #[test]

--- a/crates/konnect-core/src/tools/cli.rs
+++ b/crates/konnect-core/src/tools/cli.rs
@@ -20,6 +20,20 @@ use tracing::{debug, info, warn};
 /// Extended timeout for long operations (export, ERC, DRC).
 const LONG_TIMEOUT: Duration = Duration::from_secs(600);
 
+fn cli_failure_diagnostics(stdout: &[u8], stderr: &[u8]) -> String {
+    let stdout = String::from_utf8_lossy(stdout);
+    let stderr = String::from_utf8_lossy(stderr);
+    let stdout = stdout.trim();
+    let stderr = stderr.trim();
+
+    match (stdout.is_empty(), stderr.is_empty()) {
+        (false, false) => format!("stdout:\n{stdout}\nstderr:\n{stderr}"),
+        (false, true) => format!("stdout:\n{stdout}"),
+        (true, false) => format!("stderr:\n{stderr}"),
+        (true, true) => "no diagnostic output".to_string(),
+    }
+}
+
 // ─── Result Types ─────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -125,11 +139,10 @@ async fn run_cli(cli: &str, args: &[&str], timeout_dur: Duration) -> Result<Stri
     }
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
         anyhow::bail!(
-            "kicad-cli exited with {}: {}",
+            "kicad-cli exited with {}:\n{}",
             output.status.code().unwrap_or(-1),
-            stderr.trim()
+            cli_failure_diagnostics(&output.stdout, &output.stderr)
         );
     }
 
@@ -562,26 +575,50 @@ pub async fn export_drill(cli: &str, pcb: &Path, output_dir: &Path) -> Result<Ve
     Ok(drill_files_in(output_dir).await)
 }
 
-/// KiCAD 10: `pcb export pdf --output <path> [--layers <layer>]... <input>`
-pub async fn export_pdf(cli: &str, pcb: &Path, output: &Path, layers: &[&str]) -> Result<()> {
-    let mut args = vec!["pcb", "export", "pdf", "--output", output.to_str().unwrap()];
-    for layer in layers {
-        args.push("--layers");
-        args.push(layer);
+fn single_file_pcb_export_args(
+    format: &str,
+    output: &str,
+    layers: &[&str],
+    pcb: &str,
+) -> Vec<String> {
+    let mut args = vec![
+        "pcb".to_string(),
+        "export".to_string(),
+        format.to_string(),
+        "--output".to_string(),
+        output.to_string(),
+        "--mode-single".to_string(),
+    ];
+    if !layers.is_empty() {
+        args.push("--layers".to_string());
+        args.push(layers.join(","));
     }
-    args.push(pcb.to_str().unwrap());
+    args.push(pcb.to_string());
+    args
+}
+
+/// KiCAD 10: `pcb export pdf --output <path> --mode-single [--layers <a,b>] <input>`
+pub async fn export_pdf(cli: &str, pcb: &Path, output: &Path, layers: &[&str]) -> Result<()> {
+    let args = single_file_pcb_export_args(
+        "pdf",
+        output.to_str().unwrap(),
+        layers,
+        pcb.to_str().unwrap(),
+    );
+    let args: Vec<&str> = args.iter().map(String::as_str).collect();
     run_cli(cli, &args, LONG_TIMEOUT).await?;
     Ok(())
 }
 
-/// KiCAD 10: `pcb export svg --output <path> [--layers <layer>]... <input>`
+/// KiCAD 10: `pcb export svg --output <path> --mode-single [--layers <a,b>] <input>`
 pub async fn export_svg_pcb(cli: &str, pcb: &Path, output: &Path, layers: &[&str]) -> Result<()> {
-    let mut args = vec!["pcb", "export", "svg", "--output", output.to_str().unwrap()];
-    for layer in layers {
-        args.push("--layers");
-        args.push(layer);
-    }
-    args.push(pcb.to_str().unwrap());
+    let args = single_file_pcb_export_args(
+        "svg",
+        output.to_str().unwrap(),
+        layers,
+        pcb.to_str().unwrap(),
+    );
+    let args: Vec<&str> = args.iter().map(String::as_str).collect();
     run_cli(cli, &args, LONG_TIMEOUT).await?;
     Ok(())
 }
@@ -775,6 +812,54 @@ pub async fn render_pcb_png(
     ];
     run_cli(cli, &args, LONG_TIMEOUT).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod pcb_plot_export_tests {
+    use super::*;
+
+    #[test]
+    fn layers_are_one_comma_separated_argument_for_kicad_10() {
+        let args = single_file_pcb_export_args(
+            "svg",
+            "/out/board.svg",
+            &["F.Cu", "F.Paste", "F.SilkS", "Edge.Cuts"],
+            "/tmp/board.kicad_pcb",
+        );
+
+        assert_eq!(args.iter().filter(|arg| *arg == "--layers").count(), 1);
+        let layers = args
+            .iter()
+            .position(|arg| arg == "--layers")
+            .map(|index| args[index + 1].as_str());
+        assert_eq!(layers, Some("F.Cu,F.Paste,F.SilkS,Edge.Cuts"));
+    }
+
+    #[test]
+    fn file_output_uses_single_mode_and_empty_layers_are_omitted() {
+        let args =
+            single_file_pcb_export_args("pdf", "/out/board.pdf", &[], "/tmp/board.kicad_pcb");
+
+        assert!(args.iter().any(|arg| arg == "--mode-single"));
+        assert!(!args.iter().any(|arg| arg == "--layers"));
+        assert_eq!(
+            args.last().map(String::as_str),
+            Some("/tmp/board.kicad_pcb")
+        );
+    }
+
+    #[test]
+    fn cli_failures_include_stdout_and_stderr_diagnostics() {
+        assert_eq!(
+            cli_failure_diagnostics(b"Duplicate argument --layers\n", b""),
+            "stdout:\nDuplicate argument --layers"
+        );
+        assert_eq!(
+            cli_failure_diagnostics(b"usage text", b"fatal detail"),
+            "stdout:\nusage text\nstderr:\nfatal detail"
+        );
+        assert_eq!(cli_failure_diagnostics(b"", b""), "no diagnostic output");
+    }
 }
 
 #[cfg(test)]

--- a/crates/konnect-core/src/tools/pcb_export.rs
+++ b/crates/konnect-core/src/tools/pcb_export.rs
@@ -133,7 +133,8 @@ pub fn tools() -> Vec<ToolDef> {
                     "output": { "type": "string", "description": "Output CSV file path" },
                     "format": {
                         "type": "string",
-                        "description": "BOM format passed to kicad-cli: 'csv' (default)",
+                        "enum": ["csv"],
+                        "description": "BOM format. KiCad 10's schematic BOM export is CSV.",
                         "default": "csv"
                     },
                     "fields": {
@@ -374,14 +375,16 @@ async fn handle_export_pdf(
         })
         .unwrap_or_default();
     let layer_refs: Vec<&str> = layers.iter().map(|s| s.as_str()).collect();
+    let black_and_white = args["black_and_white"].as_bool().unwrap_or(false);
 
     let cli = &ctx.config.kicad_cli;
-    cli::export_pdf(cli, &board, &output, &layer_refs).await?;
+    cli::export_pdf(cli, &board, &output, &layer_refs, black_and_white).await?;
 
     Ok(CallToolResult::text(
         serde_json::to_string(&json!({
             "success": true,
-            "output": output.to_str().unwrap_or("")
+            "output": output.to_str().unwrap_or(""),
+            "black_and_white": black_and_white
         }))
         .unwrap(),
     ))
@@ -403,14 +406,16 @@ async fn handle_export_svg(
         })
         .unwrap_or_default();
     let layer_refs: Vec<&str> = layers.iter().map(|s| s.as_str()).collect();
+    let black_and_white = args["black_and_white"].as_bool().unwrap_or(false);
 
     let cli = &ctx.config.kicad_cli;
-    cli::export_svg_pcb(cli, &board, &output, &layer_refs).await?;
+    cli::export_svg_pcb(cli, &board, &output, &layer_refs, black_and_white).await?;
 
     Ok(CallToolResult::text(
         serde_json::to_string(&json!({
             "success": true,
-            "output": output.to_str().unwrap_or("")
+            "output": output.to_str().unwrap_or(""),
+            "black_and_white": black_and_white
         }))
         .unwrap(),
     ))
@@ -423,14 +428,16 @@ async fn handle_export_3d(
     let board = get_path(args, "board")?;
     let output = get_path(args, "output")?;
     let format = args["format"].as_str().unwrap_or("step");
+    let include_unspecified = args["include_unspecified"].as_bool().unwrap_or(false);
 
     let cli = &ctx.config.kicad_cli;
-    cli::export_3d(cli, &board, &output, format).await?;
+    cli::export_3d(cli, &board, &output, format, include_unspecified).await?;
 
     Ok(CallToolResult::text(
         serde_json::to_string(&json!({
             "success": true,
             "format": format,
+            "include_unspecified": include_unspecified,
             "output": output.to_str().unwrap_or("")
         }))
         .unwrap(),
@@ -443,6 +450,17 @@ async fn handle_export_bom(
 ) -> anyhow::Result<CallToolResult> {
     let schematic = get_path(args, "schematic")?;
     let output = get_path(args, "output")?;
+    let format = args["format"].as_str().unwrap_or("csv");
+    if format != "csv" {
+        let reason = format!("only 'csv' is supported, got '{format}'");
+        return Ok(CallToolResult::error_kind(
+            crate::mcp::error::ToolErrorKind::InvalidArgument {
+                field: "format".to_string(),
+                reason: reason.clone(),
+            },
+            format!("Argument 'format' is invalid: {reason}"),
+        ));
+    }
     let options = cli::BomOptions {
         fields: args["fields"].as_str(),
         labels: args["labels"].as_str(),
@@ -459,6 +477,7 @@ async fn handle_export_bom(
         serde_json::to_string(&json!({
             "success": true,
             "output": output.to_str().unwrap_or(""),
+            "format": format,
             "fields": options.fields,
             "exclude_dnp": options.exclude_dnp
         }))
@@ -826,6 +845,29 @@ mod new_export_format_tests {
             "compression": "zip"
         });
         assert!(handle_export_odb(&args, &ctx).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn export_bom_rejects_a_format_kicad_cannot_produce() {
+        let ctx = test_ctx();
+        let result = handle_export_bom(
+            &json!({
+                "schematic": "/tmp/design.kicad_sch",
+                "output": "/tmp/bom.xlsx",
+                "format": "xlsx"
+            }),
+            &ctx,
+        )
+        .await
+        .expect("validation does not spawn kicad-cli");
+
+        assert!(result.is_error);
+        let text = match result.content.first() {
+            Some(crate::mcp::protocol::ToolContent::Text { text }) => text,
+            other => panic!("expected text error, got {other:?}"),
+        };
+        let error: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(error["error"]["field"], "format");
     }
 }
 

--- a/crates/konnect-core/src/tools/project.rs
+++ b/crates/konnect-core/src/tools/project.rs
@@ -350,7 +350,13 @@ async fn handle_snapshot_project(
     let pdf_name = format!("{}_{}_{}.pdf", stem, label, ts);
     let pdf_path = output_dir.join(&pdf_name);
 
-    crate::tools::cli::export_schematic_pdf(&ctx.config.kicad_cli, &schematic, &pdf_path).await?;
+    crate::tools::cli::export_schematic_pdf(
+        &ctx.config.kicad_cli,
+        &schematic,
+        &pdf_path,
+        &crate::tools::cli::SchematicPdfOptions::default(),
+    )
+    .await?;
 
     let mut result = json!({
         "snapshot": pdf_path.display().to_string(),
@@ -364,8 +370,14 @@ async fn handle_snapshot_project(
         let pcb_pdf_name = format!("{}_pcb_{}_{}.pdf", stem, label, ts);
         let pcb_pdf_path = output_dir.join(&pcb_pdf_name);
         let layers = &["F.Cu", "B.Cu", "F.Silkscreen", "B.Silkscreen", "Edge.Cuts"];
-        let _ =
-            crate::tools::cli::export_pdf(&ctx.config.kicad_cli, &pcb, &pcb_pdf_path, layers).await;
+        let _ = crate::tools::cli::export_pdf(
+            &ctx.config.kicad_cli,
+            &pcb,
+            &pcb_pdf_path,
+            layers,
+            false,
+        )
+        .await;
         result["pcb_snapshot"] = json!(pcb_pdf_path.display().to_string());
     }
 

--- a/crates/konnect-core/src/tools/sch_export.rs
+++ b/crates/konnect-core/src/tools/sch_export.rs
@@ -35,7 +35,7 @@ pub fn tools() -> Vec<ToolDef> {
                     "schematic": { "type": "string", "description": "Path to .kicad_sch file" },
                     "output":    { "type": "string", "description": "Output SVG file path (directory used as output dir)" },
                     "black_and_white": { "type": "boolean", "description": "Render in black and white", "default": false },
-                    "theme": { "type": "string", "description": "KiCAD colour theme name (optional)" }
+                    "theme": { "type": "string", "description": "KiCad colour theme name (optional)" }
                 },
                 "required": ["schematic", "output"]
             }),
@@ -50,7 +50,7 @@ pub fn tools() -> Vec<ToolDef> {
                     "schematic": { "type": "string", "description": "Path to .kicad_sch file" },
                     "output":    { "type": "string", "description": "Output PDF file path" },
                     "black_and_white": { "type": "boolean", "description": "Render in black and white", "default": false },
-                    "all_sheets": { "type": "boolean", "description": "Include all hierarchical sheets", "default": true }
+                    "all_sheets": { "type": "boolean", "description": "Include all hierarchical sheets; false exports page 1 only", "default": true }
                 },
                 "required": ["schematic", "output"]
             }),
@@ -152,6 +152,10 @@ async fn handle_export_svg(
 ) -> anyhow::Result<CallToolResult> {
     let sch_path = get_path(args, "schematic")?;
     let output_path = get_path(args, "output")?;
+    let options = cli::SchematicSvgOptions {
+        black_and_white: args["black_and_white"].as_bool().unwrap_or(false),
+        theme: args["theme"].as_str(),
+    };
 
     // kicad-cli writes to an output directory and names the file <stem>.svg
     let output_dir = output_path
@@ -160,10 +164,13 @@ async fn handle_export_svg(
         .to_path_buf();
     std::fs::create_dir_all(&output_dir)?;
 
-    let svg_path = cli::export_schematic_svg(&ctx.config.kicad_cli, &sch_path, &output_dir).await?;
+    let svg_path =
+        cli::export_schematic_svg(&ctx.config.kicad_cli, &sch_path, &output_dir, &options).await?;
 
     Ok(CallToolResult::json(&json!({
-        "exported": svg_path.display().to_string()
+        "exported": svg_path.display().to_string(),
+        "black_and_white": options.black_and_white,
+        "theme": options.theme
     })))
 }
 
@@ -173,15 +180,21 @@ async fn handle_export_pdf(
 ) -> anyhow::Result<CallToolResult> {
     let sch_path = get_path(args, "schematic")?;
     let output_path = get_path(args, "output")?;
+    let options = cli::SchematicPdfOptions {
+        black_and_white: args["black_and_white"].as_bool().unwrap_or(false),
+        all_sheets: args["all_sheets"].as_bool().unwrap_or(true),
+    };
 
     if let Some(parent) = output_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
 
-    cli::export_schematic_pdf(&ctx.config.kicad_cli, &sch_path, &output_path).await?;
+    cli::export_schematic_pdf(&ctx.config.kicad_cli, &sch_path, &output_path, &options).await?;
 
     Ok(CallToolResult::json(&json!({
-        "exported": output_path.display().to_string()
+        "exported": output_path.display().to_string(),
+        "black_and_white": options.black_and_white,
+        "all_sheets": options.all_sheets
     })))
 }
 

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -168,8 +168,8 @@ Six tools, grouped into *discovery/routing* and *observability*.
 
 | Tool | Description |
 |------|-------------|
-| `export_schematic_svg` | Export a schematic sheet to an SVG file using kicad-cli. |
-| `export_schematic_pdf` | Export a schematic sheet to a PDF file using kicad-cli. |
+| `export_schematic_svg` | Export a schematic sheet to SVG using kicad-cli, with optional monochrome rendering and colour theme. |
+| `export_schematic_pdf` | Export a schematic to PDF using kicad-cli, optionally monochrome or limited to the root sheet. |
 | `generate_netlist` | Generate a KiCAD netlist file from the schematic using kicad-cli. |
 | `export_netlist_summary` | Return a human-readable JSON netlist summary (components, nets, pin counts). Does not require kicad-cli. |
 | `run_erc` | Run the Electrical Rules Check via kicad-cli and return violations filtered by severity. |
@@ -266,10 +266,10 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | Tool | Description |
 |------|-------------|
 | `export_gerber` | Export Gerber production files for all copper/mask layers using kicad-cli. |
-| `export_pdf` | Export the PCB layout to a PDF file using kicad-cli. |
-| `export_svg` | Export the PCB layout to an SVG file using kicad-cli. |
-| `export_3d` | Export the PCB as a 3D model (STEP or VRML) using kicad-cli. |
-| `export_bom` | Generate a Bill of Materials (BOM) CSV from the schematic's component data. |
+| `export_pdf` | Export selected PCB layers to one PDF file using kicad-cli, optionally in black and white. |
+| `export_svg` | Export selected PCB layers to one SVG file using kicad-cli, optionally in black and white. |
+| `export_3d` | Export the PCB as a 3D model using kicad-cli, with explicit control over unspecified footprint models. |
+| `export_bom` | Generate KiCad 10's CSV Bill of Materials from schematic fields. |
 | `export_netlist` | Export the PCB netlist in KiCAD or IPC-D-356 format. |
 | `export_position_file` | Generate a component placement (pick-and-place) position file for SMT assembly. |
 | `export_dxf` | Export the PCB to DXF, one file per requested layer, using kicad-cli. `layers` is required — there is no all-layers default. For mechanical CAD interchange. |


### PR DESCRIPTION
## User-visible problem and scope

Several export tools advertised output controls but silently used KiCad's defaults: schematic SVG/PDF monochrome settings, SVG themes, root-sheet-only PDF export, PCB PDF/SVG monochrome output, and the 3D unspecified-model policy. The BOM schema also suggested arbitrary formats although KiCad 10 produces CSV here.

This PR makes each advertised value affect the `kicad-cli` invocation and narrows BOM format validation to the supported result.

Refs #251

Depends on #266, which supplies the corrected single-file PCB PDF/SVG argument builder. Once #266 merges, this PR reduces to one focused follow-up commit.

## Root cause and design

Handlers read or defaulted the schema values, then called CLI wrappers whose signatures had no corresponding options. The responses could therefore echo values that had not affected the artifact.

Typed option structs and pure argument builders now carry the values to KiCad. PCB PDF/SVG add `--black-and-white`; schematic exports add `--black-and-white`, `--theme`, or `--pages 1`; 3D export adds `--no-unspecified` when exclusion is requested. An unsupported BOM format returns a structured `invalid_argument` instead of producing a differently formatted file.

## Compatibility and migration

Existing field names and defaults remain unchanged, but they now do what the public schema says. `export_bom.format` is explicitly limited to `csv`; callers requesting another value now get a typed error rather than a misleading success.

No source schematic or board is modified.

## Validation

- `cargo test -p konnect-core schematic_export_option_tests --locked`
- `cargo test -p konnect-core pcb_plot_export_tests --locked`
- `cargo test -p konnect-core three_d_export_option_tests --locked`
- `cargo test -p konnect-core new_export_format_tests --locked`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Combined-series CI commands: docs, Clippy, and format pass; 585/588 `konnect-core` tests pass, with only the same three installed-`Device:R` fixture-shadowing failures reproduced on unmodified `main`.

Live GUI export was not required; the changed behavior is covered at the exact CLI argument boundary.

## Risk and rollback

Risk is limited to export flags and response metadata. Older KiCad versions lacking these KiCad 10 flags will return their normal CLI error rather than silently ignoring the request. Rollback is a single commit revert after #266.
