### PR TITLE
fix(schematic): honor ignored power pins

### DIFF
--- a/crates/konnect-core/src/tools/design_review.rs
+++ b/crates/konnect-core/src/tools/design_review.rs
@@ -171,7 +171,7 @@ async fn handle_audit_decoupling(
             None => continue,
         };
 
-        let pins = extract_lib_pins(lib_sym);
+        let pins = extract_lib_pins_for_unit(lib_sym, inst.unit);
         let is_passive = inst.lib_id.contains("R_")
             || inst.lib_id.contains("C_")
             || inst.lib_id.contains("L_")
@@ -268,7 +268,7 @@ async fn handle_audit_connections(
             None => continue,
         };
 
-        let pins = extract_lib_pins(lib_sym);
+        let pins = extract_lib_pins_for_unit(lib_sym, inst.unit);
 
         // Check for I2C pull-ups
         if has_i2c_pins(&pins) {
@@ -714,20 +714,14 @@ fn inspect_schematic_coverage(
         };
         coverage.resolved_symbols += 1;
 
-        // The design-review call sites tracked by #182 still use the
-        // unit-agnostic extractor. Until that issue lands, surface every such
-        // component as partial coverage rather than pretending it was audited.
+        // Deliberately compare the complete definition with the selected unit
+        // here: this is classification, not pin placement. Every audit below
+        // resolves the selected unit before transforming its pins (#182).
         if extract_lib_pins(lib_symbol).len()
             > extract_lib_pins_for_unit(lib_symbol, instance.unit).len()
             && multi_unit_references.insert(instance.reference.clone())
         {
             coverage.multi_unit_symbols += 1;
-            diagnostics.push(json!({
-                "code": "multi_unit_review_incomplete",
-                "source": path.display().to_string(),
-                "reference": instance.reference,
-                "message": "design-review pin analysis is not unit-aware yet; tracked by issue #182"
-            }));
         }
     }
 }
