### PR TITLE
fix(windows): discover per-user KiCad installations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,6 +2381,7 @@ dependencies = [
  "tracing",
  "usvg",
  "uuid",
+ "winreg",
  "zip",
 ]
 
@@ -4595,6 +4596,16 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
+name = "winreg"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ base64 = "0.23"
 
 # Platform directories (home dir, config dir)
 dirs = "6"
+winreg = "0.56"
 
 # SVG parsing (import_svg_logo)
 usvg = "0.48"

--- a/crates/konnect-core/Cargo.toml
+++ b/crates/konnect-core/Cargo.toml
@@ -30,6 +30,9 @@ usvg.workspace = true
 zip.workspace = true
 tempfile = "3"
 
+[target.'cfg(windows)'.dependencies]
+winreg.workspace = true
+
 [dev-dependencies]
 # The pcb_components fallback tests spawn a mock KiCAD NNG endpoint to prove
 # a reachable-but-rejecting KiCAD never triggers the file-editing fallback.

--- a/crates/konnect-core/src/kicad_install.rs
+++ b/crates/konnect-core/src/kicad_install.rs
@@ -1,0 +1,395 @@
+//! KiCad installation discovery.
+//!
+//! Keep executable and bundled-library discovery behind this module so every
+//! caller sees the same installations in the same order.  Discovery is
+//! intentionally read-only: Windows and KiCad already persist install state,
+//! while an explicit Konnect configuration remains the durable override.
+
+use std::path::{Path, PathBuf};
+
+#[cfg(target_os = "windows")]
+const SUPPORTED_VERSIONS: [&str; 3] = ["10.0", "9.0", "8.0"];
+
+/// Find `kicad-cli`, honoring an explicit configured value first.
+pub fn find_cli(configured: &str) -> Option<PathBuf> {
+    resolve_configured(configured)
+        .or_else(|| cli_candidates().into_iter().find(|path| path.is_file()))
+}
+
+/// Find the KiCad project-manager executable.
+///
+/// An explicit GUI path wins. If the configured CLI is an absolute path, its
+/// sibling GUI is next so a selected KiCad version cannot be mixed with a
+/// different installation's libraries or UI.
+pub fn find_gui(configured_binary: &str, configured_cli: &str) -> Option<PathBuf> {
+    resolve_explicit_path(configured_binary)
+        .or_else(|| {
+            resolve_configured(configured_cli)
+                .and_then(|cli| installation_root_from_binary(&cli))
+                .map(|root| root.join("bin").join(gui_filename()))
+                .filter(|path| path.is_file())
+        })
+        .or_else(|| resolve_configured(configured_binary))
+        .or_else(|| gui_candidates().into_iter().find(|path| path.is_file()))
+}
+
+fn cli_candidates() -> Vec<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        installation_roots()
+            .into_iter()
+            .map(|root| root.join("bin").join(cli_filename()))
+            .collect()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let mut paths = vec![
+            PathBuf::from("/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli"),
+            PathBuf::from("/usr/local/bin/kicad-cli"),
+        ];
+        if let Some(home) = std::env::var_os("HOME") {
+            paths.push(
+                PathBuf::from(home).join("Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli"),
+            );
+        }
+        paths
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        vec![
+            PathBuf::from("/usr/bin/kicad-cli"),
+            PathBuf::from("/usr/local/bin/kicad-cli"),
+        ]
+    }
+}
+
+fn gui_candidates() -> Vec<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        installation_roots()
+            .into_iter()
+            .map(|root| root.join("bin").join(gui_filename()))
+            .collect()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        vec![PathBuf::from(
+            "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad",
+        )]
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        ["kicad"]
+            .into_iter()
+            .filter_map(|name| find_on_path(Path::new(name)))
+            .collect()
+    }
+}
+
+/// Existing roots that directly contain KiCad's `symbols`, `footprints`, and
+/// `3dmodels` directories, newest supported KiCad first.
+pub fn share_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+
+    #[cfg(target_os = "windows")]
+    for install in installation_roots() {
+        push_existing_unique(&mut roots, install.join("share").join("kicad"));
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        push_existing_unique(
+            &mut roots,
+            PathBuf::from("/Applications/KiCad/KiCad.app/Contents/SharedSupport"),
+        );
+        push_existing_unique(&mut roots, PathBuf::from("/usr/local/share/kicad"));
+        push_existing_unique(&mut roots, PathBuf::from("/opt/homebrew/share/kicad"));
+        if let Some(home) = std::env::var_os("HOME") {
+            push_existing_unique(
+                &mut roots,
+                PathBuf::from(home).join("Applications/KiCad/KiCad.app/Contents/SharedSupport"),
+            );
+        }
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        for root in [
+            PathBuf::from("/usr/share/kicad"),
+            PathBuf::from("/usr/local/share/kicad"),
+            PathBuf::from("/opt/kicad/share/kicad"),
+            PathBuf::from("/var/lib/flatpak/app/org.kicad.KiCad/current/active/files/share/kicad"),
+            PathBuf::from("/snap/kicad/current/usr/share/kicad"),
+        ] {
+            push_existing_unique(&mut roots, root);
+        }
+        if let Some(home) = std::env::var_os("HOME") {
+            push_existing_unique(
+                &mut roots,
+                PathBuf::from(home).join(
+                    ".local/share/flatpak/app/org.kicad.KiCad/current/active/files/share/kicad",
+                ),
+            );
+        }
+    }
+
+    roots
+}
+
+#[cfg(target_os = "windows")]
+fn installation_roots() -> Vec<PathBuf> {
+    static ROOTS: std::sync::OnceLock<Vec<PathBuf>> = std::sync::OnceLock::new();
+    ROOTS.get_or_init(discover_installation_roots).clone()
+}
+
+#[cfg(target_os = "windows")]
+fn discover_installation_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    for root in windows_registry_install_roots() {
+        push_existing_unique(&mut roots, root);
+    }
+    for root in windows_well_known_install_roots(
+        std::env::var_os("LOCALAPPDATA").as_deref(),
+        std::env::var_os("ProgramFiles").as_deref(),
+        std::env::var_os("ProgramFiles(x86)").as_deref(),
+    ) {
+        push_existing_unique(&mut roots, root);
+    }
+    roots
+}
+
+fn resolve_configured(configured: &str) -> Option<PathBuf> {
+    let configured = configured.trim();
+    if configured.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(configured);
+    if path.is_file() {
+        return Some(path);
+    }
+    if path.components().count() == 1 {
+        return find_on_path(&path);
+    }
+    None
+}
+
+fn resolve_explicit_path(configured: &str) -> Option<PathBuf> {
+    let path = PathBuf::from(configured.trim());
+    (path.components().count() > 1 && path.is_file()).then_some(path)
+}
+
+fn find_on_path(filename: &Path) -> Option<PathBuf> {
+    let paths = std::env::var_os("PATH")?;
+    std::env::split_paths(&paths)
+        .map(|dir| dir.join(filename))
+        .find(|path| path.is_file())
+}
+
+fn installation_root_from_binary(binary: &Path) -> Option<PathBuf> {
+    let bin_dir = binary.parent()?;
+    if !bin_dir
+        .file_name()
+        .is_some_and(|name| name.eq_ignore_ascii_case("bin"))
+    {
+        return None;
+    }
+    bin_dir.parent().map(Path::to_path_buf)
+}
+
+fn push_existing_unique(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if path.is_dir() && !paths.contains(&path) {
+        paths.push(path);
+    }
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn cli_filename() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "kicad-cli.exe"
+    } else {
+        "kicad-cli"
+    }
+}
+
+fn gui_filename() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "kicad.exe"
+    } else {
+        "kicad"
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn windows_well_known_install_roots(
+    local_app_data: Option<&std::ffi::OsStr>,
+    program_files: Option<&std::ffi::OsStr>,
+    program_files_x86: Option<&std::ffi::OsStr>,
+) -> Vec<PathBuf> {
+    let mut bases = Vec::new();
+    if let Some(path) = local_app_data {
+        bases.push(PathBuf::from(path).join("Programs").join("KiCad"));
+    }
+    if let Some(path) = program_files {
+        bases.push(PathBuf::from(path).join("KiCad"));
+    }
+    if let Some(path) = program_files_x86 {
+        bases.push(PathBuf::from(path).join("KiCad"));
+    }
+    for fallback in [
+        r"C:\Program Files\KiCad",
+        r"C:\KiCad",
+        r"D:\KiCad",
+        r"D:\Program Files\KiCad",
+    ] {
+        let fallback = PathBuf::from(fallback);
+        if !bases.contains(&fallback) {
+            bases.push(fallback);
+        }
+    }
+
+    let mut roots = Vec::new();
+    for version in SUPPORTED_VERSIONS {
+        for base in &bases {
+            roots.push(base.join(version));
+        }
+    }
+    for base in bases {
+        roots.push(base);
+    }
+    roots
+}
+
+#[cfg(target_os = "windows")]
+fn windows_registry_install_roots() -> Vec<PathBuf> {
+    use winreg::enums::{
+        HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, KEY_READ, KEY_WOW64_32KEY, KEY_WOW64_64KEY,
+    };
+    use winreg::RegKey;
+
+    const UNINSTALL: &str = r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall";
+    let mut roots = Vec::new();
+
+    for version in SUPPORTED_VERSIONS {
+        for hive in [HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE] {
+            for view in [KEY_WOW64_64KEY, KEY_WOW64_32KEY] {
+                let root = RegKey::predef(hive);
+                let Ok(uninstall) = root.open_subkey_with_flags(UNINSTALL, KEY_READ | view) else {
+                    continue;
+                };
+                for name in uninstall.enum_keys().flatten() {
+                    let Ok(key) = uninstall.open_subkey_with_flags(&name, KEY_READ | view) else {
+                        continue;
+                    };
+                    let display_name: String = key.get_value("DisplayName").unwrap_or_default();
+                    let display_version: String =
+                        key.get_value("DisplayVersion").unwrap_or_default();
+                    if !display_name.to_ascii_lowercase().starts_with("kicad ")
+                        || !(display_version.starts_with(version) || display_name.contains(version))
+                    {
+                        continue;
+                    }
+                    let location: String = key.get_value("InstallLocation").unwrap_or_default();
+                    if !location.trim().is_empty() {
+                        let path = PathBuf::from(location.trim());
+                        if path.is_dir() && !roots.contains(&path) {
+                            roots.push(path);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Older KiCad installers used vendor keys instead of an uninstall entry.
+    for version in SUPPORTED_VERSIONS {
+        for hive in [HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE] {
+            for view in [KEY_WOW64_64KEY, KEY_WOW64_32KEY] {
+                let root = RegKey::predef(hive);
+                for key_path in [
+                    format!(r"SOFTWARE\KiCad\{version}"),
+                    r"SOFTWARE\KiCad\KiCad".into(),
+                ] {
+                    let Ok(key) = root.open_subkey_with_flags(&key_path, KEY_READ | view) else {
+                        continue;
+                    };
+                    let location: String = key
+                        .get_value("InstallDir")
+                        .or_else(|_| key.get_value(""))
+                        .unwrap_or_default();
+                    if !location.trim().is_empty() {
+                        let path = PathBuf::from(location.trim());
+                        if path.is_dir() && !roots.contains(&path) {
+                            roots.push(path);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    roots
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn derives_install_root_from_cli() {
+        let cli = Path::new(r"C:\Users\casey\AppData\Local\Programs\KiCad\10.0\bin\kicad-cli.exe");
+        assert_eq!(
+            installation_root_from_binary(cli),
+            Some(PathBuf::from(
+                r"C:\Users\casey\AppData\Local\Programs\KiCad\10.0"
+            ))
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn per_user_roots_are_newest_first() {
+        use std::ffi::OsStr;
+
+        let roots = windows_well_known_install_roots(
+            Some(OsStr::new(r"C:\Users\casey\AppData\Local")),
+            Some(OsStr::new(r"C:\Program Files")),
+            None,
+        );
+        assert_eq!(
+            roots[0],
+            PathBuf::from(r"C:\Users\casey\AppData\Local\Programs\KiCad\10.0")
+        );
+        assert!(roots.contains(&PathBuf::from(
+            r"C:\Users\casey\AppData\Local\Programs\KiCad\9.0"
+        )));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    #[ignore = "requires a complete KiCad installation"]
+    fn live_install_exposes_all_bundled_library_kinds() {
+        let cli = find_cli("").expect("KiCad installation was not discovered");
+        let install = installation_root_from_binary(&cli).expect("CLI was not under <root>/bin");
+        let share = install.join("share").join("kicad");
+
+        for kind in ["symbols", "footprints", "3dmodels"] {
+            assert!(share.join(kind).is_dir(), "missing KiCad {kind} directory");
+        }
+        assert!(share_roots().contains(&share));
+    }
+
+    #[test]
+    fn explicit_cli_and_sibling_gui_win() {
+        let temp = tempfile::tempdir().unwrap();
+        let bin = temp.path().join("bin");
+        std::fs::create_dir(&bin).unwrap();
+        let cli = bin.join(cli_filename());
+        let gui = bin.join(gui_filename());
+        std::fs::write(&cli, b"").unwrap();
+        std::fs::write(&gui, b"").unwrap();
+
+        assert_eq!(find_cli(cli.to_str().unwrap()), Some(cli.clone()));
+        assert_eq!(find_gui(gui_filename(), cli.to_str().unwrap()), Some(gui));
+    }
+}

--- a/crates/konnect-core/src/kicad_install.rs
+++ b/crates/konnect-core/src/kicad_install.rs
@@ -133,6 +133,16 @@ pub fn share_roots() -> Vec<PathBuf> {
         }
     }
 
+    if roots.is_empty() {
+        static WARNED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+        WARNED.get_or_init(|| {
+            tracing::warn!(
+                target: "konnect::kicad_install",
+                "no KiCad bundled-library root was resolved; stock symbols, footprints, and 3D models may be unavailable; configure kicad_cli or the KICAD<major>_*_DIR variables"
+            );
+        });
+    }
+
     roots
 }
 

--- a/crates/konnect-core/src/lib.rs
+++ b/crates/konnect-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod design_hash;
 pub mod gates;
+pub mod kicad_install;
 pub mod mcp;
 pub mod observability;
 pub mod router;

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -1161,67 +1161,7 @@ fn moved_pin_anchors(
 /// Roots under which KiCAD ships its bundled libraries — the directory that
 /// directly contains `symbols/`, `footprints/` and `3dmodels/`.
 fn kicad_share_roots() -> Vec<std::path::PathBuf> {
-    let mut roots: Vec<std::path::PathBuf> = Vec::new();
-
-    #[cfg(target_os = "windows")]
-    {
-        // Keep these majors in step with the ones find_kicad_library_dirs
-        // reads environment variables for. A major listed there but missing
-        // here is invisible on any machine where KiCad did not export its
-        // variable — which is every machine where Konnect was not launched
-        // by KiCad.
-        for c in [
-            r"C:\KiCad\10.0\share\kicad",
-            r"C:\Program Files\KiCad\10.0\share\kicad",
-            r"C:\KiCad\9.0\share\kicad",
-            r"C:\Program Files\KiCad\9.0\share\kicad",
-            r"C:\KiCad\8.0\share\kicad",
-            r"C:\Program Files\KiCad\8.0\share\kicad",
-        ] {
-            roots.push(std::path::PathBuf::from(c));
-        }
-    }
-    #[cfg(target_os = "macos")]
-    {
-        // KiCad on macOS ships its libraries inside the app bundle.
-        roots.push(std::path::PathBuf::from(
-            "/Applications/KiCad/KiCad.app/Contents/SharedSupport",
-        ));
-        roots.push(std::path::PathBuf::from("/usr/local/share/kicad"));
-        // Homebrew (Apple Silicon prefix)
-        roots.push(std::path::PathBuf::from("/opt/homebrew/share/kicad"));
-        if let Ok(home) = std::env::var("HOME") {
-            // Per-user install (KiCad.app dragged into ~/Applications)
-            roots.push(
-                std::path::PathBuf::from(home)
-                    .join("Applications/KiCad/KiCad.app/Contents/SharedSupport"),
-            );
-        }
-    }
-    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
-    {
-        roots.push(std::path::PathBuf::from("/usr/share/kicad"));
-        roots.push(std::path::PathBuf::from("/usr/local/share/kicad"));
-        roots.push(std::path::PathBuf::from("/opt/kicad/share/kicad"));
-        // Flatpak: system-wide and per-user installs
-        roots.push(std::path::PathBuf::from(
-            "/var/lib/flatpak/app/org.kicad.KiCad/current/active/files/share/kicad",
-        ));
-        if let Ok(home) = std::env::var("HOME") {
-            roots.push(
-                std::path::PathBuf::from(&home).join(
-                    ".local/share/flatpak/app/org.kicad.KiCad/current/active/files/share/kicad",
-                ),
-            );
-        }
-        // Snap
-        roots.push(std::path::PathBuf::from(
-            "/snap/kicad/current/usr/share/kicad",
-        ));
-    }
-
-    roots.retain(|p| p.is_dir());
-    roots
+    crate::kicad_install::share_roots()
 }
 
 /// Find directories holding a bundled KiCAD library kind — `"symbols"`,

--- a/crates/konnect-core/src/tools/verification.rs
+++ b/crates/konnect-core/src/tools/verification.rs
@@ -476,43 +476,16 @@ fn ui_running(process_detected: bool, ipc_responsive: bool) -> bool {
 }
 
 /// Resolve the KiCAD binary path from config or well-known locations.
-fn find_kicad_binary(config_binary: &str) -> String {
-    if !config_binary.is_empty() && std::path::Path::new(config_binary).exists() {
-        return config_binary.to_string();
-    }
-    #[cfg(target_os = "windows")]
-    {
-        // Scan common install roots and KiCAD version directories
-        let roots = [
-            r"C:\Program Files\KiCad",
-            r"C:\KiCad",
-            r"D:\KiCad",
-            r"D:\Program Files\KiCad",
-        ];
-        let versions = ["10.0", "9.0", "8.0"];
-        for root in &roots {
-            for ver in &versions {
-                let path = format!(r"{}\{}\bin\kicad.exe", root, ver);
-                if std::path::Path::new(&path).exists() {
-                    return path;
-                }
+fn find_kicad_binary(config_binary: &str, config_cli: &str) -> String {
+    crate::kicad_install::find_gui(config_binary, config_cli)
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_else(|| {
+            if cfg!(target_os = "windows") {
+                "kicad.exe".to_string()
+            } else {
+                "kicad".to_string()
             }
-            // Also check without version subdir
-            let path = format!(r"{}\bin\kicad.exe", root);
-            if std::path::Path::new(&path).exists() {
-                return path;
-            }
-        }
-        "kicad".to_string()
-    }
-    #[cfg(target_os = "macos")]
-    {
-        "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad".to_string()
-    }
-    #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
-    {
-        "kicad".to_string()
-    }
+        })
 }
 
 fn health_timeout_seconds(args: &serde_json::Value) -> Result<u64, CallToolResult> {
@@ -601,7 +574,7 @@ async fn handle_launch_kicad_ui(
 ) -> anyhow::Result<CallToolResult> {
     let wait_ready = args["wait_ready"].as_bool().unwrap_or(true);
     let timeout_secs = args["timeout_seconds"].as_u64().unwrap_or(30);
-    let binary = find_kicad_binary(&ctx.config.kicad_binary);
+    let binary = find_kicad_binary(&ctx.config.kicad_binary, &ctx.config.kicad_cli);
 
     let mut cmd = tokio::process::Command::new(&binary);
     if let Some(project) = args["project"].as_str() {

--- a/crates/konnect/src/install.rs
+++ b/crates/konnect/src/install.rs
@@ -502,71 +502,7 @@ fn remove_hooks_from_settings(path: &Path) -> Result<()> {
 
 /// Auto-detect a KiCad installation.
 pub fn detect_kicad() -> Option<PathBuf> {
-    #[cfg(target_os = "windows")]
-    let standard_paths: Vec<PathBuf> = [
-        r"C:\KiCad\10.0\bin\kicad-cli.exe",
-        r"C:\Program Files\KiCad\10.0\bin\kicad-cli.exe",
-        r"C:\Program Files (x86)\KiCad\10.0\bin\kicad-cli.exe",
-        r"C:\KiCad\9.0\bin\kicad-cli.exe",
-        r"C:\Program Files\KiCad\9.0\bin\kicad-cli.exe",
-        r"C:\Program Files (x86)\KiCad\9.0\bin\kicad-cli.exe",
-    ]
-    .iter()
-    .map(PathBuf::from)
-    .collect();
-
-    #[cfg(target_os = "macos")]
-    let standard_paths: Vec<PathBuf> = {
-        let mut paths = vec![
-            PathBuf::from("/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli"),
-            PathBuf::from("/usr/local/bin/kicad-cli"),
-        ];
-        if let Ok(home) = std::env::var("HOME") {
-            paths.push(
-                PathBuf::from(home).join("Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli"),
-            );
-        }
-        paths
-    };
-
-    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
-    let standard_paths: Vec<PathBuf> = vec![
-        PathBuf::from("/usr/bin/kicad-cli"),
-        PathBuf::from("/usr/local/bin/kicad-cli"),
-    ];
-
-    for path in &standard_paths {
-        if path.exists() {
-            return Some(path.clone());
-        }
-    }
-    #[cfg(target_os = "windows")]
-    if let Some(path) = detect_kicad_from_registry() {
-        return Some(path);
-    }
-    None
-}
-
-#[cfg(target_os = "windows")]
-fn detect_kicad_from_registry() -> Option<PathBuf> {
-    use std::process::Command;
-    let output = Command::new("reg")
-        .args(["query", r"HKLM\SOFTWARE\KiCad\10.0", "/ve"])
-        .output()
-        .ok()?;
-    if output.status.success() {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        for line in stdout.lines() {
-            if line.contains("REG_SZ") {
-                let path_str = line.split("REG_SZ").last()?.trim();
-                let cli_path = Path::new(path_str).join("bin").join("kicad-cli.exe");
-                if cli_path.exists() {
-                    return Some(cli_path);
-                }
-            }
-        }
-    }
-    None
+    konnect_core::kicad_install::find_cli("")
 }
 
 #[cfg(test)]

--- a/plugin/settings_dialog.py
+++ b/plugin/settings_dialog.py
@@ -58,28 +58,50 @@ def detect_kicad_cli():
     binary = "kicad-cli.exe" if sys.platform == "win32" else "kicad-cli"
 
     if sys.platform == "win32":
-        # Check Windows registry for KiCAD install path
+        # Check both per-user and machine-wide uninstall records. Current-user
+        # installs are KiCad's normal result when machine-wide installation is
+        # declined, and are recorded under HKCU rather than HKLM.
         try:
             import winreg
-            for key_path in [
-                r"SOFTWARE\KiCad\KiCad",
-                r"SOFTWARE\WOW6432Node\KiCad\KiCad",
-            ]:
-                try:
-                    key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, key_path)
-                    install_dir, _ = winreg.QueryValueEx(key, "InstallDir")
-                    winreg.CloseKey(key)
-                    cli = os.path.join(install_dir, "bin", "kicad-cli.exe")
-                    if os.path.isfile(cli):
-                        return cli
-                except (FileNotFoundError, OSError):
-                    pass
+            uninstall = r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"
+            for version in ["10.0", "9.0", "8.0"]:
+                for hive in [winreg.HKEY_CURRENT_USER, winreg.HKEY_LOCAL_MACHINE]:
+                    for view in [winreg.KEY_WOW64_64KEY, winreg.KEY_WOW64_32KEY]:
+                        try:
+                            with winreg.OpenKey(
+                                    hive, uninstall, 0, winreg.KEY_READ | view) as parent:
+                                for index in range(winreg.QueryInfoKey(parent)[0]):
+                                    with winreg.OpenKey(
+                                            parent, winreg.EnumKey(parent, index)) as child:
+                                        try:
+                                            display_name = winreg.QueryValueEx(
+                                                child, "DisplayName")[0]
+                                            display_version = winreg.QueryValueEx(
+                                                child, "DisplayVersion")[0]
+                                            install_dir = winreg.QueryValueEx(
+                                                child, "InstallLocation")[0]
+                                        except (FileNotFoundError, OSError):
+                                            continue
+                                        if (display_name.lower().startswith("kicad ") and
+                                                (display_version.startswith(version) or
+                                                 version in display_name)):
+                                            cli = os.path.join(
+                                                install_dir, "bin", "kicad-cli.exe")
+                                            if os.path.isfile(cli):
+                                                return cli
+                        except (FileNotFoundError, OSError):
+                            pass
         except ImportError:
             pass
 
         # Scan common root directories for KiCad installations
         versions = ["10.0", "9.0", "8.0"]
-        roots = ["C:\\Program Files", "C:\\", "D:\\", "D:\\Program Files"]
+        roots = [
+            os.path.join(os.environ.get("LOCALAPPDATA", ""), "Programs"),
+            os.environ.get("ProgramFiles", "C:\\Program Files"),
+            os.environ.get("ProgramFiles(x86)", "C:\\Program Files (x86)"),
+            "C:\\", "D:\\", "D:\\Program Files",
+        ]
         for root in roots:
             for ver in versions:
                 cli = os.path.join(root, "KiCad", ver, "bin", "kicad-cli.exe")

--- a/plugin/tests/test_kicad_detection.py
+++ b/plugin/tests/test_kicad_detection.py
@@ -1,0 +1,90 @@
+"""Tests for the settings dialog's platform-specific KiCad discovery."""
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+PLUGIN_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_settings_dialog():
+    wx = types.ModuleType("wx")
+    wx.Dialog = object
+    sys.modules.setdefault("wx", wx)
+    spec = importlib.util.spec_from_file_location(
+        "settings_dialog_detection_under_test", PLUGIN_DIR / "settings_dialog.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeRegistryKey:
+    def __init__(self, values=None, children=None):
+        self.values = values or {}
+        self.children = children or {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+def fake_winreg(install_dir):
+    child = FakeRegistryKey({
+        "DisplayName": "KiCad 10.0 (current user)",
+        "DisplayVersion": "10.0.5",
+        "InstallLocation": install_dir,
+    })
+    uninstall = FakeRegistryKey(children={"KiCad 10.0": child})
+    module = types.ModuleType("winreg")
+    module.HKEY_CURRENT_USER = "HKCU"
+    module.HKEY_LOCAL_MACHINE = "HKLM"
+    module.KEY_READ = 1
+    module.KEY_WOW64_64KEY = 2
+    module.KEY_WOW64_32KEY = 4
+    module.OpenKey = lambda parent, name, *_args: (
+        uninstall if parent == "HKCU" else parent.children[name])
+    module.QueryInfoKey = lambda key: (len(key.children), 0, 0)
+    module.EnumKey = lambda key, index: list(key.children)[index]
+    module.QueryValueEx = lambda key, name: (key.values[name], 1)
+    return module
+
+
+class KiCadDetectionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.dialog = load_settings_dialog()
+
+    def test_current_user_uninstall_record_is_discovered(self):
+        install_dir = r"C:\Users\casey\AppData\Local\Programs\KiCad\10.0"
+        registry = fake_winreg(install_dir)
+        expected = os.path.join(install_dir, "bin", "kicad-cli.exe")
+
+        with mock.patch.object(self.dialog.sys, "platform", "win32"), \
+                mock.patch.dict(sys.modules, {"winreg": registry}), \
+                mock.patch.object(self.dialog.os.path, "isfile",
+                                  side_effect=lambda path: path == expected):
+            self.assertEqual(self.dialog.detect_kicad_cli(), expected)
+
+    def test_local_app_data_is_a_fallback_without_registry(self):
+        local_app_data = r"C:\Users\casey\AppData\Local"
+        expected = os.path.join(
+            local_app_data, "Programs", "KiCad", "10.0", "bin", "kicad-cli.exe")
+
+        with mock.patch.object(self.dialog.sys, "platform", "win32"), \
+                mock.patch.dict(self.dialog.os.environ,
+                                {"LOCALAPPDATA": local_app_data}, clear=True), \
+                mock.patch.dict(sys.modules, {"winreg": None}), \
+                mock.patch.object(self.dialog.os.path, "isfile",
+                                  side_effect=lambda path: path == expected):
+            self.assertEqual(self.dialog.detect_kicad_cli(), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem and scope

Per-user Windows KiCad installations under `%LOCALAPPDATA%\Programs\KiCad` were invisible to Konnect's executable and bundled-library discovery. The installer, core library resolver, UI launcher, and Python settings dialog had separate candidate lists that had already drifted.

This also blocks reliable PCB/Freerouting work: the native Specctra bridge and manufacturing flow need to locate `kicad-cli`, the KiCad UI, stock symbols/footprints, and 3D models on machines where KiCad was installed for the current user.

## Design

- Add one read-only `konnect-core::kicad_install` module for executable and shared-library discovery.
- Read both HKCU and HKLM uninstall records, including 32-bit and 64-bit registry views.
- Retain older KiCad vendor-key compatibility and existing platform paths.
- Add `%LOCALAPPDATA%`, `%ProgramFiles%`, and `%ProgramFiles(x86)%` fallbacks.
- Cache resolved installation roots for the process lifetime so registry enumeration occurs once.
- Preserve explicit `kicad_cli` and `kicad_binary` configuration precedence; derive the GUI beside an explicitly selected CLI before falling back to another install.
- Update the KiCad settings dialog so the path it persists can come from a current-user install.

No discovered path is written automatically. Windows/KiCad remain the persisted source of automatic discovery, and an explicit Konnect configuration remains the durable override.

## Compatibility and migration

No MCP tools, schemas, CLI flags, environment variables, config keys, or file formats change. Existing explicit paths and system-wide installs retain precedence and behavior. The only new runtime dependency is the Windows-only MIT-licensed `winreg` crate.

## Verification

- `cargo test --workspace --locked --lib --tests`
- `cargo test --workspace --locked --doc`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo build --release -p konnect`
- `python -m unittest discover -s plugin/tests -v`
- Live Windows registry-isolated check with `LOCALAPPDATA` pointed at a nonexistent directory: found the HKCU KiCad 10.0.5 installation and verified `symbols`, `footprints`, and `3dmodels`.
- `konnect status --client codex`: found `C:\Users\georg\AppData\Local\Programs\KiCad\10.0\bin\kicad-cli.exe`.

Not run locally: `cargo deny check licenses` because `cargo-deny` is not installed. CI's license job remains the authoritative gate.

## Risk and rollback

Risk is limited to installation selection order. Explicit absolute configuration wins, then the configured CLI's sibling UI, followed by registry and well-known locations, newest supported KiCad first. Reverting this commit restores the previous independent path lists; no user data or configuration migration is involved.

Closes #254