### PR TITLE
test(sch): resolve the update-from-library tests against the stub

### DIFF
--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -2912,8 +2912,11 @@ mod tests {
     #[tokio::test]
     async fn update_symbols_from_library_refreshes_a_stale_embedded_copy() {
         let (symdir, _env) = stub_symbol_dir();
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("stale.kicad_sch");
+        // The schematic must live in the stub dir: only then is the stub's
+        // project sym-lib-table the one that resolves Device:R. In its own
+        // tempdir the lookup falls through to the developer's installed KiCad,
+        // and editing the stub library below would change nothing.
+        let path = symdir.path().join("stale.kicad_sch");
         let ctx = test_ctx();
         handle_create_schematic(&json!({ "path": path.display().to_string() }), &ctx)
             .await
@@ -3007,8 +3010,9 @@ mod tests {
     #[tokio::test]
     async fn update_symbols_from_library_refuses_a_moved_pin_unless_allowed() {
         let (symdir, _env) = stub_symbol_dir();
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("guarded.kicad_sch");
+        // In the stub dir, so the pin move below lands in the library this
+        // schematic actually resolves against.
+        let path = symdir.path().join("guarded.kicad_sch");
         let ctx = test_ctx();
         handle_create_schematic(&json!({ "path": path.display().to_string() }), &ctx)
             .await
@@ -3202,8 +3206,9 @@ mod tests {
     #[tokio::test]
     async fn update_symbols_from_library_refuses_a_removed_pin() {
         let (symdir, _env) = stub_symbol_dir();
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("shrunk.kicad_sch");
+        // In the stub dir, so the pin deletion below lands in the library this
+        // schematic actually resolves against.
+        let path = symdir.path().join("shrunk.kicad_sch");
         let ctx = test_ctx();
         handle_create_schematic(&json!({ "path": path.display().to_string() }), &ctx)
             .await


### PR DESCRIPTION
## Problem

Three `update_symbols_from_library` tests fail on any developer machine that has KiCad installed:

```
tools::sch_components::tests::update_symbols_from_library_refreshes_a_stale_embedded_copy
tools::sch_components::tests::update_symbols_from_library_refuses_a_moved_pin_unless_allowed
tools::sch_components::tests::update_symbols_from_library_refuses_a_removed_pin
```

Reproduced on a clean checkout of `main` at 59d0ead, Arch Linux with KiCad 10 present (`/usr/share/kicad/symbols/Device.kicad_sym`). Deterministic — the same three fail under `--test-threads=1`, so it is not a race on the shared `KICAD10_SYMBOL_DIR` env var.

Scope is test-only. No shipped behaviour is affected.

## Root cause

`stub_symbol_dir()` documents the contract in its own comment:

> A project `sym-lib-table`, checked before the global one, is what makes this hermetic: `KICAD10_SYMBOL_DIR` alone is not enough, because the global table's own `Device` entry resolves to whatever KiCad the developer has installed and would shadow the stub.

The helper therefore returns its tempdir so the test can put the schematic inside it. These three tests instead created a second, unrelated tempdir for the schematic:

```rust
let (symdir, _env) = stub_symbol_dir();
let dir = tempfile::tempdir().unwrap();
let path = dir.path().join("stale.kicad_sch");
```

With the schematic outside the stub dir, no project table applies and `Device:R` resolves to the system library. Each test then edits the stub's `R.kicad_sym` — widening a value, moving pin 2, deleting pin 2 — but the schematic never pointed at that library, so the tool correctly reports no change and the assertions on the reported diff fail.

CI does not see this: with no KiCad installed there is no global `Device` entry to shadow the stub, so resolution falls through to `KICAD10_SYMBOL_DIR` and reaches the stub either way.

The fix places the schematic in the stub dir, matching the helper's documented contract and the pattern already used by the ten other library-sensitive tests in this module (`amp.kicad_sch`, `multi.kicad_sch`, `units.kicad_sch`, `dual.kicad_sch`, `swap.kicad_sch`, and others).

## Compatibility

None. Test-only change; no public API, schema, CLI, config, or file-format surface is touched.

## Tests

All run locally on Arch Linux, rustc 1.96.0, KiCad 10 installed:

- `cargo test --workspace --locked --lib --tests` — passes (905 tests, 0 failures; the three above previously failed)
- `cargo test --workspace --locked --doc` — passes
- `cargo clippy --workspace --locked --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Environment-dependent checks intentionally skipped: none. The live-KiCad IPC tests remain ignored as they are on `main`.

Worth noting the failure is only observable with KiCad installed, which is precisely the configuration CI lacks — so this class of shadowing bug can recur silently in other tests that call `stub_symbol_dir()` without using its directory.

## Risk and rollback

Negligible. Three test-local path bindings and their explanatory comments; revert the commit to restore prior behaviour.
