### PR TITLE
fix(pcb): validate the requested routing board

### DIFF
--- a/crates/konnect-core/src/tools/pcb_routing.rs
+++ b/crates/konnect-core/src/tools/pcb_routing.rs
@@ -25,9 +25,15 @@ where
 }
 
 macro_rules! ipc {
-    ($ctx:expr, |$c:ident| $body:expr) => {{
+    ($ctx:expr, $args:expr, |$c:ident| $body:expr) => {{
         let addr = $ctx.config.ipc_address.clone();
-        match with_ipc(addr, move |$c| $body).await? {
+        let requested_board = get_path($args, "board")?;
+        match with_ipc(addr, move |$c| {
+            $c.ensure_board_is_active(&requested_board)?;
+            $body
+        })
+        .await?
+        {
             Ok(v) => v,
             Err(msg) => {
                 return Ok(CallToolResult::error(format!(
@@ -379,7 +385,7 @@ async fn handle_route_trace(
 
     let net_ipc = net_name.clone();
     let layer_ipc = layer.clone();
-    ipc!(ctx, |c| c
+    ipc!(ctx, args, |c| c
         .add_track(&net_ipc, &layer_ipc, width, x1, y1, x2, y2));
     Ok(CallToolResult::json(&json!({
         "net": net_name, "layer": layer, "width": width,
@@ -430,7 +436,7 @@ async fn handle_route_pad_to_pad(
 
     if (x1 - x2).abs() < 0.01 || (y1 - y2).abs() < 0.01 {
         // Already axis-aligned: single segment
-        ipc!(ctx, |c| c
+        ipc!(ctx, args, |c| c
             .add_track(&net_ipc, &layer_ipc, width, x1, y1, x2, y2));
     } else {
         // L-bend: horizontal then vertical
@@ -440,7 +446,7 @@ async fn handle_route_pad_to_pad(
         let net_b = net_name.clone();
         let layer_a = layer.clone();
         let layer_b = layer.clone();
-        ipc!(ctx, |c| {
+        ipc!(ctx, args, |c| {
             c.add_track(&net_a, &layer_a, width, x1, y1, mid_x, mid_y)?;
             c.add_track(&net_b, &layer_b, width, mid_x, mid_y, x2, y2)?;
             Ok(())
@@ -516,7 +522,7 @@ async fn handle_add_via(
     let pad_size = args["pad_size"].as_f64().unwrap_or(0.8);
 
     let net_ipc = net_name.clone();
-    ipc!(ctx, |c| c.add_via(&net_ipc, x, y, drill, pad_size));
+    ipc!(ctx, args, |c| c.add_via(&net_ipc, x, y, drill, pad_size));
     Ok(CallToolResult::json(
         &json!({ "net": net_name, "x": x, "y": y, "drill": drill, "pad_size": pad_size }),
     ))
@@ -585,7 +591,7 @@ async fn handle_delete_trace(
     };
 
     let uuid_ipc = uuid.clone();
-    ipc!(ctx, |c| c.delete_track(&uuid_ipc));
+    ipc!(ctx, args, |c| c.delete_track(&uuid_ipc));
     Ok(CallToolResult::json(&json!({ "deleted_uuid": uuid })))
 }
 
@@ -596,7 +602,9 @@ async fn handle_query_traces(
     let net = args["net_name"].as_str().map(String::from);
     let layer = args["layer"].as_str().map(String::from);
 
-    let tracks = ipc!(ctx, |c| { c.get_tracks(net.as_deref(), layer.as_deref()) });
+    let tracks = ipc!(ctx, args, |c| {
+        c.get_tracks(net.as_deref(), layer.as_deref())
+    });
 
     let items: Vec<serde_json::Value> = tracks
         .iter()
@@ -616,10 +624,10 @@ async fn handle_query_traces(
 }
 
 async fn handle_get_nets_list(
-    _args: &serde_json::Value,
+    args: &serde_json::Value,
     ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
-    let nets = ipc!(ctx, |c| c.get_nets());
+    let nets = ipc!(ctx, args, |c| c.get_nets());
     let items: Vec<serde_json::Value> = nets
         .iter()
         .map(|n| json!({ "name": n.name, "netcode": n.netcode }))
@@ -666,7 +674,7 @@ async fn handle_modify_trace(
     let uuid_ipc = uuid.clone();
     let net_ipc = net_name.clone();
     let layer_ipc = layer.clone();
-    ipc!(ctx, |c| {
+    ipc!(ctx, args, |c| {
         c.delete_track(&uuid_ipc)?;
         c.add_track(&net_ipc, &layer_ipc, width, x1, y1, x2, y2)
     });
@@ -933,7 +941,7 @@ async fn handle_route_diff_pair(
     let np_ipc = net_pos.clone();
     let nn_ipc = net_neg.clone();
     let layer_ipc = layer.clone();
-    ipc!(ctx, |c| {
+    ipc!(ctx, args, |c| {
         c.add_track(
             &np_ipc,
             &layer_ipc,


### PR DESCRIPTION
## User-visible problem and scope

Seven IPC-backed routing operations required a `board` path but never used it. The related pad-to-pad router read the file for pad coordinates but still did not verify that the same board was active in KiCad. If a different board was active, a valid request could route, query, modify, or delete copper on that unintended board.

This PR makes every routing IPC call verify that the requested board is the active KiCad board before performing the operation.

Refs #251

## Root cause and design

The routing toolset's local `ipc!` helper established connectivity but, unlike the component helper, did not resolve or compare `args["board"]`. The helper now reads the path once and calls `ensure_board_is_active` inside the same blocking IPC operation before executing the requested mutation/query.

The affected tools are `route_trace`, `route_pad_to_pad`, `add_via`, `delete_trace`, `query_traces`, `get_nets_list`, `modify_trace`, and `route_differential_pair` (including both route segments where applicable).

## Compatibility and migration

No schema changes. Calls naming the actually active board behave as before. Calls naming another board now fail safely instead of operating on the wrong file.

## Validation

- `KONNECT_STATE_DIR=/private/tmp/konnect-routing-board cargo test -p konnect-core pcb_routing --locked` (16 passed)
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- The catalogue-wide guard PR independently verifies that `board` is now reached through the registered handler/macro call graph.
- Combined-series CI commands: docs, Clippy, and format pass; 585/588 `konnect-core` tests pass, with only the same three installed-`Device:R` fixture-shadowing failures reproduced on unmodified `main`.

## Risk and rollback

This intentionally adds a refusal path before IPC routing mutations. The safe failure mode is preferable to cross-board modification. No file fallback is introduced. Rollback is a single commit revert.
