### PR TITLE
refactor(sch): give the connectivity tools one shared index

### DIFF
--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -19,6 +19,7 @@ pub mod sch_analysis;
 pub mod sch_batch;
 pub mod sch_bus;
 pub mod sch_components;
+pub(crate) mod sch_connectivity;
 pub mod sch_export;
 pub mod sch_hierarchy;
 pub mod sch_wiring;
@@ -421,12 +422,16 @@ pub(crate) fn placed_pins(
         .collect()
 }
 
-/// [`placed_pins`], grouped under the reference designator that owns each
-/// placed unit, for callers that report pins by name rather than position.
+/// [`placed_pins`], grouped under the instance that placed each unit, for
+/// callers that report pins by name rather than position. The whole instance
+/// is returned because a caller reporting a pin usually wants its reference
+/// *and* something else about the component — value, uuid, unit — and a
+/// reference alone collapses on a pre-annotation sheet where every part is
+/// `R?`.
 pub(crate) fn placed_pins_by_reference(
     tree: &konnect_sexp::SexpNode,
 ) -> Vec<(
-    String,
+    konnect_sexp::schematic::SymbolInstance,
     Vec<(
         konnect_sexp::schematic::LibPin,
         konnect_sexp::geometry::PinTransform,
@@ -452,7 +457,7 @@ pub(crate) fn placed_pins_by_reference(
             .into_iter()
             .map(|p| (p, t))
             .collect();
-        by_reference.push((inst.reference, pins));
+        by_reference.push((inst, pins));
     }
     by_reference
 }

--- a/crates/konnect-core/src/tools/sch_analysis.rs
+++ b/crates/konnect-core/src/tools/sch_analysis.rs
@@ -1,17 +1,18 @@
 //! `sch_analysis` toolset — net connectivity, pin queries, trace paths, overlap/orphan detection.
 //!
-//! All operations are read-only S-expression analysis.
-//! Net graph uses union-find (O(W+L+P)), matching net_analysis.py.
+//! All operations are read-only S-expression analysis. Connectivity — the net
+//! graph and what counts as attached at a point — lives in `sch_connectivity`.
 
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
+use crate::tools::sch_connectivity::{net_graph_for, pt_key, ConnectivityIndex};
 use crate::tools::{get_path, opt_f64, require_f64, require_str, ToolContext, ToolDef};
 use konnect_schematic_editor as cse;
 use konnect_sexp::{
     geometry::{point_on_segment, points_coincident},
     schematic::{
-        extract_all_net_labels, extract_junctions, extract_labels, extract_symbol_instances,
-        extract_wires, find_lib_symbol, read_schematic, Label, Wire,
+        extract_all_net_labels, extract_symbol_instances, extract_wires, find_lib_symbol,
+        read_schematic, LabelKind, Wire,
     },
 };
 use serde_json::json;
@@ -183,126 +184,6 @@ pub fn tools() -> Vec<ToolDef> {
     ]
 }
 