@@ -1146,7 +1140,7 @@ fn collect_capacitor_nets(
         }
         let lib_sym = find_lib_symbol(lib_syms, inst);
         if let Some(sym) = lib_sym {
-            let pins = extract_lib_pins(sym);
+            let pins = extract_lib_pins_for_unit(sym, inst.unit);
             for pin in &pins {
                 let (px, py) = pin_endpoint(pin, inst.pin_transform());
                 if let Some(net) = find_net_at_point(content, px, py) {
@@ -1188,7 +1182,7 @@ fn collect_bulk_cap_nets(
 
         let lib_sym = find_lib_symbol(lib_syms, inst);
         if let Some(sym) = lib_sym {
-            let pins = extract_lib_pins(sym);
+            let pins = extract_lib_pins_for_unit(sym, inst.unit);
             for pin in &pins {
                 let (px, py) = pin_endpoint(pin, inst.pin_transform());
                 if let Some(net) = find_net_at_point(content, px, py) {
@@ -1302,7 +1296,7 @@ fn has_pull_up_on_net(
         }
         let lib_sym = find_lib_symbol(lib_syms, inst);
         if let Some(sym) = lib_sym {
-            let pins = extract_lib_pins(sym);
+            let pins = extract_lib_pins_for_unit(sym, inst.unit);
             let pin_nets: Vec<Option<String>> = pins
                 .iter()
                 .map(|p| {
@@ -1536,7 +1530,7 @@ mod review_completion_tests {
         (pin input line (at 0 0 0) (length 2.54) (name "A") (number "1"))
       )
       (symbol "DUAL_2_1"
-        (pin output line (at 0 0 0) (length 2.54) (name "Y") (number "2"))
+        (pin power_in line (at 0 0 0) (length 2.54) (name "VCC") (number "2"))
       )
     )
   )
@@ -1702,20 +1696,28 @@ mod review_completion_tests {
     }
 
     #[tokio::test]
-    async fn multi_unit_symbol_is_partial_until_issue_182_lands() {
+    async fn multi_unit_symbol_is_fully_reviewed() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path().join("multi.kicad_sch");
         std::fs::write(&root, multi_unit_schematic()).unwrap();
 
         let result = review(&root, None).await;
         let report = &result["design_review"];
-        assert_eq!(report["status"], "partial");
+        assert_eq!(report["status"], "complete");
         assert_eq!(report["coverage"]["schematic"]["multi_unit_symbols"], 1);
-        assert!(report["diagnostics"]
+        assert!(!report["diagnostics"]
             .as_array()
             .unwrap()
             .iter()
             .any(|item| item["code"] == "multi_unit_review_incomplete"));
+        assert!(
+            !report["findings"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|finding| finding.to_string().contains("'VCC'")),
+            "the unplaced unit-2 pin must not be audited at unit 1's position: {report}"
+        );
     }
 
     #[tokio::test]

--- a/crates/konnect-core/src/tools/sch_analysis.rs
+++ b/crates/konnect-core/src/tools/sch_analysis.rs
@@ -10,8 +10,8 @@ use konnect_schematic_editor as cse;
 use konnect_sexp::{
     geometry::{point_on_segment, points_coincident},
     schematic::{
-        extract_junctions, extract_labels, extract_symbol_instances, extract_wires,
-        find_lib_symbol, read_schematic, Wire,
+        extract_junctions, extract_labels, extract_lib_pins_for_unit, extract_symbol_instances,
+        extract_wires, find_lib_symbol, pin_endpoint, read_schematic, Wire,
     },
 };
 use serde_json::json;
@@ -429,30 +429,17 @@ async fn handle_get_pin_connections(
     let instances = extract_symbol_instances(&tree);
     let wires = extract_wires(&tree);
     let labels = extract_labels(&tree);
-    let inst = instances
-        .iter()
-        .find(|i| i.reference == reference)
-        .ok_or_else(|| anyhow::anyhow!("Component '{}' not found", reference))?;
     let lib_syms = tree
         .find("lib_symbols")
         .map(|n| n.find_all("symbol"))
         .unwrap_or_default();
-    let lib_sym = find_lib_symbol(&lib_syms, inst);
-    let pin_ep = lib_sym.and_then(|sym| {
-        konnect_sexp::schematic::extract_lib_pins(sym)
-            .iter()
-            .find(|p| p.number == pin_number)
-            .map(|p| konnect_sexp::schematic::pin_endpoint(p, inst.pin_transform()))
-    });
-    let (px, py) = match pin_ep {
-        Some(ep) => ep,
-        None => {
-            return Ok(CallToolResult::error(format!(
-                "Pin '{}' not found on '{}'",
-                pin_number, reference
-            )))
-        }
-    };
+    let (pin, transform) =
+        match super::sch_wiring::resolve_placed_pin(&instances, &lib_syms, &reference, &pin_number)
+        {
+            Ok(placed) => placed,
+            Err(error) => return Ok(CallToolResult::error(format!("{error:#}"))),
+        };
+    let (px, py) = pin_endpoint(&pin, transform);
     let mut g = build_net_graph(&wires, &labels, &extract_junctions(&tree));
     Ok(CallToolResult::json(
         &json!({ "reference": reference, "pin": pin_number, "pin_x": px, "pin_y": py, "net": g.net_at(px, py) }),
@@ -472,25 +459,39 @@ async fn handle_get_component_nets(
     let instances = extract_symbol_instances(&tree);
     let wires = extract_wires(&tree);
     let labels = extract_labels(&tree);
-    let inst = instances
+    let placed: Vec<_> = instances
         .iter()
-        .find(|i| i.reference == reference)
-        .ok_or_else(|| anyhow::anyhow!("Component '{}' not found", reference))?;
+        .filter(|instance| instance.reference == reference)
+        .collect();
+    if placed.is_empty() {
+        return Ok(CallToolResult::error(format!(
+            "Component '{}' not found",
+            reference
+        )));
+    }
     let lib_syms = tree
         .find("lib_symbols")
         .map(|n| n.find_all("symbol"))
         .unwrap_or_default();
-    let lib_sym = find_lib_symbol(&lib_syms, inst);
     let mut g = build_net_graph(&wires, &labels, &extract_junctions(&tree));
-    let pins: Vec<serde_json::Value> = if let Some(sym) = lib_sym {
-        let t = inst.pin_transform();
-        konnect_sexp::schematic::extract_lib_pins(sym).iter().map(|p| {
-            let (px, py) = konnect_sexp::schematic::pin_endpoint(p, t);
-            json!({ "pin": p.number, "name": p.name, "x": px, "y": py, "net": g.net_at(px, py) })
-        }).collect()
-    } else {
-        Vec::new()
-    };
+    let mut pins: Vec<serde_json::Value> = Vec::new();
+    for instance in placed {
+        let Some(symbol) = find_lib_symbol(&lib_syms, instance) else {
+            continue;
+        };
+        let transform = instance.pin_transform();
+        for pin in extract_lib_pins_for_unit(symbol, instance.unit) {
+            let (px, py) = pin_endpoint(&pin, transform);
+            pins.push(json!({
+                "pin": pin.number,
+                "name": pin.name,
+                "unit": instance.unit,
+                "x": px,
+                "y": py,
+                "net": g.net_at(px, py)
+            }));
+        }
+    }
     Ok(CallToolResult::json(
         &json!({ "reference": reference, "pins": pins }),
     ))
@@ -520,12 +521,12 @@ async fn handle_get_net_components(
         .filter_map(|inst| {
             let ls = find_lib_symbol(&lib_syms, inst)?;
             let t = inst.pin_transform();
-            let connected: Vec<_> = konnect_sexp::schematic::extract_lib_pins(ls)
+            let connected: Vec<_> = extract_lib_pins_for_unit(ls, inst.unit)
                 .iter()
                 .filter_map(|p| {
                     let (px, py) = konnect_sexp::schematic::pin_endpoint(p, t);
                     if net_pts.contains(&pt_key(px, py)) {
-                        Some(json!({ "pin": p.number, "name": p.name }))
+                        Some(json!({ "pin": p.number, "name": p.name, "unit": inst.unit }))
                     } else {
                         None
                     }
@@ -534,7 +535,12 @@ async fn handle_get_net_components(
             if connected.is_empty() {
                 None
             } else {
-                Some(json!({ "reference": inst.reference, "value": inst.value, "pins": connected }))
+                Some(json!({
+                    "reference": inst.reference,
+                    "value": inst.value,
+                    "unit": inst.unit,
+                    "pins": connected
+                }))
             }
         })
         .collect();
@@ -684,25 +690,27 @@ async fn handle_get_connected_items(
         .map(|n| n.find_all("symbol"))
         .unwrap_or_default();
 
-    let inst = match instances.iter().find(|i| i.reference == reference) {
-        Some(i) => i,
-        None => {
-            return Ok(CallToolResult::error(format!(
-                "Component '{}' not found",
-                reference
-            )))
-        }
-    };
-
-    let lib_sym = find_lib_symbol(&lib_syms, inst);
+    let placed: Vec<_> = instances
+        .iter()
+        .filter(|instance| instance.reference == reference)
+        .collect();
+    if placed.is_empty() {
+        return Ok(CallToolResult::error(format!(
+            "Component '{}' not found",
+            reference
+        )));
+    }
     let mut g = build_net_graph(&wires, &labels, &extract_junctions(&tree));
 
-    // Get nets for each pin
+    // Get nets for every actually placed unit of the component.
     let mut connected_nets: HashSet<String> = HashSet::new();
-    if let Some(sym) = lib_sym {
-        let t = inst.pin_transform();
-        for p in konnect_sexp::schematic::extract_lib_pins(sym) {
-            let (px, py) = konnect_sexp::schematic::pin_endpoint(&p, t);
+    for instance in placed {
+        let Some(symbol) = find_lib_symbol(&lib_syms, instance) else {
+            continue;
+        };
+        let transform = instance.pin_transform();
+        for pin in extract_lib_pins_for_unit(symbol, instance.unit) {
+            let (px, py) = pin_endpoint(&pin, transform);
             if let Some(net) = g.net_at(px, py) {
                 connected_nets.insert(net);
             }
@@ -732,20 +740,33 @@ async fn handle_get_connected_items(
         .collect();
 
     // Find other components on the same nets (excluding the queried one)
-    let connected_components: Vec<serde_json::Value> = instances.iter()
+    let connected_components: Vec<serde_json::Value> = instances
+        .iter()
         .filter(|i| i.reference != reference)
         .filter_map(|i| {
             let ls = find_lib_symbol(&lib_syms, i)?;
             let t = i.pin_transform();
-            let matching_pins: Vec<_> = konnect_sexp::schematic::extract_lib_pins(ls).iter()
+            let matching_pins: Vec<_> = extract_lib_pins_for_unit(ls, i.unit)
+                .iter()
                 .filter_map(|p| {
-                    let (px, py) = konnect_sexp::schematic::pin_endpoint(p, t);
+                    let (px, py) = pin_endpoint(p, t);
                     if all_net_pts.contains(&pt_key(px, py)) {
-                        Some(json!({ "pin": p.number, "name": p.name }))
-                    } else { None }
-                }).collect();
-            if matching_pins.is_empty() { None }
-            else { Some(json!({ "reference": i.reference, "value": i.value, "connected_pins": matching_pins })) }
+                        Some(json!({ "pin": p.number, "name": p.name, "unit": i.unit }))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            if matching_pins.is_empty() {
+                None
+            } else {
+                Some(json!({
+                    "reference": i.reference,
+                    "value": i.value,
+                    "unit": i.unit,
+                    "connected_pins": matching_pins
+                }))
+            }
         })
         .collect();
 
@@ -827,4 +848,160 @@ async fn handle_check_overlaps(
     Ok(CallToolResult::json(
         &json!({ "overlap_count": all.len(), "overlaps": all }),
     ))
+}
+
+#[cfg(test)]
+mod multi_unit_analysis_tests {
+    use super::*;
+    use crate::tools::ServerConfig;
+    use std::sync::Arc;
+
+    /// Both units own a pin at the same local coordinate. They share a
+    /// reference but are placed on different labelled points, which exposes
+    /// any code that transforms unit 2 through unit 1's placement (#182).
+    const SCHEMATIC: &str = r#"(kicad_sch
+  (version 20260306)
+  (uuid "root")
+  (lib_symbols
+    (symbol "Test:DUAL"
+      (symbol "DUAL_1_1"
+        (pin input line (at 0 0 0) (length 0) (name "A") (number "1"))
+      )
+      (symbol "DUAL_2_1"
+        (pin output line (at 0 0 0) (length 0) (name "Y") (number "2"))
+      )
+    )
+  )
+  (label "UNIT1" (at 100 100 0))
+  (label "UNIT2" (at 100 120 0))
+  (symbol (lib_id "Test:DUAL") (at 100 100 0) (unit 1) (uuid "u1a")
+    (property "Reference" "U1" (at 100 100 0))
+    (property "Value" "DUAL" (at 100 100 0))
+  )
+  (symbol (lib_id "Test:DUAL") (at 100 120 0) (unit 2) (uuid "u1b")
+    (property "Reference" "U1" (at 100 120 0))
+    (property "Value" "DUAL" (at 100 120 0))
+  )
+  (symbol (lib_id "Test:DUAL") (at 200 100 0) (unit 1) (uuid "u2a")
+    (property "Reference" "U2" (at 200 100 0))
+    (property "Value" "DUAL" (at 200 100 0))
+  )
+  (symbol (lib_id "Test:DUAL") (at 100 120 0) (unit 2) (uuid "u2b")
+    (property "Reference" "U2" (at 100 120 0))
+    (property "Value" "DUAL" (at 100 120 0))
+  )
+)
+"#;
+
+    fn context() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+                eager_toolsets: false,
+            },
+            Arc::new(crate::router::ToolRouter::new()),
+        )
+    }
+
+    fn fixture() -> (tempfile::TempDir, std::path::PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("multi.kicad_sch");
+        std::fs::write(&path, SCHEMATIC).unwrap();
+        (directory, path)
+    }
+
+    fn body(result: CallToolResult) -> serde_json::Value {
+        assert!(!result.is_error, "analysis unexpectedly failed");
+        let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text result");
+        };
+        serde_json::from_str(text).unwrap()
+    }
+
+    #[tokio::test]
+    async fn pin_query_finds_the_unit_that_owns_the_pin() {
+        let (_directory, path) = fixture();
+        let result = body(
+            handle_get_pin_connections(
+                &json!({
+                    "schematic": path,
+                    "reference": "U1",
+                    "pin_number": "2"
+                }),
+                &context(),
+            )
+            .await
+            .unwrap(),
+        );
+        assert_eq!(result["pin_y"], 120.0);
+        assert_eq!(result["net"], "UNIT2");
+    }
+
+    #[tokio::test]
+    async fn component_query_reports_each_units_real_pin_and_net() {
+        let (_directory, path) = fixture();
+        let result = body(
+            handle_get_component_nets(&json!({ "schematic": path, "reference": "U1" }), &context())
+                .await
+                .unwrap(),
+        );
+        let pins = result["pins"].as_array().unwrap();
+        assert_eq!(pins.len(), 2, "one pin per placed unit: {result}");
+        assert!(pins
+            .iter()
+            .any(|pin| pin["pin"] == "1" && pin["unit"] == 1 && pin["net"] == "UNIT1"));
+        assert!(pins
+            .iter()
+            .any(|pin| pin["pin"] == "2" && pin["unit"] == 2 && pin["net"] == "UNIT2"));
+    }
+
+    #[tokio::test]
+    async fn net_query_never_reports_another_units_phantom_pin() {
+        let (_directory, path) = fixture();
+        let result = body(
+            handle_get_net_components(&json!({ "schematic": path, "net": "UNIT2" }), &context())
+                .await
+                .unwrap(),
+        );
+        let u1 = result["components"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|component| component["reference"] == "U1")
+            .unwrap();
+        assert_eq!(u1["unit"], 2);
+        assert_eq!(u1["pins"].as_array().unwrap().len(), 1);
+        assert_eq!(u1["pins"][0]["pin"], "2");
+    }
+
+    #[tokio::test]
+    async fn connected_items_traces_every_unit_and_classifies_peers_by_unit() {
+        let (_directory, path) = fixture();
+        let result = body(
+            handle_get_connected_items(
+                &json!({ "schematic": path, "reference": "U1" }),
+                &context(),
+            )
+            .await
+            .unwrap(),
+        );
+        let nets = result["nets"].as_array().unwrap();
+        assert!(nets.contains(&json!("UNIT1")), "{result}");
+        assert!(nets.contains(&json!("UNIT2")), "{result}");
+
+        let peer = result["connected_components"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|component| component["reference"] == "U2")
+            .unwrap();
+        assert_eq!(peer["unit"], 2);
+        assert_eq!(peer["connected_pins"].as_array().unwrap().len(), 1);
+        assert_eq!(peer["connected_pins"][0]["pin"], "2");
+    }
 }

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -278,9 +278,9 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "validate_component_connections",
-            "Check that every non-passive pin on every component has at least one wire \
-             or label connected. Reports unconnected pins with reference, pin number, \
-             and schematic position.",
+            "Check that every selected component pin has at least one wire or label \
+             connected. Can exclude pins whose KiCad electrical type is power_in or \
+             power_out. Reports unconnected pins with type and position.",
             json!({
                 "type": "object",
                 "properties": {
@@ -1252,6 +1252,7 @@ async fn handle_validate_component_connections(
                 .collect()
         })
         .unwrap_or_default();
+    let ignore_power_pins = args["ignore_power_pins"].as_bool().unwrap_or(false);
     let tol = 0.01_f64;
 
     let (_, tree) = read_schematic(&sch_path)?;
@@ -1310,6 +1311,7 @@ async fn handle_validate_component_connections(
     };
 
     let mut unconnected: Vec<serde_json::Value> = Vec::new();
+    let mut ignored_power_pin_count = 0usize;
 
     for inst in &instances {
         if !filter_refs.is_empty() && !filter_refs.contains(&inst.reference) {
@@ -1319,6 +1321,12 @@ async fn handle_validate_component_connections(
         if let Some(sym) = lib_sym {
             let t = inst.pin_transform();
             for pin in extract_lib_pins_for_unit(sym, inst.unit) {
+                if ignore_power_pins
+                    && matches!(pin.electrical_type.as_str(), "power_in" | "power_out")
+                {
+                    ignored_power_pin_count += 1;
+                    continue;
+                }
                 let (px, py) = pin_endpoint(&pin, t);
 
                 // Skip intentional no-connects
@@ -1335,6 +1343,7 @@ async fn handle_validate_component_connections(
                         "value": inst.value,
                         "pin": pin.number,
                         "pin_name": pin.name,
+                        "electrical_type": pin.electrical_type,
                         "x": px,
                         "y": py
                     }));
@@ -1346,6 +1355,8 @@ async fn handle_validate_component_connections(
     Ok(CallToolResult::json(&json!({
         "valid": unconnected.is_empty(),
         "unconnected_count": unconnected.len(),
+        "ignore_power_pins": ignore_power_pins,
+        "ignored_power_pin_count": ignored_power_pin_count,
         "unconnected_pins": unconnected
     })))
 }
@@ -1691,6 +1702,100 @@ mod midwire_pin_tests {
                 "with_junction={with_junction}: {body}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod power_pin_validation_tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::{ServerConfig, ToolContext};
+    use std::sync::Arc;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+                eager_toolsets: false,
+            },
+            Arc::new(ToolRouter::new()),
+        )
+    }
+
+    fn power_and_signal_schematic() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("power-pins.kicad_sch");
+        std::fs::write(
+            &path,
+            r#"(kicad_sch
+  (version 20260306)
+  (generator "eeschema")
+  (uuid "root")
+  (lib_symbols
+    (symbol "Test:IC"
+      (symbol "IC_1_1"
+        (pin power_in line (at 0 0 0) (length 2.54)
+          (name "VDD") (number "1"))
+        (pin input line (at 0 5 0) (length 2.54)
+          (name "IN") (number "2"))
+      )
+    )
+  )
+  (symbol
+    (lib_id "Test:IC")
+    (at 100 80 0)
+    (unit 1)
+    (uuid "u1")
+    (property "Reference" "U1" (at 100 75 0))
+    (property "Value" "IC" (at 100 85 0))
+  )
+  (sheet_instances (path "/" (page "1")))
+)
+"#,
+        )
+        .unwrap();
+        (dir, path)
+    }
+
+    fn result_json(result: &CallToolResult) -> serde_json::Value {
+        let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text content");
+        };
+        serde_json::from_str(text).unwrap()
+    }
+
+    #[tokio::test]
+    async fn ignore_power_pins_uses_the_library_electrical_type() {
+        let (_dir, path) = power_and_signal_schematic();
+
+        let all = handle_validate_component_connections(
+            &json!({ "schematic": path.display().to_string() }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        let all = result_json(&all);
+        assert_eq!(all["unconnected_count"], 2);
+
+        let signals = handle_validate_component_connections(
+            &json!({
+                "schematic": path.display().to_string(),
+                "ignore_power_pins": true
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        let signals = result_json(&signals);
+        assert_eq!(signals["unconnected_count"], 1);
+        assert_eq!(signals["ignored_power_pin_count"], 1);
+        assert_eq!(signals["unconnected_pins"][0]["pin"], "2");
+        assert_eq!(signals["unconnected_pins"][0]["electrical_type"], "input");
     }
 }
 

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -15,8 +15,9 @@ use konnect_schematic_editor as cse;
 use konnect_sexp::{
     geometry::{point_on_segment, points_coincident, snap_point},
     schematic::{
-        extract_labels, extract_lib_pins, extract_symbol_instances, extract_wires, find_lib_symbol,
-        format_net_label, format_wire, pin_endpoint, pin_label_rotation, read_schematic,
+        extract_labels, extract_lib_pins_for_unit, extract_symbol_instances, extract_wires,
+        find_lib_symbol, format_net_label, format_wire, pin_endpoint, pin_label_rotation,
+        read_schematic,
     },
     writer::{
         apply_edits, find_block_with_leading_whitespace, find_enclosing_direct_child_block,
@@ -1171,7 +1172,7 @@ async fn handle_validate_wire_connections(
         let lib_sym = find_lib_symbol(&lib_syms, inst);
         if let Some(sym) = lib_sym {
             let t = inst.pin_transform();
-            for pin in extract_lib_pins(sym) {
+            for pin in extract_lib_pins_for_unit(sym, inst.unit) {
                 pin_points.push(pin_endpoint(&pin, t));
             }
         }
@@ -1317,7 +1318,7 @@ async fn handle_validate_component_connections(
         let lib_sym = find_lib_symbol(&lib_syms, inst);
         if let Some(sym) = lib_sym {
             let t = inst.pin_transform();
-            for pin in extract_lib_pins(sym) {
+            for pin in extract_lib_pins_for_unit(sym, inst.unit) {
                 let (px, py) = pin_endpoint(&pin, t);
 
                 // Skip intentional no-connects
@@ -1876,11 +1877,15 @@ mod connect_to_net_orientation_tests {
 
 #[cfg(test)]
 mod multi_unit_pin_tests {
-    use crate::tools::sch_batch::tools;
+    use super::{handle_validate_component_connections, handle_validate_wire_connections, tools};
+    use crate::mcp::protocol::{CallToolResult, ToolContent};
+    use crate::tools::{ServerConfig, ToolContext};
     use konnect_sexp::schematic::{
         extract_lib_pins_for_unit, extract_symbol_instances, pin_endpoint, read_schematic,
     };
+    use serde_json::json;
     use std::io::Write;
+    use std::sync::Arc;
 
     /// Two units of one symbol, placed 15.24mm apart. Unit 1 owns pin 1, unit 2
     /// owns pin 3; both sit at local x = -7.62 in their own unit's drawing.
@@ -1918,6 +1923,61 @@ mod multi_unit_pin_tests {
 	)
 )
 "#;
+
+    const PHANTOM_PIN_SCH: &str = r#"(kicad_sch
+  (version 20260306)
+  (uuid "root")
+  (lib_symbols
+    (symbol "Test:DUAL"
+      (symbol "DUAL_1_1"
+        (pin input line (at 0 0 0) (length 0) (name "A") (number "1"))
+      )
+      (symbol "DUAL_2_1"
+        (pin output line (at 10 0 0) (length 0) (name "Y") (number "2"))
+      )
+    )
+  )
+  (wire (start 110 100) (end 110 110) (uuid "floating"))
+  (symbol (lib_id "Test:DUAL") (at 100 100 0) (unit 1) (uuid "u1a")
+    (property "Reference" "U1" (at 100 100 0))
+    (property "Value" "DUAL" (at 100 100 0))
+  )
+  (symbol (lib_id "Test:DUAL") (at 200 200 0) (unit 2) (uuid "u1b")
+    (property "Reference" "U1" (at 200 200 0))
+    (property "Value" "DUAL" (at 200 200 0))
+  )
+)
+"#;
+
+    fn context() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+                eager_toolsets: false,
+            },
+            Arc::new(crate::router::ToolRouter::new()),
+        )
+    }
+
+    fn fixture(contents: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("multi.kicad_sch");
+        std::fs::write(&path, contents).unwrap();
+        (directory, path)
+    }
+
+    fn body(result: CallToolResult) -> serde_json::Value {
+        assert!(!result.is_error, "validator unexpectedly failed");
+        let ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text result");
+        };
+        serde_json::from_str(text).unwrap()
+    }
 
     /// The regression: resolving a pin used the FIRST instance with a matching
     /// reference, so every pin of a multi-unit part was transformed by unit 1's
@@ -1972,6 +2032,44 @@ mod multi_unit_pin_tests {
     #[test]
     fn batch_connect_to_net_is_registered() {
         assert!(tools().iter().any(|t| t.name == "batch_connect_to_net"));
+    }
+
+    #[tokio::test]
+    async fn component_validator_reports_only_the_real_unwired_unit_pin() {
+        let mut connected_unit_one = SCH.to_string();
+        let insert = connected_unit_one.rfind("\n)").unwrap();
+        connected_unit_one.insert_str(
+            insert,
+            "\t(wire (start 90 100) (end 92.38 100) (uuid \"w1\"))\n\
+             \t(label \"UNIT1\" (at 90 100 0))\n",
+        );
+        let (_directory, path) = fixture(&connected_unit_one);
+        let result = body(
+            handle_validate_component_connections(
+                &json!({ "schematic": path, "references": ["U1"] }),
+                &context(),
+            )
+            .await
+            .unwrap(),
+        );
+        let pins = result["unconnected_pins"].as_array().unwrap();
+        assert_eq!(pins.len(), 1, "{result}");
+        assert_eq!(pins[0]["pin"], "3");
+        assert!((pins[0]["y"].as_f64().unwrap() - 115.24).abs() < 0.01);
+    }
+
+    #[tokio::test]
+    async fn wire_validator_ignores_an_unplaced_units_phantom_endpoint() {
+        let (_directory, path) = fixture(PHANTOM_PIN_SCH);
+        let result = body(
+            handle_validate_wire_connections(
+                &json!({ "schematic": path, "tolerance": 0.01 }),
+                &context(),
+            )
+            .await
+            .unwrap(),
+        );
+        assert_eq!(result["floating_count"], 2, "both ends float: {result}");
     }
 }
 

--- a/crates/konnect-core/src/tools/sch_export.rs
+++ b/crates/konnect-core/src/tools/sch_export.rs
@@ -10,8 +10,8 @@ use crate::tools::{get_path, ToolContext, ToolDef};
 use konnect_sexp::{
     geometry::{point_on_segment, points_coincident},
     schematic::{
-        extract_labels, extract_lib_pins, extract_symbol_instances, extract_wires, find_lib_symbol,
-        pin_endpoint, read_schematic,
+        extract_labels, extract_lib_pins_for_unit, extract_symbol_instances, extract_wires,
+        find_lib_symbol, pin_endpoint, read_schematic,
     },
     writer::{
         apply_edits, find_block_with_leading_whitespace, write_atomic_if_unchanged, SexpEdit,
@@ -239,7 +239,7 @@ async fn handle_export_netlist_summary(
 
             let pins: Vec<serde_json::Value> = if let Some(sym) = lib_sym {
                 let t = inst.pin_transform();
-                extract_lib_pins(sym)
+                extract_lib_pins_for_unit(sym, inst.unit)
                     .iter()
                     .map(|p| {
                         let (px, py) = pin_endpoint(p, t);
@@ -261,6 +261,7 @@ async fn handle_export_netlist_summary(
                 "value": inst.value,
                 "footprint": inst.footprint,
                 "lib_id": inst.lib_id,
+                "unit": inst.unit,
                 "pin_count": pins.len(),
                 "pins": pins
             })
@@ -355,7 +356,7 @@ async fn handle_fix_connectivity(
         let lib_sym = find_lib_symbol(&lib_syms, inst);
         if let Some(sym) = lib_sym {
             let t = inst.pin_transform();
-            for pin in extract_lib_pins(sym) {
+            for pin in extract_lib_pins_for_unit(sym, inst.unit) {
                 snap_targets.push(pin_endpoint(&pin, t));
             }
         }
@@ -453,4 +454,139 @@ async fn handle_fix_connectivity(
         "dry_run": dry_run,
         "fixes": fixes
     })))
+}
+
+#[cfg(test)]
+mod multi_unit_export_tests {
+    use super::*;
+    use crate::tools::ServerConfig;
+    use std::sync::Arc;
+
+    const SUMMARY_SCHEMATIC: &str = r#"(kicad_sch
+  (version 20260306)
+  (uuid "root")
+  (lib_symbols
+    (symbol "Test:DUAL"
+      (symbol "DUAL_1_1"
+        (pin input line (at 0 0 0) (length 0) (name "A") (number "1"))
+      )
+      (symbol "DUAL_2_1"
+        (pin output line (at 0 0 0) (length 0) (name "Y") (number "2"))
+      )
+    )
+  )
+  (label "UNIT1" (at 100 100 0))
+  (label "UNIT2" (at 100 120 0))
+  (symbol (lib_id "Test:DUAL") (at 100 100 0) (unit 1) (uuid "u1a")
+    (property "Reference" "U1" (at 100 100 0))
+    (property "Value" "DUAL" (at 100 100 0))
+    (property "Footprint" "" (at 100 100 0))
+  )
+  (symbol (lib_id "Test:DUAL") (at 100 120 0) (unit 2) (uuid "u1b")
+    (property "Reference" "U1" (at 100 120 0))
+    (property "Value" "DUAL" (at 100 120 0))
+    (property "Footprint" "" (at 100 120 0))
+  )
+)
+"#;
+
+    const PHANTOM_SNAP_SCHEMATIC: &str = r#"(kicad_sch
+  (version 20260306)
+  (uuid "root")
+  (lib_symbols
+    (symbol "Test:DUAL"
+      (symbol "DUAL_1_1"
+        (pin input line (at 0 0 0) (length 0) (name "A") (number "1"))
+      )
+      (symbol "DUAL_2_1"
+        (pin output line (at 10 0 0) (length 0) (name "Y") (number "2"))
+      )
+    )
+  )
+  (wire (start 110.03 100) (end 120 100) (uuid "near-phantom"))
+  (symbol (lib_id "Test:DUAL") (at 100 100 0) (unit 1) (uuid "u1a")
+    (property "Reference" "U1" (at 100 100 0))
+    (property "Value" "DUAL" (at 100 100 0))
+  )
+  (symbol (lib_id "Test:DUAL") (at 200 200 0) (unit 2) (uuid "u1b")
+    (property "Reference" "U1" (at 200 200 0))
+    (property "Value" "DUAL" (at 200 200 0))
+  )
+)
+"#;
+
+    fn context() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+                eager_toolsets: false,
+            },
+            Arc::new(crate::router::ToolRouter::new()),
+        )
+    }
+
+    fn fixture(contents: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("multi.kicad_sch");
+        std::fs::write(&path, contents).unwrap();
+        (directory, path)
+    }
+
+    fn body(result: CallToolResult) -> serde_json::Value {
+        assert!(!result.is_error, "export helper unexpectedly failed");
+        let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text result");
+        };
+        serde_json::from_str(text).unwrap()
+    }
+
+    #[tokio::test]
+    async fn netlist_summary_reports_only_each_placed_units_pins() {
+        let (_directory, path) = fixture(SUMMARY_SCHEMATIC);
+        let result = body(
+            handle_export_netlist_summary(&json!({ "schematic": path }), &context())
+                .await
+                .unwrap(),
+        );
+        let components = result["components"].as_array().unwrap();
+        assert_eq!(components.len(), 2);
+        let unit1 = components
+            .iter()
+            .find(|component| component["unit"] == 1)
+            .unwrap();
+        let unit2 = components
+            .iter()
+            .find(|component| component["unit"] == 2)
+            .unwrap();
+        assert_eq!(unit1["pin_count"], 1);
+        assert_eq!(unit1["pins"][0]["number"], "1");
+        assert_eq!(unit1["pins"][0]["net"], "UNIT1");
+        assert_eq!(unit2["pin_count"], 1);
+        assert_eq!(unit2["pins"][0]["number"], "2");
+        assert_eq!(unit2["pins"][0]["net"], "UNIT2");
+    }
+
+    #[tokio::test]
+    async fn connectivity_fix_does_not_snap_to_another_units_phantom_pin() {
+        let (_directory, path) = fixture(PHANTOM_SNAP_SCHEMATIC);
+        let result = body(
+            handle_fix_connectivity(
+                &json!({
+                    "schematic": path,
+                    "snap_tolerance": 0.05,
+                    "dry_run": true
+                }),
+                &context(),
+            )
+            .await
+            .unwrap(),
+        );
+        assert_eq!(result["fixes_found"], 0, "{result}");
+        assert_eq!(result["fixes"], json!([]));
+    }
 }

--- a/crates/konnect-sexp/src/schematic.rs
+++ b/crates/konnect-sexp/src/schematic.rs
@@ -325,6 +325,8 @@ pub fn find_lib_symbol<'a>(
 pub struct LibPin {
     pub number: String,
     pub name: String,
+    /// KiCad electrical type token, e.g. `passive`, `input`, `power_in`.
+    pub electrical_type: String,
     /// Position in symbol-local Y-up space (mm).
     pub local_x: f64,
     pub local_y: f64,
@@ -415,9 +417,15 @@ fn parse_lib_pin(node: &SexpNode) -> Option<LibPin> {
         .and_then(|n| n.as_str())
         .unwrap_or("")
         .to_string();
+    let electrical_type = node
+        .get(1)
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string();
     Some(LibPin {
         number,
         name,
+        electrical_type,
         local_x: x,
         local_y: y,
         rotation,
@@ -774,6 +782,20 @@ mod unit_pin_tests {
     }
 
     #[test]
+    fn extraction_preserves_the_kicad_electrical_type() {
+        let root = parse_sexp(
+            "(kicad_symbol_lib (symbol \"PWR\" (pin power_in line (at 0 0 0) \
+             (length 2.54) (name \"VDD\") (number \"1\"))))",
+        )
+        .unwrap();
+        let pin = extract_lib_pins(root.find("symbol").unwrap())
+            .into_iter()
+            .next()
+            .unwrap();
+        assert_eq!(pin.electrical_type, "power_in");
+    }
+
+    #[test]
     fn underscored_base_names_parse_their_unit_suffix() {
         assert_eq!(parse_subsymbol_unit("R_Small_1_1"), Some(1));
         assert_eq!(parse_subsymbol_unit("OP_DUAL_2_1"), Some(2));
@@ -796,6 +818,7 @@ mod pin_endpoint_tests {
         LibPin {
             number: number.to_string(),
             name: "~".to_string(),
+            electrical_type: "passive".to_string(),
             local_x: 0.0,
             local_y,
             rotation,
@@ -1030,6 +1053,7 @@ mod pin_label_rotation_tests {
         LibPin {
             number: "1".into(),
             name: "PIN".into(),
+            electrical_type: "passive".into(),
             // Tip sits 10 mm out from the origin, opposite the way it points.
             local_x: -10.0 * rad.cos(),
             local_y: -10.0 * rad.sin(),

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -158,7 +158,7 @@ Six tools, grouped into *discovery/routing* and *observability*.
 | `add_schematic_text` | Add a text annotation (non-net label) to the schematic at a given position. |
 | `get_schematic_layout` | Return a compact spatial summary of the schematic: component positions, bounding box, optionally wires and labels. |
 | `validate_wire_connections` | Check all wire endpoints for floating ends not connected to a pin, label, or another wire. |
-| `validate_component_connections` | Check that every non-passive pin has at least one wire or label connected. Reports unconnected pins. |
+| `validate_component_connections` | Check selected component pins for a wire or label; optionally exclude KiCad `power_in`/`power_out` pins and report each remaining pin's electrical type. |
 | `batch_place_components` | Place multiple symbols from KiCAD libraries in a single file read/write cycle. Pass explicit references -- there is no auto-numbering; an omitted reference becomes '?' like an eeschema-unannotated symbol, same as `add_schematic_component`. |
 | `batch_connect_pins` | Connect multiple component pin pairs by reference and pin number, in a single file read/write cycle. |
 


### PR DESCRIPTION
## User-visible problem and scope

`validate_component_connections(ignore_power_pins: true)` advertised that power pins would be ignored, but the handler never read the flag. Designs could therefore report unwanted unconnected-power findings even when the caller explicitly excluded them.

This PR parses KiCad library pin electrical types and omits only `power_in` and `power_out` pins when requested.

Refs #251

Depends on #272, which makes placed-unit pin resolution correct for multi-unit symbols. Once #272 merges, this PR reduces to one focused follow-up commit.

## Root cause and design

The validator had pin coordinates and numbers but not the library electrical type, so the schema value was inert. `LibPin` now carries the parsed KiCad type. Validation applies the option after resolving the actual placed unit, reports how many power pins were ignored, and leaves all non-power pins under the existing rules.

## Compatibility and migration

The public field and its default remain unchanged. `false` preserves existing behavior. `true` now implements the documented behavior; no schematic is modified.

## Validation

- `KONNECT_STATE_DIR=/private/tmp/konnect-power-pins cargo test -p konnect-core power_pin_validation_tests --locked`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Combined-series CI commands: docs, Clippy, and format pass; 585/588 `konnect-core` tests pass, with only the same three installed-`Device:R` fixture-shadowing failures reproduced on unmodified `main`.

## Risk and rollback

Risk is limited to classification of KiCad's `power_in`/`power_out` pin tokens. Unknown types remain validated rather than being skipped. Rollback is one commit after #272.
