### PR TITLE
docs: add developer architecture and tool guides

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -2,6 +2,10 @@
 
 Internal reference for developing and maintaining the Rust port.
 
+New to the codebase? Start with the map in
+[docs/DEVELOPER_OVERVIEW.md](docs/DEVELOPER_OVERVIEW.md), then return here for
+the detailed implementation reference and current statistics.
+
 Repository-wide naming, public API, branch, and pull-request rules live in
 [docs/NAMING_CONVENTIONS.md](docs/NAMING_CONVENTIONS.md).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,162 @@
+# Architecture
+
+Konnect separates process concerns, MCP/tool behavior, and KiCad data access.
+This page describes both those static boundaries and the runtime flows through
+them. `DEV.md` remains the deeper implementation reference.
+
+## Static Boundaries
+
+### Server process: `crates/konnect`
+
+`crates/konnect/src/main.rs` classifies help, version, installer, transaction,
+and server invocations before any server-side writes occur. It loads
+`Config`, initializes tracing on stderr, constructs `McpHandler`, and selects
+stdio, HTTP, or both transports.
+
+`crates/konnect/src/config.rs` owns TOML/JSON discovery and the environment
+fallback for `KICAD_API_SOCKET`. The transport implementations live in
+`crates/konnect/src/transport/stdio.rs` and `http.rs`. Client guidance
+installation is owned by `crates/konnect/src/install.rs`; schematic transaction
+inspection and recovery commands are owned by `transaction_cli.rs`.
+
+### MCP and domain logic: `crates/konnect-core`
+
+`crates/konnect-core/src/mcp/handler.rs` handles MCP methods, enforces required
+argument presence, dispatches tool calls, emits tool-list notifications, and
+records calls through `observability.rs`.
+
+`crates/konnect-core/src/router/registry.rs` declares toolsets and resolves each
+toolset to its definitions. `router/mod.rs` tracks loaded definitions, and
+`router/meta_tools.rs` implements the always-visible discovery, loading, and
+observability tools.
+
+`crates/konnect-core/src/tools/mod.rs` owns `ToolDef`, `ToolContext`,
+`ServerConfig`, the `tool!` macro, required-argument helpers, and shared path and
+library helpers. Domain handlers live in the other files under `src/tools`.
+
+### KiCad data layers
+
+`crates/konnect-sexp` owns low-level KiCad S-expression parsing, edits, geometry,
+layer/net primitives, atomic replacement, reversible commands, and multi-file
+transaction journals. It does not require a live KiCad process.
+
+`crates/konnect-schematic-editor` owns the typed schematic model, library symbol
+resolution, and parse-mutate-serialize workflows for symbols, wires, labels,
+sheets, and related schematic concepts.
+
+`crates/konnect-ipc` owns the KiCad IPC client, generated protobuf types, NNG
+request/reply transport, typed board operations, and the distinction between an
+unreachable transport and a request KiCad received and rejected.
+
+### Non-workspace and non-Rust boundaries
+
+`crates/schematic-viewer` is a separate Tauri application and is deliberately
+outside the Cargo workspace. `plugin` is the thin Python KiCad integration
+layer. `packaging` contains the PCM build scripts, metadata, schema, and package
+validation. Bundled AI guidance under `crates/konnect/assets/skills` and
+`assets/agents` is user-facing workflow behavior and must track the tools it
+names.
+
+## Server Startup
+
+```text
+crates/konnect/src/main.rs
+  -> classify invocation
+  -> Config::load or Config::load_from
+  -> McpHandler::new
+  -> ToolRouter with starter toolsets (or every toolset when configured)
+  -> stdio and/or HTTP transport
+```
+
+`McpHandler::new` in `mcp/handler.rs` uses the `STARTER_KIT` declared by
+`router/registry.rs` unless `eager_toolsets` requests a complete initial list.
+The latter exists for clients that do not refresh after
+`notifications/tools/list_changed`; the configuration contract is documented
+beside the fields in `crates/konnect/src/config.rs`.
+
+## Listing, Loading, And Calling Tools
+
+```text
+tools/list
+  -> McpHandler::dispatch
+  -> meta_tools::meta_tool_descriptions
+  -> ToolRouter::active_tools
+
+tools/call load_toolset
+  -> router/meta_tools.rs
+  -> ToolRouter::load
+  -> notifications/tools/list_changed
+
+tools/call domain_tool
+  -> McpHandler::execute_tool
+  -> meta-tool or loaded domain definition
+  -> required-field gate
+  -> handler
+  -> CallToolResult and observability record
+```
+
+`load_toolset` accepts one name or an array of names in
+`router/meta_tools.rs`. If an unloaded tool is called, `mcp/handler.rs` either
+auto-loads its owner when configured or returns a structured
+`toolset_not_loaded` error. Stdio delivers list-change notifications through
+`transport/stdio.rs`; HTTP delivers them through the SSE path in
+`transport/http.rs`.
+
+## Schematic File Mutation
+
+Schematic handlers in `tools/sch_*.rs` read a saved schematic, mutate it through
+`konnect-schematic-editor` or `konnect-sexp`, and commit with revision-aware
+atomic replacement. If the source changes after it is read, the writer must
+return a conflict instead of overwriting it.
+
+Multi-file schematic changes use the write-ahead journal in
+`konnect-sexp/src/transaction.rs`. The `konnect transaction` commands in
+`crates/konnect/src/transaction_cli.rs` inspect, recover, or explicitly abandon
+those journals.
+
+## Board Mutation And Write Gates
+
+Board writes use three distinct patterns:
+
+1. Live IPC handlers call `KiCadIpcClient::ensure_board_is_active` in
+   `konnect-ipc/src/client.rs` before changing the editor document.
+2. Hybrid handlers use `attempt_ipc_write` in
+   `konnect-core/src/tools/pcb_board.rs`. Only an unreachable IPC transport may
+   fall back to a file edit; a reached-and-rejected request fails closed.
+3. File-only board handlers call `refuse_if_board_open_in_kicad` in
+   `tools/pcb_board.rs` so KiCad cannot later overwrite an invisible file edit.
+
+Closed-board move, rotate, and flip behavior is implemented in
+`tools/pcb_components.rs`. These paths preserve rigid-body footprint geometry
+and refuse inputs whose geometry cannot be transformed safely.
+
+`update_pcb_from_schematic` is a special live-only path in `tools/pcb_sync.rs`.
+It exports the saved schematic hierarchy through the CLI wrapper, creates a dry
+run plan, requires that plan's revision for apply, performs one IPC commit, and
+reads the result back. The read-back check exists because a prior protobuf type
+mistake converted footprint graphics into pads while every layer reported
+success.
+
+## Checks, Exports, And Verdicts
+
+`crates/konnect-core/src/tools/cli.rs` is the subprocess wrapper for KiCad CLI
+checks and exports. Domain-facing handlers in `verification.rs`,
+`pcb_export.rs`, `sch_export.rs`, `manufacturing.rs`, and `design_review.rs`
+interpret those results.
+
+Positive review and manufacturing verdicts are evidence-gated. In particular,
+the DRC model in `tools/cli.rs` preserves KiCad's design-rule,
+unconnected-item, and schematic-parity categories; `design_review.rs` and
+`manufacturing.rs` treat unavailable evidence as incomplete rather than clean.
+
+## Ownership Rules
+
+- CLI lifecycle, configuration, installer behavior, and transports belong in
+  `crates/konnect`.
+- MCP protocol handling, routing, tool responses, and observability belong in
+  `crates/konnect-core`.
+- Schematic and general KiCad file primitives belong in `konnect-sexp` or
+  `konnect-schematic-editor`.
+- Live board IPC behavior and transport classification belong in `konnect-ipc`;
+  policy for using it belongs in the calling `konnect-core` handler.
+- KiCad plugin and PCM changes belong in `plugin` and `packaging`.

