### PR TITLE
fix(sch): refuse a batch_add_wire element missing a coordinate

### DIFF
--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -262,7 +262,7 @@ macro_rules! tool {
 /// Build a structured `InvalidArgument` CallToolResult. Used by the
 /// `require_*` helpers so every handler that uses them emits structured
 /// errors the client / observer can match on — no per-handler change needed.
-fn invalid_arg(field: &str, reason: &str) -> CallToolResult {
+pub(crate) fn invalid_arg(field: &str, reason: &str) -> CallToolResult {
     CallToolResult::error_kind(
         crate::mcp::error::ToolErrorKind::InvalidArgument {
             field: field.to_string(),

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -618,6 +618,22 @@ async fn handle_batch_add_wire(
         Err(e) => return Ok(e),
     };
 
+    // v0.6.0 made top-level required arguments refuse instead of defaulting,
+    // but array items took the same silent path one level down (#234): an
+    // element missing `x2` became a real wire to x=0 across the sheet,
+    // reported as success. Validate every element before touching anything,
+    // so a malformed batch changes nothing.
+    for (i, w) in wires.iter().enumerate() {
+        for key in ["x1", "y1", "x2", "y2"] {
+            if w[key].as_f64().is_none() {
+                return Ok(crate::tools::invalid_arg(
+                    &format!("wires[{i}].{key}"),
+                    "missing or not a number",
+                ));
+            }
+        }
+    }
+
     let mut sch = cse::Schematic::load(&sch_path)?;
     let mut added = 0usize;
 
@@ -2190,6 +2206,38 @@ mod unit_aware_wiring_tests {
         for (x, y) in tees {
             assert_eq!(junctions_at(&path, x, y), 1, "T at ({x}, {y})");
         }
+    }
+
+    /// Regression for #234: a malformed element used to default its missing
+    /// coordinate to 0 and land a real wire across the sheet, while the
+    /// single-wire tool refused the same omission.
+    #[tokio::test]
+    async fn batch_add_wire_refuses_a_malformed_element_and_writes_nothing() {
+        let (_d, path) = bare_schematic();
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        let result = handle_batch_add_wire(
+            &json!({
+                "schematic": path.display().to_string(),
+                "wires": [
+                    { "x1": 150.0, "y1": 150.0, "x2": 160.0, "y2": 150.0 },
+                    { "x1": 170.0, "y1": 170.0, "y2": 170.0 }
+                ]
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_error, "{:?}", result.content);
+        let msg = format!("{:?}", result.content);
+        assert!(
+            msg.contains("wires[1].x2"),
+            "must name the element and field: {msg}"
+        );
+        // The valid first element must not have been written either — the
+        // batch fails atomically.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), before);
     }
 
     // ─── connect_to_net stub orientation ───────────────────────────────────


### PR DESCRIPTION
Fixes #234.

v0.6.0 made top-level required arguments refuse instead of defaulting, but array items kept the silent path one level down: a `wires` element missing any of `x1`/`y1`/`x2`/`y2` had it defaulted to 0, producing a **real wire across the sheet** — not a degenerate point — reported as `{"added_wires": N}`. Meanwhile the single-wire `add_wire` refuses the identical omission with a structured `invalid_argument`, so the two tools disagreed about the same input.

Every element is now validated before anything is touched, and a malformed batch fails **atomically** with an error naming the element and field (`wires[1].x2`). The valid elements of a malformed batch are deliberately not applied — partial application is how a retry doubles the good wires. The test asserts both the error shape and that the file is byte-identical afterwards.

`invalid_arg` becomes `pub(crate)` so handlers with array arguments can emit the same structured error the `require_*` helpers produce.

Scope note: the same `as_f64().unwrap_or(...)` pattern exists on other array items (e.g. `library.rs` pad and pin elements). This PR fixes the case #234 documents; happy to sweep the rest in a follow-up if you want them handled the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)