### PR TITLE
fix(pcb): keep every item of a DRC violation

### DIFF
--- a/crates/konnect-core/src/tools/cli.rs
+++ b/crates/konnect-core/src/tools/cli.rs
@@ -26,8 +26,22 @@ const LONG_TIMEOUT: Duration = Duration::from_secs(600);
 pub struct ErcViolation {
     pub severity: String,
     pub description: String,
+    /// KiCad's rule key (`"pin_to_pin"`, `"pin_not_connected"`, …). Stable,
+    /// unlike the prose description beside it.
+    pub rule: String,
     pub sheet: Option<String>,
+    /// Every item the rule caught, in report order. A `pin_to_pin` violation
+    /// always names two pins and the second is regularly the actionable one,
+    /// so keeping only the first hid what explains the violation.
+    pub items: Vec<ErcItem>,
+}
+
+/// One item involved in an ERC violation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErcItem {
+    pub description: String,
     pub pos: Option<ErcPos>,
+    pub uuid: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -180,35 +194,44 @@ fn parse_erc_json(raw: &serde_json::Value) -> Vec<ErcViolation> {
             continue;
         };
         for v in violations {
-            let first_item = v
+            let items: Vec<ErcItem> = v
                 .get("items")
                 .and_then(|i| i.as_array())
-                .and_then(|i| i.first());
+                .map(|items| items.iter().map(parse_erc_item).collect())
+                .unwrap_or_default();
             let mut description = v["description"].as_str().unwrap_or("").to_string();
             // The per-item description names the offender ("Symbol R1 Pin 1…")
             // — without it "Pin not connected" is unactionable.
-            if let Some(detail) = first_item
-                .and_then(|item| item.get("description"))
-                .and_then(|d| d.as_str())
+            if let Some(detail) = items
+                .first()
+                .map(|item| item.description.as_str())
+                .filter(|detail| !detail.is_empty())
             {
-                if !detail.is_empty() {
-                    description = format!("{}: {}", description, detail);
-                }
+                description = format!("{}: {}", description, detail);
             }
             out.push(ErcViolation {
                 severity: v["severity"].as_str().unwrap_or("error").to_string(),
                 description,
+                rule: v["type"].as_str().unwrap_or("").to_string(),
                 sheet: sheet_path.clone(),
-                pos: first_item.and_then(|item| item.get("pos")).and_then(|p| {
-                    Some(ErcPos {
-                        x: p["x"].as_f64()?,
-                        y: p["y"].as_f64()?,
-                    })
-                }),
+                items,
             });
         }
     }
     out
+}
+
+fn parse_erc_item(item: &serde_json::Value) -> ErcItem {
+    ErcItem {
+        description: item["description"].as_str().unwrap_or("").to_string(),
+        pos: item.get("pos").and_then(|p| {
+            Some(ErcPos {
+                x: p["x"].as_f64()?,
+                y: p["y"].as_f64()?,
+            })
+        }),
+        uuid: item["uuid"].as_str().map(String::from),
+    }
 }
 
 // ─── DRC ─────────────────────────────────────────────────────────────────────
@@ -901,6 +924,23 @@ mod erc_parse_tests {
                             ],
                             "severity": "warning",
                             "type": "pin_not_connected"
+                        },
+                        {
+                            "description": "Pins of type Power output and Power output are connected",
+                            "items": [
+                                {
+                                    "description": "Symbol #PWR031 Pin 1 [Power output, Line]",
+                                    "pos": { "x": 1.4351, "y": 0.889 },
+                                    "uuid": "0f7ec4d9-8a03-4a2f-8f9c-3d8f3f4e1c22"
+                                },
+                                {
+                                    "description": "Symbol U2 Pin 5 [VOUT, Power output, Line]",
+                                    "pos": { "x": 1.6002, "y": 1.016 },
+                                    "uuid": "5b6a1f42-2c17-4f0b-9a6e-8c3f7d21e0a4"
+                                }
+                            ],
+                            "severity": "error",
+                            "type": "pin_to_pin"
                         }
                     ]
                 }