--- a/docs/DEVELOPER_OVERVIEW.md
+++ b/docs/DEVELOPER_OVERVIEW.md
@@ -1,0 +1,62 @@
+# Developer Overview
+
+This is the map layer for developers who need to understand Konnect before
+changing it. Detailed implementation notes and the authoritative current tool
+statistics remain in [`DEV.md`](../DEV.md); public naming and contribution rules
+remain in [`CONTRIBUTING.md`](../CONTRIBUTING.md) and
+[`NAMING_CONVENTIONS.md`](NAMING_CONVENTIONS.md).
+
+Konnect is a Rust MCP server with KiCad integration and packaging support. An
+MCP client talks to the `konnect` binary, which exposes a small starter surface,
+loads domain toolsets on demand, and routes each call to a file, IPC, or
+`kicad-cli` backend.
+
+## Main Components
+
+| Component | Source | Responsibility |
+|---|---|---|
+| Server binary | `crates/konnect` | CLI classification, configuration, installer/status commands, MCP transports, and plugin FFI exports |
+| Core tool server | `crates/konnect-core` | MCP handling, routing, observability, tool definitions, and domain handlers |
+| S-expression engine | `crates/konnect-sexp` | KiCad file parsing/writing, atomic edits, reversible commands, and transaction journals |
+| Typed schematic editor | `crates/konnect-schematic-editor` | Higher-level schematic parse, mutation, library resolution, and serialization |
+| KiCad IPC client | `crates/konnect-ipc` | Typed KiCad IPC messages, NNG transport, board targeting, and failure classification |
+| Schematic viewer | `crates/schematic-viewer` | Separate Tauri application for live schematic rendering |
+| KiCad launcher plugin | `plugin` | Python ActionPlugin and settings UI for the packaged server |
+| Packaging | `packaging` | KiCad PCM metadata, package assembly, and package validation |
+
+## Runtime Shape
+
+The main ownership flow is:
+
+```text
+MCP client
+  -> transport in crates/konnect/src/transport
+  -> McpHandler in crates/konnect-core/src/mcp/handler.rs
+  -> ToolRouter in crates/konnect-core/src/router
+  -> handler in crates/konnect-core/src/tools
+  -> one of:
+       schematic model or S-expression file edit
+       KiCad IPC request
+       guarded closed-board file edit
+       kicad-cli check or export
+       external data/integration operation
+```
+
+The backend is selected per operation, not merely by file type. The write-path
+decision and its safety gates are described in
+[`KICAD_INTEGRATION.md`](KICAD_INTEGRATION.md) and implemented principally in
+`tools/pcb_board.rs`, `tools/pcb_components.rs`, `tools/pcb_sync.rs`, and
+`konnect-ipc/src/client.rs`.
+
+## Reading Order
+
+1. [Architecture](ARCHITECTURE.md) covers static ownership and the dynamic
+   startup, routing, mutation, and recovery flows.
+2. [Tool system](TOOL_SYSTEM.md) covers definitions, toolsets, dispatch,
+   argument contracts, response evidence, and structured errors.
+3. [Developing tools](DEVELOPING_TOOLS.md) is the implementation checklist for
+   adding or changing a tool safely.
+4. [KiCad integration](KICAD_INTEGRATION.md) explains the file, IPC, and CLI
+   paths and the gates between them.
+5. [Testing and release](TESTING_AND_RELEASE.md) maps changes to tests, CI, live
+   KiCad validation, documentation, and packaging.

