### PR TITLE
feat(pcb): add set_predefined_sizes for the router palette

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -101,7 +101,7 @@ Konnect/
 │   │           ├── footprint_metadata.rs # footprint description, tags, and attribute edits
 │   │           ├── footprint_models.rs # footprint 3D model validation and atomic edits
 │   │           ├── integration.rs    # 8 tools (JLCPCB SQLite, Freerouting discovery, datasheets)
-│   │           ├── verification.rs   # 8 tools (DRC, design rules, KiCAD UI)
+│   │           ├── verification.rs   # 10 tools (DRC, design rules, KiCAD UI)
 │   │           ├── config.rs         # 7 tools (user/project config, design rules)
 │   │           ├── design_review.rs  # 6 tools (decoupling/connection/power/DFM audits)
 │   │           ├── templates.rs      # 4 tools (6 built-in reference circuit templates)
@@ -303,7 +303,7 @@ Source: [`crates/konnect-core/src/observability.rs`](crates/konnect-core/src/obs
 
 ## Tool Routing (Starter Kit + On-Demand Loading)
 
-The server does NOT expose all 214 tools (220 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
+The server does NOT expose all 216 tools (222 total with the 6 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
 
 - **Startup**: only `STARTER_KIT` toolsets are pre-loaded (see `router/registry.rs::STARTER_KIT`). Currently: `project`, `config`. Combined with the 6 meta-tools, baseline `tools/list` is 20 tools ≈ 2K tokens.
 - **On demand**: the LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose a toolset's tools in subsequent `tools/list` responses. `unload_toolset(name)` prunes them when the task shifts.
@@ -378,9 +378,9 @@ convention for other `kicad-cli`-calling code.
 
 ## Current Stats
 
-- **20 toolsets, 214 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
+- **20 toolsets, 216 tools** + 6 meta-tools (4 routing + 2 observability — see `tool-directory.md`)
 - Baseline `tools/list`: 20 tools / ~2K tokens (starter kit + meta-tools)
-- Full-catalog `tools/list` (all loaded): 220 tools (214 registered + 6 meta) / ~25K tokens
+- Full-catalog `tools/list` (all loaded): 222 tools (216 registered + 6 meta) / ~25K tokens
 - **0 IPC stubs** (all protobuf methods implemented)
 - **0 unimplemented tools**
 - **Specctra DSN/SES are PCB-editor operations**, not `kicad-cli` commands. Konnect

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Rust binary — that lets Claude and other AI assistants design schematics and PCBs
 through the [Model Context Protocol](https://modelcontextprotocol.io) (MCP).
 
-**214 tools across 20 on-demand toolsets.** Schematic capture, PCB layout and
+**216 tools across 20 on-demand toolsets.** Schematic capture, PCB layout and
 routing, ERC/DRC, design-review audits, JLCPCB part search, reference
 circuits, and a full manufacturing export pipeline — with bundled skills and agents
 that teach Claude KiCAD conventions out of the box.
@@ -70,7 +70,7 @@ through its own S-expression engine with atomic writes (write, fsync, rename), U
 preservation, and round-trip tests — no third-party schematic library with known
 gaps, no text-manipulation workarounds.
 
-**Context economy is a feature.** Exposing all 214 tools to an LLM costs roughly 23K
+**Context economy is a feature.** Exposing all 216 tools to an LLM costs roughly 23K
 tokens of context on every listing. Konnect's router loads a starter kit (~2K
 tokens) and lets the model pull in toolsets on demand — plus built-in observability
 (`get_recent_calls`, `server_stats`, JSONL call logs) so the model can diagnose its

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -112,7 +112,7 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         name: "verification",
         description: "DRC, design rules, layer constraints, clearance checks, KiCAD UI control (ERC is in sch_export)",
         category: "verification",
-        tool_count: 8,
+        tool_count: 10,
     },
     ToolsetMeta {
         name: "config",

--- a/crates/konnect-core/src/tools/verification.rs
+++ b/crates/konnect-core/src/tools/verification.rs
@@ -8,7 +8,7 @@ use crate::tool;
 use crate::tools::{get_path, require_f64, require_str, ToolContext, ToolDef};
 use anyhow::Context;
 use konnect_sexp::writer::write_atomic;
-use serde_json::json;
+use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
 use tokio::task;
 
@@ -73,6 +73,54 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board"]
             }),
             |args, ctx| async move { handle_get_design_rules(args, ctx).await }
+        ),
+        tool!(
+            "set_predefined_sizes",
+            "Write the PCB editor Pre-defined Sizes list (track widths and via pad/drill \
+             pairs) into the sibling .kicad_pro. These populate the Track/Via dropdowns \
+             and W/Shift+W while routing; they are not DRC limits and do not change \
+             netclasses. A leading 0 mm track and 0/0 via is always kept as the \
+             'use netclass' sentinel. Pass only the lists you want to replace. KiCad \
+             reads the change on next project open. The board file is not modified.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "board": { "type": "string", "description": "Path to .kicad_pcb file; the sibling .kicad_pro is edited" },
+                    "track_widths": {
+                        "type": "array",
+                        "description": "Track widths in mm for the router dropdown, excluding the 0 mm netclass sentinel (that row is always prepended). An empty array leaves only the sentinel.",
+                        "items": { "type": "number" }
+                    },
+                    "via_dimensions": {
+                        "type": "array",
+                        "description": "Via pad/drill pairs in mm for the router dropdown, excluding the 0/0 netclass sentinel (that row is always prepended). An empty array leaves only the sentinel.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "diameter": { "type": "number", "description": "Via pad diameter in mm" },
+                                "drill": { "type": "number", "description": "Via drill diameter in mm" }
+                            },
+                            "required": ["diameter", "drill"]
+                        }
+                    }
+                },
+                "required": ["board"]
+            }),
+            |args, ctx| async move { handle_set_predefined_sizes(args, ctx).await }
+        ),
+        tool!(
+            "get_predefined_sizes",
+            "Return the PCB editor Pre-defined Sizes list from the sibling .kicad_pro: \
+             track_widths (mm) and via_dimensions (diameter/drill mm), including the \
+             0 / 0,0 netclass sentinel KiCad keeps at the front of each list.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "board": { "type": "string", "description": "Path to .kicad_pcb file; the sibling .kicad_pro is read" }
+                },
+                "required": ["board"]
+            }),
+            |args, ctx| async move { handle_get_predefined_sizes(args, ctx).await }
         ),
         tool!(
             "check_kicad_ui",
@@ -426,6 +474,241 @@ async fn handle_get_design_rules(
         }))
         .unwrap(),
     ))