@@ -913,7 +953,7 @@ mod erc_parse_tests {
         let violations = parse_erc_json(&real_report());
         assert_eq!(
             violations.len(),
-            2,
+            3,
             "must flatten sheets[].violations — a top-level 'violations' key does not exist in ERC reports"
         );
         assert_eq!(violations[0].severity, "error");
@@ -923,9 +963,65 @@ mod erc_parse_tests {
             "description should name the offending item"
         );
         assert_eq!(violations[0].sheet.as_deref(), Some("/"));
-        let pos = violations[0].pos.as_ref().expect("position from items[0]");
+        let pos = violations[0].items[0].pos.as_ref().expect("item position");
         assert!((pos.x - 1.0033).abs() < 1e-9);
         assert_eq!(violations[1].severity, "warning");
+    }
+
+    /// A `pin_to_pin` violation names both conflicting pins, and the second is
+    /// regularly the one that explains the first — here the regulator output
+    /// that makes the `PWR_FLAG` redundant. Keeping only `items[0]` sent the
+    /// caller back to `kicad-cli` by hand.
+    #[test]
+    fn every_item_of_a_violation_survives() {
+        let conflict = &parse_erc_json(&real_report())[2];
+        assert_eq!(conflict.items.len(), 2);
+        assert!(conflict.items[0].description.contains("#PWR031"));
+        let explains = &conflict.items[1];
+        assert!(explains.description.contains("U2 Pin 5"));
+        assert!((explains.pos.as_ref().expect("item position").y - 1.016).abs() < 1e-9);
+        assert_eq!(
+            explains.uuid.as_deref(),
+            Some("5b6a1f42-2c17-4f0b-9a6e-8c3f7d21e0a4")
+        );
+    }
+
+    /// `type` is the addressable key; `description` beside it is prose.
+    #[test]
+    fn violations_carry_kicads_rule_key() {
+        let violations = parse_erc_json(&real_report());
+        assert_eq!(violations[0].rule, "pin_not_connected");
+        assert_eq!(violations[2].rule, "pin_to_pin");
+    }
+
+    /// The violation description predates `items` and callers read it, so a
+    /// second item must not change what it says.
+    #[test]
+    fn the_description_still_names_the_first_item_only() {
+        let conflict = &parse_erc_json(&real_report())[2];
+        assert!(conflict.description.contains("#PWR031"));
+        assert!(!conflict.description.contains("U2"));
+    }
+
+    /// KiCad omits `pos` and `uuid` on some item kinds; that must not drop the
+    /// item, whose description is still the only thing naming the offender.
+    #[test]
+    fn an_item_without_a_position_is_still_reported() {
+        let violations = parse_erc_json(&serde_json::json!({
+            "sheets": [{
+                "path": "/",
+                "violations": [{
+                    "description": "Label not connected",
+                    "items": [{ "description": "Label VIN" }],
+                    "severity": "warning",
+                    "type": "label_dangling"
+                }]
+            }]
+        }));
+        assert_eq!(violations[0].items.len(), 1);
+        assert!(violations[0].items[0].pos.is_none());
+        assert!(violations[0].items[0].uuid.is_none());
+        assert!(violations[0].description.contains("Label VIN"));
     }
 
     #[test]

--- a/crates/konnect-core/src/tools/cli.rs
+++ b/crates/konnect-core/src/tools/cli.rs
@@ -33,19 +33,23 @@ pub struct ErcViolation {
     /// Every item the rule caught, in report order. A `pin_to_pin` violation
     /// always names two pins and the second is regularly the actionable one,
     /// so keeping only the first hid what explains the violation.
-    pub items: Vec<ErcItem>,
+    pub items: Vec<ReportItem>,
 }
 