--- a/docs/DEVELOPING_TOOLS.md
+++ b/docs/DEVELOPING_TOOLS.md
@@ -1,0 +1,87 @@
+# Developing Tools
+
+Use this checklist when adding or changing an MCP tool. Start with
+`CONTRIBUTING.md`, `docs/NAMING_CONVENTIONS.md`, and the related handler module;
+the safest implementation usually follows an existing neighboring tool.
+
+## Choose The Backend And Gate
+
+| Operation | Preferred path | Required safety gate |
+|---|---|---|
+| Saved schematic mutation | `konnect-schematic-editor` or `konnect-sexp` | Revision-aware atomic write; transaction journal for multi-file changes |
+| Live board mutation | `konnect-ipc` | `KiCadIpcClient::ensure_board_is_active` before sending the mutation |
+| Board mutation with a safe closed-file implementation | IPC first, file fallback | `attempt_ipc_write` in `tools/pcb_board.rs`; fallback only when IPC is unreachable |
+| Board file mutation with no IPC implementation | `konnect-sexp` or focused parser/edit code | `refuse_if_board_open_in_kicad` before touching the file |
+| KiCad-supported check or export | `kicad-cli` through `tools/cli.rs` | Validate exit status, output existence, and parsed result coverage |
+
+Do not fall back to a file edit after a request reached KiCad and was rejected or
+timed out. `konnect-ipc` classifies that differently from an unreachable
+transport because KiCad may already hold or have changed the target document.
+
+## Define And Implement The Tool
+
+1. Add the definition to the related `tools()` vector under
+   `crates/konnect-core/src/tools`.
+2. Implement the handler near related handlers and reuse their target checks and
+   response conventions.
+3. Use the existing JSON-schema style and list every required field.
+4. Read required values with `require_*` or `get_path`, never with a silent
+   default.
+5. Validate the target and all preconditions before the first mutation.
+6. Use `CallToolResult::json`, `text`, `image`, or `error_kind` as appropriate.
+7. Update `router/registry.rs`, `tool-directory.md`, and the guarded documentation
+   named by `CONTRIBUTING.md`.
+
+For an IPC write that accepts a layer name, use `try_layer_from_name` so an
+unknown layer is refused before it becomes an invalid KiCad message.
+
+## Evidence Rules
+
+Treat success, counts, and verdicts as claims that require evidence.
+
+- Derive response fields from the parsed result, committed state, or read-back;
+  do not populate them from the request merely because the call returned.
+- A positive review/manufacturing verdict requires every prerequisite check. If
+  a required check could not run, return an incomplete result with the missing
+  evidence named.
+- Preserve all categories returned by an external tool. The DRC parser in
+  `tools/cli.rs` must retain design-rule violations, unconnected items, and
+  schematic parity because each category can independently make a board fail.
+- After a risky IPC transformation, compare a bounded post-state with what was
+  sent. `tools/pcb_sync.rs` is the reference for a commit plus read-back check.
+
+These rules address failures where the transport and KiCad both returned
+success but the resulting board was wrong, and where a verdict appeared clean
+only because one result category was ignored.
+
+## Errors And Compatibility
+
+Use stable structured errors for caller-actionable failures: wrong arguments,
+missing files, conflicts, inactive toolsets, and similar conditions. Do not
+classify failures by matching display strings when a typed marker or enum can
+cross the layer boundary.
+
+Treat MCP tool names, schema fields, CLI flags, config keys, environment
+variables, and documented paths as public API. Renames require compatibility or
+an explicit migration note.
+
+## Tests
+
+Add the lowest-level test that can prove the risky behavior, then add handler or
+protocol coverage when the public contract is involved:
+
+- parser/writer logic in `konnect-sexp`;
+- typed model behavior in `konnect-schematic-editor`;
+- handler and response behavior in `konnect-core`;
+- IPC message construction/classification in `konnect-ipc`;
+- MCP/CLI behavior in `crates/konnect/tests`.
+
+Fixtures that parse boards, footprints, symbols, or KiCad reports should come
+from real KiCad output. Synthetic fixtures are useful for narrow grammar tests,
+but they omit optional or positionless forms that real KiCad emits. Minimize a
+real fixture only after the failing shape remains represented.
+
+For a mutating tool, cover the refusal path before the success path: wrong open
+board, reachable IPC rejection, stale file revision, unsupported geometry, or
+missing evidence. For IPC behavior that mocks cannot prove, add an ignored live
+test and record the live validation command in the PR.

