### PR TITLE
docs(troubleshooting): explain Copilot tool limits

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -185,7 +185,8 @@ call it. That is the symptom in
 [#169](https://github.com/mixelpixx/Konnect/issues/169) — reported against
 Claude Desktop.
 
-The fix for those clients is to make the *first* listing complete:
+For clients that cache the initial list but do not also cap the number of
+callable tools, the fix is to make the *first* listing complete:
 
 ```json
 { "eager_toolsets": true }
@@ -200,6 +201,48 @@ It is off by default because it costs what the router exists to save: roughly
 Note that `auto_load_toolsets` does **not** solve this. It loads a toolset when
 a tool from it is *called*, which helps only a client that already knows the
 tool name — so it does nothing for a client whose tool list is stale.
+
+## VS Code Copilot says a tool is "currently disabled by the user"
+
+That exact message comes from the VS Code Copilot client layer, not Konnect.
+In the confirmed report in
+[#325](https://github.com/mixelpixx/Konnect/issues/325), the attempted calls did
+not appear in Konnect's `get_recent_calls` output because Copilot refused them
+before they reached the server.
+
+Two Copilot behaviors make the normal toolset settings ineffective:
+
+- With `eager_toolsets = false`, Copilot caches the initial `tools/list` and
+  does not re-fetch it after `notifications/tools/list_changed`. Tools loaded
+  later therefore remain unavailable to the model.
+- With `eager_toolsets = true`, Konnect advertises its full catalog at startup,
+  but Copilot applies its own total callable-tool budget across all configured
+  MCP servers. The #325 reporter measured a 128-tool ceiling and saw only an
+  arbitrary, changing subset of Konnect tools exposed. Tools outside that
+  subset produced "currently disabled by the user."
+
+Changing Konnect from stdio to HTTP/SSE does not remove a limit applied by the
+client after it receives `tools/list`. Reloading the VS Code window also does
+not make an over-budget catalog callable.
+
+Current options are:
+
+1. Disable unrelated MCP servers or tools if that brings the complete set you
+   need below the client's budget.
+2. Use an MCP client that honors `tools/list_changed` or can expose Konnect's
+   full catalog.
+3. Use the community two-tool proxy pattern demonstrated in
+   [the #325 follow-up](https://github.com/mixelpixx/Konnect/issues/325#issuecomment-5407317596):
+   expose only `konnect_help` and `konnect_call` to Copilot, let
+   `konnect_help()` list names or return one tool's description and schema,
+   and let `konnect_call(tool, arguments)` forward the actual call to a child
+   Konnect process started with `eager_toolsets = true`.
+
+The proxy is a community workaround attached to the issue, not code shipped or
+reviewed by Konnect; inspect it and configure its executable path before use.
+A native compact tool-surface mode and MCP tool-directory resource are planned
+in the [client compatibility roadmap](../ROADMAP.md#4-client-compatibility),
+but are not available yet.
 
 ## Plugin doesn't appear in KiCAD
 


### PR DESCRIPTION
## Problem and scope

Issue #325 documents a VS Code Copilot failure mode where Konnect tools are discovered but only an arbitrary subset is callable. The existing troubleshooting advice recommended `eager_toolsets = true` for clients that cache the initial tool list, but that does not solve a client-wide callable-tool ceiling.

This documentation-only change:

- distinguishes initial-list caching from Copilot's total tool budget;
- explains why the `currently disabled by the user` error never reaches Konnect;
- records the reporter's measured 128-tool ceiling without treating it as a Konnect limit;
- points readers to the community two-tool relay demonstrated in #325;
- makes clear that the relay is not shipped or reviewed by Konnect; and
- points to the planned native compact tool surface in the roadmap.

## Root cause and design

The evidence in #325 shows two client-side behaviors: Copilot does not refresh the tool list after `notifications/tools/list_changed` when lazy loading is used, while eager loading exceeds Copilot's aggregate callable-tool budget. The troubleshooting guidance now steers users according to those distinct cases and preserves #325 for the native server-side compact-surface work.

## Compatibility

Documentation only. No runtime behavior, API, configuration default, or generated asset changes.

## Verification

- `cargo test -p konnect --locked --test asset_references --test doc_tool_counts`
- `cargo fmt --all -- --check`
- `git diff --check`

## Risk and rollback

The primary risk is future Copilot behavior changing. The text attributes the measured ceiling to the #325 report and presents the relay as a current community workaround. Rollback is a single documentation commit.

Refs #325