### PR TITLE
fix(sch): move a sheet's captions and pins with its box

### DIFF
--- a/crates/konnect-schematic-editor/src/schematic/sheet.rs
+++ b/crates/konnect-schematic-editor/src/schematic/sheet.rs
@@ -335,8 +335,32 @@ impl Sheet {
         (self.at.x, self.at.y)
     }
     pub fn move_to(&mut self, x: f64, y: f64) {
-        self.at.x = x;
-        self.at.y = y;
+        self.translate(x - self.at.x, y - self.at.y);
+    }
+
+    /// Move the box and everything positioned against it.
+    ///
+    /// Sheet properties and sheet pins carry absolute `(at ...)` coordinates in
+    /// `.kicad_sch`, exactly as symbol properties do, so moving only `self.at`
+    /// leaves the `Sheetname` and `Sheetfile` captions and every pin behind at
+    /// the old spot. This mirrors [`Symbol::translate`].
+    pub fn translate(&mut self, dx: f64, dy: f64) {
+        self.at.x += dx;
+        self.at.y += dy;
+        for prop in &mut self.properties {
+            for node in &mut prop.sub_nodes {
+                if node.tag() == Some("at") {
+                    if let Some(mut at) = At::from_sexp(node) {
+                        at.translate(dx, dy);
+                        *node = at.to_sexp();
+                    }
+                }
+            }
+        }
+        // Pins sit on the box edge; KiCad stores them in sheet coordinates too.
+        for pin in &mut self.pins {
+            pin.at.translate(dx, dy);
+        }
     }
     pub fn set_size(&mut self, width: f64, height: f64) {
         self.width = width;
@@ -559,6 +583,108 @@ mod tests {
         sheet.set_page("", "/", "3");
         assert_eq!(sheet.page(""), Some("3"));
         assert_eq!(sheet.instances.len(), 1);
+    }
+
+    /// A sheet as KiCad writes one: the captions and the pins all carry
+    /// absolute coordinates, offset from the box.
+    fn placed_sheet() -> Sheet {
+        let src = concat!(
+            "(sheet (at 100 50) (size 40 30) ",
+            "(uuid \"5c2a1e3f-0000-0000-0000-000000000000\") ",
+            "(property \"Sheetname\" \"Power\" (at 100 49.2 0)) ",
+            "(property \"Sheetfile\" \"power.kicad_sch\" (at 100 80.4 0)) ",
+            "(pin \"VIN\" input (at 140 60 0) ",
+            "(uuid \"8b1f0000-0000-0000-0000-000000000000\")))"
+        );
+        Sheet::from_sexp(&parse_one(src)).unwrap()
+    }
+
+    fn property_position(sheet: &Sheet, name: &str) -> (f64, f64) {
+        let prop = sheet
+            .properties
+            .iter()
+            .find(|p| p.name == name)
+            .expect("property present");
+        let node = prop
+            .sub_nodes
+            .iter()
+            .find(|n| n.tag() == Some("at"))
+            .expect("property carries an (at ...)");
+        let at = At::from_sexp(node).expect("(at ...) parses");
+        (at.x, at.y)
+    }
+
+    /// The reported defect: `move_to` set only `self.at`, so the box separated
+    /// from its captions and both stayed at the old spot.
+    #[test]
+    fn move_to_carries_the_captions_along() {
+        let mut sheet = placed_sheet();
+        sheet.move_to(200.0, 90.0);
+
+        assert_eq!(sheet.position(), (200.0, 90.0));
+        // Name sits 0.8 above the box, file 0.4 below its bottom edge.
+        assert_eq!(property_position(&sheet, "Sheetname"), (200.0, 89.2));
+        assert_eq!(property_position(&sheet, "Sheetfile"), (200.0, 120.4));
+    }
+
+    /// Not in the report, but the same cause: sheet pins sit on the box edge in
+    /// absolute coordinates, so they were left behind too — a moved sheet
+    /// arrived without its pins.
+    #[test]
+    fn move_to_carries_the_pins_along() {
+        let mut sheet = placed_sheet();
+        // The pin is on the right edge: 100 + 40.
+        assert_eq!((sheet.pins[0].at.x, sheet.pins[0].at.y), (140.0, 60.0));
+
+        sheet.move_to(200.0, 90.0);
+
+        assert_eq!(
+            (sheet.pins[0].at.x, sheet.pins[0].at.y),
+            (240.0, 100.0),
+            "pin must stay on the box edge"
+        );
+    }
+
+    #[test]
+    fn a_move_of_zero_changes_nothing() {
+        let mut sheet = placed_sheet();
+        let before = sheet.to_sexp();
+        sheet.move_to(100.0, 50.0);
+        assert_eq!(sheet.to_sexp(), before);
+    }
+
+    /// The offsets `Sheet::new` establishes must survive a move, or the
+    /// delete-and-recreate workaround would be the only way to place a sheet.
+    #[test]
+    fn a_constructed_sheet_keeps_its_offsets_across_a_move() {
+        let mut sheet = Sheet::new("Power", "power.kicad_sch", 10.0, 20.0, 40.0, 30.0);
+        let name_before = property_position(&sheet, "Sheetname");
+        let file_before = property_position(&sheet, "Sheetfile");
+
+        sheet.translate(7.0, -3.0);
+
+        assert_eq!(sheet.position(), (17.0, 17.0));
+        assert_eq!(
+            property_position(&sheet, "Sheetname"),
+            (name_before.0 + 7.0, name_before.1 - 3.0)
+        );
+        assert_eq!(
+            property_position(&sheet, "Sheetfile"),
+            (file_before.0 + 7.0, file_before.1 - 3.0)
+        );
+    }
+
+    /// The move must reach the file, not just the in-memory struct.
+    #[test]
+    fn a_move_reaches_the_serialised_form() {
+        let mut sheet = placed_sheet();
+        sheet.move_to(200.0, 90.0);
+        let out = format!("{:?}", sheet.to_sexp());
+        assert!(
+            !out.contains("49.2"),
+            "old caption position survived: {out}"
+        );
+        assert!(out.contains("89.2"), "new caption position missing: {out}");
     }
 
     #[test]


### PR DESCRIPTION
Closes #287.

`Sheet::move_to` set only `self.at`. Sheet properties carry absolute `(at ...)`
coordinates, so the `Sheetname` and `Sheetfile` captions stayed where they were
and the box slid out from under them.

`Symbol::translate` already does this correctly, with a comment explaining why,
and a test. `Sheet` now mirrors it.

## Sheet pins have the same cause

Not in the report. Pins sit on the box edge in absolute coordinates too — in
KiCad's own `CM5_MINIMA_3` demo, a sheet at `(at 77.47 130.175)` with
`(size 25.4 12.065)` has its pins at `x = 102.87`, exactly the right edge — so
they were left behind as well.

Measured on KiCad 10.0.4, moving a sheet from (60, 40) to (150, 120):

| | caption | pin |
|---|---|---|
| before | 120.9 mm from the box | snaps to the top edge, y = 120.64 |
| after | 0.8 mm, against the box | y = 135.63, its intended offset |

KiCad loads both files without complaint, which is why this goes unnoticed. It
does not drop an off-box pin either — it snaps it back onto the box, but at the
wrong place: the pin belongs 15 mm below the top edge and arrives at the top.
With several pins their order along the edge scrambles.

## Tests

Six: captions follow, pins follow, a zero move changes nothing, a sheet built by
`Sheet::new` keeps its offsets across a translate, and one checking the move
reaches the serialised form rather than only the struct.

`cargo test --no-fail-fast --workspace` green, fmt and clippy clean.

Confined to `sheet.rs`; the handlers in `sch_hierarchy.rs` are untouched, so
this does not collide with #307.