+}
+
+// ─── Pre-defined sizes (Board Setup → Design Rules → Pre-defined Sizes) ───────
+//
+// KiCad stores the router palette in board.design_settings.track_widths /
+// via_dimensions. A leading 0 (track) or {diameter:0, drill:0} (via) is the
+// "use netclass values" sentinel the dropdown always shows first. These lists
+// are not DRC floors and are not netclass widths.
+
+fn project_design_settings_mut(
+    project: &mut Value,
+) -> anyhow::Result<&mut serde_json::Map<String, Value>> {
+    let project = project
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("KiCAD project root must be a JSON object"))?;
+    let board = project
+        .entry("board")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("KiCAD project 'board' must be a JSON object"))?;
+    board
+        .entry("design_settings")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .ok_or_else(|| {
+            anyhow::anyhow!("KiCAD project 'board.design_settings' must be a JSON object")
+        })
+}
+
+fn load_sibling_project(board: &Path) -> anyhow::Result<Result<(PathBuf, Value), CallToolResult>> {
+    let project_path = sibling_project_path(board);
+    if !project_path.exists() {
+        return Ok(Err(CallToolResult::error(format!(
+            "No project file at {} — Pre-defined Sizes live in the .kicad_pro, \
+             and a list written anywhere else is never read. Create the project \
+             (KiCad: File > Save a Copy, or place the board inside a project) and retry.",
+            project_path.display()
+        ))));
+    }
+    let settings: Value = serde_json::from_str(&std::fs::read_to_string(&project_path)?)
+        .map_err(|e| anyhow::anyhow!("{} is not valid JSON: {e}", project_path.display()))?;
+    Ok(Ok((project_path, settings)))
+}
+
+fn finite_positive(value: f64, field: &str) -> Result<f64, CallToolResult> {
+    if value.is_finite() && value > 0.0 {
+        Ok(value)
+    } else {
+        Err(CallToolResult::error(format!(
+            "Argument '{field}' is invalid: must be a finite number greater than 0 mm, got {value}"
+        )))
+    }
+}
+
+/// Palette track widths, with the 0 mm netclass sentinel always first.
+/// Caller zeros are dropped rather than duplicated.
+fn parse_track_widths(raw: &[Value]) -> Result<Vec<Value>, CallToolResult> {
+    let mut out = vec![json!(0.0)];
+    for (i, item) in raw.iter().enumerate() {
+        let width = item.as_f64().ok_or_else(|| {
+            CallToolResult::error(format!(
+                "Argument 'track_widths[{i}]' is invalid: missing or not a number"
+            ))
+        })?;
+        if width == 0.0 {
+            continue;
+        }
+        let width = finite_positive(width, &format!("track_widths[{i}]"))?;
+        let encoded = json!(width);
+        if !out.contains(&encoded) {
+            out.push(encoded);
+        }
+    }
+    Ok(out)
+}
+
+/// Palette vias, with the 0/0 netclass sentinel always first.
+fn parse_via_dimensions(raw: &[Value]) -> Result<Vec<Value>, CallToolResult> {
+    let mut out = vec![json!({ "diameter": 0.0, "drill": 0.0 })];
+    for (i, item) in raw.iter().enumerate() {
+        let obj = item.as_object().ok_or_else(|| {
+            CallToolResult::error(format!(
+                "Argument 'via_dimensions[{i}]' is invalid: missing or not an object"
+            ))
+        })?;
+        let diameter = obj.get("diameter").and_then(Value::as_f64).ok_or_else(|| {
+            CallToolResult::error(format!(
+                "Argument 'via_dimensions[{i}].diameter' is invalid: missing or not a number"
+            ))
+        })?;
+        let drill = obj.get("drill").and_then(Value::as_f64).ok_or_else(|| {
+            CallToolResult::error(format!(
+                "Argument 'via_dimensions[{i}].drill' is invalid: missing or not a number"
+            ))
+        })?;
+        if diameter == 0.0 && drill == 0.0 {
+            continue;
+        }
+        let diameter = finite_positive(diameter, &format!("via_dimensions[{i}].diameter"))?;
+        let drill = finite_positive(drill, &format!("via_dimensions[{i}].drill"))?;
+        if diameter <= drill {
+            return Err(CallToolResult::error(format!(
+                "Argument 'via_dimensions[{i}]' is invalid: diameter ({diameter} mm) \
+                 must be greater than drill ({drill} mm)"
+            )));
+        }
+        let encoded = json!({ "diameter": diameter, "drill": drill });
+        if !out.contains(&encoded) {
+            out.push(encoded);
+        }
+    }
+    Ok(out)
+}
+
+fn current_predefined_sizes(project: &Value) -> (Value, Value) {
+    let settings = &project["board"]["design_settings"];
+    let track_widths = settings["track_widths"].clone();
+    let via_dimensions = settings["via_dimensions"].clone();
+    (
+        if track_widths.is_array() {
+            track_widths
+        } else {
+            json!([0.0])
+        },
+        if via_dimensions.is_array() {
+            via_dimensions
+        } else {
+            json!([{ "diameter": 0.0, "drill": 0.0 }])
+        },
+    )
+}
+
+async fn handle_set_predefined_sizes(
+    args: &Value,
+    ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let board = get_path(args, "board")?;
+    let tracks_arg = match args.get("track_widths") {
+        None | Some(Value::Null) => None,
+        Some(Value::Array(items)) => match parse_track_widths(items) {
+            Ok(v) => Some(v),
+            Err(e) => return Ok(e),
+        },
+        Some(_) => {
+            return Ok(CallToolResult::error(
+                "Argument 'track_widths' is invalid: missing or not an array".to_string(),
+            ))
+        }
+    };
+    let vias_arg = match args.get("via_dimensions") {
+        None | Some(Value::Null) => None,
+        Some(Value::Array(items)) => match parse_via_dimensions(items) {
+            Ok(v) => Some(v),
+            Err(e) => return Ok(e),
+        },
+        Some(_) => {
+            return Ok(CallToolResult::error(
+                "Argument 'via_dimensions' is invalid: missing or not an array".to_string(),
+            ))
+        }
+    };
+    if tracks_arg.is_none() && vias_arg.is_none() {
+        return Ok(CallToolResult::error(
+            "Argument 'track_widths' is invalid: name at least one of track_widths, via_dimensions"
+                .to_string(),
+        ));
+    }
+
+    if let Some(refusal) = crate::tools::pcb_board::refuse_if_board_open_in_kicad(
+        ctx.config.ipc_address.clone(),
+        &board,
+        "Pre-defined Sizes list",
+    )
+    .await?
+    {
+        return Ok(refusal);
+    }
+
+    let (project_path, mut project) = match load_sibling_project(&board)? {
+        Ok(v) => v,
+        Err(refusal) => return Ok(refusal),
+    };
+
+    let (mut track_widths, mut via_dimensions) = current_predefined_sizes(&project);
+    let mut changed_fields = Vec::new();
+    if let Some(next) = tracks_arg {
+        let next = Value::Array(next);
+        if next != track_widths {
+            changed_fields.push("track_widths");
+            track_widths = next;
+        }
+    }
+    if let Some(next) = vias_arg {
+        let next = Value::Array(next);
+        if next != via_dimensions {
+            changed_fields.push("via_dimensions");
+            via_dimensions = next;
+        }
+    }
+
+    if !changed_fields.is_empty() {
+        let settings = project_design_settings_mut(&mut project)?;
+        settings.insert("track_widths".into(), track_widths.clone());
+        settings.insert("via_dimensions".into(), via_dimensions.clone());
+        let mut content = serde_json::to_string_pretty(&project)?;
+        content.push('\n');
+        write_atomic(&project_path, &content)?;
+    }
+
+    Ok(CallToolResult::json(&json!({
+        "success": true,
+        "project": project_path,
+        "changed": changed_fields,
+        "track_widths": track_widths,
+        "via_dimensions": via_dimensions,
+        "note": "Pre-defined Sizes live in the project file and fill the Track/Via dropdowns. \
+                 They are not DRC limits. KiCad reads the change on next project open."
+    })))
+}
+
+async fn handle_get_predefined_sizes(
+    args: &Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let board = get_path(args, "board")?;
+    let (project_path, project) = match load_sibling_project(&board)? {
+        Ok(v) => v,
+        Err(refusal) => return Ok(refusal),
+    };
+    let (track_widths, via_dimensions) = current_predefined_sizes(&project);
+    Ok(CallToolResult::json(&json!({
+        "project": project_path,
+        "track_widths": track_widths,
+        "via_dimensions": via_dimensions
+    })))
 }
 
 // ─── KiCAD UI management ──────────────────────────────────────────────────────
