### PR TITLE
fix(sch): keep every item of an ERC violation

### DIFF
--- a/crates/konnect-core/src/tools/cli.rs
+++ b/crates/konnect-core/src/tools/cli.rs
@@ -26,8 +26,22 @@ const LONG_TIMEOUT: Duration = Duration::from_secs(600);
 pub struct ErcViolation {
     pub severity: String,
     pub description: String,
+    /// KiCad's rule key (`"pin_to_pin"`, `"pin_not_connected"`, …). Stable,
+    /// unlike the prose description beside it.
+    pub rule: String,
     pub sheet: Option<String>,
+    /// Every item the rule caught, in report order. A `pin_to_pin` violation
+    /// always names two pins and the second is regularly the actionable one,
+    /// so keeping only the first hid what explains the violation.
+    pub items: Vec<ErcItem>,
+}
+
+/// One item involved in an ERC violation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErcItem {
+    pub description: String,
     pub pos: Option<ErcPos>,
+    pub uuid: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -180,35 +194,44 @@ fn parse_erc_json(raw: &serde_json::Value) -> Vec<ErcViolation> {
             continue;
         };
         for v in violations {
-            let first_item = v
+            let items: Vec<ErcItem> = v
                 .get("items")
                 .and_then(|i| i.as_array())
-                .and_then(|i| i.first());
+                .map(|items| items.iter().map(parse_erc_item).collect())
+                .unwrap_or_default();
             let mut description = v["description"].as_str().unwrap_or("").to_string();
             // The per-item description names the offender ("Symbol R1 Pin 1…")
             // — without it "Pin not connected" is unactionable.
-            if let Some(detail) = first_item
-                .and_then(|item| item.get("description"))
-                .and_then(|d| d.as_str())
+            if let Some(detail) = items
+                .first()
+                .map(|item| item.description.as_str())
+                .filter(|detail| !detail.is_empty())
             {
-                if !detail.is_empty() {
-                    description = format!("{}: {}", description, detail);
-                }
+                description = format!("{}: {}", description, detail);
             }
             out.push(ErcViolation {
                 severity: v["severity"].as_str().unwrap_or("error").to_string(),
                 description,
+                rule: v["type"].as_str().unwrap_or("").to_string(),
                 sheet: sheet_path.clone(),
-                pos: first_item.and_then(|item| item.get("pos")).and_then(|p| {
-                    Some(ErcPos {
-                        x: p["x"].as_f64()?,
-                        y: p["y"].as_f64()?,
-                    })
-                }),
+                items,
             });
         }
     }
     out
+}
+
+fn parse_erc_item(item: &serde_json::Value) -> ErcItem {
+    ErcItem {
+        description: item["description"].as_str().unwrap_or("").to_string(),
+        pos: item.get("pos").and_then(|p| {
+            Some(ErcPos {
+                x: p["x"].as_f64()?,
+                y: p["y"].as_f64()?,
+            })
+        }),
+        uuid: item["uuid"].as_str().map(String::from),
+    }
 }
 
 // ─── DRC ─────────────────────────────────────────────────────────────────────
@@ -901,6 +924,23 @@ mod erc_parse_tests {
                             ],
                             "severity": "warning",
                             "type": "pin_not_connected"
+                        },
+                        {
+                            "description": "Pins of type Power output and Power output are connected",
+                            "items": [
+                                {
+                                    "description": "Symbol #PWR031 Pin 1 [Power output, Line]",
+                                    "pos": { "x": 1.4351, "y": 0.889 },
+                                    "uuid": "0f7ec4d9-8a03-4a2f-8f9c-3d8f3f4e1c22"
+                                },
+                                {
+                                    "description": "Symbol U2 Pin 5 [VOUT, Power output, Line]",
+                                    "pos": { "x": 1.6002, "y": 1.016 },
+                                    "uuid": "5b6a1f42-2c17-4f0b-9a6e-8c3f7d21e0a4"
+                                }
+                            ],
+                            "severity": "error",
+                            "type": "pin_to_pin"
                         }
                     ]
                 }