-/// One item involved in an ERC violation.
+/// One item involved in an ERC or DRC violation. Both reports use the same
+/// item shape, so both parsers decode it the same way.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ErcItem {
+pub struct ReportItem {
     pub description: String,
-    pub pos: Option<ErcPos>,
+    pub pos: Option<ReportPos>,
+    /// Absent rather than null when KiCad names no item id, which is the
+    /// shape both the ERC and DRC responses have always had.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub uuid: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ErcPos {
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ReportPos {
     pub x: f64,
     pub y: f64,
 }
@@ -62,7 +66,13 @@ pub struct DrcViolation {
     /// per violation, so this is the first item's — which is what the report
     /// used to try to read from a top-level `pos` field that does not exist,
     /// making every position `null`.
-    pub pos: Option<ErcPos>,
+    pub pos: Option<ReportPos>,
+    /// Every item the rule caught, in report order. The prose description of
+    /// an `unconnected_items` violation is a constant, so the pads and the net
+    /// its items name are the only record of what is unrouted — and two
+    /// violations sharing a rule, a description and a first position differ
+    /// nowhere else.
+    pub items: Vec<ReportItem>,
 }
 
 /// Everything `kicad-cli pcb drc` reports, not just the part Konnect used to
@@ -194,10 +204,10 @@ fn parse_erc_json(raw: &serde_json::Value) -> Vec<ErcViolation> {
             continue;
         };
         for v in violations {
-            let items: Vec<ErcItem> = v
+            let items: Vec<ReportItem> = v
                 .get("items")
                 .and_then(|i| i.as_array())
-                .map(|items| items.iter().map(parse_erc_item).collect())
+                .map(|items| items.iter().map(parse_report_item).collect())
                 .unwrap_or_default();
             let mut description = v["description"].as_str().unwrap_or("").to_string();
             // The per-item description names the offender ("Symbol R1 Pin 1…")
@@ -221,17 +231,22 @@ fn parse_erc_json(raw: &serde_json::Value) -> Vec<ErcViolation> {
     out
 }
 
-fn parse_erc_item(item: &serde_json::Value) -> ErcItem {
-    ErcItem {
+/// Decode one item of an ERC or DRC violation — the two reports spell it the
+/// same way.
+fn parse_report_item(item: &serde_json::Value) -> ReportItem {
+    ReportItem {
         description: item["description"].as_str().unwrap_or("").to_string(),
-        pos: item.get("pos").and_then(|p| {
-            Some(ErcPos {
-                x: p["x"].as_f64()?,
-                y: p["y"].as_f64()?,
-            })
-        }),
+        pos: parse_item_pos(item),
         uuid: item["uuid"].as_str().map(String::from),
     }
+}
+
+fn parse_item_pos(item: &serde_json::Value) -> Option<ReportPos> {
+    let pos = item.get("pos")?;
+    Some(ReportPos {
+        x: pos["x"].as_f64()?,
+        y: pos["y"].as_f64()?,
+    })
 }
 
 // ─── DRC ─────────────────────────────────────────────────────────────────────
@@ -271,21 +286,20 @@ fn parse_drc_report(raw: &serde_json::Value) -> Result<DrcReport> {
             raw.get(key)?
                 .as_array()?
                 .iter()
-                .map(|v| DrcViolation {
-                    severity: v["severity"].as_str().unwrap_or("error").to_string(),
-                    description: v["description"].as_str().unwrap_or("").to_string(),
-                    rule: v["type"].as_str().unwrap_or("").to_string(),
-                    // The position lives on each involved item; a violation has
-                    // no `pos` of its own.
-                    pos: v["items"].as_array().and_then(|items| {
-                        items.iter().find_map(|item| {
-                            let p = item.get("pos")?;
-                            Some(ErcPos {
-                                x: p["x"].as_f64()?,
-                                y: p["y"].as_f64()?,
-                            })
-                        })
-                    }),
+                .map(|v| {
+                    let items: Vec<ReportItem> = v["items"]
+                        .as_array()
+                        .map(|items| items.iter().map(parse_report_item).collect())
+                        .unwrap_or_default();
+                    DrcViolation {
+                        severity: v["severity"].as_str().unwrap_or("error").to_string(),
+                        description: v["description"].as_str().unwrap_or("").to_string(),
+                        rule: v["type"].as_str().unwrap_or("").to_string(),
+                        // The position lives on each involved item; a violation
+                        // has no `pos` of its own.
+                        pos: items.iter().find_map(|item| item.pos),
+                        items,
+                    }
                 })
                 .collect(),
         )
@@ -857,6 +871,54 @@ mod drc_parse_tests {
         let unconnected = &report.unconnected_items.as_ref().unwrap()[0];
         assert_eq!(unconnected.rule, "unconnected_items");
         assert!(unconnected.pos.is_some());
+    }
+
+    /// `unconnected_items` says "Missing connection between items" and nothing
+    /// else; the pads and the net live in the items, so dropping them left the
+    /// caller with "something, somewhere, is unrouted".
+    #[test]
+    fn a_violation_keeps_every_item_it_names() {
+        let report = parse_drc_report(&real_report()).unwrap();
+        let unconnected = &report.unconnected_items.as_ref().unwrap()[0];
+
+        assert_eq!(unconnected.description, "Missing connection between items");
+        assert_eq!(unconnected.items.len(), 2);
+        assert_eq!(
+            unconnected.items[0].description,
+            "PTH pad 1 [Net-(P3-P1)] of C1"
+        );
+        assert_eq!(
+            unconnected.items[1].description,
+            "PTH pad 1 [Net-(P3-P1)] of P3"
+        );
+        assert!(unconnected.items.iter().all(|item| item.uuid.is_some()));
+        assert!(unconnected.items.iter().all(|item| item.pos.is_some()));
+
+        // The violation's own position stays the first item's.
+        let pos = unconnected.pos.as_ref().unwrap();
+        let first = unconnected.items[0].pos.as_ref().unwrap();
+        assert_eq!((pos.x, pos.y), (first.x, first.y));
+    }
+
+    /// The two `silk_edge_clearance` violations share a severity, a rule, a
+    /// description and a first-item position. Without the items they serialise
+    /// identically, and a caller cannot tell there are two problems.
+    #[test]
+    fn two_violations_alike_but_for_their_items_stay_distinguishable() {
+        let report = parse_drc_report(&real_report()).unwrap();
+        let (first, second) = (&report.violations[0], &report.violations[1]);
+
+        assert_eq!(first.rule, second.rule);
+        assert_eq!(first.description, second.description);
+        assert_eq!(
+            serde_json::to_value(&first.items[0]).unwrap(),
+            serde_json::to_value(&second.items[0]).unwrap()
+        );
+        assert_ne!(
+            serde_json::to_value(first).unwrap(),
+            serde_json::to_value(second).unwrap(),
+            "two different problems must not serialise byte-identically"
+        );
     }
 
     /// A report missing `violations` is not a DRC report. Defaulting it to an

--- a/crates/konnect-core/src/tools/design_review.rs
+++ b/crates/konnect-core/src/tools/design_review.rs
@@ -893,6 +893,7 @@ async fn handle_run_design_review(
                         "rule": violation.rule,
                         "message": violation.description,
                         "location": violation.pos.as_ref().map(|p| json!({ "x": p.x, "y": p.y })),
+                        "items": violation.items,
                     })
                 }));
                 audits.push(drc);

--- a/crates/konnect-core/src/tools/pcb_export.rs
+++ b/crates/konnect-core/src/tools/pcb_export.rs
@@ -709,7 +709,8 @@ async fn handle_get_drc_violations(
             "severity": v.severity,
             "rule": v.rule,
             "description": v.description,
-            "pos": v.pos.as_ref().map(|p| json!({ "x": p.x, "y": p.y }))
+            "pos": v.pos.as_ref().map(|p| json!({ "x": p.x, "y": p.y })),
+            "items": v.items
         })).collect::<Vec<_>>()
     });
 

