### PR TITLE
fix(pcb): write the Default netclass complete, and repair one that is not

### DIFF
--- a/crates/konnect-core/src/tools/pcb_routing.rs
+++ b/crates/konnect-core/src/tools/pcb_routing.rs
@@ -222,7 +222,10 @@ pub fn tools() -> Vec<ToolDef> {
              changes only the values you name, and this is the only way to see the \
              rest. A net can match several classes: KiCad takes each property from \
              the highest-priority class that sets it (lower number = higher \
-             priority) and falls back to Default.",
+             priority) and falls back to Default. Settings are reported \
+             resolved, with 'inherits' naming the ones a class takes from the \
+             Default rather than setting itself; 'missing_fields' on the \
+             Default names settings nothing can resolve.",
             json!({
                 "type": "object",
                 "properties": {
@@ -682,9 +685,9 @@ fn kicad_default_class() -> serde_json::Value {
         "bus_width": 12,
         "line_style": 0,
         "clearance": 0.2,
-        "track_width": 0.25,
-        "via_diameter": 0.8,
-        "via_drill": 0.4,
+        "track_width": 0.2,
+        "via_diameter": 0.6,
+        "via_drill": 0.3,
         "microvia_diameter": 0.3,
         "microvia_drill": 0.1,
         "diff_pair_width": 0.2,
@@ -781,8 +784,9 @@ async fn handle_create_netclass(
         false
     } else {
         // Sparse on purpose: a key omitted here resolves from the Default, so
-        // writing the full set would sever that inheritance.
-        let mut class = json!({ "name": name, "priority": 0 });
+        // writing the full set would sever that inheritance. -1 is what
+        // KiCad's constructor gives every non-default class.
+        let mut class = json!({ "name": name, "priority": -1 });
         for (key, arg, default) in FIELDS {
             class[key] = json!(opt_f64(args, arg).unwrap_or(default));
         }
@@ -820,6 +824,7 @@ async fn handle_create_netclass(
     Ok(CallToolResult::json(&json!({
         "created_netclass": name,
         "updated_existing": updated,
+        "is_default": is_default,
         "clearance": stored["clearance"], "trace_width": stored["track_width"],
         "via_drill": stored["via_drill"], "via_diameter": stored["via_diameter"],
         "file": pro.display().to_string(),
@@ -867,6 +872,10 @@ fn wildcard_matches(pattern: &str, name: &str) -> bool {
 /// The four settings `create_netclass` writes, as (KiCad's key, this API's
 /// name). Reported per class so a caller can see what a class holds before
 /// overwriting it — the gap that made #220 hard to review.
+///
+/// A key absent from a named class means inheritance, not an unset value, so
+/// these are reported resolved with `inherits` naming what came from the
+/// Default (#326).
 const NETCLASS_FIELDS: [(&str, &str); 4] = [
     ("clearance", "clearance"),
     ("track_width", "trace_width"),
@@ -923,6 +932,16 @@ async fn handle_get_netclasses(
         ),
     };
 
+    // What an omitted key resolves to. A Default in the file is the whole
+    // fallback, holes included; KiCad's seeded one applies only when the file
+    // has none.
+    let seeded = kicad_default_class();
+    let effective_default = classes
+        .iter()
+        .find(|c| c["name"] == json!(DEFAULT_CLASS_NAME))
+        .cloned()
+        .unwrap_or_else(|| seeded.clone());
+
     let mut out = Vec::new();
     for class in &classes {
         let name = class["name"].as_str().unwrap_or_default().to_string();
@@ -954,8 +973,40 @@ async fn handle_get_netclasses(
             "patterns": pattern_strings,
             "matched_nets": matched,
         });
+        let mut inherits: Vec<&str> = Vec::new();
         for (key, api) in NETCLASS_FIELDS {
-            entry[api] = class[key].clone();
+            let own = class.get(key).filter(|v| !v.is_null());
+            entry[api] = match own {
+                Some(value) => value.clone(),
+                None if !is_default => {
+                    let inherited = effective_default[key].clone();
+                    if !inherited.is_null() {
+                        inherits.push(api);
+                    }
+                    inherited
+                }
+                None => serde_json::Value::Null,
+            };
+        }
+        entry["inherits"] = json!(inherits);
+
+        // Nothing backfills the Default, so a key missing here is missing
+        // project-wide — and KiCad reports none of it.
+        if is_default {
+            let missing: Vec<&str> = seeded
+                .as_object()
+                .expect("kicad_default_class builds an object")
+                .keys()
+                .filter(|key| class.get(*key).is_none_or(|v| v.is_null()))
+                .map(String::as_str)
+                .collect();
+            if !missing.is_empty() {
+                entry["note"] = json!(format!(
+                    "Incomplete Default: KiCad resolves these from nothing. Repair with \
+                     create_netclass(name=\"Default\")."
+                ));
+            }
+            entry["missing_fields"] = json!(missing);
         }
         out.push(entry);
     }
@@ -1370,6 +1421,12 @@ mod netclass_tests {
         assert_eq!(default["wire_width"], json!(6), "{default}");
         assert_eq!(default["bus_width"], json!(12), "{default}");
         assert_eq!(default["line_style"], json!(0), "{default}");
+        // KiCad's own values, not this tool's schema defaults: a written
+        // Default replaces the seeded one, so anything else silently re-specs
+        // the board's routing rules.
+        assert_eq!(default["track_width"], json!(0.2), "{default}");
+        assert_eq!(default["via_diameter"], json!(0.6), "{default}");
+        assert_eq!(default["via_drill"], json!(0.3), "{default}");
         assert_eq!(default["priority"], json!(i32::MAX), "{default}");
         for key in ["schematic_color", "pcb_color", "tuning_profile"] {
             assert!(default.get(key).is_some(), "{key} missing from {default}");
@@ -1438,6 +1495,8 @@ mod netclass_tests {
         let hv = project_json(&board)["net_settings"]["classes"][0].clone();
         assert!(hv.get("wire_width").is_none(), "{hv}");
         assert!(hv.get("diff_pair_gap").is_none(), "{hv}");
+        // KiCad's constructor gives every non-default class -1.
+        assert_eq!(hv["priority"], json!(-1), "{hv}");
     }
 
     /// A project with no Default in its file keeps the one KiCad seeds at
@@ -1810,6 +1869,72 @@ mod netclass_tests {
                 "both classes claim the net: {class}"
             );
         }
+    }
+
+    /// A key absent from a named class is inheritance, not an unset value:
+    /// KiCad fills it from the Default at load. Reporting the raw absence as
+    /// null told a caller a class had no clearance when it had the Default's,
+    /// which is exactly what this tool exists to prevent (#326).
+    #[tokio::test]
+    async fn get_netclasses_reports_inherited_settings_as_inherited() {
+        let (_dir, board) = fixture(true);
+        let pro_path = board.with_extension("kicad_pro");
+        let mut settings = project_json(&board);
+        settings["net_settings"] = json!({
+            "classes": [
+                { "name": "Default", "clearance": 0.3, "track_width": 0.2,
+                  "via_diameter": 0.6, "via_drill": 0.3, "wire_width": 6 },
+                { "name": "HV", "clearance": 0.9 }
+            ],
+            "netclass_patterns": []
+        });
+        std::fs::write(&pro_path, serde_json::to_string_pretty(&settings).unwrap()).unwrap();
+
+        let body = get_classes(&board).await;
+        let hv = body["netclasses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["name"] == "HV")
+            .unwrap()
+            .clone();
+        assert_eq!(hv["clearance"], json!(0.9), "its own value: {hv}");
+        assert_eq!(hv["trace_width"], json!(0.2), "resolved from Default: {hv}");
+        assert_eq!(
+            hv["inherits"],
+            json!(["trace_width", "via_drill", "via_diameter"]),
+            "{hv}"
+        );
+    }
+
+    /// The Default is the root of that inheritance and nothing backfills it,
+    /// so a key missing here is missing project-wide, with no ERC violation
+    /// and no visible error in KiCad. Naming it is the only way a caller finds
+    /// out before the junction dots stop working.
+    #[tokio::test]
+    async fn get_netclasses_names_what_an_incomplete_default_cannot_resolve() {
+        let (_dir, board) = fixture(true);
+        let pro_path = board.with_extension("kicad_pro");
+        let mut settings = project_json(&board);
+        settings["net_settings"] = json!({
+            "classes": [{ "name": "Default", "clearance": 0.2, "track_width": 0.25,
+                          "via_drill": 0.4, "via_diameter": 0.8 }],
+            "netclass_patterns": []
+        });
+        std::fs::write(&pro_path, serde_json::to_string_pretty(&settings).unwrap()).unwrap();
+
+        let body = get_classes(&board).await;
+        let default = body["netclasses"][0].clone();
+        let missing = default["missing_fields"].as_array().unwrap();
+        assert!(missing.contains(&json!("wire_width")), "{default}");
+        assert!(!missing.contains(&json!("clearance")), "{default}");
+        assert!(
+            default["note"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("Default"),
+            "{default}"
+        );
     }
 
     /// A pattern naming a class that does not exist does nothing in KiCad and

--- a/crates/konnect-core/src/tools/pcb_routing.rs
+++ b/crates/konnect-core/src/tools/pcb_routing.rs
@@ -194,7 +194,11 @@ pub fn tools() -> Vec<ToolDef> {
              class holds, call get_netclasses rather than this tool: naming a class \
              that does not exist here creates it with the defaults, so a call meant \
              as a look writes one instead — and its result is nearly \
-             indistinguishable from a read of an existing class.",
+             indistinguishable from a read of an existing class. The class \
+             named 'Default' is special: it is written complete, because KiCad \
+             replaces its own default with it and backfills every other class \
+             from it. Calling this on an existing, incomplete 'Default' \
+             repairs it in place without touching values already set.",
             json!({
                 "type": "object",
                 "properties": {
@@ -655,6 +659,40 @@ fn save_project_settings(
     Ok(())
 }
 
+/// The class every other class inherits from. `SetName` marks it on an exact
+/// match (`netclass.h:96`), so casing matters.
+const DEFAULT_CLASS_NAME: &str = "Default";
+
+/// KiCad's own Default, field for field (`netclass.cpp:36-50`). Schematic
+/// fields are mils, PCB fields mm.
+///
+/// A written Default replaces the one KiCad seeds rather than merging with it,
+/// and nothing backfills it, so every key omitted here resolves from nothing.
+/// Without `wire_width` that means no junction dots anywhere in the project,
+/// silently (#326). See `docs/KICAD_NETCLASS_DEFAULTS.md`.
+fn kicad_default_class() -> serde_json::Value {
+    json!({
+        // Ranks the Default last. A C++ int (`net_settings.cpp:69`), so not
+        // widened past i32.
+        "priority": i32::MAX,
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "tuning_profile": "",
+        "wire_width": 6,
+        "bus_width": 12,
+        "line_style": 0,
+        "clearance": 0.2,
+        "track_width": 0.25,
+        "via_diameter": 0.8,
+        "via_drill": 0.4,
+        "microvia_diameter": 0.3,
+        "microvia_drill": 0.1,
+        "diff_pair_width": 0.2,
+        "diff_pair_gap": 0.25,
+        "diff_pair_via_gap": 0.25
+    })
+}
+
 async fn handle_create_netclass(
     args: &serde_json::Value,
     _ctx: &ToolContext,
@@ -674,6 +712,8 @@ async fn handle_create_netclass(
         ("via_drill", "via_drill", 0.4),
         ("via_diameter", "via_diameter", 0.8),
     ];
+    // Only the Default must be complete. Every other class may stay sparse.
+    let is_default = name == DEFAULT_CLASS_NAME;
 
     let (pro, mut settings) = match load_project_settings(&board_path)? {
         Ok(v) => v,
@@ -699,6 +739,7 @@ async fn handle_create_netclass(
     // KiCad keys classes by name; a second entry with the same name is
     // undefined in its dialog, so an existing class is updated in place.
     let mut changed = true;
+    let mut backfilled: Vec<String> = Vec::new();
     let updated = if let Some(class) = classes.iter_mut().find(|c| c["name"] == json!(name)) {
         let before = class.clone();
         for (key, arg, _) in FIELDS {
@@ -706,9 +747,41 @@ async fn handle_create_netclass(
                 class[key] = json!(value);
             }
         }
+        // KiCad backfills from the Default, never into it, so a Default left
+        // incomplete by an older Konnect can only be repaired here. Absent
+        // keys only: overwriting one already set is #220.
+        if is_default {
+            let complete = kicad_default_class();
+            let seeded = complete
+                .as_object()
+                .expect("kicad_default_class builds an object");
+            let class = class.as_object_mut().ok_or_else(|| {
+                anyhow::anyhow!("{}: netclass '{name}' is not an object", pro.display())
+            })?;
+            for (key, value) in seeded {
+                if class.get(key).is_none_or(|v| v.is_null()) {
+                    class.insert(key.clone(), value.clone());
+                    backfilled.push(key.clone());
+                }
+            }
+        }
         changed = *class != before;
         true
+    } else if is_default {
+        // A partial write here erases KiCad's values rather than falling back
+        // to them, so start from the full set.
+        let mut class = kicad_default_class();
+        class["name"] = json!(name);
+        for (key, arg, _) in FIELDS {
+            if let Some(value) = opt_f64(args, arg) {
+                class[key] = json!(value);
+            }
+        }
+        classes.push(class);
+        false
     } else {
+        // Sparse on purpose: a key omitted here resolves from the Default, so
+        // writing the full set would sever that inheritance.
         let mut class = json!({ "name": name, "priority": 0 });
         for (key, arg, default) in FIELDS {
             class[key] = json!(opt_f64(args, arg).unwrap_or(default));
@@ -731,14 +804,26 @@ async fn handle_create_netclass(
         save_project_settings(&pro, &settings)?;
     }
 
+    let note = if backfilled.is_empty() {
+        "Netclasses live in the project file; assign nets with assign_net_to_class. \
+         KiCad reads the change on next project open."
+            .to_string()
+    } else {
+        format!(
+            "Repaired an incomplete Default netclass by adding {}. A Default missing \
+             wire_width stops Eeschema placing junctions anywhere in the project; \
+             reopen the project in KiCad to pick the change up. Netclasses live in the \
+             project file; assign nets with assign_net_to_class.",
+            backfilled.join(", ")
+        )
+    };
     Ok(CallToolResult::json(&json!({
         "created_netclass": name,
         "updated_existing": updated,
         "clearance": stored["clearance"], "trace_width": stored["track_width"],
         "via_drill": stored["via_drill"], "via_diameter": stored["via_diameter"],
         "file": pro.display().to_string(),
-        "note": "Netclasses live in the project file; assign nets with assign_net_to_class. \
-                 KiCad reads the change on next project open."
+        "note": note
     })))
 }
 
@@ -1269,6 +1354,128 @@ mod netclass_tests {
         assert_eq!(pro["meta"]["filename"], json!("demo.kicad_pro"));
     }
 
+    /// #326: a Default written with only the four PCB fields leaves KiCad's
+    /// schematic side resolved from nothing — Eeschema silently refuses to
+    /// place a junction anywhere in the project. KiCad replaces its own seeded
+    /// default with whatever the file holds and backfills nothing into it, so
+    /// the file must carry the whole class.
+    #[tokio::test]
+    async fn create_netclass_writes_the_default_class_complete() {
+        let (_dir, board) = fixture(true);
+        let result = create(&board, json!({ "name": "Default" })).await;
+        assert!(!result.is_error, "{}", text_of(&result));
+
+        let pro = project_json(&board);
+        let default = pro["net_settings"]["classes"][0].clone();
+        assert_eq!(default["wire_width"], json!(6), "{default}");
+        assert_eq!(default["bus_width"], json!(12), "{default}");
+        assert_eq!(default["line_style"], json!(0), "{default}");
+        assert_eq!(default["priority"], json!(i32::MAX), "{default}");
+        for key in ["schematic_color", "pcb_color", "tuning_profile"] {
+            assert!(default.get(key).is_some(), "{key} missing from {default}");
+        }
+    }
+
+    /// The caller still wins over KiCad's values on the Default.
+    #[tokio::test]
+    async fn create_netclass_lets_the_caller_override_the_default_class() {
+        let (_dir, board) = fixture(true);
+        create(&board, json!({ "name": "Default", "trace_width": 0.35 })).await;
+
+        let default = project_json(&board)["net_settings"]["classes"][0].clone();
+        assert_eq!(default["track_width"], json!(0.35), "{default}");
+        assert_eq!(default["wire_width"], json!(6), "{default}");
+    }
+
+    /// The repair path. A project written by an older Konnect already holds a
+    /// four-field Default, and KiCad cannot recover it: `addMissingDefaults`
+    /// fills other classes *from* the Default, never the Default itself. So
+    /// the update path fills what is absent — and nothing else, or this
+    /// reintroduces #220.
+    #[tokio::test]
+    async fn create_netclass_backfills_an_incomplete_default_without_touching_set_values() {
+        let (_dir, board) = fixture(true);
+        let pro_path = board.with_extension("kicad_pro");
+        let mut pro = project_json(&board);
+        pro["net_settings"] = json!({
+            "classes": [{
+                "name": "Default", "priority": 0,
+                "clearance": 1.5, "track_width": 0.25,
+                "via_drill": 0.4, "via_diameter": 0.8
+            }],
+            "meta": { "version": 5 },
+            "netclass_patterns": []
+        });
+        std::fs::write(&pro_path, serde_json::to_string_pretty(&pro).unwrap()).unwrap();
+
+        let result = create(&board, json!({ "name": "Default" })).await;
+        assert!(!result.is_error, "{}", text_of(&result));
+
+        let default = project_json(&board)["net_settings"]["classes"][0].clone();
+        assert_eq!(default["wire_width"], json!(6), "{default}");
+        assert_eq!(default["bus_width"], json!(12), "{default}");
+        // Everything the file already stated survives, priority included:
+        // absent is repaired, present is left alone.
+        assert_eq!(default["clearance"], json!(1.5), "{default}");
+        assert_eq!(default["track_width"], json!(0.25), "{default}");
+        assert_eq!(default["priority"], json!(0), "{default}");
+
+        let echoed: serde_json::Value = serde_json::from_str(&text_of(&result)).unwrap();
+        let note = echoed["note"].as_str().unwrap_or_default();
+        assert!(note.contains("wire_width"), "{note}");
+        assert!(!note.contains("clearance"), "{note}");
+    }
+
+    /// Only the Default carries the completeness requirement. A named class
+    /// that omits a field inherits it, so writing the full set here would
+    /// sever that inheritance and freeze the class against later edits to the
+    /// Default.
+    #[tokio::test]
+    async fn create_netclass_leaves_a_named_class_sparse() {
+        let (_dir, board) = fixture(true);
+        create(&board, json!({ "name": "HV", "clearance": 0.5 })).await;
+
+        let hv = project_json(&board)["net_settings"]["classes"][0].clone();
+        assert!(hv.get("wire_width").is_none(), "{hv}");
+        assert!(hv.get("diff_pair_gap").is_none(), "{hv}");
+    }
+
+    /// A project with no Default in its file keeps the one KiCad seeds at
+    /// construction, which is complete. Inventing a Default alongside a named
+    /// class would replace that healthy class with this tool's idea of it —
+    /// the same failure as #326, wearing a different hat.
+    #[tokio::test]
+    async fn create_netclass_does_not_invent_a_default_alongside_a_named_class() {
+        let (_dir, board) = fixture(true);
+        create(&board, json!({ "name": "HV" })).await;
+
+        let classes = project_json(&board)["net_settings"]["classes"]
+            .as_array()
+            .unwrap()
+            .clone();
+        assert_eq!(classes.len(), 1, "{classes:?}");
+        assert_eq!(classes[0]["name"], json!("HV"), "{classes:?}");
+    }
+
+    /// The name is what makes a class the default, not its place in the array:
+    /// `SetName` sets `m_isDefault` on an exact match and the loader branches
+    /// on that alone. A sparse class sitting at index 0 is ordinary.
+    #[tokio::test]
+    async fn create_netclass_treats_the_default_by_name_not_by_position() {
+        let (_dir, board) = fixture(true);
+        create(&board, json!({ "name": "HV" })).await;
+        create(&board, json!({ "name": "Default" })).await;
+
+        let classes = project_json(&board)["net_settings"]["classes"]
+            .as_array()
+            .unwrap()
+            .clone();
+        assert_eq!(classes[0]["name"], json!("HV"), "{classes:?}");
+        assert!(classes[0].get("wire_width").is_none(), "{classes:?}");
+        assert_eq!(classes[1]["name"], json!("Default"), "{classes:?}");
+        assert_eq!(classes[1]["wire_width"], json!(6), "{classes:?}");
+    }
+
     /// No project file means nowhere KiCad would ever read the class from;
     /// inventing one risks orphan settings, so the tool refuses instead.
     #[tokio::test]
@@ -1633,14 +1840,14 @@ mod netclass_tests {
             serde_json::from_str(&std::fs::read_to_string(&pro).unwrap()).unwrap();
         settings["net_settings"] = json!({
             "classes": [{ "name": "Default", "clearance": 0.2, "track_width": 0.25,
-                          "priority": 2147483647i64 }],
+                          "priority": i32::MAX }],
             "netclass_patterns": []
         });
         std::fs::write(&pro, serde_json::to_string_pretty(&settings).unwrap()).unwrap();
 
         let body = get_classes(&board).await;
         assert_eq!(body["netclasses"][0]["is_default"], json!(true));
-        assert_eq!(body["netclasses"][0]["priority"], json!(2147483647i64));
+        assert_eq!(body["netclasses"][0]["priority"], json!(i32::MAX));
     }
 
     /// Reading must not write. The project file is byte-identical afterwards —

--- a/crates/konnect/tests/e2e_kicad.rs
+++ b/crates/konnect/tests/e2e_kicad.rs
@@ -299,3 +299,147 @@ fn full_design_loop_with_real_kicad() {
 
     eprintln!("E2E OK: project created, wired, ERC'd, {produced} gerber files, DRC'd");
 }
+
+/// #326 in plotted form: wire groups drawn with no stroke, and the junction
+/// dot's radius, which collapses from 0.4572 mm to 0.0001 mm when the Default
+/// has no `wire_width`. Neither shows up in ERC, so plotting is the only
+/// headless way to see it.
+fn plotted_wires_and_junction(kicad_cli: &str, sch: &std::path::Path) -> (usize, f64) {
+    let out = sch.parent().unwrap().join("svg");
+    let _ = std::fs::remove_dir_all(&out);
+    let status = Command::new(kicad_cli)
+        .args([
+            "sch",
+            "export",
+            "svg",
+            "--exclude-drawing-sheet",
+            "--output",
+        ])
+        .arg(&out)
+        .arg(sch)
+        .status()
+        .expect("kicad-cli sch export svg failed to run");
+    assert!(status.success(), "kicad-cli sch export svg exited {status}");
+
+    let svg_path = std::fs::read_dir(&out)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .find(|p| p.extension().is_some_and(|e| e == "svg"))
+        .expect("kicad-cli wrote no SVG");
+    let svg = std::fs::read_to_string(svg_path).unwrap();
+
+    // Groups containing wires only. A healthy junction dot is filled rather
+    // than stroked, so it carries `stroke:none` too.
+    let mut strokeless = 0;
+    let chunks: Vec<&str> = svg.split("style=\"").collect();
+    for chunk in chunks.iter().skip(1) {
+        let Some((style, body)) = chunk.split_once('"') else {
+            continue;
+        };
+        if body.contains("<path d=") && style.contains("stroke:none") {
+            strokeless += 1;
+        }
+    }
+
+    // With two bare wires the only circle is the junction dot.
+    let radius = svg
+        .split("<circle")
+        .skip(1)
+        .filter_map(|c| c.split_once("r=\""))
+        .filter_map(|(_, rest)| rest.split_once('"'))
+        .filter_map(|(r, _)| r.parse::<f64>().ok())
+        .fold(0.0_f64, f64::max);
+
+    (strokeless, radius)
+}
+
+/// #326: a Default written with only the four PCB fields left eeschema unable
+/// to place a junction anywhere in the project. The failure is in how KiCad
+/// resolves the class rather than in the JSON, so only real eeschema can
+/// confirm the fix.
+#[test]
+#[ignore = "requires kicad-cli; run via e2e workflow"]
+fn a_written_default_netclass_still_plots_wires() {
+    let Some(kicad_cli) = find_kicad_cli() else {
+        panic!("kicad-cli not found — set KICAD_CLI or install KiCAD (this test is e2e-only)");
+    };
+    let tmp = tempfile::tempdir().unwrap();
+    let proj = tmp.path().join("nc");
+    let sch = proj.join("nc.kicad_sch");
+    let pcb = proj.join("nc.kicad_pcb");
+    let mut p = Mcp::spawn(&kicad_cli);
+
+    p.tool(
+        "create_project",
+        json!({"name": "nc", "path": proj.to_string_lossy()}),
+    );
+    p.load("sch_wiring");
+    // A T at (120, 100), where the junction dot belongs.
+    p.tool(
+        "batch_add_wire",
+        json!({
+            "schematic": sch.to_string_lossy(),
+            "wires": [
+                { "x1": 100.0, "y1": 100.0, "x2": 140.0, "y2": 100.0 },
+                { "x1": 120.0, "y1": 100.0, "x2": 120.0, "y2": 120.0 }
+            ]
+        }),
+    );
+    // Baseline: no net_settings, so KiCad's seeded Default applies. The
+    // radius comes from the wire width, which is what the assertions below
+    // compare against.
+    let (strokeless, radius) = plotted_wires_and_junction(&kicad_cli, &sch);
+    assert_eq!(
+        strokeless, 0,
+        "a project with no net_settings must plot normally — the fixture is wrong, not the fix"
+    );
+    assert!(
+        radius > 0.1,
+        "no junction dot on the baseline plot (r={radius}) — the fixture is wrong, not the fix"
+    );
+
+    // The reported repro, exactly: name the Default and change nothing else.
+    p.load("pcb_routing");
+    p.tool(
+        "create_netclass",
+        json!({"board": pcb.to_string_lossy(), "name": "Default"}),
+    );
+    let (strokeless, after) = plotted_wires_and_junction(&kicad_cli, &sch);
+    assert_eq!(
+        strokeless, 0,
+        "a Default written by create_netclass left eeschema with no wire width (#326)"
+    );
+    // Before the fix this collapsed to 0.0001 mm. Compared against the
+    // baseline rather than a literal in case KiCad changes the ratio.
+    assert!(
+        (after - radius).abs() < 1e-6,
+        "junction dot changed size after writing the Default: {radius} -> {after} (#326)"
+    );
+
+    // KiCad picks the default by name, not position, so a sparse named class
+    // must not disturb it. Guards against "fixing" #326 by completing
+    // whichever class comes first.
+    p.tool(
+        "create_netclass",
+        json!({"board": pcb.to_string_lossy(), "name": "HV", "clearance": 0.5}),
+    );
+    let classes: Value =
+        serde_json::from_str(&std::fs::read_to_string(proj.join("nc.kicad_pro")).unwrap()).unwrap();
+    let names: Vec<&str> = classes["net_settings"]["classes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c["name"].as_str().unwrap_or_default())
+        .collect();
+    assert_eq!(names, vec!["Default", "HV"], "unexpected class order");
+    let (strokeless, after) = plotted_wires_and_junction(&kicad_cli, &sch);
+    assert_eq!(
+        strokeless, 0,
+        "a sparse named class must not disturb the Default"
+    );
+    assert!(
+        (after - radius).abs() < 1e-6,
+        "a sparse named class changed the junction dot: {radius} -> {after}"
+    );
+}

--- a/docs/KICAD_NETCLASS_DEFAULTS.md
+++ b/docs/KICAD_NETCLASS_DEFAULTS.md
@@ -1,0 +1,163 @@
+# KiCad Netclass Defaults
+
+Netclasses live in `.kicad_pro` under `net_settings.classes`. Konnect writes them
+from `create_netclass` (`crates/konnect-core/src/tools/pcb_routing.rs`).
+
+This file records what KiCad itself considers a complete netclass, and which
+fields may safely be omitted. The values below are taken from KiCad 10 source and
+cross-checked byte-for-byte against a `.kicad_pro` written by KiCad 10.0.5.
+
+## Why Completeness Matters
+
+A netclass that exists but omits `wire_width` breaks schematic editing outright.
+KiCad does not default the key, so junction dot size resolves from nothing:
+Eeschema silently refuses to place junctions anywhere in the project, strips
+existing ones on every save, and connectivity degrades without an ERC violation
+or any visible error. Wires also plot with `stroke:none`.
+
+An explicit `"wire_width": 0` is fine — `0` is KiCad's "use the default"
+sentinel, the same convention as `(width 0)` on a wire stroke. The failure comes
+from the key being absent, not from a zero value.
+
+The chain, in `common/project/net_settings.cpp` unless noted:
+
+| Step | Location | Behaviour |
+|---|---|---|
+| 1 | `net_settings.cpp:67` | Constructor seeds `m_defaultNetClass` via `NETCLASS(Default, true)`, so a project with no `net_settings` at all is fine. |
+| 2 | `net_settings.cpp:133` | `readNetClass` builds every JSON class with `NETCLASS(name, false)` — no defaults. |
+| 3 | `net_settings.cpp:168` | `wire_width` is applied only `if` the key is present. |
+| 4 | `net_settings.cpp:216` | A parsed class that `IsDefault()` **replaces** the seeded default outright. |
+| 4a | `netclass.h:96` | `IsDefault()` reads `m_isDefault`, which `SetName` sets only on an exact `aName == "Default"`. |
+| 5 | `net_settings.cpp:1320` | `addMissingDefaults()` backfills other classes *from* the Default. Nothing backfills the Default itself. |
+
+## It Is The Name, Not The Position
+
+`saveNetclass` writes `m_defaultNetClass` first and the rest after
+(`net_settings.cpp:194`), so in every `.kicad_pro` KiCad has written the Default
+*is* `classes[0]`. That is an output convention, not a read rule. The loader
+(`net_settings.cpp:209`) is a plain range-for with no index and no
+first-iteration branch, and the only thing that marks a class as the default is
+the exact name match in `SetName`. Confirmed empirically against KiCad 10.0.5: a
+sparse class at `classes[0]` with a complete `Default` behind it plots
+correctly, and a sparse class that is the sole entry with no `Default` at all
+plots correctly too, because the seeded default is never replaced.
+
+A writer must therefore key completeness off the name. Completing whichever
+class comes first fixes the common case and leaves the bug live.
+
+## Only The Default Class Must Be Complete
+
+`addMissingDefaults()` fills any field a netclass omits from the Default class, so
+a non-Default class legitimately omitting fields simply inherits. The
+completeness requirement applies **only to the class named `Default`**, because it
+is the root of that inheritance.
+
+A writer therefore needs to emit a full field set for `Default`, but may leave a
+named class partial. A reader must not treat absence on a non-Default class as
+malformed — it means "inherits".
+
+## Defaults
+
+From `common/netclass.cpp:36-50`. Units are not uniform: the serialiser
+(`net_settings.cpp:71`) writes schematic fields in **mils** and PCB fields in
+**mm**.
+
+| Key | Value | Unit | Constant |
+|---|---|---|---|
+| `wire_width` | `6` | mils | `DEFAULT_WIRE_WIDTH` |
+| `bus_width` | `12` | mils | `DEFAULT_BUS_WIDTH` |
+| `line_style` | `0` | enum (solid) | `DEFAULT_LINE_STYLE` |
+| `clearance` | `0.2` | mm | `DEFAULT_CLEARANCE` |
+| `track_width` | `0.2` | mm | `DEFAULT_TRACK_WIDTH` |
+| `via_diameter` | `0.6` | mm | `DEFAULT_VIA_DIAMETER` |
+| `via_drill` | `0.3` | mm | `DEFAULT_VIA_DRILL` |
+| `microvia_diameter` | `0.3` | mm | `DEFAULT_UVIA_DIAMETER` |
+| `microvia_drill` | `0.1` | mm | `DEFAULT_UVIA_DRILL` |
+| `diff_pair_width` | `0.2` | mm | `DEFAULT_DIFF_PAIR_WIDTH` |
+| `diff_pair_gap` | `0.25` | mm | `DEFAULT_DIFF_PAIR_GAP` |
+| `diff_pair_via_gap` | `0.25` | mm | `DEFAULT_DIFF_PAIR_VIAGAP` |
+
+These twelve are the inheritable set — `saveNetclass` writes each one
+conditionally (`if( nc->HasWireWidth() )` and friends), so KiCad's own output
+omits them on classes that do not set them.
+
+## Always Written
+
+`saveNetclass` emits these unconditionally, set or not:
+
+| Key | Value |
+|---|---|
+| `name` | class name |
+| `priority` | `2147483647` for `Default`, `-1` otherwise |
+| `schematic_color` | `"rgba(0, 0, 0, 0.000)"` |
+| `pcb_color` | `"rgba(0, 0, 0, 0.000)"` |
+| `tuning_profile` | `""` |
+
+`priority` comes from two places: `net_settings.cpp:69` sets
+`std::numeric_limits<int>::max()` on the Default, and the NETCLASS constructor
+(`netclass.cpp:57`) sets `-1` for every other class. KiCad treats the Default as
+the lowest-priority fallback, so `2147483647` is not arbitrary.
+
+## A Complete Default Class
+
+```json
+{
+  "name": "Default",
+  "priority": 2147483647,
+  "schematic_color": "rgba(0, 0, 0, 0.000)",
+  "pcb_color": "rgba(0, 0, 0, 0.000)",
+  "tuning_profile": "",
+  "wire_width": 6,
+  "bus_width": 12,
+  "line_style": 0,
+  "clearance": 0.2,
+  "track_width": 0.2,
+  "via_diameter": 0.6,
+  "via_drill": 0.3,
+  "microvia_diameter": 0.3,
+  "microvia_drill": 0.1,
+  "diff_pair_width": 0.2,
+  "diff_pair_gap": 0.25,
+  "diff_pair_via_gap": 0.25
+}
+```
+
+## Verifying Without KiCad
+
+A project whose Default class lacks `wire_width` plots every wire with no
+stroke, which is detectable headlessly:
+
+```
+kicad-cli sch export svg --output out --exclude-drawing-sheet <sheet>.kicad_sch
+grep -c 'fill:none; stroke:none;' out/*.svg
+```
+
+`0` is healthy. `1` means every wire was plotted with no stroke.
+
+Keep the `fill:none; ` prefix. It is what scopes the match to the wire group: a
+junction dot is filled rather than stroked, so a perfectly healthy sheet
+carries a bare `stroke:none` and grepping for that alone reports a passing plot
+as a failing one.
+
+The junction dot is the sharper signal, and the one that matches the reported
+symptom. eeschema still emits the `<circle>`, it just collapses the radius:
+
+| | Junction dot | Wire group |
+|---|---|---|
+| Healthy | `r="0.4572"` | `stroke:#009600; stroke-width:0.1524` |
+| Incomplete Default | `r="0.0001"` | `fill:none; stroke:none;` |
+
+0.4572 mm is 18 mils, three times the 6 mil wire, so the radius tracks the
+resolved wire width and pinning it against a known-good baseline is a stronger
+assertion than any literal. Both rows measured on KiCad 10.0.5.
+
+## Source References
+
+- `common/netclass.cpp:36-50` — the `DEFAULT_*` constants
+- `common/netclass.cpp:52-80` — `NETCLASS::NETCLASS`, and what `aInitWithDefaults` gates
+- `common/project/net_settings.cpp:71` — `saveNetclass`, including the unit split
+- `common/project/net_settings.cpp:128` — `readNetClass`
+- `common/project/net_settings.cpp:1252` — `addMissingDefaults`
+
+Read from the GitHub mirror `KiCad/kicad-source-mirror`; upstream is GitLab at
+`kicad/code/kicad`.


### PR DESCRIPTION
Fixes #326.

Fixing this turned up adjacent problems in the same code — netclass priorities, the Default's PCB values, how `get_netclasses` reports an omitted key. Rather than fold them in, they're split by what they touch: **the first commit changes only the class named `Default`, the second changes everything else.**

The first commit does stands alone, if you'd prefer a small pr. 

### `fix(pcb)` — the fix

The triage suggested extending the `FIELDS` table, but that table drives creation for *every* class, and only the Default must be complete:

- `addMissingDefaults` fills other classes *from* the Default, so a named class omitting a key is inheriting, not broken. Completing them would sever that. They're untouched here.
- Nothing fills the Default itself, and a parsed `Default` *replaces* KiCad's seeded one (`net_settings.cpp:216`) rather than merging. An update now backfills **absent** keys only, leaving present ones alone, so #220 stays fixed.
- It's the name, not the position: `SetName` sets `m_isDefault` on an exact match (`netclass.h:96`) and the loader has no index branch. KiCad's *writer* emits the Default first, so it's always `classes[0]` in KiCad-written files — an output convention, not a read rule. Completing whichever class comes first would leave the bug live.

### `refactor(pcb)` — beyond the fix

Priorities now match KiCad (`int` max for Default, `-1` otherwise). The Default takes KiCad's PCB values rather than this tool's schema defaults, since a written Default replaces the seeded one and was silently re-speccing boards — **worth your explicit call, happy to split it out.** And `get_netclasses` reports settings resolved with `inherits`/`missing_fields` instead of `null`, which **breaks callers reading `null` as "unset"**.

### Testing

Nine unit tests plus an `#[ignore]` e2e test that drives the MCP tools and plots through eeschema. Against KiCad 10.0.5 it passes with the fix and fails without it. The junction dot's radius is the sharpest signal — 0.4572 mm healthy, 0.0001 mm when the Default is incomplete — so the test compares against a baseline plot rather than a literal. Note a bare `stroke:none` grep false-positives: a healthy junction dot is filled, not stroked.