@@ -913,7 +953,7 @@ mod erc_parse_tests {
         let violations = parse_erc_json(&real_report());
         assert_eq!(
             violations.len(),
-            2,
+            3,
             "must flatten sheets[].violations — a top-level 'violations' key does not exist in ERC reports"
         );
         assert_eq!(violations[0].severity, "error");
@@ -923,9 +963,65 @@ mod erc_parse_tests {
             "description should name the offending item"
         );
         assert_eq!(violations[0].sheet.as_deref(), Some("/"));
-        let pos = violations[0].pos.as_ref().expect("position from items[0]");
+        let pos = violations[0].items[0].pos.as_ref().expect("item position");
         assert!((pos.x - 1.0033).abs() < 1e-9);
         assert_eq!(violations[1].severity, "warning");
+    }
+
+    /// A `pin_to_pin` violation names both conflicting pins, and the second is
+    /// regularly the one that explains the first — here the regulator output
+    /// that makes the `PWR_FLAG` redundant. Keeping only `items[0]` sent the
+    /// caller back to `kicad-cli` by hand.
+    #[test]
+    fn every_item_of_a_violation_survives() {
+        let conflict = &parse_erc_json(&real_report())[2];
+        assert_eq!(conflict.items.len(), 2);
+        assert!(conflict.items[0].description.contains("#PWR031"));
+        let explains = &conflict.items[1];
+        assert!(explains.description.contains("U2 Pin 5"));
+        assert!((explains.pos.as_ref().expect("item position").y - 1.016).abs() < 1e-9);
+        assert_eq!(
+            explains.uuid.as_deref(),
+            Some("5b6a1f42-2c17-4f0b-9a6e-8c3f7d21e0a4")
+        );
+    }
+
+    /// `type` is the addressable key; `description` beside it is prose.
+    #[test]
+    fn violations_carry_kicads_rule_key() {
+        let violations = parse_erc_json(&real_report());
+        assert_eq!(violations[0].rule, "pin_not_connected");
+        assert_eq!(violations[2].rule, "pin_to_pin");
+    }
+
+    /// The violation description predates `items` and callers read it, so a
+    /// second item must not change what it says.
+    #[test]
+    fn the_description_still_names_the_first_item_only() {
+        let conflict = &parse_erc_json(&real_report())[2];
+        assert!(conflict.description.contains("#PWR031"));
+        assert!(!conflict.description.contains("U2"));
+    }
+
+    /// KiCad omits `pos` and `uuid` on some item kinds; that must not drop the
+    /// item, whose description is still the only thing naming the offender.
+    #[test]
+    fn an_item_without_a_position_is_still_reported() {
+        let violations = parse_erc_json(&serde_json::json!({
+            "sheets": [{
+                "path": "/",
+                "violations": [{
+                    "description": "Label not connected",
+                    "items": [{ "description": "Label VIN" }],
+                    "severity": "warning",
+                    "type": "label_dangling"
+                }]
+            }]
+        }));
+        assert_eq!(violations[0].items.len(), 1);
+        assert!(violations[0].items[0].pos.is_none());
+        assert!(violations[0].items[0].uuid.is_none());
+        assert!(violations[0].description.contains("Label VIN"));
     }
 
     #[test]

--- a/crates/konnect-core/src/tools/sch_export.rs
+++ b/crates/konnect-core/src/tools/sch_export.rs
@@ -95,7 +95,7 @@ pub fn tools() -> Vec<ToolDef> {
                 "type": "object",
                 "properties": {
                     "schematic": { "type": "string", "description": "Path to .kicad_sch file" },
-                    "output":    { "type": "string", "description": "Optional path to write ERC report JSON" },
+                    "output":    { "type": "string", "description": "Optional path to write this tool's filtered violation list as JSON (not KiCad's own ERC report)" },
                     "severity":  {
                         "type": "string",
                         "description": "Minimum severity to report: 'error', 'warning', 'info'",
@@ -275,6 +275,14 @@ async fn handle_export_netlist_summary(
     })))
 }
 
