### PR TITLE
test(sch): cover the sheet-pin branch of the junction reconciler

### DIFF
--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -2414,6 +2414,77 @@ mod unit_aware_wiring_tests {
         assert!(has_dot(&out, "120.65", "139.7"));
     }
 
+    /// A hierarchical sheet pin justifies a dot exactly as a symbol pin does —
+    /// the `|| idx.has_sheet_pin(..)` half of the keep rule, which nothing else
+    /// reaches. Candidate points come from moved *symbol* pins, so the branch
+    /// only decides anything when a symbol pin vacates a point a sheet pin also
+    /// holds: in this fixture R1's pin, `test`'s SHPIN and the dot all sit at
+    /// (139.7, 190.5) on a wire's interior. Ask about it with R1 gone — the
+    /// post-move state — and the dot must stay.
+    ///
+    /// Its own fixture rather than an addition to `junction_reconcile`, so the
+    /// tests already merged against that sheet keep the inputs they were written
+    /// for. Built with Konnect tools, then rewritten by `kicad-cli sch upgrade`
+    /// so the committed text is eeschema's own — including the sheet-pin
+    /// placement, which KiCad snaps to the sheet border.
+    #[test]
+    fn reconcile_keeps_a_dot_a_sheet_pin_still_justifies() {
+        const SHEET_PIN_SCH: &str =
+            include_str!("../../tests/fixtures/junction_sheet_pin.kicad_sch");
+        let without_r1 = fixture_without_symbol(SHEET_PIN_SCH, "R1");
+
+        let (out, added, pruned) = reconcile_junctions_at(without_r1, &[(139.7, 190.5)]);
+        assert_eq!(
+            (added, pruned),
+            (0, 0),
+            "the sheet pin still justifies the dot"
+        );
+        assert!(
+            has_dot(&out, "139.7", "190.5"),
+            "the dot must survive: {out}"
+        );
+    }
+
+    /// The fixture with one placed symbol removed, so its pins vanish — the
+    /// post-move state without needing a move.
+    ///
+    /// Guarded, because a silent failure here would be invisible:
+    /// `reconcile_junctions_at` returns its input unchanged when the sheet does
+    /// not parse, which is exactly what a passing sheet-pin test looks like. If
+    /// this ever stops removing what it should, the assertions below fail loudly
+    /// instead of the test going quietly green.
+    fn fixture_without_symbol(src: &str, reference: &str) -> String {
+        let needle = format!("(property \"Reference\" \"{reference}\"");
+        let at = src.find(&needle).expect("fixture carries that reference");
+        let start = src[..at]
+            .rfind("(symbol")
+            .expect("reference sits inside a symbol");
+        let mut depth = 0usize;
+        let mut end = start;
+        for (i, c) in src[start..].char_indices() {
+            match c {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = start + i + 1;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        assert!(end > start, "never closed the symbol block");
+        let out = format!("{}{}", &src[..start], &src[end..]);
+        assert!(!out.contains(&needle), "the symbol is still there");
+        assert_eq!(
+            out.matches('(').count(),
+            out.matches(')').count(),
+            "removal left unbalanced parens, so the sheet would not parse"
+        );
+        out
+    }
+
     /// A real T — two wires meeting — is never touched.
     #[test]
     fn reconcile_keeps_a_real_tee() {

--- a/crates/konnect-core/tests/fixtures/junction_sheet_pin.kicad_sch
+++ b/crates/konnect-core/tests/fixtures/junction_sheet_pin.kicad_sch
@@ -1,0 +1,299 @@
+(kicad_sch
+	(version 20260306)
+	(generator "eeschema")
+	(generator_version "10.0")
+	(uuid "91c5185a-d073-42a0-afa9-7e178a3c1c49")
+	(paper "A4")
+	(lib_symbols
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(junction
+		(at 139.7 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5a8cde2f-9cb4-4a62-8002-1d2123652006")
+	)
+	(wire
+		(pts
+			(xy 119.38 190.5) (xy 160.02 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "62fbb9fc-aca6-4f15-aac0-5b13ae457afa")
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 139.7 186.69 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "706e5fce-c33a-4899-9446-7e6d6a9ef5d2")
+		(property "Reference" "R1"
+			(at 141.732 186.69 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1k"
+			(at 139.7 186.69 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 186.69 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 139.7 186.69 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 186.69 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "cf1d10eb-32cb-4e10-af77-33df0287bd63")
+		)
+		(pin "2"
+			(uuid "eb8664f7-927d-4ff7-a807-4085bb55293e")
+		)
+		(instances
+			(project "probe"
+				(path "/91c5185a-d073-42a0-afa9-7e178a3c1c49"
+					(reference "R1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(sheet
+		(at 109.22 180.34)
+		(size 30.48 25.4)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(stroke
+			(width 0.1524)
+			(type solid)
+		)
+		(fill
+			(color 0 0 0 0)
+		)
+		(uuid "6d56e2ba-48e8-474c-a0a4-34a68efd2865")
+		(property "Sheetname" "test"
+			(at 109.22 179.705 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "test.kicad_sch"
+			(at 109.22 206.375 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "SHPIN" input
+			(at 139.7 190.5 0)
+			(uuid "71a25bcb-7ed6-49b4-b138-c4d9846b5a3d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(instances
+			(project "probe"
+				(path "/91c5185a-d073-42a0-afa9-7e178a3c1c49"
+					(page "2")
+				)
+			)
+		)
+	)
+)


### PR DESCRIPTION
## Summary

Follow-up to #330, closing the gap you flagged there rather than blocked on: `attached = has_pin || has_sheet_pin` had no test for its second half. Tests only — no behaviour change.

## Approach

The branch is reachable exactly one way. Candidate points come from moved *symbol* pins, so the sheet-pin clause only decides anything when a symbol pin vacates a point a hierarchical sheet pin also holds. The fixture puts R1's pin, the sheet's `SHPIN` and the dot all at `(139.7, 190.5)` on a wire's interior; the test removes R1 — the post-move state — and asserts the dot survives on the sheet pin alone.

**Its own fixture rather than an addition to `junction_reconcile.kicad_sch`.** My first attempt added a sheet to the shared one, which perturbed the inputs of the six tests already merged against it and forced edits to `bulk_move_prunes_the_junction_its_pin_vacates`'s dot counts. Adjusting merged assertions to accommodate a new test is the wrong trade, so this leaves them untouched.

Two details KiCad decided rather than me, both preserved in the committed text: a sheet pin snaps to the sheet **border**, so the sheet is placed with its right border on the target point and sized `30.48` (24 × 1.27) to land on the grid a symbol pin snaps to — my first attempt had the pin at `170.18` while the symbol pin sat at `139.7`, silently not coincident and passing for the wrong reason. Its `Sheetfile` names an existing fixture so the reference resolves rather than dangling.

## Compatibility and safety

None — no source behaviour changes, no public names, no schema. One new fixture file and one test plus its helper.

The helper that strips the symbol is guarded, because a silent failure here is invisible: `reconcile_junctions_at` returns its input unchanged when the sheet does not parse, which is exactly what a passing sheet-pin test looks like. It asserts the symbol is gone and the parens balance.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --locked --lib --tests` — 768 pass, 1 ignored
- [x] `cargo test --workspace --locked --doc`
- [x] `cargo clippy --workspace --locked --all-targets -- -D warnings`

Two mutation checks, since a test that merely runs near a branch is not coverage:

- deleting `|| idx.has_sheet_pin(px, py)` → **this test fails, and only this test**
- sabotaging the strip helper's paren balancing → **fails loudly** rather than going green

Fixture is `kicad-cli sch upgrade` output and byte-identical to a fresh rewrite, so the provenance claim is checkable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)