-// ─── Union-Find net graph ─────────────────────────────────────────────────────
-
-pub(crate) fn pt_key(x: f64, y: f64) -> (i64, i64) {
-    ((x * 1000.0).round() as i64, (y * 1000.0).round() as i64)
-}
-
-pub(crate) struct NetGraph {
-    pub(crate) point_nets: HashMap<(i64, i64), String>,
-    pub(crate) parent: HashMap<(i64, i64), (i64, i64)>,
-}
-
-impl NetGraph {
-    pub(crate) fn new() -> Self {
-        NetGraph {
-            point_nets: HashMap::new(),
-            parent: HashMap::new(),
-        }
-    }
-
-    pub(crate) fn ensure(&mut self, k: (i64, i64)) {
-        self.parent.entry(k).or_insert(k);
-    }
-
-    pub(crate) fn find(&mut self, k: (i64, i64)) -> (i64, i64) {
-        self.ensure(k);
-        let p = self.parent[&k];
-        if p == k {
-            return k;
-        }
-        let root = self.find(p);
-        self.parent.insert(k, root);
-        root
-    }
-
-    pub(crate) fn union(&mut self, a: (i64, i64), b: (i64, i64)) {
-        let ra = self.find(a);
-        let rb = self.find(b);
-        if ra != rb {
-            self.parent.insert(rb, ra);
-        }
-    }
-
-    pub(crate) fn add_wire(&mut self, w: &Wire) {
-        let a = pt_key(w.x1, w.y1);
-        let b = pt_key(w.x2, w.y2);
-        self.ensure(a);
-        self.ensure(b);
-        self.union(a, b);
-    }
-
-    pub(crate) fn add_label(&mut self, x: f64, y: f64, net: &str) {
-        let k = pt_key(x, y);
-        self.ensure(k);
-        self.point_nets.insert(k, net.to_string());
-    }
-
-    pub(crate) fn net_at(&mut self, x: f64, y: f64) -> Option<String> {
-        let k = pt_key(x, y);
-        self.ensure(k);
-        let root = self.find(k);
-        let labels: Vec<_> = self.point_nets.clone().into_iter().collect();
-        for (lk, net) in labels {
-            if self.find(lk) == root {
-                return Some(net);
-            }
-        }
-        None
-    }
-
-    pub(crate) fn points_on_net(&mut self, net: &str) -> Vec<(i64, i64)> {
-        // Collect keys first to avoid simultaneous borrow of point_nets and self.find()
-        let net_keys: Vec<(i64, i64)> = self
-            .point_nets
-            .iter()
-            .filter(|(_, n)| n.as_str() == net)
-            .map(|(k, _)| *k)
-            .collect();
-        let net_roots: HashSet<(i64, i64)> = net_keys.iter().map(|k| self.find(*k)).collect();
-        let all_keys: Vec<(i64, i64)> = self.parent.keys().cloned().collect();
-        all_keys
-            .into_iter()
-            .filter(|k| net_roots.contains(&self.find(*k)))
-            .collect()
-    }
-}
-
-/// Build the connectivity graph. `labels` must be
-/// [`extract_all_net_labels`] — power symbols name nets too, and a graph
-/// built from [`extract_labels`] alone reports every `power:` rail
-/// unconnected.
-pub(crate) fn build_net_graph(
-    wires: &[Wire],
-    labels: &[Label],
-    junctions: &[(f64, f64)],
-) -> NetGraph {
-    let mut g = NetGraph::new();
-    for w in wires {
-        g.add_wire(w);
-    }
-    // Labels and junction dots connect anywhere along a wire, not only at
-    // endpoints — union each such point with the segment it sits on.
-    // ponytail: O(P×W) scan; fine at schematic scale, index wires if it hurts.
-    let attach = |g: &mut NetGraph, x: f64, y: f64| {
-        for w in wires {
-            if point_on_segment(x, y, w.x1, w.y1, w.x2, w.y2, 0.01) {
-                g.union(pt_key(x, y), pt_key(w.x1, w.y1));
-            }
-        }
-    };
-    for l in labels {
-        g.add_label(l.x, l.y, &l.net);
-        attach(&mut g, l.x, l.y);
-    }
-    for &(jx, jy) in junctions {
-        g.ensure(pt_key(jx, jy));
-        attach(&mut g, jx, jy);
-    }
-    g
-}
-
 // ─── Handlers ─────────────────────────────────────────────────────────────────
 
 async fn handle_list_wires(
@@ -375,7 +256,7 @@ async fn handle_get_net_connections(
         .filter(|l| l.net == net)
         .map(|l| json!({ "type": format!("{:?}", l.kind), "x": l.x, "y": l.y }))
         .collect();
-    let mut g = build_net_graph(&wires, &labels, &extract_junctions(&tree));
+    let mut g = net_graph_for(&tree, &wires, &labels);
     let pts = g.points_on_net(&net).len();
     Ok(CallToolResult::json(
         &json!({ "net": net, "label_count": matching.len(), "labels": matching, "connected_points": pts }),
@@ -394,7 +275,7 @@ async fn handle_get_net_connectivity(
     let (_, tree) = read_schematic(&sch_path)?;
     let wires = extract_wires(&tree);
     let labels = extract_all_net_labels(&tree);
-    let mut g = build_net_graph(&wires, &labels, &extract_junctions(&tree));
+    let mut g = net_graph_for(&tree, &wires, &labels);
     let net_pts: HashSet<(i64, i64)> = g.points_on_net(&net).into_iter().collect();
     let net_wires: Vec<_> = wires
         .iter()
@@ -461,7 +342,7 @@ async fn handle_get_pin_connections(
             )))
         }
     };
-    let mut g = build_net_graph(&wires, &labels, &extract_junctions(&tree));
+    let mut g = net_graph_for(&tree, &wires, &labels);
     Ok(CallToolResult::json(
         &json!({ "reference": reference, "pin": pin_number, "pin_x": px, "pin_y": py, "net": g.net_at(px, py) }),
     ))
@@ -489,7 +370,7 @@ async fn handle_get_component_nets(
         .map(|n| n.find_all("symbol"))
         .unwrap_or_default();
     let lib_sym = find_lib_symbol(&lib_syms, inst);
-    let mut g = build_net_graph(&wires, &labels, &extract_junctions(&tree));
+    let mut g = net_graph_for(&tree, &wires, &labels);
     let pins: Vec<serde_json::Value> = if let Some(sym) = lib_sym {
         let t = inst.pin_transform();
         konnect_sexp::schematic::extract_lib_pins(sym).iter().map(|p| {
@@ -521,7 +402,7 @@ async fn handle_get_net_components(
         .find("lib_symbols")
         .map(|n| n.find_all("symbol"))
         .unwrap_or_default();
-    let mut g = build_net_graph(&wires, &labels, &extract_junctions(&tree));
+    let mut g = net_graph_for(&tree, &wires, &labels);
     let net_pts: HashSet<(i64, i64)> = g.points_on_net(&net).into_iter().collect();
     let result: Vec<serde_json::Value> = instances
         .iter()
@@ -568,7 +449,7 @@ async fn handle_trace_from_point(
     let (_, tree) = read_schematic(&sch_path)?;
     let wires = extract_wires(&tree);
     let labels = extract_all_net_labels(&tree);
-    let mut g = build_net_graph(&wires, &labels, &extract_junctions(&tree));
+    let mut g = net_graph_for(&tree, &wires, &labels);
     let on_wire: Vec<_> = wires
         .iter()
         .filter(|w| {
@@ -588,120 +469,6 @@ async fn handle_trace_from_point(
     ))
 }
 
-/// Points bucketed at the coincidence tolerance, so a lookup probes nine cells
-/// instead of scanning every point. `points_coincident` compares an L∞ box of
-/// side `tol`, which the 3×3 neighbourhood covers exactly.
-struct PointIndex {
-    tol: f64,
-    buckets: HashMap<(i64, i64), Vec<(f64, f64)>>,
-}
-
-impl PointIndex {
-    fn build(points: impl IntoIterator<Item = (f64, f64)>, tol: f64) -> Self {
-        let mut index = PointIndex {
-            tol,
-            buckets: HashMap::new(),
-        };
-        for (x, y) in points {
-            let key = index.cell(x, y);
-            index.buckets.entry(key).or_default().push((x, y));
-        }
-        index
-    }
-
-    fn cell(&self, x: f64, y: f64) -> (i64, i64) {
-        ((x / self.tol).floor() as i64, (y / self.tol).floor() as i64)
-    }
-
-    /// How many indexed points coincide with `(x, y)`.
-    fn count_at(&self, x: f64, y: f64) -> usize {
-        let (cx, cy) = self.cell(x, y);
-        let mut found = 0;
-        for dx in -1..=1 {
-            for dy in -1..=1 {
-                let Some(bucket) = self.buckets.get(&(cx + dx, cy + dy)) else {
-                    continue;
-                };
-                found += bucket
-                    .iter()
-                    .filter(|(px, py)| points_coincident(x, y, *px, *py, self.tol))
-                    .count();
-            }
-        }
-        found
-    }
-
-    fn contains(&self, x: f64, y: f64) -> bool {
-        self.count_at(x, y) > 0
-    }
-}
-
-/// Wires bucketed by the coordinate they hold constant: a horizontal wire can
-/// only be met in its own row, a vertical one in its own column. Mirrors
-/// `point_on_segment`, which answers `false` for anything diagonal.
-struct WireIndex<'a> {
-    tol: f64,
-    rows: HashMap<i64, Vec<&'a Wire>>,
-    columns: HashMap<i64, Vec<&'a Wire>>,
-}
-
-impl<'a> WireIndex<'a> {
-    fn build(wires: &'a [Wire], tol: f64) -> Self {
-        let mut index = WireIndex {
-            tol,
-            rows: HashMap::new(),
-            columns: HashMap::new(),
-        };
-        for wire in wires {
-            if (wire.x1 - wire.x2).abs() < tol {
-                index
-                    .columns
-                    .entry(bucket(wire.x1, tol))
-                    .or_default()
-                    .push(wire);
-            } else if (wire.y1 - wire.y2).abs() < tol {
-                index
-                    .rows
-                    .entry(bucket(wire.y1, tol))
-                    .or_default()
-                    .push(wire);
-            }
-        }
-        index
-    }
-
-    /// Every wire that could pass through `(x, y)`.
-    fn candidates(&self, x: f64, y: f64) -> impl Iterator<Item = &&'a Wire> {
-        let cell_x = bucket(x, self.tol);
-        let cell_y = bucket(y, self.tol);
-        (-1..=1).flat_map(move |delta| {
-            let column = self.columns.get(&(cell_x + delta)).into_iter().flatten();
-            let row = self.rows.get(&(cell_y + delta)).into_iter().flatten();
-            column.chain(row)
-        })
-    }
-
-    /// Lies anywhere on a wire, endpoints included.
-    fn covers(&self, x: f64, y: f64) -> bool {
-        self.candidates(x, y)
-            .any(|wire| point_on_segment(x, y, wire.x1, wire.y1, wire.x2, wire.y2, self.tol))
-    }
-
-    /// Lies on the interior of a wire — a T-junction, which KiCAD connects
-    /// without splitting the crossed wire.
-    fn covers_interior(&self, x: f64, y: f64) -> bool {
-        self.candidates(x, y).any(|wire| {
-            point_on_segment(x, y, wire.x1, wire.y1, wire.x2, wire.y2, self.tol)
-                && !points_coincident(x, y, wire.x1, wire.y1, self.tol)
-                && !points_coincident(x, y, wire.x2, wire.y2, self.tol)
-        })
-    }
-}
-
-fn bucket(value: f64, tolerance: f64) -> i64 {
-    (value / tolerance).floor() as i64
-}
-
 async fn handle_find_orphan_items(
     args: &serde_json::Value,
     _ctx: &ToolContext,
@@ -716,72 +483,35 @@ async fn handle_find_orphan_items(
 
     let (_, tree) = read_schematic(&sch_path)?;
     let wires = extract_wires(&tree);
-    let labels = extract_labels(&tree);
-
-    // Unit-aware, so a multi-unit symbol does not contribute another unit's
-    // pins as phantom connection points (#35).
-    let placed = crate::tools::placed_pins_by_reference(&tree);
-    let pins: Vec<(&str, &konnect_sexp::schematic::LibPin, (f64, f64))> = placed
-        .iter()
-        .flat_map(|(reference, pins)| {
-            pins.iter().map(move |(pin, transform)| {
-                (
-                    reference.as_str(),
-                    pin,
-                    konnect_sexp::schematic::pin_endpoint(pin, *transform),
-                )
-            })
-        })
-        .collect();
-
-    let on_wire = WireIndex::build(&wires, tolerance);
-    let wire_ends = PointIndex::build(
-        wires
-            .iter()
-            .flat_map(|wire| [(wire.x1, wire.y1), (wire.x2, wire.y2)]),
-        tolerance,
-    );
-    let label_points = PointIndex::build(labels.iter().map(|label| (label.x, label.y)), tolerance);
-    let pin_points = PointIndex::build(pins.iter().map(|(_, _, at)| *at), tolerance);
-    let junctions = PointIndex::build(extract_junctions(&tree), tolerance);
-    let no_connects = PointIndex::build(
-        konnect_sexp::schematic::extract_no_connects(&tree),
-        tolerance,
-    );
-    let sheet_pins = PointIndex::build(
-        konnect_sexp::schematic::extract_sheet_pins(&tree),
-        tolerance,
-    );
+    // Every net name, so the index is the same one every other tool builds. A
+    // power symbol's pseudo-label sits on the pin already indexed, so feeding
+    // them changes no coincidence answer below.
+    let labels = extract_all_net_labels(&tree);
+    let index = ConnectivityIndex::build(&tree, &wires, &labels, tolerance);
 
     let mut all: Vec<serde_json::Value> = Vec::new();
 
     // A wire end is dangling only when nothing terminates it. Ending on a
     // component or hierarchical sheet pin is the normal case.
-    for wire in &wires {
-        for (x, y) in [(wire.x1, wire.y1), (wire.x2, wire.y2)] {
-            let connected = pin_points.contains(x, y)
-                || label_points.contains(x, y)
-                || sheet_pins.contains(x, y)
-                || junctions.contains(x, y)
-                || no_connects.contains(x, y)
-                // This end is itself indexed; a second hit is another wire.
-                || wire_ends.count_at(x, y) >= 2
-                || on_wire.covers_interior(x, y);
-            if !connected {
-                all.push(json!({
-                    "type": "dangling_wire_end",
-                    "x": x,
-                    "y": y,
-                    "wire_uuid": wire.uuid
-                }));
-            }
-        }
+    for (x, y, wire_uuid) in index.floating_wire_ends() {
+        all.push(json!({
+            "type": "dangling_wire_end",
+            "x": x,
+            "y": y,
+            "wire_uuid": wire_uuid
+        }));
     }
 
     // Labels connect anywhere along a wire, not only at its endpoint, or
-    // directly on a bare symbol pin.
-    for label in &labels {
-        if !on_wire.covers(label.x, label.y) && !pin_points.contains(label.x, label.y) {
+    // directly on a bare symbol pin. Only real labels are reported: a power
+    // symbol that connects to nothing is an unconnected pin, below, and
+    // reporting it twice would be a second answer to one question.
+    for label in index
+        .labels()
+        .iter()
+        .filter(|label| label.kind != LabelKind::PowerSymbol)
+    {
+        if !index.on_wire(label.x, label.y) && !index.has_pin(label.x, label.y) {
             all.push(json!({
                 "type": "floating_label",
                 "net": label.net,
@@ -793,22 +523,17 @@ async fn handle_find_orphan_items(
 
     // Report the unconnected pins promised by the tool description. A pin
     // sitting mid-wire connects only through a junction dot (#104).
-    for (reference, pin, (x, y)) in &pins {
-        let (x, y) = (*x, *y);
-        if pin.electrical_type == "no_connect" || no_connects.contains(x, y) {
+    for placed in index.placed_pins() {
+        let (x, y) = placed.at;
+        if placed.pin.electrical_type == "no_connect" || index.has_no_connect(x, y) {
             continue;
         }
-        let connected = wire_ends.contains(x, y)
-            || label_points.contains(x, y)
-            // This pin is itself indexed; a second hit is a stacked pin.
-            || pin_points.count_at(x, y) >= 2
-            || (junctions.contains(x, y) && on_wire.covers(x, y));
-        if !connected {
+        if !index.attaches_pin(x, y) {
             all.push(json!({
                 "type": "unconnected_pin",
-                "reference": reference,
-                "pin": pin.number,
-                "pin_name": pin.name,
+                "reference": placed.reference,
+                "pin": placed.pin.number,
+                "pin_name": placed.pin.name,
                 "x": x,
                 "y": y
             }));
@@ -830,7 +555,7 @@ async fn handle_find_shorted_nets(
     let (_, tree) = read_schematic(&sch_path)?;
     let wires = extract_wires(&tree);
     let labels = extract_all_net_labels(&tree);
-    let mut g = build_net_graph(&wires, &labels, &extract_junctions(&tree));
+    let mut g = net_graph_for(&tree, &wires, &labels);
     let mut root_nets: HashMap<(i64, i64), Vec<String>> = HashMap::new();
     for l in &labels {
         let root = g.find(pt_key(l.x, l.y));
@@ -907,7 +632,7 @@ async fn handle_get_connected_items(
     };
 
     let lib_sym = find_lib_symbol(&lib_syms, inst);
-    let mut g = build_net_graph(&wires, &labels, &extract_junctions(&tree));
+    let mut g = net_graph_for(&tree, &wires, &labels);
 
     // Get nets for each pin
     let mut connected_nets: HashSet<String> = HashSet::new();

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -13,11 +13,10 @@ use crate::tools::{
 };
 use konnect_schematic_editor as cse;
 use konnect_sexp::{
-    geometry::{point_on_segment, points_coincident, snap_point},
+    geometry::{points_coincident, snap_point},
     schematic::{
-        extract_all_net_labels, extract_labels, extract_lib_pins, extract_symbol_instances,
-        extract_wires, find_lib_symbol, format_net_label, format_wire, pin_endpoint,
-        pin_label_rotation, read_schematic,
+        extract_all_net_labels, extract_labels, extract_symbol_instances, extract_wires,
+        format_net_label, format_wire, pin_endpoint, pin_label_rotation, read_schematic,
     },
     writer::{
         apply_edits, find_block_with_leading_whitespace, find_enclosing_direct_child_block,
@@ -27,8 +26,7 @@ use konnect_sexp::{
 use serde_json::json;
 use std::collections::HashSet;
 
-// Re-use the crate-internal net-graph primitives from sch_analysis.
-use super::sch_analysis::build_net_graph;
+use super::sch_connectivity::{ConnectivityIndex, COINCIDENT_TOLERANCE};
 // Re-use the single-item component placer and pin-to-pin router.
 use super::sch_components::place_one_component;
 use super::sch_wiring::{resolve_pin_endpoint, resolve_placed_pin, route_between};
@@ -1159,78 +1157,14 @@ async fn handle_validate_wire_connections(
 
     let (_, tree) = read_schematic(&sch_path)?;
     let wires = extract_wires(&tree);
-    let labels = extract_labels(&tree);
-    let instances = extract_symbol_instances(&tree);
-    let lib_syms = tree
-        .find("lib_symbols")
-        .map(|n| n.find_all("symbol"))
-        .unwrap_or_default();
+    let labels = extract_all_net_labels(&tree);
+    let index = ConnectivityIndex::build(&tree, &wires, &labels, tol);
 
-    // Collect all valid pin endpoints
-    let mut pin_points: Vec<(f64, f64)> = Vec::new();
-    for inst in &instances {
-        let lib_sym = find_lib_symbol(&lib_syms, inst);
-        if let Some(sym) = lib_sym {
-            let t = inst.pin_transform();
-            for pin in extract_lib_pins(sym) {
-                pin_points.push(pin_endpoint(&pin, t));
-            }
-        }
-    }
-
-    let label_points: Vec<(f64, f64)> = labels.iter().map(|l| (l.x, l.y)).collect();
-    // All wire endpoints as a flat list (for quick counting)
-    let all_wire_eps: Vec<(f64, f64)> = wires
-        .iter()
-        .flat_map(|w| [(w.x1, w.y1), (w.x2, w.y2)])
+    let floating: Vec<serde_json::Value> = index
+        .floating_wire_ends()
+        .into_iter()
+        .map(|(x, y, wire_uuid)| json!({ "x": x, "y": y, "wire_uuid": wire_uuid }))
         .collect();
-
-    let is_connected = |px: f64, py: f64| -> bool {
-        // Another wire endpoint at the same position (count >= 2 because px/py itself is in the list)
-        let same_ep_count = all_wire_eps
-            .iter()
-            .filter(|(wx, wy)| points_coincident(px, py, *wx, *wy, tol))
-            .count();
-        if same_ep_count >= 2 {
-            return true;
-        }
-
-        // T-junction: lies on the INTERIOR of another wire
-        if wires.iter().any(|w| {
-            point_on_segment(px, py, w.x1, w.y1, w.x2, w.y2, tol)
-                && !points_coincident(px, py, w.x1, w.y1, tol)
-                && !points_coincident(px, py, w.x2, w.y2, tol)
-        }) {
-            return true;
-        }
-
-        // Label at this point
-        if label_points
-            .iter()
-            .any(|(lx, ly)| points_coincident(px, py, *lx, *ly, tol))
-        {
-            return true;
-        }
-
-        // Pin endpoint at this point
-        if pin_points
-            .iter()
-            .any(|(ppx, ppy)| points_coincident(px, py, *ppx, *ppy, tol))
-        {
-            return true;
-        }
-
-        false
-    };
-
-    let mut floating: Vec<serde_json::Value> = Vec::new();
-    for w in &wires {
-        for (px, py) in [(w.x1, w.y1), (w.x2, w.y2)] {
-            if !is_connected(px, py) {
-                floating.push(json!({ "x": px, "y": py, "wire_uuid": w.uuid }));
-            }
-        }
-    }
 
     Ok(CallToolResult::json(&json!({
         "valid": floating.is_empty(),
@@ -1244,7 +1178,7 @@ async fn handle_validate_component_connections(
     _ctx: &crate::tools::ToolContext,
 ) -> anyhow::Result<CallToolResult> {
     let sch_path = get_path(args, "schematic")?;
-    let filter_refs: Vec<String> = args["references"]
+    let filter_refs: HashSet<String> = args["references"]
         .as_array()
         .map(|a| {
             a.iter()
@@ -1252,87 +1186,33 @@ async fn handle_validate_component_connections(
                 .collect()
         })
         .unwrap_or_default();
-    let tol = 0.01_f64;
-
     let (_, tree) = read_schematic(&sch_path)?;
-    let instances = extract_symbol_instances(&tree);
     let wires = extract_wires(&tree);
     let labels = extract_all_net_labels(&tree);
-    let lib_syms = tree
-        .find("lib_symbols")
-        .map(|n| n.find_all("symbol"))
-        .unwrap_or_default();
-
-    // No-connect positions (pins with intentional no-connect markers are exempt)
-    let no_connect_pts = konnect_sexp::schematic::extract_no_connects(&tree);
-
-    // Build net graph so we can check connectivity. Junctions matter: a pin
-    // sitting mid-wire is connected only through a junction dot, so without
-    // them this validator reports false "not connected" (#104).
-    let junction_pts = konnect_sexp::schematic::extract_junctions(&tree);
-    let mut g = build_net_graph(&wires, &labels, &junction_pts);
-    // Also build flat wire-endpoint list for direct presence checks
-    let all_wire_eps: Vec<(f64, f64)> = wires
-        .iter()
-        .flat_map(|w| [(w.x1, w.y1), (w.x2, w.y2)])
-        .collect();
-
-    // `g.net_at` requires &mut self, so we need a `mut` closure.
-    let mut has_connection = |px: f64, py: f64| -> bool {
-        // Connected to a wire endpoint
-        if all_wire_eps
-            .iter()
-            .any(|(wx, wy)| points_coincident(px, py, *wx, *wy, tol))
-        {
-            return true;
-        }
-        // A pin landing mid-wire connects only through a junction dot — KiCad's
-        // netlister registers the unsplit wire at a junction point, so a dot
-        // alone is enough and no wire split is required (#104).
-        if junction_pts
-            .iter()
-            .any(|(jx, jy)| points_coincident(px, py, *jx, *jy, tol))
-            && wires
-                .iter()
-                .any(|w| point_on_segment(px, py, w.x1, w.y1, w.x2, w.y2, tol))
-        {
-            return true;
-        }
-        // Or has a named net (label at or reachable from pin via wires)
-        g.net_at(px, py).is_some()
-    };
+    let index = ConnectivityIndex::build(&tree, &wires, &labels, COINCIDENT_TOLERANCE);
 
     let mut unconnected: Vec<serde_json::Value> = Vec::new();
 
-    for inst in &instances {
-        if !filter_refs.is_empty() && !filter_refs.contains(&inst.reference) {
+    for placed in index.placed_pins() {
+        if !filter_refs.is_empty() && !filter_refs.contains(&placed.reference) {
             continue;
         }
-        let lib_sym = find_lib_symbol(&lib_syms, inst);
-        if let Some(sym) = lib_sym {
-            let t = inst.pin_transform();
-            for pin in extract_lib_pins(sym) {
-                let (px, py) = pin_endpoint(&pin, t);
+        let (px, py) = placed.at;
 
-                // Skip intentional no-connects
-                if no_connect_pts
-                    .iter()
-                    .any(|(nx, ny)| points_coincident(px, py, *nx, *ny, tol))
-                {
-                    continue;
-                }
+        // Skip intentional no-connects.
+        if index.has_no_connect(px, py) {
+            continue;
+        }
 
-                if !has_connection(px, py) {
-                    unconnected.push(json!({
-                        "reference": inst.reference,
-                        "value": inst.value,
-                        "pin": pin.number,
-                        "pin_name": pin.name,
-                        "x": px,
-                        "y": py
-                    }));
-                }
-            }
+        if !index.attaches_pin(px, py) {
+            unconnected.push(json!({
+                "reference": placed.reference,
+                "value": placed.value,
+                "pin": placed.pin.number,
+                "pin_name": placed.pin.name,
+                "x": px,
+                "y": py
+            }));
         }
     }
 

--- a/crates/konnect-core/src/tools/sch_connectivity.rs
+++ b/crates/konnect-core/src/tools/sch_connectivity.rs
@@ -1,0 +1,817 @@
+//! One shared answer to "what is attached at (x, y)".
+//!
+//! The connectivity tools each used to carry their own tolerance and their own
+//! set of items that count as a connection, so they disagreed on real sheets: a
+//! wire ending on a hierarchical sheet pin was terminated for `find_orphan_items`
+//! and floating for `validate_wire_connections`, and two pins placed directly on
+//! each other were connected for the first and unconnected for
+//! `validate_component_connections`. The net graph was a fourth answer again,
+//! burying its attach tolerance in the function body and knowing nothing about
+//! sheet pins. That tolerance is now a property of the [`WireIndex`] the seeder
+//! is handed rather than a literal — the value every production caller uses is
+//! still [`COINCIDENT_TOLERANCE`], so this is structure, not a behaviour change.
+//!
+//! One invariant is worth stating, because the two layers are not identical:
+//! coincidence is a **superset** of the graph. A point is coincident within the
+//! index's tolerance, while [`NetGraph`] joins nodes on exact [`pt_key`]
+//! equality plus the attach step. So a wire ending 5 µm off a sheet pin is
+//! *terminated* for the validators yet does not reach that pin's net. That is
+//! the safe direction and it is deliberate: leniency suppresses a false
+//! "floating end" from a rounding artefact, while strictness keeps the graph
+//! from inventing a net connection KiCad's own netlister would not make.
+//! KiCad snaps to grid, so exact agreement is the normal case.
+//!
+//! [`ConnectivityIndex`] is built once per tree and holds every item that can
+//! terminate a point — wires, wire endpoints, labels, pins with the reference
+//! that owns them, sheet pins, junctions and no-connects — under a single
+//! tolerance, and the tools express policy over it. One [`seed_net_graph`] is
+//! the only definition of the graph, so the ten read-only tools that want net
+//! names cannot drift from the three that ask about attachment.
+
+use konnect_sexp::{
+    geometry::{point_on_segment, points_coincident},
+    schematic::{
+        extract_junctions, extract_no_connects, extract_sheet_pins, pin_endpoint, Label, LabelKind,
+        LibPin, Wire,
+    },
+    SexpNode,
+};
+use std::collections::{HashMap, HashSet};
+
+/// The coincidence tolerance the connectivity tools have always used, in mm.
+/// `find_orphan_items` takes its own as an argument; the rest use this.
+pub(crate) const COINCIDENT_TOLERANCE: f64 = 0.01;
+
+// ─── Spatial indices ──────────────────────────────────────────────────────────
+
+fn bucket(value: f64, tolerance: f64) -> i64 {
+    (value / tolerance).floor() as i64
+}
+
+/// Points bucketed at the coincidence tolerance, so a lookup probes nine cells
+/// instead of scanning every point. `points_coincident` compares an L∞ box of
+/// side `tol`, which the 3×3 neighbourhood covers exactly.
+struct PointIndex {
+    tol: f64,
+    buckets: HashMap<(i64, i64), Vec<(f64, f64)>>,
+}
+
+impl PointIndex {
+    fn build(points: impl IntoIterator<Item = (f64, f64)>, tol: f64) -> Self {
+        let mut index = PointIndex {
+            tol,
+            buckets: HashMap::new(),
+        };
+        for (x, y) in points {
+            let key = index.cell(x, y);
+            index.buckets.entry(key).or_default().push((x, y));
+        }
+        index
+    }
+
+    fn cell(&self, x: f64, y: f64) -> (i64, i64) {
+        ((x / self.tol).floor() as i64, (y / self.tol).floor() as i64)
+    }
+
+    /// How many indexed points coincide with `(x, y)`.
+    fn count_at(&self, x: f64, y: f64) -> usize {
+        let (cx, cy) = self.cell(x, y);
+        let mut found = 0;
+        for dx in -1..=1 {
+            for dy in -1..=1 {
+                let Some(bucket) = self.buckets.get(&(cx + dx, cy + dy)) else {
+                    continue;
+                };
+                found += bucket
+                    .iter()
+                    .filter(|(px, py)| points_coincident(x, y, *px, *py, self.tol))
+                    .count();
+            }
+        }
+        found
+    }
+
+    fn contains(&self, x: f64, y: f64) -> bool {
+        self.count_at(x, y) > 0
+    }
+}
+
+/// Wires bucketed by the coordinate they hold constant: a horizontal wire can
+/// only be met in its own row, a vertical one in its own column. Mirrors
+/// `point_on_segment`, which answers `false` for anything diagonal.
+struct WireIndex<'a> {
+    tol: f64,
+    rows: HashMap<i64, Vec<&'a Wire>>,
+    columns: HashMap<i64, Vec<&'a Wire>>,
+}
+
+impl<'a> WireIndex<'a> {
+    fn build(wires: &'a [Wire], tol: f64) -> Self {
+        let mut index = WireIndex {
+            tol,
+            rows: HashMap::new(),
+            columns: HashMap::new(),
+        };
+        for wire in wires {
+            if (wire.x1 - wire.x2).abs() < tol {
+                index
+                    .columns
+                    .entry(bucket(wire.x1, tol))
+                    .or_default()
+                    .push(wire);
+            } else if (wire.y1 - wire.y2).abs() < tol {
+                index
+                    .rows
+                    .entry(bucket(wire.y1, tol))
+                    .or_default()
+                    .push(wire);
+            }
+        }
+        index
+    }
+
+    /// Every wire that could pass through `(x, y)`.
+    fn candidates(&self, x: f64, y: f64) -> impl Iterator<Item = &&'a Wire> {
+        let cell_x = bucket(x, self.tol);
+        let cell_y = bucket(y, self.tol);
+        (-1..=1).flat_map(move |delta| {
+            let column = self.columns.get(&(cell_x + delta)).into_iter().flatten();
+            let row = self.rows.get(&(cell_y + delta)).into_iter().flatten();
+            column.chain(row)
+        })
+    }
+
+    /// Every wire that actually passes through `(x, y)`.
+    fn hits(&self, x: f64, y: f64) -> impl Iterator<Item = &&'a Wire> {
+        self.candidates(x, y).filter(move |wire| {
+            point_on_segment(x, y, wire.x1, wire.y1, wire.x2, wire.y2, self.tol)
+        })
+    }
+
+    /// Lies anywhere on a wire, endpoints included.
+    fn covers(&self, x: f64, y: f64) -> bool {
+        self.hits(x, y).next().is_some()
+    }
+
+    /// Lies on the interior of a wire — a T-junction, which KiCAD connects
+    /// without splitting the crossed wire.
+    fn covers_interior(&self, x: f64, y: f64) -> bool {
+        self.hits(x, y).any(|wire| {
+            !points_coincident(x, y, wire.x1, wire.y1, self.tol)
+                && !points_coincident(x, y, wire.x2, wire.y2, self.tol)
+        })
+    }
+}
+
+// ─── Union-find net graph ─────────────────────────────────────────────────────
+
+/// A graph node's identity: coordinates quantized to 1 µm.
+///
+/// Deliberately *not* the index's tolerance. This is an equality key, and a
+/// bucket boundary would separate two points closer together than two points it
+/// keeps — so widening it does not make near-misses union, it only makes which
+/// ones union depend on where the grid falls. Tolerance is applied by
+/// [`seed_net_graph`]'s attach step, which is where a near-miss is resolved
+/// against a wire it lies on.
+pub(crate) fn pt_key(x: f64, y: f64) -> (i64, i64) {
+    ((x * 1000.0).round() as i64, (y * 1000.0).round() as i64)
+}
+
+pub(crate) struct NetGraph {
+    pub(crate) point_nets: HashMap<(i64, i64), String>,
+    pub(crate) parent: HashMap<(i64, i64), (i64, i64)>,
+}
+
+impl NetGraph {
+    pub(crate) fn new() -> Self {
+        NetGraph {
+            point_nets: HashMap::new(),
+            parent: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn ensure(&mut self, k: (i64, i64)) {
+        self.parent.entry(k).or_insert(k);
+    }
+
+    pub(crate) fn find(&mut self, k: (i64, i64)) -> (i64, i64) {
+        self.ensure(k);
+        let p = self.parent[&k];
+        if p == k {
+            return k;
+        }
+        let root = self.find(p);
+        self.parent.insert(k, root);
+        root
+    }
+
+    pub(crate) fn union(&mut self, a: (i64, i64), b: (i64, i64)) {
+        let ra = self.find(a);
+        let rb = self.find(b);
+        if ra != rb {
+            self.parent.insert(rb, ra);
+        }
+    }
+
+    pub(crate) fn add_wire(&mut self, w: &Wire) {
+        let a = pt_key(w.x1, w.y1);
+        let b = pt_key(w.x2, w.y2);
+        self.ensure(a);
+        self.ensure(b);
+        self.union(a, b);
+    }
+
+    pub(crate) fn add_label(&mut self, x: f64, y: f64, net: &str) {
+        let k = pt_key(x, y);
+        self.ensure(k);
+        self.point_nets.insert(k, net.to_string());
+    }
+
+    pub(crate) fn net_at(&mut self, x: f64, y: f64) -> Option<String> {
+        let k = pt_key(x, y);
+        self.ensure(k);
+        let root = self.find(k);
+        let labels: Vec<_> = self.point_nets.clone().into_iter().collect();
+        for (lk, net) in labels {
+            if self.find(lk) == root {
+                return Some(net);
+            }
+        }
+        None
+    }
+
+    pub(crate) fn points_on_net(&mut self, net: &str) -> Vec<(i64, i64)> {
+        // Collect keys first to avoid simultaneous borrow of point_nets and self.find()
+        let net_keys: Vec<(i64, i64)> = self
+            .point_nets
+            .iter()
+            .filter(|(_, n)| n.as_str() == net)
+            .map(|(k, _)| *k)
+            .collect();
+        let net_roots: HashSet<(i64, i64)> = net_keys.iter().map(|k| self.find(*k)).collect();
+        let all_keys: Vec<(i64, i64)> = self.parent.keys().cloned().collect();
+        all_keys
+            .into_iter()
+            .filter(|k| net_roots.contains(&self.find(*k)))
+            .collect()
+    }
+}
+
+/// Seed a graph from the terminals that name and join nets. Both
+/// [`net_graph_for`] and [`ConnectivityIndex::net_graph`] come through here, so
+/// the two cannot answer differently.
+///
+/// Labels and junction dots connect anywhere along a wire, not only at an
+/// endpoint, so each is unioned with every wire it lies on.
+///
+/// Sheet pins are only *registered*, never attached mid-span. A hierarchical
+/// sheet pin is a pin, and KiCad connects a pin landing mid-wire only through a
+/// junction dot (#104) — the rule [`ConnectivityIndex::attaches_pin`] states for
+/// symbol pins. A wire that *ends* on a sheet pin is already unioned by
+/// `add_wire`, and one that merely passes through its coordinates must not be:
+/// a wire routed along a sheet edge would otherwise merge with whatever net
+/// that pin carries, inventing a short KiCad does not see. Registering the
+/// point is still worth doing, so a query at a sheet pin resolves its net.
+fn seed_net_graph(
+    wires: &[Wire],
+    labels: &[Label],
+    junctions: &[(f64, f64)],
+    sheet_pins: &[(f64, f64)],
+    on_wire: &WireIndex,
+) -> NetGraph {
+    let mut graph = NetGraph::new();
+    for wire in wires {
+        graph.add_wire(wire);
+    }
+    let attach = |graph: &mut NetGraph, x: f64, y: f64| {
+        for wire in on_wire.hits(x, y) {
+            graph.union(pt_key(x, y), pt_key(wire.x1, wire.y1));
+        }
+    };
+    for label in labels {
+        graph.add_label(label.x, label.y, &label.net);
+        attach(&mut graph, label.x, label.y);
+    }
+    for &(x, y) in junctions {
+        graph.ensure(pt_key(x, y));
+        attach(&mut graph, x, y);
+    }
+    for &(x, y) in sheet_pins {
+        graph.ensure(pt_key(x, y));
+    }
+    graph
+}
+
+/// The net graph for a whole tree, at [`COINCIDENT_TOLERANCE`].
+///
+/// `labels` must be `extract_all_net_labels` — power symbols name nets too, and
+/// a graph built from `extract_labels` alone reports every `power:` rail
+/// unconnected.
+///
+/// This deliberately does not go through [`ConnectivityIndex`]: the graph reads
+/// none of the pin geometry an index parses, and this is the entry point ten
+/// read-only tools use.
+pub(crate) fn net_graph_for(tree: &SexpNode, wires: &[Wire], labels: &[Label]) -> NetGraph {
+    seed_net_graph(
+        wires,
+        labels,
+        &extract_junctions(tree),
+        &extract_sheet_pins(tree),
+        &WireIndex::build(wires, COINCIDENT_TOLERANCE),
+    )
+}
+
+// ─── The index ────────────────────────────────────────────────────────────────
+
+/// A pin on the sheet, with the reference designator that owns it. Unit-aware
+/// via `placed_pins_by_reference`, so a multi-unit symbol never contributes
+/// another unit's pins as phantom connection points (#35).
+pub(crate) struct PlacedPin {
+    pub(crate) reference: String,
+    /// The owning component's value, carried so a caller reporting a pin does
+    /// not re-walk the instances this was built from.
+    pub(crate) value: String,
+    pub(crate) pin: LibPin,
+    pub(crate) at: (f64, f64),
+}
+
+/// Every item that can terminate a point on one sheet, under one tolerance.
+pub(crate) struct ConnectivityIndex<'a> {
+    wires: &'a [Wire],
+    labels: &'a [Label],
+    on_wire: WireIndex<'a>,
+    wire_ends: PointIndex,
+    label_points: PointIndex,
+    pin_points: PointIndex,
+    sheet_pin_points: PointIndex,
+    junction_points: PointIndex,
+    no_connect_points: PointIndex,
+    placed_pins: Vec<PlacedPin>,
+}
+
+impl<'a> ConnectivityIndex<'a> {
+    /// `labels` should be `extract_all_net_labels`: a power symbol names a net
+    /// exactly as a label does, and [`net_graph`](Self::net_graph) needs both.
+    /// Its points coincide with the power symbol's own pin, so passing them
+    /// changes no coincidence answer — only the names the graph can reach.
+    pub(crate) fn build(
+        tree: &SexpNode,
+        wires: &'a [Wire],
+        labels: &'a [Label],
+        tolerance: f64,
+    ) -> Self {
+        let placed_pins: Vec<PlacedPin> = crate::tools::placed_pins_by_reference(tree)
+            .into_iter()
+            .flat_map(|(inst, pins)| {
+                pins.into_iter().map(move |(pin, transform)| PlacedPin {
+                    reference: inst.reference.clone(),
+                    value: inst.value.clone(),
+                    at: pin_endpoint(&pin, transform),
+                    pin,
+                })
+            })
+            .collect();
+        let junctions = extract_junctions(tree);
+        let sheet_pins = extract_sheet_pins(tree);
+
+        ConnectivityIndex {
+            wires,
+            labels,
+            on_wire: WireIndex::build(wires, tolerance),
+            wire_ends: PointIndex::build(
+                wires
+                    .iter()
+                    .flat_map(|wire| [(wire.x1, wire.y1), (wire.x2, wire.y2)]),
+                tolerance,
+            ),
+            // Power symbols excluded on purpose. `extract_power_symbol_labels`
+            // places a pseudo-label *on the symbol's own pin*, so indexing it
+            // here would make every power pin see a label at its own position
+            // and report itself attached — hiding the unwired GND that is one
+            // of the commonest real mistakes on a sheet. A wire arriving at a
+            // power symbol is terminated by its pin, which `pin_points` covers.
+            label_points: PointIndex::build(
+                labels
+                    .iter()
+                    .filter(|label| label.kind != LabelKind::PowerSymbol)
+                    .map(|label| (label.x, label.y)),
+                tolerance,
+            ),
+            pin_points: PointIndex::build(placed_pins.iter().map(|p| p.at), tolerance),
+            sheet_pin_points: PointIndex::build(sheet_pins, tolerance),
+            junction_points: PointIndex::build(junctions, tolerance),
+            no_connect_points: PointIndex::build(extract_no_connects(tree), tolerance),
+            placed_pins,
+        }
+    }
+
+    pub(crate) fn placed_pins(&self) -> &[PlacedPin] {
+        &self.placed_pins
+    }
+
+    pub(crate) fn labels(&self) -> &[Label] {
+        self.labels
+    }
+
+    /// How many wire endpoints lie at `(x, y)`. A point that is itself a wire
+    /// endpoint counts itself, so two or more means wires meet here.
+    pub(crate) fn wire_ends_at(&self, x: f64, y: f64) -> usize {
+        self.wire_ends.count_at(x, y)
+    }
+
+    pub(crate) fn has_wire_end(&self, x: f64, y: f64) -> bool {
+        self.wire_ends.contains(x, y)
+    }
+
+    /// Lies anywhere on a wire, endpoints included.
+    pub(crate) fn on_wire(&self, x: f64, y: f64) -> bool {
+        self.on_wire.covers(x, y)
+    }
+
+    /// Lies on a wire's interior — a T-junction KiCAD connects without
+    /// splitting the crossed wire.
+    pub(crate) fn on_wire_interior(&self, x: f64, y: f64) -> bool {
+        self.on_wire.covers_interior(x, y)
+    }
+
+    pub(crate) fn has_label(&self, x: f64, y: f64) -> bool {
+        self.label_points.contains(x, y)
+    }
+
+    /// How many pins lie at `(x, y)`. A point that is itself a pin counts
+    /// itself, so two or more means pins are stacked — a legal connection.
+    pub(crate) fn pins_at(&self, x: f64, y: f64) -> usize {
+        self.pin_points.count_at(x, y)
+    }
+
+    pub(crate) fn has_pin(&self, x: f64, y: f64) -> bool {
+        self.pin_points.contains(x, y)
+    }
+
+    pub(crate) fn has_sheet_pin(&self, x: f64, y: f64) -> bool {
+        self.sheet_pin_points.contains(x, y)
+    }
+
+    pub(crate) fn has_junction(&self, x: f64, y: f64) -> bool {
+        self.junction_points.contains(x, y)
+    }
+
+    pub(crate) fn has_no_connect(&self, x: f64, y: f64) -> bool {
+        self.no_connect_points.contains(x, y)
+    }
+
+    /// Whether a wire endpoint at `(x, y)` is terminated. Everything but the
+    /// endpoint itself terminates it: a pin, a label, a hierarchical sheet pin,
+    /// a junction dot, a no-connect flag, another wire's endpoint, or the
+    /// interior of a wire it lands mid-span on.
+    pub(crate) fn terminates_wire_end(&self, x: f64, y: f64) -> bool {
+        self.has_pin(x, y)
+            || self.has_label(x, y)
+            || self.has_sheet_pin(x, y)
+            || self.has_junction(x, y)
+            || self.has_no_connect(x, y)
+            || self.wire_ends_at(x, y) >= 2
+            || self.on_wire_interior(x, y)
+    }
+
+    /// Whether a pin at `(x, y)` is attached to anything. A wire ending on it,
+    /// a label naming it, a hierarchical sheet pin meeting it, or a second pin
+    /// stacked on it all connect. A pin landing mid-wire connects only through
+    /// a junction dot: KiCAD's netlister registers the unsplit wire at a
+    /// junction point, so the dot alone is enough (#104).
+    pub(crate) fn attaches_pin(&self, x: f64, y: f64) -> bool {
+        self.has_wire_end(x, y)
+            || self.has_label(x, y)
+            || self.has_sheet_pin(x, y)
+            || self.pins_at(x, y) >= 2
+            || (self.has_junction(x, y) && self.on_wire(x, y))
+    }
+
+    /// Every wire endpoint that nothing terminates, as `(x, y, wire uuid)`.
+    /// Both tools that report floating ends read this, so a refinement to what
+    /// counts as terminated cannot land in only one of them.
+    pub(crate) fn floating_wire_ends(&self) -> Vec<(f64, f64, Option<&str>)> {
+        self.wires
+            .iter()
+            .flat_map(|wire| {
+                [(wire.x1, wire.y1), (wire.x2, wire.y2)].map(|(x, y)| (x, y, wire.uuid.as_deref()))
+            })
+            .filter(|&(x, y, _)| !self.terminates_wire_end(x, y))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod agreement_tests {
+    use super::*;
+    use crate::tools::{ServerConfig, ToolContext};
+    use konnect_sexp::schematic::{extract_all_net_labels, extract_wires, read_schematic};
+    use serde_json::json;
+    use std::io::Write;
+    use std::sync::Arc;
+
+    /// Run a registered tool from either schematic toolset against a temporary
+    /// file, exactly as the MCP dispatch layer does after selecting its
+    /// `ToolDef`. Both toolsets are searched so one test can ask two tools the
+    /// same question — which is the whole point of this module.
+    async fn call(
+        tool_name: &str,
+        schematic: &str,
+        mut args: serde_json::Value,
+    ) -> serde_json::Value {
+        let mut file = tempfile::NamedTempFile::with_suffix(".kicad_sch").unwrap();
+        file.write_all(schematic.as_bytes()).unwrap();
+        file.flush().unwrap();
+        args["schematic"] = json!(file.path().to_str().unwrap());
+
+        let definition = crate::tools::sch_analysis::tools()
+            .into_iter()
+            .chain(crate::tools::sch_batch::tools())
+            .find(|tool| tool.name == tool_name)
+            .unwrap_or_else(|| panic!("no tool named {tool_name}"));
+        let context = ToolContext::new(
+            ServerConfig::default(),
+            Arc::new(crate::router::ToolRouter::new()),
+        );
+        let result = (definition.handler)(&args, Arc::new(context))
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{tool_name} failed: {:?}", result.content);
+        let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text content from {tool_name}");
+        };
+        serde_json::from_str(text).unwrap()
+    }
+
+    /// A one-pin symbol whose connection point is the placement origin.
+    const LIB: &str = "\t(lib_symbols\n\t\t(symbol \"Test:P1\"\n\t\t\t(symbol \"P1_1_1\"\n\t\t\t\t(pin passive line (at 0 0 0) (length 2.54)\n\t\t\t\t\t(name \"~\" (effects (font (size 1.27 1.27))))\n\t\t\t\t\t(number \"1\" (effects (font (size 1.27 1.27))))\n\t\t\t\t)\n\t\t\t)\n\t\t)\n\t)\n";
+
+    fn symbol(reference: &str, uuid: &str, x: f64, y: f64) -> String {
+        format!(
+            "\t(symbol\n\t\t(lib_id \"Test:P1\")\n\t\t(at {x} {y} 0)\n\t\t(unit 1)\n\t\t(uuid \"{uuid}\")\n\t\t(property \"Reference\" \"{reference}\"\n\t\t\t(at {x} {y} 0)\n\t\t)\n\t)\n"
+        )
+    }
+
+    fn sheet(x: f64, y: f64, pin_x: f64, pin_y: f64) -> String {
+        format!(
+            "\t(sheet\n\t\t(at {x} {y})\n\t\t(size 20 20)\n\t\t(uuid \"sh1\")\n\t\t(pin \"OUT\" input\n\t\t\t(at {pin_x} {pin_y} 180)\n\t\t\t(uuid \"sp1\")\n\t\t)\n\t)\n"
+        )
+    }
+
+    fn schematic(body: &str) -> String {
+        format!("(kicad_sch\n\t(version 20260306)\n\t(generator \"eeschema\")\n\t(uuid \"root\")\n{LIB}{body}\t(sheet_instances (path \"/\" (page \"1\")))\n)\n")
+    }
+
+    /// U1 —— wire —— sheet pin. Both ends of the wire are terminated, and every
+    /// tool has to say so: `validate_wire_connections` used to report the
+    /// sheet-pin end as floating because sheet pins were not in its item set.
+    #[tokio::test]
+    async fn a_sheet_pin_terminates_a_wire_end_for_every_tool() {
+        let sch = schematic(&format!(
+            "\t(wire\n\t\t(pts (xy 100 80) (xy 120 80))\n\t\t(uuid \"w1\")\n\t)\n{}{}",
+            symbol("U1", "u1", 100.0, 80.0),
+            sheet(120.0, 70.0, 120.0, 80.0),
+        ));
+
+        let orphans = call("find_orphan_items", &sch, json!({})).await;
+        assert_eq!(orphans["orphan_count"], 0, "{orphans}");
+
+        let wires = call("validate_wire_connections", &sch, json!({})).await;
+        assert_eq!(wires["floating_count"], 0, "{wires}");
+    }
+
+    /// Two pins placed on each other are a legal connection with no wire at
+    /// all. `find_orphan_items` has always counted it; the component validator
+    /// used to demand a wire endpoint and report both pins unconnected.
+    #[tokio::test]
+    async fn stacked_pins_are_connected_for_every_tool() {
+        let sch = schematic(&format!(
+            "{}{}",
+            symbol("U1", "u1", 100.0, 80.0),
+            symbol("U2", "u2", 100.0, 80.0),
+        ));
+
+        let orphans = call("find_orphan_items", &sch, json!({})).await;
+        assert_eq!(orphans["orphan_count"], 0, "{orphans}");
+
+        let components = call("validate_component_connections", &sch, json!({})).await;
+        assert_eq!(components["unconnected_count"], 0, "{components}");
+    }
+
+    /// A lone pin is unconnected for both tools — the agreement has to hold in
+    /// the direction that still reports a fault, or the fix above is just a
+    /// blanket "everything is connected".
+    #[tokio::test]
+    async fn an_isolated_pin_is_unconnected_for_every_tool() {
+        let sch = schematic(&symbol("U1", "u1", 100.0, 80.0));
+
+        let orphans = call("find_orphan_items", &sch, json!({})).await;
+        assert_eq!(orphans["orphan_count"], 1, "{orphans}");
+        assert_eq!(orphans["orphans"][0]["type"], "unconnected_pin");
+
+        let components = call("validate_component_connections", &sch, json!({})).await;
+        assert_eq!(components["unconnected_count"], 1, "{components}");
+        assert_eq!(components["unconnected_pins"][0]["reference"], "U1");
+    }
+
+    /// The component validator still reports the value it always has, which now
+    /// comes from a lookup rather than from the instance being iterated.
+    #[tokio::test]
+    async fn an_unconnected_pin_still_reports_its_component_value() {
+        let sch = schematic(&symbol("U1", "u1", 100.0, 80.0).replace(
+            "(property \"Reference\" \"U1\"",
+            "(property \"Value\" \"10k\"\n\t\t\t(at 100 80 0)\n\t\t)\n\t\t(property \"Reference\" \"U1\"",
+        ));
+
+        let components = call("validate_component_connections", &sch, json!({})).await;
+        assert_eq!(
+            components["unconnected_pins"][0]["value"], "10k",
+            "{components}"
+        );
+    }
+
+    /// A graph seeded exactly as `net_graph_for` seeds one, but at a chosen
+    /// tolerance, so a test can vary the only knob the seeder takes.
+    fn graph_at(
+        tree: &konnect_sexp::SexpNode,
+        wires: &[Wire],
+        labels: &[Label],
+        tol: f64,
+    ) -> NetGraph {
+        seed_net_graph(
+            wires,
+            labels,
+            &extract_junctions(tree),
+            &extract_sheet_pins(tree),
+            &WireIndex::build(wires, tol),
+        )
+    }
+
+    fn index_for(sch: &str) -> (konnect_sexp::SexpNode, Vec<Wire>, Vec<Label>) {
+        let mut file = tempfile::NamedTempFile::with_suffix(".kicad_sch").unwrap();
+        file.write_all(sch.as_bytes()).unwrap();
+        file.flush().unwrap();
+        let (_, tree) = read_schematic(file.path()).unwrap();
+        let wires = extract_wires(&tree);
+        let labels = extract_all_net_labels(&tree);
+        (tree, wires, labels)
+    }
+
+    /// The graph now attaches at the index's tolerance instead of a hardcoded
+    /// 0.01, so a label 0.03 mm off a wire joins that wire's net when the
+    /// caller asked for 0.05 and stays an island when it asked for 0.01.
+    #[tokio::test]
+    async fn the_graph_attaches_at_the_index_tolerance() {
+        let sch = schematic(
+            "\t(wire\n\t\t(pts (xy 100 80) (xy 120 80))\n\t\t(uuid \"w1\")\n\t)\n\t(label \"NETA\"\n\t\t(at 110 80.03 0)\n\t\t(uuid \"l1\")\n\t)\n",
+        );
+        let (tree, wires, labels) = index_for(&sch);
+
+        for (tolerance, expected) in [(0.05, Some("NETA".to_string())), (0.01, None)] {
+            let mut graph = graph_at(&tree, &wires, &labels, tolerance);
+            assert_eq!(
+                graph.net_at(100.0, 80.0),
+                expected,
+                "tolerance {tolerance} should have given {expected:?}"
+            );
+        }
+    }
+
+    /// A wire *ending* on a sheet pin reaches it, so the net does not stop at
+    /// the sheet boundary — the blindness this index was built to remove.
+    #[tokio::test]
+    async fn a_wire_ending_on_a_sheet_pin_joins_its_net() {
+        let sch = schematic(&format!(
+            "\t(wire\n\t\t(pts (xy 100 80) (xy 120 80))\n\t\t(uuid \"w1\")\n\t)\n\t(label \"NETA\"\n\t\t(at 100 80 0)\n\t\t(uuid \"l1\")\n\t)\n{}",
+            sheet(120.0, 70.0, 120.0, 80.0),
+        ));
+        let (tree, wires, labels) = index_for(&sch);
+        let index = ConnectivityIndex::build(&tree, &wires, &labels, COINCIDENT_TOLERANCE);
+
+        assert!(index.has_sheet_pin(120.0, 80.0));
+        let mut graph = net_graph_for(&tree, &wires, &labels);
+        assert_eq!(graph.net_at(120.0, 80.0), Some("NETA".to_string()));
+    }
+
+    /// A sheet pin a wire merely passes through is a pin landing mid-wire, and
+    /// KiCad connects one of those only through a junction dot (#104). Merging
+    /// without the dot would invent a short between the net on the wire and
+    /// whatever the sheet pin carries.
+    #[tokio::test]
+    async fn a_sheet_pin_mid_wire_joins_its_net_only_through_a_junction() {
+        for (junction, expected) in [
+            ("", None),
+            (
+                "\t(junction (at 120 80) (diameter 0) (color 0 0 0 0) (uuid \"j1\"))\n",
+                Some("NETA".to_string()),
+            ),
+        ] {
+            let sch = schematic(&format!(
+                "\t(wire\n\t\t(pts (xy 100 80) (xy 140 80))\n\t\t(uuid \"w1\")\n\t)\n\t(label \"NETA\"\n\t\t(at 100 80 0)\n\t\t(uuid \"l1\")\n\t)\n{junction}{}",
+                sheet(110.0, 70.0, 120.0, 80.0),
+            ));
+            let (tree, wires, labels) = index_for(&sch);
+            let index = ConnectivityIndex::build(&tree, &wires, &labels, COINCIDENT_TOLERANCE);
+
+            assert!(index.has_sheet_pin(120.0, 80.0));
+            let mut graph = net_graph_for(&tree, &wires, &labels);
+            assert_eq!(
+                graph.net_at(120.0, 80.0),
+                expected,
+                "junction present: {}",
+                !junction.is_empty()
+            );
+        }
+    }
+    fn power_symbol(reference: &str, value: &str, x: f64, y: f64) -> String {
+        format!(
+            "\t(symbol\n\t\t(lib_id \"power:GND\")\n\t\t(at {x} {y} 0)\n\t\t(unit 1)\n\t\t(uuid \"p1\")\n\t\t(property \"Reference\" \"{reference}\"\n\t\t\t(at {x} {y} 0)\n\t\t)\n\t\t(property \"Value\" \"{value}\"\n\t\t\t(at {x} {y} 0)\n\t\t)\n\t)\n"
+        )
+    }
+
+    /// A power symbol's net name is synthesised as a pseudo-label sitting on
+    /// the symbol's own pin. Index that as a label and every power pin sees a
+    /// label at its own position and reports itself attached — so an unwired
+    /// GND, one of the commonest real mistakes, becomes invisible.
+    #[tokio::test]
+    async fn an_unwired_power_symbol_is_still_an_orphan() {
+        let sch = format!(
+            "(kicad_sch\n\t(version 20260306)\n\t(generator \"eeschema\")\n\t(uuid \"root\")\n\t(lib_symbols\n\t\t(symbol \"power:GND\"\n\t\t\t(power)\n\t\t\t(symbol \"GND_0_1\"\n\t\t\t\t(pin power_in line (at 0 0 270) (length 0)\n\t\t\t\t\t(name \"~\") (number \"1\"))\n\t\t\t)\n\t\t)\n\t)\n{}\t(sheet_instances (path \"/\" (page \"1\")))\n)\n",
+            power_symbol("#PWR01", "GND", 100.0, 80.0)
+        );
+
+        let orphans = call("find_orphan_items", &sch, json!({})).await;
+        assert_eq!(orphans["orphan_count"], 1, "{orphans}");
+        assert_eq!(orphans["orphans"][0]["type"], "unconnected_pin");
+        assert_eq!(orphans["orphans"][0]["reference"], "#PWR01");
+    }
+
+    /// Values are read from the instance that placed each pin, not looked up by
+    /// reference: on a pre-annotation sheet every part is `R?`, and a
+    /// reference-keyed map would report one arbitrary value for all of them.
+    #[tokio::test]
+    async fn unannotated_components_keep_their_own_values() {
+        let with_value = |reference: &str, uuid: &str, value: &str, x: f64| {
+            symbol(reference, uuid, x, 80.0).replace(
+                "(property \"Reference\"",
+                &format!("(property \"Value\" \"{value}\"\n\t\t\t(at {x} 80 0)\n\t\t)\n\t\t(property \"Reference\""),
+            )
+        };
+        let sch = schematic(&format!(
+            "{}{}",
+            with_value("R?", "r1", "1k", 100.0),
+            with_value("R?", "r2", "10k", 120.0),
+        ));
+
+        let body = call("validate_component_connections", &sch, json!({})).await;
+        let mut values: Vec<&str> = body["unconnected_pins"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|pin| pin["value"].as_str().unwrap())
+            .collect();
+        values.sort_unstable();
+        assert_eq!(values, ["10k", "1k"], "{body}");
+    }
+
+    /// The power-symbol trap again, one layer down. A pseudo-label is kept out
+    /// of the index's label points, but the *graph* still holds it — so a
+    /// reachability fallback answered "connected" for a power symbol attached
+    /// to nothing, disagreeing with `find_orphan_items` on the same sheet.
+    ///
+    /// There is no such fallback now: every point the graph can name is a wire
+    /// endpoint, label, junction or sheet pin, and `attaches_pin` already
+    /// covers all four at tolerance rather than at exact `pt_key` equality.
+    #[tokio::test]
+    async fn an_unwired_power_symbol_is_unconnected_for_every_tool() {
+        let sch = format!(
+            "(kicad_sch\n\t(version 20260306)\n\t(generator \"eeschema\")\n\t(uuid \"root\")\n\t(lib_symbols\n\t\t(symbol \"power:GND\"\n\t\t\t(power)\n\t\t\t(symbol \"GND_0_1\"\n\t\t\t\t(pin power_in line (at 0 0 270) (length 0)\n\t\t\t\t\t(name \"~\") (number \"1\"))\n\t\t\t)\n\t\t)\n\t)\n{}\t(sheet_instances (path \"/\" (page \"1\")))\n)\n",
+            power_symbol("#PWR01", "GND", 100.0, 80.0)
+        );
+
+        let orphans = call("find_orphan_items", &sch, json!({})).await;
+        assert_eq!(orphans["orphan_count"], 1, "{orphans}");
+        assert_eq!(orphans["orphans"][0]["reference"], "#PWR01");
+
+        let components = call("validate_component_connections", &sch, json!({})).await;
+        assert_eq!(components["unconnected_count"], 1, "{components}");
+        assert_eq!(components["unconnected_pins"][0]["reference"], "#PWR01");
+    }
+
+    /// A power symbol wired to something is connected for both — the agreement
+    /// has to hold in the direction that reports no fault, too.
+    #[tokio::test]
+    async fn a_wired_power_symbol_is_connected_for_every_tool() {
+        let sch = format!(
+            "(kicad_sch\n\t(version 20260306)\n\t(generator \"eeschema\")\n\t(uuid \"root\")\n\t(lib_symbols\n\t\t(symbol \"power:GND\"\n\t\t\t(power)\n\t\t\t(symbol \"GND_0_1\"\n\t\t\t\t(pin power_in line (at 0 0 270) (length 0)\n\t\t\t\t\t(name \"~\") (number \"1\"))\n\t\t\t)\n\t\t)\n\t\t(symbol \"Test:P1\"\n\t\t\t(symbol \"P1_1_1\"\n\t\t\t\t(pin passive line (at 0 0 0) (length 2.54)\n\t\t\t\t\t(name \"~\") (number \"1\"))\n\t\t\t)\n\t\t)\n\t)\n\t(wire\n\t\t(pts (xy 100 80) (xy 120 80))\n\t\t(uuid \"w1\")\n\t)\n{}{}\t(sheet_instances (path \"/\" (page \"1\")))\n)\n",
+            power_symbol("#PWR01", "GND", 100.0, 80.0),
+            symbol("U1", "u1", 120.0, 80.0),
+        );
+
+        let orphans = call("find_orphan_items", &sch, json!({})).await;
+        assert_eq!(orphans["orphan_count"], 0, "{orphans}");
+
+        let components = call("validate_component_connections", &sch, json!({})).await;
+        assert_eq!(components["unconnected_count"], 0, "{components}");
+    }
+}

--- a/crates/konnect-core/src/tools/sch_export.rs
+++ b/crates/konnect-core/src/tools/sch_export.rs
@@ -22,7 +22,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use super::cli;
-use super::sch_analysis::build_net_graph;
+use super::sch_connectivity::net_graph_for;
 
 // ─── Tool definitions ─────────────────────────────────────────────────────────
 
@@ -223,11 +223,7 @@ async fn handle_export_netlist_summary(
         .map(|n| n.find_all("symbol"))
         .unwrap_or_default();
 
-    let mut g = build_net_graph(
-        &wires,
-        &labels,
-        &konnect_sexp::schematic::extract_junctions(&tree),
-    );
+    let mut g = net_graph_for(&tree, &wires, &labels);
 
     // Collect distinct net names
     let mut net_names: Vec<String> = labels.iter().map(|l| l.net.clone()).collect();


### PR DESCRIPTION
## Summary

Asking "is this point connected" had four answers in the tree, and they disagreed on real sheets:

| Where | Tolerance | Counts as connected |
|---|---|---|
| `sch_analysis::find_orphan_items` | argument, default 0.05 | wire end, wire interior, pin, label, sheet pin, junction, no-connect |
| `sch_batch::validate_wire_connections` | argument, default 0.01 | wire end, wire interior, pin, label |
| `sch_batch::validate_component_connections` | hardcoded 0.01 | wire end, junction on a wire, net-graph reachability |
| `build_net_graph` | hardcoded 0.01, whatever the caller asked | wires, labels, junctions — no sheet pins |

Reproduced against `main` before writing any tests:

```
wire ending on a sheet pin: find_orphan_items 0 orphans | validate_wire_connections 1 floating end
two pins placed on each other: find_orphan_items 0 orphans | validate_component_connections 2 unconnected
```

No linked issue — the tracker has nothing on the divergence itself.

## Approach

One `ConnectivityIndex` (`crates/konnect-core/src/tools/sch_connectivity.rs`) built once per tree, holding wires, wire endpoints, labels, unit-aware pins with the instance that placed them, sheet pins, junctions and no-connects **under a single tolerance**. Two predicates carry the policy the tools each used to invent:

- `terminates_wire_end` — a pin, label, sheet pin, junction, no-connect, second wire end, or a wire interior it lands mid-span on.
- `attaches_pin` — a wire end, a label, a sheet pin, a second stacked pin, or a junction dot on a wire.

`NetGraph` moved into the same module and `build_net_graph` became `net_graph_for(tree, wires, labels)`, which reads junctions *and sheet pins* off the tree itself — so all ten call sites gained sheet-pin awareness in a one-line swap. One `seed_net_graph` is the only definition of the graph, and its attach tolerance is a property of the `WireIndex` it is handed rather than a literal in the function body. Every production caller still passes `COINCIDENT_TOLERANCE`, so that part is structure, not a behaviour change.

`placed_pins_by_reference` now yields the whole `SymbolInstance`, so a caller reporting a pin reads the value from the instance that placed it rather than from a reference-keyed map — which collapses on a pre-annotation sheet where every part is `R?`.

## What changes for callers

All in the direction of fewer false faults:

- `validate_wire_connections` — sheet pins, junctions and no-connects terminate a wire end; its pins are unit-aware.
- `validate_component_connections` — stacked pins, a label at a pin, and sheet pins all connect; its pins are unit-aware. Its net-graph reachability fallback is gone (see the third trap below), so an unwired power symbol is now reported.
- `find_orphan_items` — a pin meeting a sheet pin now counts as connected. The only behaviour change it takes.

**Public tolerance defaults are unchanged and no tool schema or JSON key moved.** `find_orphan_items` keeps its `tolerance` argument defaulting to 0.05, `validate_wire_connections` keeps its 0.01, and `validate_component_connections` keeps its hardcoded 0.01 — now the named `COINCIDENT_TOLERANCE` rather than four scattered literals. "One tolerance" is one *per index*, not one global; collapsing the defaults is a separate, user-visible change.

## Three traps worth knowing about

All three were caught in review after an earlier version got them wrong, and all three are now pinned by tests:

- **A power symbol's pseudo-label sits on the symbol's own pin.** Index it as a label and every power pin sees a label at its own position and reports itself attached — which hides an unwired `GND`, one of the commonest real mistakes on a sheet, from `find_orphan_items` entirely. Power symbols are excluded from the index's *label points*; the graph still gets every label, because naming is what it needs them for.
- **A hierarchical sheet pin is a pin.** It is registered in the graph but never attached mid-span: a wire that *ends* on one connects, a wire that merely passes through its coordinates does not, and a junction dot bridges the difference — the same #104 rule `attaches_pin` states for symbol pins. Attaching mid-span would merge a wire routed along a sheet edge with whatever net that pin carries, inventing a short KiCad does not see.
- **The reachability fallback had to go, not stay.** An earlier version kept `graph.net_at(…)` after the coincidence test, on the theory that a fallback can only *remove* false positives. It cannot fire legitimately: every point the graph can name is a wire endpoint, label, junction or sheet pin, and `attaches_pin` covers all four *at tolerance* rather than at exact `pt_key` equality — so `net_at` returning `Some` implies `attaches_pin` already returned true. The single case it did fire on was the power-symbol pseudo-label the index deliberately excludes, so an unwired `GND` came back clean from `validate_component_connections` while `find_orphan_items` called it an orphan. That is this PR'"'"'s own divergence, surviving inside the fix for it. Removing it makes the two agree and costs nothing else.

### One invariant worth stating

Coincidence is a **superset** of the graph, and stays that way. A point is coincident within the index'"'"'s tolerance; the graph joins nodes on exact `pt_key` equality plus the attach step. A wire ending 5 µm off a sheet pin is therefore *terminated* for the validators yet does not reach that pin'"'"'s net. That is the safe direction: leniency suppresses a false "floating end" from a rounding artefact, while strictness stops the graph inventing a connection KiCad'"'"'s own netlister would not make. KiCad snaps to grid, so exact agreement is the normal case. Documented at `pt_key` and in the module header.

## Overlap with open PRs

Both touch handlers this PR rewrites, and both are on the **unit-blind pin resolution** axis (#182) rather than the definition of "connected" — a different axis, deliberately not addressed here:

- **#272 (`fix(schematic): resolve pins through their placed unit`)** — its two `sch_batch` hunks are each one `extract_lib_pins` → `extract_lib_pins_for_unit` line. This PR reaches the same result by a different route, because the index sources pins from `placed_pins_by_reference`, unit-aware since #35/#143. **Its `design_review` and `sch_export` hunks are untouched here and still needed.** It is currently `CONFLICTING` against main independently of this PR.
- **#267 (`fix(schematic): respect intentional unconnected pins`)** — its exemption work on `validate_component_connections` (`electrical_type == "no_connect"`, `ignore_power_pins`, a reported `pin_type`) is policy *over* the connectivity answer rather than the answer itself. Deliberately **not** included here; it stays that PR's to land, and rebasing it onto this index should be mechanical.

Happy to rebase this behind either if maintainers would rather land those first.

## Not in scope

`design_review::find_net_at_point` — the fourth row of the table — resolves nets by a 0.5 mm text scan for `(label "`, follows no wires and knows no power symbols. It never used the net graph, so it is untouched here; moving the audits onto this index is its own change, and the index now exists for it.

A fifth answer turned up while reviewing this one: `sch_export::handle_fix_connectivity` builds its own `snap_targets` at its own 0.01 with its own inline T-junction test, and no sheet pins, junctions or no-connects. It is the worst-placed duplicate because it is the one that *writes* — a wire ending on a sheet pin reads as a near miss and gets snapped. Migrating it changes what the tool edits, so it needs its own PR.

## Testing

Full local gate green: `cargo fmt --check`, `cargo clippy --workspace --locked --all-targets -- -D warnings`, `cargo test --workspace --locked --lib --tests` (609 in `konnect-core`), `cargo test --workspace --locked --doc`. `schematic-viewer` untouched; no MCP tools added or removed, so no count sync needed.

Eleven new tests in `sch_connectivity::agreement_tests`, most asking two tools the same question:

- `a_sheet_pin_terminates_a_wire_end_for_every_tool`
- `stacked_pins_are_connected_for_every_tool`
- `an_isolated_pin_is_unconnected_for_every_tool` — the agreement has to hold in the direction that still reports a fault, or the unification is just a blanket "everything is connected"
- `an_unwired_power_symbol_is_still_an_orphan`
- `an_unwired_power_symbol_is_unconnected_for_every_tool`
- `a_wired_power_symbol_is_connected_for_every_tool`
- `unannotated_components_keep_their_own_values`
- `a_wire_ending_on_a_sheet_pin_joins_its_net`
- `a_sheet_pin_mid_wire_joins_its_net_only_through_a_junction`
- `the_graph_attaches_at_the_index_tolerance`
- `an_unconnected_pin_still_reports_its_component_value`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