+/// ERC positions ride on the entry itself as `x`/`y`, not as a nested object.
+fn flatten_pos(entry: &mut serde_json::Value, pos: Option<&cli::ErcPos>) {
+    if let Some(pos) = pos {
+        entry["x"] = json!(pos.x);
+        entry["y"] = json!(pos.y);
+    }
+}
+
 async fn handle_run_erc(
     args: &serde_json::Value,
     ctx: &ToolContext,
@@ -295,17 +303,33 @@ async fn handle_run_erc(
         .iter()
         .filter(|v| severity_rank(&v.severity) >= min_rank)
         .map(|v| {
+            let items: Vec<serde_json::Value> = v
+                .items
+                .iter()
+                .map(|item| {
+                    let mut entry = json!({ "description": item.description });
+                    flatten_pos(&mut entry, item.pos.as_ref());
+                    if let Some(uuid) = &item.uuid {
+                        entry["uuid"] = json!(uuid);
+                    }
+                    entry
+                })
+                .collect();
             let mut entry = json!({
                 "severity": v.severity,
                 "description": v.description,
+                // KiCad's stable key for the rule; `description` is prose.
+                "rule": v.rule,
+                // A pin conflict names two pins, and `description` above
+                // carries only the first.
+                "items": items,
             });
             if let Some(sheet) = &v.sheet {
                 entry["sheet"] = json!(sheet);
             }
-            if let Some(pos) = &v.pos {
-                entry["x"] = json!(pos.x);
-                entry["y"] = json!(pos.y);
-            }
+            // The violation's own x/y predate `items` and stay the first
+            // item's.
+            flatten_pos(&mut entry, v.items.first().and_then(|i| i.pos.as_ref()));
             entry
         })
         .collect();


### PR DESCRIPTION
`run_erc` reports one of the two pins in a pin conflict.

`cli.rs::parse_erc_json` takes `items.first()` for both the description suffix and the
position. A `pin_to_pin` violation always carries two items, and the second is regularly
the actionable one. Placing a `PWR_FLAG` on a `+3V3` rail produced:

```
Konnect: Pins of type Power output and Power output are connected:
         Symbol #PWR031 Pin 1 [Power output, Line]
KiCad:   … the same, plus Symbol U2 Pin 5 [VOUT, Power output, Line]
```

The flag is the item Konnect names; `U2`'s `VOUT` is the item that explains why the flag
is redundant. Recovering it meant running `kicad-cli sch erc` by hand.

#31 fixed the parser that read the wrong key; this is the next layer down in the same
function.

## What changed

- `ErcViolation` carries `items` — every item KiCad reported, each with its
  `description`, `pos` and `uuid` — plus `rule`, KiCad's `type` key (`pin_to_pin`). That
  is the stable key next to a description that is prose, and `rule` is the name
  `get_drc_violations` already uses for the same concept.
- `run_erc`'s response gains `rule` and `items`. Its existing `description`, `x` and `y`
  keys still describe the first item, so anything parsing the response today is
  unaffected.
- The `output` argument's description promised "ERC report JSON" while writing Konnect's
  own severity-filtered list. It now says which of the two it is. The file's shape is
  unchanged — rewriting it as KiCad's raw report would break whatever parses it today.

## Testing

`cargo fmt --check`, `cargo clippy -D warnings`, `--lib --tests` and `--doc` all pass.
Four new tests in `erc_parse_tests`, with the fixture extended by the real two-item
`pin_to_pin` violation above: both items survive with position and uuid, the rule key
parses, the first-item fields do not move, and an item with no `pos` is still reported.

Three `update_symbols_from_library` tests fail on this branch, but they fail identically
on `main` at 59d0ead with none of these changes — unrelated to this PR.

## Not in this PR

This PR deliberately touches no DRC line, so the DRC counterpart below can be reviewed
and merged independently of it, in either order.

`parse_drc_report` has the same loss, one report over, and worse: it reads `items` only
for a position and keeps no item description at all. In the DRC fixture this repo already
ships, every violation is two-item, and for `unconnected_items` the descriptions are the
only place the net and both pads appear — so `get_drc_violations` reports that something
somewhere is unrouted. The two `silk_edge_clearance` violations in that same fixture also
serialise byte-identically, because they differ only in their second item. Happy to file
it, or send it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
