### PR TITLE
fix(api): remove ignored tool parameters

### DIFF
--- a/crates/konnect-core/src/tools/design_review.rs
+++ b/crates/konnect-core/src/tools/design_review.rs
@@ -28,18 +28,13 @@ pub fn tools() -> Vec<ToolDef> {
     vec![
         tool!(
             "audit_decoupling",
-            "Check that all ICs have appropriate decoupling capacitors. Finds power pins \
-             without nearby capacitors and flags wrong values. The #1 most common PCB design mistake.",
+            "Audit schematic connectivity between IC power nets and decoupling capacitors. \
+             This does not inspect PCB placement distance; use PCB clearance/placement tools \
+             for a physical review.",
             json!({
                 "type": "object",
                 "properties": {
-                    "schematic": { "type": "string", "description": "Path to .kicad_sch file" },
-                    "board": { "type": "string", "description": "Path to .kicad_pcb file (optional, for distance check)" },
-                    "max_distance_mm": {
-                        "type": "number",
-                        "description": "Max allowed distance from power pin to decoupling cap on PCB (mm)",
-                        "default": 5.0
-                    }
+                    "schematic": { "type": "string", "description": "Path to .kicad_sch file" }
                 },
                 "required": ["schematic"]
             }),
@@ -232,6 +227,8 @@ async fn handle_audit_decoupling(
     Ok(CallToolResult::text(
         serde_json::to_string(&json!({
             "audit": "decoupling",
+            "scope": "schematic_connectivity",
+            "pcb_distance_checked": false,
             "findings": findings,
             "pass_count": pass_count,
             "total_power_pins": total_power_pins,

--- a/crates/konnect-core/src/tools/manufacturing.rs
+++ b/crates/konnect-core/src/tools/manufacturing.rs
@@ -37,11 +37,6 @@ pub fn tools() -> Vec<ToolDef> {
                         "description": "Include BOM + pick-and-place files for SMT assembly",
                         "default": true
                     },
-                    "quantity": {
-                        "type": "integer",
-                        "description": "Production quantity (for BOM pricing context)",
-                        "default": 5
-                    },
                     "bom_fields": {
                         "type": "string",
                         "description": "Ordered, comma-separated BOM columns, e.g. 'Reference,Value,Footprint,MPN,${QUANTITY}'. Any schematic field name works — this is how MPN/LCSC columns reach the fab. Omit for KiCAD's default Reference,Value,Footprint,QUANTITY,DNP."
@@ -62,15 +57,14 @@ pub fn tools() -> Vec<ToolDef> {
         tool!(
             "validate_for_manufacturing",
             "Pre-flight check before ordering: verifies the design is ready for the target \
-             fab house. Runs KiCAD's DRC and checks board outline, design rules, BOM \
-             completeness, and assembly constraints. Returns NOT READY — never READY — if \
+             fab house. Runs KiCad's DRC and checks board outline, design rules, footprints, \
+             and routing evidence. Returns NOT READY — never READY — if \
              DRC reports errors or could not be run, so a READY verdict always rests on \
              evidence rather than on an absence of findings.",
             json!({
                 "type": "object",
                 "properties": {
                     "board": { "type": "string", "description": "Path to .kicad_pcb file" },
-                    "schematic": { "type": "string", "description": "Path to .kicad_sch file (optional, for BOM checks)" },
                     "fab_house": {
                         "type": "string",
                         "description": "Target manufacturer: 'jlcpcb', 'pcbway', 'oshpark'",
@@ -84,12 +78,12 @@ pub fn tools() -> Vec<ToolDef> {
         tool!(
             "estimate_cost",
             "Estimate the total manufacturing cost for PCB fabrication and assembly at a given fab house. \
-             Returns itemized breakdown: PCB, components, assembly, and total.",
+             Counts components from board footprints and returns an itemized rough estimate: \
+             PCB, components, assembly, and total.",
             json!({
                 "type": "object",
                 "properties": {
                     "board": { "type": "string", "description": "Path to .kicad_pcb file" },
-                    "schematic": { "type": "string", "description": "Path to .kicad_sch file (for component count)" },
                     "fab_house": {
                         "type": "string",
                         "description": "'jlcpcb' (default), 'pcbway'",

--- a/crates/konnect-core/src/tools/pcb_export.rs
+++ b/crates/konnect-core/src/tools/pcb_export.rs
@@ -272,16 +272,11 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "refill_zones",
-            "Refill all copper pour zones on the board. Requires a running KiCAD instance with IPC enabled; returns an error with instructions if KiCAD is not open.",
+            "Refill all copper pour zones on the board. KiCad IPC refills the complete board; per-zone selection is not available. Requires a running KiCad instance with IPC enabled.",
             json!({
                 "type": "object",
                 "properties": {
-                    "board": { "type": "string", "description": "Path to .kicad_pcb file" },
-                    "zones": {
-                        "type": "array",
-                        "description": "Net names of specific zones to refill (empty = all zones, currently not filtered)",
-                        "items": { "type": "string" }
-                    }
+                    "board": { "type": "string", "description": "Path to .kicad_pcb file" }
                 },
                 "required": ["board"]
             }),

--- a/crates/konnect-core/src/tools/sch_hierarchy.rs
+++ b/crates/konnect-core/src/tools/sch_hierarchy.rs
@@ -162,8 +162,7 @@ pub fn tools() -> Vec<ToolDef> {
                 "properties": {
                     "schematic": { "type": "string", "description": "Path to the parent .kicad_sch file" },
                     "sheet_name": { "type": "string" },
-                    "side": { "type": "string", "enum": ["right", "left"], "description": "Which edge to place new pins on. Default: 'right'" },
-                    "project_name": { "type": "string", "description": PROJECT_NAME_DESC }
+                    "side": { "type": "string", "enum": ["right", "left"], "description": "Which edge to place new pins on. Default: 'right'" }
                 },
                 "required": ["schematic", "sheet_name"]
             }),

--- a/crates/konnect-core/src/tools/verification.rs
+++ b/crates/konnect-core/src/tools/verification.rs
@@ -23,7 +23,8 @@ pub fn tools() -> Vec<ToolDef> {
             "Run the Design Rule Check on the PCB and return structured violation results, \
              with separate error and warning counts in the summary. Prefer this over \
              `get_drc_violations` (pcb_export toolset) — they run the same underlying \
-             kicad-cli check, but `run_drc` returns a cleaner breakdown.",
+             kicad-cli check, but `run_drc` returns a cleaner breakdown. KiCad runs the \
+             complete configured DRC ruleset; kicad-cli has no per-test selector.",
             json!({
                 "type": "object",
                 "properties": {
@@ -33,11 +34,6 @@ pub fn tools() -> Vec<ToolDef> {
                         "type": "string",
                         "description": "Minimum violation severity to include: 'error', 'warning' (default), 'info'",
                         "default": "warning"
-                    },
-                    "tests": {
-                        "type": "array",
-                        "description": "Specific DRC test IDs to run (empty = all tests)",
-                        "items": { "type": "string" }
                     },
                     "limit": {
                         "type": "integer",

--- a/crates/konnect/assets/skills/kicad-manufacture/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-manufacture/SKILL.md
@@ -74,7 +74,7 @@ Every schematic symbol must have a footprint assigned. Check for:
 ### One-Shot Export (Recommended)
 
 ```
-export_manufacturing_package(board, output_dir, fab_house?, schematic?, quantity?)
+export_manufacturing_package(board, output_dir, fab_house?, schematic?)
 ```
 
 `fab_house` selects the house profile (there is no `format` argument). Pass
@@ -177,7 +177,7 @@ Use `add_design_rule` or `list_design_rules` to configure project rules to match
 ## Cost Estimation
 
 ```
-estimate_cost(board, quantity?, layers?, fab_house?, schematic?)
+estimate_cost(board, quantity?, layers?, fab_house?)
 ```
 
 Factors that increase cost:

--- a/crates/konnect/tests/schema_migrations.rs
+++ b/crates/konnect/tests/schema_migrations.rs
@@ -1,0 +1,54 @@
+//! Regression coverage for public inputs removed because they never affected
+//! the operation. Every removal has a user-facing migration entry.
+
+use konnect_core::router::registry;
+
+const REMOVED: &[(&str, &str)] = &[
+    ("import_sheet_pins", "project_name"),
+    ("refill_zones", "zones"),
+    ("run_drc", "tests"),
+    ("audit_decoupling", "board"),
+    ("audit_decoupling", "max_distance_mm"),
+    ("export_manufacturing_package", "quantity"),
+    ("validate_for_manufacturing", "schematic"),
+    ("estimate_cost", "schematic"),
+];
+
+fn tool(name: &str) -> konnect_core::tools::ToolDef {
+    registry::ALL_TOOLSETS
+        .iter()
+        .flat_map(|toolset| registry::tools_for(toolset.name).unwrap_or_default())
+        .find(|tool| tool.name == name)
+        .unwrap_or_else(|| panic!("registered tool {name}"))
+}
+
+#[test]
+fn ignored_inputs_are_no_longer_advertised() {
+    for &(tool_name, field) in REMOVED {
+        let definition = tool(tool_name);
+        assert!(
+            definition.input_schema["properties"].get(field).is_none(),
+            "{tool_name}.{field} never affected its operation and must not return"
+        );
+    }
+}
+
+#[test]
+fn every_removed_input_has_a_migration_note() {
+    let migrations = include_str!("../../../docs/API_MIGRATIONS.md");
+    for &(tool_name, field) in REMOVED {
+        assert!(
+            migrations.contains(&format!("`{tool_name}.{field}`")),
+            "missing migration for {tool_name}.{field}"
+        );
+    }
+}
+
+#[test]
+fn narrowed_tools_describe_their_real_scope() {
+    assert!(tool("audit_decoupling")
+        .description
+        .contains("does not inspect PCB placement distance"));
+    assert!(tool("run_drc").description.contains("no per-test selector"));
+    assert!(tool("refill_zones").description.contains("complete board"));
+}

--- a/docs/API_MIGRATIONS.md
+++ b/docs/API_MIGRATIONS.md
@@ -1,0 +1,23 @@
+# Konnect MCP API migrations
+
+Konnect's tool schemas are public API. This file records intentional argument
+removals and the supported replacement workflow.
+
+## Unreleased: remove inputs that never affected an operation
+
+The following optional inputs were advertised but never read by their handlers.
+Keeping them would let a client believe a request was honoured when the result was
+identical without it.
+
+| Removed input | Migration |
+|---|---|
+| `import_sheet_pins.project_name` | Omit it. Importing hierarchical labels as sheet pins does not modify project-instance paths. |
+| `refill_zones.zones` | Omit it. KiCad IPC refills every zone on the active board and exposes no per-net selector. |
+| `run_drc.tests` | Omit it. `kicad-cli pcb drc` runs the complete configured ruleset. Configure rules/waivers in KiCad; `severity` and `limit` only filter Konnect's returned report. |
+| `audit_decoupling.board` and `audit_decoupling.max_distance_mm` | Run `audit_decoupling(schematic)` for net-connectivity coverage, then use PCB placement/clearance inspection for physical capacitor distance. The audit never measured PCB distance. |
+| `export_manufacturing_package.quantity` | Omit it from export. Manufacturing files are quantity-independent; pass `quantity` to `estimate_cost` for pricing context. |
+| `validate_for_manufacturing.schematic` | Run the board validator without it. Use `check_bom_health(schematic)` for the separate schematic/BOM review. |
+| `estimate_cost.schematic` | Omit it. The estimator counts placed board footprints, which are the components relevant to assembly pricing. |
+
+These removals narrow the schema to behavior Konnect can verify. They do not change
+the generated files or analysis because the removed values had no implementation.

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -7,6 +7,9 @@ Canonical reference for every MCP tool exposed by Konnect. Generated from the Ru
 - Meta-tool definitions: `crates/konnect-core/src/router/meta_tools.rs` (`meta_tool_descriptions()`)
 - Per-tool names + descriptions: `crates/konnect-core/src/tools/<toolset>.rs` (each `tool!(…)` in the `tools()` vec)
 
+Compatibility notes for removed or narrowed arguments are recorded in
+[`docs/API_MIGRATIONS.md`](docs/API_MIGRATIONS.md).
+
 ## Overview
 
 - **19 toolsets** organized into 10 categories
@@ -276,7 +279,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `export_gencad` | Export the PCB in GenCAD format using kicad-cli. |
 | `export_ipc2581` | Export the PCB in IPC-2581 format using kicad-cli — a unified fab/assembly/test data format. |
 | `export_odb` | Export the PCB in ODB++ format using kicad-cli — a unified fabrication data format. |
-| `refill_zones` | Refill all copper pour zones over KiCAD IPC. Requires a running KiCAD with the board open — there is no kicad-cli fallback. |
+| `refill_zones` | Refill every copper pour zone over KiCad IPC. Per-zone selection is not available; requires a running KiCad with the board open. |
 | `get_drc_violations` | Run the Design Rule Check and return a list of violations. |
 
 ---
@@ -337,7 +340,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 
 | Tool | Description |
 |------|-------------|
-| `run_drc` | Run the Design Rule Check on the PCB and return structured violation results. |
+| `run_drc` | Run KiCad's complete configured DRC ruleset and return structured violation results. |
 | `set_design_rules` | Set board-level design rules (clearance, trace width, via size) in the sibling `.kicad_pro` project file. The board file is not modified. |
 | `get_design_rules` | Return the current design rule constraints from the sibling `.kicad_pro` project file. |
 | `check_kicad_ui` | Check whether the KiCAD GUI application is running and responsive. |
@@ -374,7 +377,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 
 | Tool | Description |
 |------|-------------|
-| `audit_decoupling` | Check that all ICs have appropriate decoupling caps. Finds power pins without nearby caps and flags wrong values. |
+| `audit_decoupling` | Audit schematic connectivity between IC power nets and decoupling capacitors; does not measure PCB placement distance. |
 | `audit_connections` | Check for common connection mistakes: missing pull-ups on I2C/reset, missing series resistors on LEDs, floating inputs, shorted outputs. |
 | `audit_power_rails` | Check power rail integrity: missing bulk capacitance, no test points, missing regulator output caps. |
 | `audit_manufacturing` | DFM checks for the configured fab house: component spacing, silkscreen overlap, via-in-pad, acid traps, board-outline issues. |
@@ -410,8 +413,8 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | Tool | Description |
 |------|-------------|
 | `export_manufacturing_package` | Generate ALL files needed for PCB fab + assembly in one call: Gerbers, drill, fab-house BOM, pick-and-place. Targets JLCPCB, PCBWay, etc. |
-| `validate_for_manufacturing` | Pre-flight check before ordering: verifies the design is ready for the target fab house (board outline, design rules, BOM completeness, assembly constraints). |
-| `estimate_cost` | Estimate total manufacturing cost (PCB + components + assembly) with itemized breakdown. |
+| `validate_for_manufacturing` | Board pre-flight before ordering: checks outline, design rules, footprints, routing evidence, and complete DRC results. |
+| `estimate_cost` | Estimate total manufacturing cost from board dimensions, layers, and footprint count, with an itemized breakdown. |
 
 ---
 


### PR DESCRIPTION
## User-visible problem and scope

Eight optional MCP inputs were advertised even though their handlers never read them. A caller could reasonably believe those values changed validation, costing, review, hierarchy, zone refill, or manufacturing output when they did nothing.

This PR removes only those dead inputs, corrects overstated descriptions, and records a supported replacement workflow for every removal.

Refs #251

## Root cause and design

Schemas and handlers evolved independently. The unused fields survived because existing tests checked registration and required arguments, but not whether every advertised property reached implementation behavior.

The schemas now match the operations Konnect can verify. `docs/API_MIGRATIONS.md` is the explicit compatibility record, and `schema_migrations.rs` prevents a removed field from returning without a migration note.

## Compatibility and migration

Removed fields:

- `import_sheet_pins.project_name`
- `refill_zones.zones`
- `run_drc.tests`
- `audit_decoupling.board`
- `audit_decoupling.max_distance_mm`
- `export_manufacturing_package.quantity`
- `validate_for_manufacturing.schematic`
- `estimate_cost.schematic`

All were optional and behaviorally inert, so generated files and analysis results are unchanged. The migration document points callers to project-instance workflows, complete-board zone refill, KiCad DRC configuration, PCB placement inspection, `estimate_cost.quantity`, `check_bom_health`, and board-footprint counting as appropriate.

## Validation

- `cargo test -p konnect --test schema_migrations --locked`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Combined-series CI commands: docs, Clippy, and format pass; 585/588 `konnect-core` tests pass, with only the same three installed-`Device:R` fixture-shadowing failures reproduced on unmodified `main`.

## Risk and rollback

The intentional API narrowing may expose clients that were sending inert fields. Migration is omission or the documented companion tool; no data format or file write changes. Rollback is one commit, including the migration and regression test.