--- a/crates/konnect-core/src/tools/sch_export.rs
+++ b/crates/konnect-core/src/tools/sch_export.rs
@@ -95,7 +95,7 @@ pub fn tools() -> Vec<ToolDef> {
                 "type": "object",
                 "properties": {
                     "schematic": { "type": "string", "description": "Path to .kicad_sch file" },
-                    "output":    { "type": "string", "description": "Optional path to write ERC report JSON" },
+                    "output":    { "type": "string", "description": "Optional path to write this tool's filtered violation list as JSON (not KiCad's own ERC report)" },
                     "severity":  {
                         "type": "string",
                         "description": "Minimum severity to report: 'error', 'warning', 'info'",
@@ -275,6 +275,14 @@ async fn handle_export_netlist_summary(
     })))
 }
 
+/// ERC positions ride on the entry itself as `x`/`y`, not as a nested object.
+fn flatten_pos(entry: &mut serde_json::Value, pos: Option<&cli::ErcPos>) {
+    if let Some(pos) = pos {
+        entry["x"] = json!(pos.x);
+        entry["y"] = json!(pos.y);
+    }
+}
+
 async fn handle_run_erc(
     args: &serde_json::Value,
     ctx: &ToolContext,
@@ -295,17 +303,33 @@ async fn handle_run_erc(
         .iter()
         .filter(|v| severity_rank(&v.severity) >= min_rank)
         .map(|v| {
+            let items: Vec<serde_json::Value> = v
+                .items
+                .iter()
+                .map(|item| {
+                    let mut entry = json!({ "description": item.description });
+                    flatten_pos(&mut entry, item.pos.as_ref());
+                    if let Some(uuid) = &item.uuid {
+                        entry["uuid"] = json!(uuid);
+                    }
+                    entry
+                })
+                .collect();
             let mut entry = json!({
                 "severity": v.severity,
                 "description": v.description,
+                // KiCad's stable key for the rule; `description` is prose.
+                "rule": v.rule,
+                // A pin conflict names two pins, and `description` above
+                // carries only the first.
+                "items": items,
             });
             if let Some(sheet) = &v.sheet {
                 entry["sheet"] = json!(sheet);
             }
-            if let Some(pos) = &v.pos {
-                entry["x"] = json!(pos.x);
-                entry["y"] = json!(pos.y);
-            }
+            // The violation's own x/y predate `items` and stay the first
+            // item's.
+            flatten_pos(&mut entry, v.items.first().and_then(|i| i.pos.as_ref()));
             entry
         })
         .collect();

--- a/crates/konnect-core/src/tools/sch_export.rs
+++ b/crates/konnect-core/src/tools/sch_export.rs
@@ -276,7 +276,7 @@ async fn handle_export_netlist_summary(
 }
 
 /// ERC positions ride on the entry itself as `x`/`y`, not as a nested object.
-fn flatten_pos(entry: &mut serde_json::Value, pos: Option<&cli::ErcPos>) {
+fn flatten_pos(entry: &mut serde_json::Value, pos: Option<&cli::ReportPos>) {
     if let Some(pos) = pos {
         entry["x"] = json!(pos.x);
         entry["y"] = json!(pos.y);

--- a/crates/konnect-core/src/tools/verification.rs
+++ b/crates/konnect-core/src/tools/verification.rs
@@ -231,7 +231,8 @@ async fn handle_run_drc(
                 "severity": v.severity,
                 "rule": v.rule,
                 "description": v.description,
-                "pos": v.pos.as_ref().map(|p| json!({ "x": p.x, "y": p.y }))
+                "pos": v.pos.as_ref().map(|p| json!({ "x": p.x, "y": p.y })),
+                "items": v.items
             })).collect::<Vec<_>>()
         }))
         .unwrap(),