--- a/docs/KICAD_INTEGRATION.md
+++ b/docs/KICAD_INTEGRATION.md
@@ -1,0 +1,92 @@
+# KiCad Integration
+
+Konnect uses direct KiCad file editing, KiCad IPC, and `kicad-cli`. The correct
+path depends on the operation and whether KiCad currently owns the document.
+
+## Schematic File Editing
+
+Schematic handlers under `crates/konnect-core/src/tools/sch_*.rs` operate on
+saved `.kicad_sch` files through `konnect-schematic-editor` and
+`konnect-sexp`. These paths work without a running KiCad process and preserve
+the embedded library definitions, UUIDs, and instance information needed by
+KiCad.
+
+Existing-file writes use the atomic/conflict-aware machinery in
+`konnect-sexp/src/writer.rs`. Multi-file changes use
+`konnect-sexp/src/transaction.rs`; a source revision change must become a
+conflict rather than an overwrite.
+
+## KiCad IPC
+
+`crates/konnect-ipc` sends typed protobuf requests over NNG. The socket comes
+from `ipc_address` or `KICAD_API_SOCKET`; KiCad-provided credentials such as
+`KICAD_API_TOKEN` are carried in the IPC client request metadata.
+
+The three board-write gates are:
+
+- `KiCadIpcClient::ensure_board_is_active` in `konnect-ipc/src/client.rs`
+  prevents a request naming one board from changing another open board.
+- `attempt_ipc_write` in `konnect-core/src/tools/pcb_board.rs` permits a file
+  fallback only when IPC is unreachable. A response from KiCad, including a
+  rejection, fails closed.
+- `refuse_if_board_open_in_kicad` in the same module protects file-only tools
+  from edits KiCad would discard on its next save.
+
+Closed-board move, rotate, and flip in `tools/pcb_components.rs` are narrowly
+scoped exceptions with explicit geometry checks. They are not a general license
+to edit a live board file.
+
+## Schematic-To-Board Sync
+
+`update_pcb_from_schematic` in `tools/pcb_sync.rs` is live-IPC-only. It uses
+`tools/cli.rs` to export a netlist from the saved hierarchy, plans against a live
+snapshot, requires the current plan revision for apply, performs one IPC commit,
+and reads the affected footprint shapes back.
+
+The read-back is a correctness boundary, not merely a diagnostic convenience.
+In earlier releases, protobuf `Any` values carrying footprint graphics decoded
+as empty pads because unknown proto fields are skipped; KiCad accepted the
+mutation. The v0.7 path discriminates the declared type and verifies the board
+after commit.
+
+## `kicad-cli`
+
+`crates/konnect-core/src/tools/cli.rs` is the shared subprocess and result parser
+for ERC, DRC, exports, and rendering. Callers should use it rather than build
+ad-hoc command lines.
+
+The DRC result model preserves design-rule violations, unconnected items, and
+schematic parity. `verification.rs`, `pcb_export.rs`, `design_review.rs`, and
+`manufacturing.rs` consume that complete result; unavailable categories or a
+failed CLI run cannot be treated as a clean board.
+
+Freerouting remains usable through its KiCad ActionPlugin, but Konnect does not
+currently have a safe DSN/SES bridge. The `autoroute` behavior in
+`tools/integration.rs` reports that limitation instead of claiming KiCad removed
+CLI commands that never existed.
+
+## Configuration
+
+`crates/konnect/src/config.rs` searches, in order:
+
+1. `konnect.toml` in the working directory;
+2. `settings.json` in the working directory;
+3. `settings.json` beside the executable;
+4. `settings.json` one directory above the executable;
+5. the platform configuration directory.
+
+`--config <path>` loads an explicit file. Relevant fields include `kicad_cli`,
+`kicad_binary`, `ipc_address`, `transport`, `http_address`, `jlcpcb_db_path`,
+`log_level`, `auto_load_toolsets`, and `eager_toolsets`. The legacy
+`ipc_socket_path` alias is accepted by the serde definition in `config.rs`.
+
+## Plugin, Viewer, And Packaging
+
+`plugin` is a thin Python KiCad integration layer that launches/configures the
+Rust server included in a PCM bundle. The standalone viewer in
+`crates/schematic-viewer` watches schematic files and renders through
+`kicad-cli`; it is built and tested separately from the Rust workspace.
+
+The PCM assembly scripts in `packaging/build-pcm.ps1` and `build-pcm.sh` stage
+only metadata, plugin files, icons, and binaries. Repository developer
+documentation under `docs/` is intentionally not part of the install zip.

