### PR TITLE
fix(library): name the way out when a footprint has a pre-6.0 (module) root

### DIFF
--- a/crates/konnect-core/src/tools/footprint_graphics.rs
+++ b/crates/konnect-core/src/tools/footprint_graphics.rs
@@ -449,7 +449,10 @@ pub(super) fn inspect_graphics(
     let tree = konnect_sexp::parse_sexp(source)
         .map_err(|error| invalid("footprint_path", format!("invalid S-expression: {error}")))?;
     if tree.head() != Some("footprint") {
-        return Err(invalid("footprint_path", "file root must be a footprint"));
+        return Err(invalid(
+            "footprint_path",
+            crate::tools::footprint_root_reason(tree.head()),
+        ));
     }
 
     let mut graphics = Vec::new();
@@ -836,7 +839,10 @@ fn prepare_mutation(
     let tree = konnect_sexp::parse_sexp(source)
         .map_err(|error| invalid("footprint_path", format!("invalid S-expression: {error}")))?;
     if tree.head() != Some("footprint") {
-        return Err(invalid("footprint_path", "file root must be a footprint"));
+        return Err(invalid(
+            "footprint_path",
+            crate::tools::footprint_root_reason(tree.head()),
+        ));
     }
 
     let direct_children = find_direct_child_blocks(source, "footprint");

--- a/crates/konnect-core/src/tools/footprint_metadata.rs
+++ b/crates/konnect-core/src/tools/footprint_metadata.rs
@@ -210,7 +210,10 @@ fn prepare_mutation(
     let root = konnect_sexp::parse_sexp(source)
         .map_err(|error| invalid("footprint_path", format!("invalid S-expression: {error}")))?;
     if root.head() != Some("footprint") {
-        return Err(invalid("footprint_path", "file root must be a footprint"));
+        return Err(invalid(
+            "footprint_path",
+            crate::tools::footprint_root_reason(root.head()),
+        ));
     }
 
     let mut description = None;

--- a/crates/konnect-core/src/tools/footprint_models.rs
+++ b/crates/konnect-core/src/tools/footprint_models.rs
@@ -258,7 +258,10 @@ fn prepare_mutation(source: &str, request: &ModelRequest) -> Result<PreparedMuta
     let root = konnect_sexp::parse_sexp(source)
         .map_err(|error| invalid("footprint_path", format!("invalid S-expression: {error}")))?;
     if root.head() != Some("footprint") {
-        return Err(invalid("footprint_path", "file root must be a footprint"));
+        return Err(invalid(
+            "footprint_path",
+            crate::tools::footprint_root_reason(root.head()),
+        ));
     }
 
     let mut selected = Vec::new();
@@ -464,6 +467,31 @@ mod tests {
     (rotate (xyz 0 0 90)))
 )
 "#;
+
+    /// Regression for #304: a pre-6.0 `(module ...)` root was refused with the
+    /// generic message, which reads like a dead end when `kicad-cli fp upgrade`
+    /// migrates the file in one command. The refusal stays; the message names
+    /// the way out.
+    #[test]
+    fn module_root_refusal_names_the_migration() {
+        let legacy = "(module TRIM_PART (layer F.Cu) (tedit 62174BF4)\n  (pad 1 smd rect (at 0 0) (size 1 1) (layers F.Cu)))\n";
+        let request = ModelRequest {
+            mode: ModelMode::Delete,
+            models: Vec::new(),
+        };
+        let err = prepare_mutation(legacy, &request).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("pre-6.0"),
+            "must name the legacy format: {msg}"
+        );
+        assert!(msg.contains("fp upgrade"), "must name the migration: {msg}");
+        // Anything else that is not a footprint keeps the generic message.
+        let err = prepare_mutation("(kicad_pcb)", &request).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("must be a footprint"), "{msg}");
+        assert!(!msg.contains("fp upgrade"), "{msg}");
+    }
 
     fn test_ctx() -> ToolContext {
         ToolContext::new(

--- a/crates/konnect-core/src/tools/library.rs
+++ b/crates/konnect-core/src/tools/library.rs
@@ -855,10 +855,10 @@ async fn handle_edit_footprint_pad(
     let content = read_consistent(&path)?;
     match parse_sexp(&content) {
         Ok(root) if root.head() == Some("footprint") => {}
-        Ok(_) => {
+        Ok(root) => {
             return Ok(invalid_library_argument(
                 "footprint_path",
-                "file root must be a footprint",
+                crate::tools::footprint_root_reason(root.head()),
             ))
         }
         Err(error) => {

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -272,6 +272,22 @@ fn invalid_arg(field: &str, reason: &str) -> CallToolResult {
     )
 }
 
+/// The reason string for a footprint file whose root is not `(footprint ...)`.
+///
+/// A pre-6.0 library file has a `(module ...)` root instead, and those are
+/// still everywhere — vendor downloads and older personal libraries. The
+/// generic "file root must be a footprint" reads like a dead end there, when
+/// one shipped command migrates the file (#304). Name the situation and the
+/// way out; keep the generic message for everything else.
+pub(crate) fn footprint_root_reason(head: Option<&str>) -> String {
+    match head {
+        Some("module") => "file root is a pre-6.0 `(module ...)` footprint — \
+             convert it with `kicad-cli fp upgrade <dir-or-file>`, then retry"
+            .to_string(),
+        _ => "file root must be a footprint".to_string(),
+    }
+}
+
 /// Extract a required string argument, returning a structured
 /// `InvalidArgument` error result if missing or not a string.
 pub fn require_str<'a>(args: &'a Value, key: &str) -> Result<&'a str, CallToolResult> {


### PR DESCRIPTION
Fixes #304.

The refusal itself was right — the writers only understand the modern `(footprint …)` root, and the file is left untouched — but "file root must be a footprint" reads like a dead end when it is not one: `kicad-cli fp upgrade <dir-or-file>` migrates the file in one command, and the identical call then succeeds. Pre-6.0 `(module …)` files are still everywhere in vendor downloads and older personal libraries.

A shared `footprint_root_reason()` now names the legacy format and the migration command when the root is `module`, and keeps the generic message for every other non-footprint root:

```
file root is a pre-6.0 `(module ...)` footprint — convert it with `kicad-cli fp upgrade <dir-or-file>`, then retry
```

Wired into all five refusal sites — `set_footprint_models`, `set_footprint_metadata`, the library inspector, and both footprint-graphics readers; the last two were found by sweeping for the message rather than trusting the issue's list. Test covers both the module case and that other roots keep the generic message; verified end-to-end over stdio that the structured error carries the new reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)