@@ -1103,6 +1386,173 @@ mod tests {
         assert_eq!(rules["min_through_hole_diameter"], 0.30);
         assert_eq!(rules["min_via_diameter"], 0.70);
         assert_eq!(rules["min_hole_to_hole"], 0.45);
+    }
+
+    fn text_of(result: &CallToolResult) -> String {
+        match result.content.first() {
+            Some(crate::mcp::protocol::ToolContent::Text { text }) => text.clone(),
+            other => panic!("expected text, got {other:?}"),
+        }
+    }
+
+    fn project_json(project: &std::path::Path) -> serde_json::Value {
+        serde_json::from_slice(&std::fs::read(project).unwrap()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn set_predefined_sizes_writes_palette_and_leaves_the_board_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = dir.path().join("board.kicad_pcb");
+        let project = dir.path().join("board.kicad_pro");
+        tokio::fs::write(&board, blank_board()).await.unwrap();
+        tokio::fs::write(&project, blank_project()).await.unwrap();
+        let original_board = tokio::fs::read(&board).await.unwrap();
+
+        let result = handle_set_predefined_sizes(
+            &json!({
+                "board": board,
+                "track_widths": [0.2, 0.5, 0.8],
+                "via_dimensions": [
+                    { "diameter": 0.6, "drill": 0.3 },
+                    { "diameter": 0.8, "drill": 0.4 }
+                ]
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error, "{}", text_of(&result));
+        assert_eq!(tokio::fs::read(&board).await.unwrap(), original_board);
+
+        let stored = project_json(&project);
+        assert_eq!(
+            stored["board"]["design_settings"]["track_widths"],
+            json!([0.0, 0.2, 0.5, 0.8])
+        );
+        assert_eq!(
+            stored["board"]["design_settings"]["via_dimensions"],
+            json!([
+                { "diameter": 0.0, "drill": 0.0 },
+                { "diameter": 0.6, "drill": 0.3 },
+                { "diameter": 0.8, "drill": 0.4 }
+            ])
+        );
+        assert_eq!(stored["meta"]["filename"], json!("board.kicad_pro"));
+    }
+
+    #[tokio::test]
+    async fn get_predefined_sizes_reads_what_set_wrote() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = dir.path().join("board.kicad_pcb");
+        let project = dir.path().join("board.kicad_pro");
+        tokio::fs::write(&board, blank_board()).await.unwrap();
+        tokio::fs::write(&project, blank_project()).await.unwrap();
+        handle_set_predefined_sizes(
+            &json!({ "board": board, "track_widths": [0.2] }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        let result = handle_get_predefined_sizes(&json!({ "board": board }), &test_ctx())
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{}", text_of(&result));
+        let body: serde_json::Value = serde_json::from_str(&text_of(&result)).unwrap();
+        assert_eq!(body["track_widths"], json!([0.0, 0.2]));
+        assert_eq!(
+            body["via_dimensions"],
+            json!([{ "diameter": 0.0, "drill": 0.0 }])
+        );
+    }
+
+    #[tokio::test]
+    async fn set_predefined_sizes_without_a_project_file_refuses_and_writes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = dir.path().join("board.kicad_pcb");
+        tokio::fs::write(&board, blank_board()).await.unwrap();
+        let original_board = tokio::fs::read(&board).await.unwrap();
+
+        let result = handle_set_predefined_sizes(
+            &json!({ "board": board, "track_widths": [0.2] }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(result.is_error, "{}", text_of(&result));
+        assert!(
+            text_of(&result).contains("kicad_pro"),
+            "{}",
+            text_of(&result)
+        );
+        assert_eq!(tokio::fs::read(&board).await.unwrap(), original_board);
+        assert!(!dir.path().join("board.kicad_pro").exists());
+    }
+
+    #[tokio::test]
+    async fn set_predefined_sizes_refuses_a_via_with_no_annular_ring() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = dir.path().join("board.kicad_pcb");
+        let project = dir.path().join("board.kicad_pro");
+        tokio::fs::write(&board, blank_board()).await.unwrap();
+        tokio::fs::write(&project, blank_project()).await.unwrap();
+        let original_project = tokio::fs::read(&project).await.unwrap();
+
+        let result = handle_set_predefined_sizes(
+            &json!({
+                "board": board,
+                "via_dimensions": [{ "diameter": 0.3, "drill": 0.3 }]
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(result.is_error, "{}", text_of(&result));
+        assert!(
+            text_of(&result).contains("greater than drill"),
+            "{}",
+            text_of(&result)
+        );
+        assert_eq!(tokio::fs::read(&project).await.unwrap(), original_project);
+    }
+
+    #[tokio::test]
+    async fn set_predefined_sizes_omitting_vias_leaves_existing_vias_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = dir.path().join("board.kicad_pcb");
+        let project = dir.path().join("board.kicad_pro");
+        tokio::fs::write(&board, blank_board()).await.unwrap();
+        tokio::fs::write(&project, blank_project()).await.unwrap();
+        handle_set_predefined_sizes(
+            &json!({
+                "board": board,
+                "track_widths": [0.2],
+                "via_dimensions": [{ "diameter": 0.6, "drill": 0.3 }]
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        let result = handle_set_predefined_sizes(
+            &json!({ "board": board, "track_widths": [0.2, 0.5] }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error, "{}", text_of(&result));
+        let stored = project_json(&project);
+        assert_eq!(
+            stored["board"]["design_settings"]["track_widths"],
+            json!([0.0, 0.2, 0.5])
+        );
+        assert_eq!(
+            stored["board"]["design_settings"]["via_dimensions"],
+            json!([
+                { "diameter": 0.0, "drill": 0.0 },
+                { "diameter": 0.6, "drill": 0.3 }
+            ])
+        );
     }
 
     #[tokio::test]

--- a/crates/konnect/assets/skills/kicad-pcb/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-pcb/SKILL.md
@@ -52,7 +52,7 @@ Load additional toolsets as needed:
 
 ```
 load_toolset('config')           # design rule storage: add_design_rule, list_design_rules
-load_toolset('verification')     # run_drc, set_design_rules, get_design_rules, check_clearance
+load_toolset('verification')     # run_drc, set_design_rules, set_predefined_sizes, check_clearance
 ```
 
 Always call `get_active_toolsets()` first to see what is already loaded.
@@ -219,6 +219,20 @@ Common netclass configurations:
 - Standard signal via: 0.4mm drill, 0.8mm pad diameter
 - Power via: 0.6mm drill, 1.0mm pad diameter
 - Micro via (HDI): 0.1mm drill, 0.3mm pad diameter
+
+### Pre-defined sizes
+
+Netclass width is the default. The Track/Via dropdowns are a separate palette
+in the sibling `.kicad_pro`. Fill them with `set_predefined_sizes` so `W` /
+`Shift+W` can step through extra widths without changing netclasses:
+
+```
+set_predefined_sizes(board, track_widths=[0.2, 0.5, 0.8],
+    via_dimensions=[{diameter:0.6, drill:0.3}, {diameter:0.8, drill:0.4}])
+```
+
+A leading 0 mm / 0,0 via is always kept as “use netclass values”. These sizes
+are not DRC limits. KiCad reads the list on next project open.
 
 ---
 

--- a/crates/konnect/assets/skills/konnect/SKILL.md
+++ b/crates/konnect/assets/skills/konnect/SKILL.md
@@ -55,6 +55,7 @@ Only to answer questions not available through exports (sheet hierarchy, title b
 | "Add a 100nF cap to U3 VCC" | 1 | `load_toolset("sch_components")` + `load_toolset("sch_wiring")` |
 | "Rename net /CLK to /SYS_CLK" | 1 | Warn about downstream effects, then MCP tools |
 | "Run DRC" | 1 | `load_toolset("verification")` then `run_drc` |
+| "Add track widths to the PCB dropdown" | 1 | `load_toolset("verification")` then `set_predefined_sizes` |
 | "Export Gerbers" | 1 | `load_toolset("pcb_export")` then `export_gerber` |
 | "Just patch line 247 of the .kicad_sch" | REFUSE | Explain risks, offer MCP alternative |
 | "Add ESD protection to USB lines" | 1 | `load_toolset("sch_components")` + `load_toolset("sch_wiring")` |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -192,7 +192,7 @@ The fix for those clients is to make the *first* listing complete:
 ```
 
 in `konnect.toml` in the working directory, or a `settings.json` beside the binary. Every toolset is then loaded at
-startup, so `tools/list` carries all 220 tools from the first call.
+startup, so `tools/list` carries all 222 tools from the first call.
 
 It is off by default because it costs what the router exists to save: roughly
 25K tokens per listing instead of ~2K. Turn it on only if your client needs it.

--- a/packaging/metadata.json
+++ b/packaging/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://go.kicad.org/pcm/schemas/v1",
   "name": "Konnect",
-  "description": "AI-assisted PCB design via the Model Context Protocol. Enables Claude and other AI assistants to design schematics and PCBs with 214 tools organized into on-demand toolsets.",
+  "description": "AI-assisted PCB design via the Model Context Protocol. Enables Claude and other AI assistants to design schematics and PCBs with 216 tools organized into on-demand toolsets.",
   "description_full": "Konnect exposes a complete set of KiCAD design tools to AI assistants via the Model Context Protocol (MCP). It supports schematic editing, PCB layout, routing, library management, JLCPCB part search, Freerouting installation checks, ERC/DRC, design review audits, and full export pipelines. Tools are organized into 20 toolsets loaded on demand so the AI only sees relevant tools at once.",
   "identifier": "com.github.mixelpixx.konnect",
   "type": "plugin",

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "identifier": "com.github.mixelpixx.konnect",
   "name": "Konnect",
-  "description": "AI-assisted PCB design via the Model Context Protocol. 214 tools for schematic editing, PCB layout, routing, design review, and manufacturing export.",
+  "description": "AI-assisted PCB design via the Model Context Protocol. 216 tools for schematic editing, PCB layout, routing, design review, and manufacturing export.",
   "runtime": {
     "type": "exec"
   },

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -13,7 +13,7 @@ Compatibility notes for removed or narrowed arguments are recorded in
 ## Overview
 
 - **20 toolsets** organized into 10 categories
-- **214 registered tools** + **6 always-visible meta-tools** = **220 total**
+- **216 registered tools** + **6 always-visible meta-tools** = **222 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -358,7 +358,7 @@ bridge and every call failed; `check_freerouting` remains available for diagnost
 
 ## Verification
 
-### `verification` · 8 tools
+### `verification` · 10 tools
 **Purpose:** DRC, design rules, layer constraints, clearance checks, KiCAD UI control. ERC lives in `sch_export` (`run_erc`), not here.
 **Source:** [`crates/konnect-core/src/tools/verification.rs`](crates/konnect-core/src/tools/verification.rs)
 
@@ -367,6 +367,8 @@ bridge and every call failed; `check_freerouting` remains available for diagnost
 | `run_drc` | Run KiCad's complete configured DRC ruleset and return structured violation results. |
 | `set_design_rules` | Set board-level design rules (clearance, trace width, via size) in the sibling `.kicad_pro` project file. The board file is not modified. |
 | `get_design_rules` | Return the current design rule constraints from the sibling `.kicad_pro` project file. |
+| `set_predefined_sizes` | Write the PCB editor Pre-defined Sizes list (track widths and via pad/drill pairs) into the sibling `.kicad_pro`. These fill the Track/Via dropdowns; they are not DRC limits. |
+| `get_predefined_sizes` | Return the Pre-defined Sizes list from the sibling `.kicad_pro`, including the 0 / 0,0 netclass sentinel. |
 | `check_kicad_ui` | Check whether the KiCad GUI is running and whether IPC responds within the requested bounded timeout. |
 | `launch_kicad_ui` | Launch the KiCAD GUI application and optionally open a project file. |
 | `copy_routing_pattern` | Copy a routing pattern (traces and vias) from one region of the board to another. |


### PR DESCRIPTION
## Problem

PCB Editor → Board Setup → Design Rules → Pre-defined Sizes (the Track / Via dropdowns, `W` / `Shift+W`) had no MCP path. Agents either patched `.kicad_pro` by hand or called the wrong tools:

- `set_design_rules` writes DRC **floors** (`min_track_width`, `min_clearance`, …)
- `create_netclass` writes netclass **optima**
- the palette lives in `board.design_settings.track_widths` / `via_dimensions`

Those are three different keys. Filling one does not fill the others.

Fixes #345.

## Design

Two tools in `verification` (8 → 10):

- `set_predefined_sizes(board, track_widths?, via_dimensions?)` writes the sibling `.kicad_pro` only
- `get_predefined_sizes(board)` reads it back

The handler always keeps KiCad’s leading sentinel (`0.0` tracks, `{diameter:0, drill:0}` vias). Caller lists are extra rows in mm; omit a list to leave it; `[]` clears extras. Via pad must be `> drill`. Missing project file refuses. If pcbnew holds the board, `refuse_if_board_open_in_kicad` refuses so a live save cannot clobber the write. KiCad picks the list up on next project open.

## Compatibility

Additive public API. No renames, no schema changes to existing tools. Catalogue 214 → 216 registered (220 → 222 with meta). Agents on an old Konnect binary will not see the tools until they pull, rebuild, and restart MCP.

## Tests

Local:

- `cargo fmt --all -- --check`
- `cargo test -p konnect-core set_predefined` / `get_predefined` / `registry_tool_counts_match_reality`
- `cargo test -p konnect --test doc_tool_counts`
- `cargo test -p konnect --test schema_parameter_usage`
- `cargo test -p konnect --test asset_references`

Not run here (CI will): full `--workspace --locked` lib/tests/doc, `clippy -D warnings`. No live-KiCad test for the open-board refuse path.

## Risk / rollback

Writes JSON in `.kicad_pro` the same way `create_netclass` does (`write_atomic`, pretty-print). Does not touch `.kicad_pcb`. Revert the commit to remove the tools; already-written palettes in user projects stay until edited.

## Agent use

```
load_toolset("verification")
set_predefined_sizes(board, track_widths=[0.2, 0.5, 0.8],
  via_dimensions=[{diameter:0.6, drill:0.3}, {diameter:0.8, drill:0.4}])
get_predefined_sizes(board)
```