--- a/docs/TESTING_AND_RELEASE.md
+++ b/docs/TESTING_AND_RELEASE.md
@@ -1,0 +1,86 @@
+# Testing And Release
+
+The pull-request baseline is defined in `CONTRIBUTING.md`. Run the same commands
+locally when the required platform dependencies are available:
+
+```bash
+cargo test --workspace --locked --lib --tests
+cargo test --workspace --locked --doc
+cargo clippy --workspace --locked --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+`protoc` and its well-known type includes are required by
+`crates/konnect-ipc/build.rs`.
+
+## Coverage Map
+
+| Area | Source of tests |
+|---|---|
+| MCP protocol, CLI, and asset contracts | `crates/konnect/tests` and `crates/konnect/src` unit tests |
+| Router and toolset invariants | `crates/konnect-core/src/router` tests |
+| Dispatch and required-argument behavior | `crates/konnect-core/src/mcp/handler.rs` tests |
+| Domain handlers and evidence rules | tests beside modules in `crates/konnect-core/src/tools` |
+| S-expression parsing and atomic writes | `crates/konnect-sexp` tests |
+| Typed schematic model | `crates/konnect-schematic-editor` tests |
+| IPC builders, transport, and client behavior | `crates/konnect-ipc` tests |
+| Real KiCad behavior | ignored live tests and `.github/workflows/e2e-kicad.yml` |
+| Viewer | `crates/schematic-viewer` tests and its CI job |
+| Python plugin | `plugin/tests` and the plugin CI job |
+| PCM package | `packaging/validate-pcm.py` and packaging CI jobs |
+
+The viewer is outside the Cargo workspace. Build or test it from
+`crates/schematic-viewer`; workspace commands do not cover it.
+
+## Evidence-Focused Regression Tests
+
+When a tool returns a count, success state, or verdict, test the evidence behind
+that field. The v0.7 reference cases include:
+
+- complete DRC category parsing in `tools/cli.rs`;
+- DRC-backed review/readiness decisions in `tools/design_review.rs` and
+  `tools/manufacturing.rs`;
+- footprint-type discrimination and post-commit read-back in
+  `tools/pcb_sync.rs` and `konnect-ipc/src/builders.rs`;
+- closed-board placement and flip refusal cases in `tools/pcb_components.rs`.
+
+Use real KiCad-generated fixtures for formats KiCad owns. For an IPC path, unit
+tests should prove request construction and failure classification; an ignored
+live test or the end-to-end workflow should prove behavior that depends on a
+running editor.
+
+## CI And Live Validation
+
+`.github/workflows/ci.yml` covers the Rust workspace, formatting, clippy,
+documentation tests, viewer, plugin, Nix, and PCM validation. The live KiCad
+workflow is separate because it requires an installed graphical application and
+is not an ordinary per-PR gate.
+
+In the PR description, list every command run and explicitly name checks skipped
+because they require KiCad, another operating system, credentials, or release
+infrastructure.
+
+## Documentation
+
+For a public behavior change, inspect README, `DEV.md`, `tool-directory.md`,
+these developer maps, and bundled guidance under
+`crates/konnect/assets/skills` and `assets/agents`. Tool-count locations and
+their enforcement are defined by `CONTRIBUTING.md` and
+`crates/konnect/tests/doc_tool_counts.rs`; link to the authoritative catalogue
+instead of copying totals into new documents.
+
+Every behavioral claim in these maps should name its source module. When the
+module changes, a contributor can find the claim by searching for the old path.
+Describe unimplemented future behavior explicitly as design intent rather than
+current capability.
+
+## Packaging And Release
+
+Build the server with `cargo build --release -p konnect`. Build the viewer
+separately when it is in scope. Changes to plugin files, binary layout, metadata,
+icons, or release scripts require PCM assembly and
+`packaging/validate-pcm.py` validation.
+
+`packaging/build-pcm.ps1` and `build-pcm.sh` enumerate the files staged into the
+PCM archive. Developer documentation stays in the repository and is not added
+to release zips.

--- a/docs/TOOL_SYSTEM.md
+++ b/docs/TOOL_SYSTEM.md
@@ -1,0 +1,95 @@
+# Tool System
+
+Konnect exposes always-visible meta-tools plus domain toolsets loaded on demand.
+The implementation is split between `crates/konnect-core/src/mcp`, `router`, and
+`tools`.
+
+## Definitions And Context
+
+`ToolDef` in `crates/konnect-core/src/tools/mod.rs` is the unit exposed through
+MCP. It carries a public name, description, JSON input schema, and async handler.
+The `tool!` macro constructs definitions in each domain module.
+
+`ToolContext` carries `ServerConfig`, the shared `ToolRouter`, the call observer,
+and shared integration state. Public tool names and schema fields are API; apply
+the naming and compatibility rules in `docs/NAMING_CONVENTIONS.md` and
+`CONTRIBUTING.md`.
+
+## Toolsets And Meta-Tools
+
+`crates/konnect-core/src/router/registry.rs` declares `ALL_TOOLSETS`, the starter
+set, each toolset's metadata, and the `tools_for` mapping. Registry tests compare
+declared per-toolset counts with the definitions returned by the domain module.
+
+`router/meta_tools.rs` defines the always-visible discovery, load/unload, and
+observability surface. Meta-tools are outside `ALL_TOOLSETS`. `load_toolset`
+accepts either one name or an array; a successful change causes
+`mcp/handler.rs` to emit `notifications/tools/list_changed`.
+
+## Dispatch
+
+`McpHandler` in `mcp/handler.rs` dispatches in this order:
+
+1. Handle a meta-tool.
+2. Handle a loaded domain tool.
+3. If `auto_load_toolsets` is enabled, load the owning toolset and retry.
+4. If a registered tool is not loaded, return `toolset_not_loaded`.
+5. Otherwise return `unknown_tool`.
+
+This distinction lets a client recover from an unloaded tool without confusing
+it with a misspelled or removed public API.
+
+## Argument Contracts
+
+`mcp/handler.rs` enforces the schema's `required` list before invoking a domain
+handler. Presence is only the first gate: handlers must use the typed helpers in
+`tools/mod.rs` so a value of the wrong JSON type produces a structured
+`invalid_argument` response.
+
+Use the appropriate helper, including:
+
+- `require_str`
+- `require_f64`
+- `require_array`
+- `require_u64`
+- `get_path`
+
+Do not use an `unwrap_or` default for a schema-required argument. An explicit
+empty array is a value; an omitted required array is an invalid request.
+
+## Response And Evidence Contracts
+
+A response must describe what the backend observed or committed, not merely echo
+what the caller requested. This rule is especially important across IPC and CLI
+boundaries:
+
+- `tools/pcb_sync.rs` compares the post-commit board with the footprint shapes
+  it sent and reports or refuses mismatches.
+- `tools/cli.rs` derives DRC results from every category KiCad reports rather
+  than treating an absent finding in one category as a clean board.
+- `tools/design_review.rs` and `tools/manufacturing.rs` require DRC evidence for
+  a positive verdict and distinguish "not checked" from "none found."
+
+When a successful write cannot be trusted from the immediate return value,
+prefer a bounded read-back or an independently derived result. If the evidence
+is unavailable, return an incomplete/diagnostic state rather than a positive
+claim.
+
+## Structured Errors
+
+`CallToolResult` does not provide a separate top-level structured error object.
+`crates/konnect-core/src/mcp/error.rs` serializes the error detail into text
+content while setting `is_error`.
+
+Common error kinds include `toolset_not_loaded`, `unknown_tool`,
+`invalid_argument`, `file_not_found`, `conflict`, and `handler_error`. Add a new
+kind in `mcp/error.rs` only when callers need a stable new classification; use
+`CallToolResult::error_kind` to return it.
+
+## Documentation Coupling
+
+When tools are added, removed, or renamed, update the domain `tools()` list,
+`router/registry.rs`, `tool-directory.md`, and the guarded count locations named
+by `CONTRIBUTING.md`. Do not repeat catalogue totals in these map documents;
+`crates/konnect/tests/doc_tool_counts.rs` enforces the designated sources and
+sweeps documentation for stale totals.


### PR DESCRIPTION
## Summary

- add a six-page developer map for architecture, runtime flows, tool contracts, KiCad integration, implementation workflow, and release testing
- fold the proposed runtime-flow page into architecture as requested in discussion #301
- document the v0.7.0 evidence rules and the `attempt_ipc_write`, `refuse_if_board_open_in_kicad`, and `ensure_board_is_active` write-path gates
- keep `DEV.md` as the detailed implementation/count source and link new contributors to the map

This implements the scope approved in https://github.com/mixelpixx/Konnect/discussions/301#discussioncomment-18100643. Per the maintainer's direction there, this goes directly from the discussion to a PR rather than opening a duplicate tracking issue.

## Compatibility and packaging

- written against the v0.7.0 tag
- repeats no catalogue totals outside the guarded sources
- names owning modules beside behavioral claims so future drift is searchable
- adds repository documentation only; PCM assembly remains unchanged and `docs/` is not added to release archives

## Validation

- `cargo test --workspace --locked --lib --tests`
- `cargo test --workspace --locked --doc`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Live KiCad tests remain ignored by the existing suite and were not required for this documentation-only change.

## Risk and rollback

Documentation-only. Rollback is removal of the six guide files and the `DEV.md` entry link; no MCP API, file format, IPC, installer, or packaging behavior changes.