### PR DESCRIPTION
`get_drc_violations`, `run_drc` and `run_design_review` report a violation without any of
the items it names.

`cli.rs::parse_drc_report` reads `items` only to find a position, and drops every item's
`description` and `uuid`. For an `unconnected_items` violation the prose description is a
constant, so the whole finding is:

```
Konnect: Missing connection between items
KiCad:   … plus PTH pad 1 [Net-(P3-P1)] of C1
              and PTH pad 1 [Net-(P3-P1)] of P3
```

The net name and both pads appear nowhere but the items, so what Konnect reports is that
something somewhere is unrouted.

Worse, the two `silk_edge_clearance` violations in the repo's own DRC fixture share a
severity, a rule, a description *and* a first-item position — they differ only in their
second item, so they serialise to two byte-identical JSON objects. A caller cannot tell
there are two problems, or where either one is.

#245 recovered the three sibling arrays the report was dropping; this is the layer below,
the items inside a violation. It is the same loss #297 fixes on the ERC side.

## What changed

- `DrcViolation` carries `items` — every item KiCad reported, each with its
  `description`, `pos` and `uuid`. `severity`, `rule`, `description` and the violation's
  own `pos` keep their existing meaning, so anything parsing a response today is
  unaffected.
- `get_drc_violations`, `run_drc` and `run_design_review` each surface `items` beside the
  fields they already returned. `run_drc`'s `output` file gains them too, since it
  serialises the report.
- DRC keeps its nested `pos: {x, y}` where ERC flattens `x`/`y`. Neither moved to match
  the other.
- Both reports spell an item the same way, so decoding one is now a single helper shared
  by the ERC and DRC parsers. The shared type is `ReportItem`/`ReportPos`, renamed from
  `ErcItem`/`ErcPos` — Rust-internal names; no JSON key, tool argument or toolset name
  changes.

## Testing

`cargo fmt --check`, `cargo clippy -D warnings`, `--lib --tests` and `--doc` all pass on
this branch. Two new tests in `drc_parse_tests`, against the DRC fixture already in the
repo: an `unconnected_items` violation keeps both pads with their positions and uuids and
its own position still points at the first item, and the two `silk_edge_clearance`
violations no longer serialise identically.

## Based on #297

The first commit here is #297's — this change renames the item type that PR introduces,
so it cannot stand alone. Review the second commit only, and land it after #297; the diff
collapses to the DRC commit once that merges.
