### PR TITLE
fix(sch): write the rotation a sheet pin's `at` must carry

### DIFF
--- a/crates/konnect-core/src/tools/sch_hierarchy.rs
+++ b/crates/konnect-core/src/tools/sch_hierarchy.rs
@@ -1832,6 +1832,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn add_sheet_pin_writes_a_rotation_kicad_can_load() {
+        // Regression for #303: the pin used to be written as `(at x y)` with no
+        // rotation, and KiCAD then refused to load the whole schematic.
+        let tmp = TempDir::new().unwrap();
+        let root = blank_schematic(tmp.path(), "root.kicad_sch");
+        let ctx = test_ctx();
+        handle_add_hierarchical_sheet(
+            &json!({ "schematic": root.display().to_string(), "sheet_file": "a.kicad_sch", "sheet_name": "A" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        let result = handle_add_sheet_pin(
+            &json!({ "schematic": root.display().to_string(), "sheet_name": "A", "pin_name": "TESTNET", "pin_type": "input", "x": 100.0, "y": 105.0 }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error);
+
+        let written = std::fs::read_to_string(&root).unwrap();
+        assert!(
+            written.contains("(at 100 105 0)"),
+            "sheet pin must be written with a rotation, got: {}",
+            written
+                .lines()
+                .skip_while(|l| !l.contains("(pin \"TESTNET\""))
+                .take(3)
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+
+        // And it must survive a reload through the same parser.
+        let parent = cse::Schematic::load(&root).unwrap();
+        let pin_rotation = parent.sheets.by_name("A").unwrap().pins[0].at.rotation;
+        assert_eq!(pin_rotation, Some(0.0));
+    }
+
+    #[tokio::test]
     async fn add_sheet_pin_rejects_duplicate_name() {
         let tmp = TempDir::new().unwrap();
         let root = blank_schematic(tmp.path(), "root.kicad_sch");

--- a/crates/konnect-schematic-editor/src/schematic/sheet.rs
+++ b/crates/konnect-schematic-editor/src/schematic/sheet.rs
@@ -22,7 +22,9 @@ impl SheetPin {
         SheetPin {
             name: name.into(),
             pin_type: pin_type.into(),
-            at: At::new(x, y),
+            // A sheet pin's `at` must carry all three values — KiCAD refuses
+            // to load the whole schematic when the rotation is absent.
+            at: At::with_rotation(x, y, 0.0),
             uuid: uuid::Uuid::new_v4().to_string(),
             effects: None,
         }
@@ -548,6 +550,17 @@ mod tests {
         assert!(sheet.remove_pin("VCC"));
         assert!(sheet.pin_by_name("VCC").is_none());
         assert!(!sheet.remove_pin("VCC")); // already gone
+    }
+
+    #[test]
+    fn new_pin_serializes_with_rotation() {
+        // KiCAD requires `(at x y rotation)` on a sheet pin — a two-value `at`
+        // makes it refuse to load the whole schematic (#303).
+        let out = crate::sexp::writer::write(&SheetPin::new("VCC", "input", 90.0, 55.0).to_sexp());
+        assert!(
+            out.contains("(at 90 55 0)"),
+            "sheet pin must serialize a rotation, got: {out}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #303.

`SheetPin::new` used `At::new`, which leaves rotation `None`, so `add_sheet_pin` emitted `(at x y)` with no third value — and KiCad refuses to load the whole schematic over it, not just the pin. The tool reported success, and the next thing to open the project failed on a file that was fine a moment earlier.

`import_sheet_pins` never hit this because it patches `pin.at.rotation` after construction — which is also why it worked as the workaround. The fix moves the default into `SheetPin::new` itself, so every future caller gets a loadable pin; `import_sheet_pins` still overrides it with its edge-based rotation as before.

**Verified against KiCad 10.0.5**: the exact repro from #303 now writes `(at 100 105 0)` and `kicad-cli sch export netlist` exits 0, where it exited 3 with "Failed to load schematic" before. Unit test asserts the serialized form; integration test runs the handler and checks both the written file and a reload round-trip.

The missing `(effects …)` block noted in #303 is deliberately not addressed — its absence does not affect loading (verified in the issue's isolation table), and KiCad normalises it on save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)