### PR TITLE
fix(pcb): preserve library user text during refresh

### DIFF
--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -380,6 +380,14 @@ fn text_size(node: &konnect_sexp::SexpNode) -> f64 {
         .unwrap_or(1.0)
 }
 
+/// Explicit font stroke width, falling back to KiCad's 15%-of-size default.
+fn text_stroke_width(node: &konnect_sexp::SexpNode) -> f64 {
+    node.find("effects")
+        .and_then(|effects| effects.find("font"))
+        .and_then(|font| font.find_f64("thickness"))
+        .unwrap_or_else(|| text_size(node) * 0.15)
+}
+
 /// Text position and angle from `(at x y [rot])`.
 fn text_at(node: &konnect_sexp::SexpNode, kind: &str) -> anyhow::Result<((f64, f64), f64)> {
     let at = node
@@ -522,6 +530,7 @@ pub(crate) fn extract_graphic_definitions(
             rotation,
             layer: graphic_layer(text, "fp_text")?,
             size: text_size(text),
+            stroke_width: text_stroke_width(text),
         });
     }
     for property in footprint.find_all("property") {
@@ -546,6 +555,7 @@ pub(crate) fn extract_graphic_definitions(
             rotation,
             layer,
             size: text_size(property),
+            stroke_width: text_stroke_width(property),
         });
     }
     Ok(graphics)

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -530,7 +530,7 @@ pub(crate) fn extract_graphic_definitions(
             rotation,
             layer: graphic_layer(text, "fp_text")?,
             size: text_size(text),
-            stroke_width: text_stroke_width(text),
+            stroke_width_mm: text_stroke_width(text),
         });
     }
     for property in footprint.find_all("property") {
@@ -555,7 +555,7 @@ pub(crate) fn extract_graphic_definitions(
             rotation,
             layer,
             size: text_size(property),
-            stroke_width: text_stroke_width(property),
+            stroke_width_mm: text_stroke_width(property),
         });
     }
     Ok(graphics)

--- a/crates/konnect-core/src/tools/pcb_footprint_update.rs
+++ b/crates/konnect-core/src/tools/pcb_footprint_update.rs
@@ -843,6 +843,7 @@ fn validate_user_text(text: &konnect_sexp::SexpNode) -> Result<()> {
     let mut saw_at = false;
     let mut saw_layer = false;
     let mut saw_effects = false;
+    let mut identifier = None;
     for clause in text.children().unwrap_or_default().iter().skip(3) {
         let tag = clause
             .head()
@@ -881,6 +882,12 @@ fn validate_user_text(text: &konnect_sexp::SexpNode) -> Result<()> {
                 }
             }
             "uuid" | "tstamp" => {
+                if let Some(previous) = identifier {
+                    bail!(
+                        "fp_text user contains multiple identifier clauses ('{previous}' and '{tag}')"
+                    );
+                }
+                identifier = Some(tag);
                 if clause.children().map_or(0, |children| children.len()) != 2
                     || clause
                         .get(1)
@@ -1451,14 +1458,14 @@ fn mirror_graphic(
             rotation,
             layer,
             size,
-            stroke_width,
+            stroke_width_mm,
         } => Graphic::Text {
             text: text.clone(),
             position: point(*position),
             rotation: 180.0 - rotation,
             layer: flip_layer_name(layer)?,
             size: *size,
-            stroke_width: *stroke_width,
+            stroke_width_mm: *stroke_width_mm,
         },
     })
 }
@@ -1788,13 +1795,13 @@ mod tests {
                     rotation,
                     layer,
                     size,
-                    stroke_width,
+                    stroke_width_mm,
                 } if text == "${REFERENCE}"
                     && *position == (0.0, 1.5)
                     && *rotation == 0.0
                     && layer == "F.Fab"
                     && *size == 1.0
-                    && *stroke_width == 0.15
+                    && *stroke_width_mm == 0.15
             )
         }));
         assert_eq!(library.datasheet.as_deref(), Some("new-datasheet.pdf"));
@@ -2051,9 +2058,9 @@ mod tests {
             konnect_ipc::IpcGraphicDefinition::Text {
                 text,
                 size,
-                stroke_width,
+                stroke_width_mm,
                 ..
-            } if text == "${REFERENCE}" && *size == 0.8 && *stroke_width == 0.11
+            } if text == "${REFERENCE}" && *size == 0.8 && *stroke_width_mm == 0.11
         )));
         assert_eq!(library.models.len(), 1);
         let model = &library.models[0];
@@ -2270,6 +2277,16 @@ mod tests {
                 "(effects (font (size 0.8 0.8) (thickness 0.11)))",
                 "(effects (font (size 0.8 0.8)))",
                 "missing its thickness",
+            ),
+            (
+                "(uuid \"f96c2efe-5925-4f74-81d2-f89a56f57e13\")",
+                "(uuid \"f96c2efe-5925-4f74-81d2-f89a56f57e13\") (uuid \"duplicate\")",
+                "multiple identifier clauses",
+            ),
+            (
+                "(uuid \"f96c2efe-5925-4f74-81d2-f89a56f57e13\")",
+                "(uuid \"f96c2efe-5925-4f74-81d2-f89a56f57e13\") (tstamp \"legacy-too\")",
+                "multiple identifier clauses",
             ),
         ] {
             let unsupported = LIBRARY_FOOTPRINT.replacen(from, to, 1);

--- a/crates/konnect-core/src/tools/pcb_footprint_update.rs
+++ b/crates/konnect-core/src/tools/pcb_footprint_update.rs
@@ -807,10 +807,14 @@ fn validate_supported_children(root: &konnect_sexp::SexpNode) -> Result<()> {
                     .get(1)
                     .and_then(konnect_sexp::SexpNode::as_str)
                     .context("fp_text is missing its kind")?;
-                if !matches!(kind, "reference" | "value") {
-                    bail!(
-                        "fp_text kind '{kind}' is not supported losslessly by typed library refresh"
-                    );
+                match kind {
+                    "reference" | "value" => {}
+                    "user" => validate_user_text(child)?,
+                    _ => {
+                        bail!(
+                            "fp_text kind '{kind}' is not supported losslessly by typed library refresh"
+                        );
+                    }
                 }
             }
             "property" => {
@@ -825,6 +829,157 @@ fn validate_supported_children(root: &konnect_sexp::SexpNode) -> Result<()> {
             _ => {}
         }
     }
+    Ok(())
+}
+
+/// Accept only the `fp_text user` subset the typed IPC rebuild can reproduce.
+/// Refusing an unknown clause is intentional: silently dropping even a visual
+/// modifier would make a refreshed board differ from its library definition.
+fn validate_user_text(text: &konnect_sexp::SexpNode) -> Result<()> {
+    text.get(2)
+        .and_then(konnect_sexp::SexpNode::as_str)
+        .context("fp_text user is missing its text")?;
+
+    let mut saw_at = false;
+    let mut saw_layer = false;
+    let mut saw_effects = false;
+    for clause in text.children().unwrap_or_default().iter().skip(3) {
+        let tag = clause
+            .head()
+            .context("fp_text user contains an unsupported atom")?;
+        match tag {
+            "at" => {
+                if saw_at {
+                    bail!("fp_text user contains duplicate 'at' clauses");
+                }
+                saw_at = true;
+                let count = clause.children().map_or(0, |children| children.len());
+                if !matches!(count, 3 | 4) {
+                    bail!("fp_text user 'at' must contain x, y, and optional rotation");
+                }
+                for index in 1..count {
+                    let value = clause
+                        .get_f64(index)
+                        .with_context(|| format!("fp_text user 'at' value {index} is invalid"))?;
+                    if !value.is_finite() {
+                        bail!("fp_text user 'at' values must be finite");
+                    }
+                }
+            }
+            "layer" => {
+                if saw_layer {
+                    bail!("fp_text user contains duplicate 'layer' clauses");
+                }
+                saw_layer = true;
+                if clause.children().map_or(0, |children| children.len()) != 2
+                    || clause
+                        .get(1)
+                        .and_then(konnect_sexp::SexpNode::as_str)
+                        .is_none_or(str::is_empty)
+                {
+                    bail!("fp_text user 'layer' must name exactly one layer");
+                }
+            }
+            "uuid" | "tstamp" => {
+                if clause.children().map_or(0, |children| children.len()) != 2
+                    || clause
+                        .get(1)
+                        .and_then(konnect_sexp::SexpNode::as_str)
+                        .is_none_or(str::is_empty)
+                {
+                    bail!("fp_text user '{tag}' must contain exactly one identifier");
+                }
+            }
+            "effects" => {
+                if saw_effects {
+                    bail!("fp_text user contains duplicate 'effects' clauses");
+                }
+                saw_effects = true;
+                validate_user_text_effects(clause)?;
+            }
+            unsupported => {
+                bail!("fp_text user clause '{unsupported}' is not supported losslessly");
+            }
+        }
+    }
+
+    if !saw_at {
+        bail!("fp_text user is missing its 'at' clause");
+    }
+    if !saw_layer {
+        bail!("fp_text user is missing its 'layer' clause");
+    }
+    if !saw_effects {
+        bail!("fp_text user is missing its 'effects' clause");
+    }
+    Ok(())
+}
+
+fn validate_user_text_effects(effects: &konnect_sexp::SexpNode) -> Result<()> {
+    let mut font = None;
+    for clause in effects.children().unwrap_or_default().iter().skip(1) {
+        let tag = clause
+            .head()
+            .context("fp_text user effects contain an unsupported atom")?;
+        if tag != "font" {
+            bail!("fp_text user effects clause '{tag}' is not supported losslessly");
+        }
+        if font.replace(clause).is_some() {
+            bail!("fp_text user contains duplicate font clauses");
+        }
+    }
+    let font = font.context("fp_text user effects are missing the font clause")?;
+
+    let mut size = None;
+    let mut thickness = None;
+    for clause in font.children().unwrap_or_default().iter().skip(1) {
+        let tag = clause
+            .head()
+            .context("fp_text user font contains an unsupported atom")?;
+        match tag {
+            "size" => {
+                if size.is_some() {
+                    bail!("fp_text user contains duplicate font size clauses");
+                }
+                if clause.children().map_or(0, |children| children.len()) != 3 {
+                    bail!("fp_text user font size must contain width and height");
+                }
+                let width = clause
+                    .get_f64(1)
+                    .context("fp_text user font width is invalid")?;
+                let height = clause
+                    .get_f64(2)
+                    .context("fp_text user font height is invalid")?;
+                if !width.is_finite() || !height.is_finite() || width <= 0.0 || height <= 0.0 {
+                    bail!("fp_text user font size must be finite and positive");
+                }
+                if width != height {
+                    bail!("fp_text user non-square font size is not supported losslessly");
+                }
+                size = Some(width);
+            }
+            "thickness" => {
+                if thickness.is_some() {
+                    bail!("fp_text user contains duplicate font thickness clauses");
+                }
+                if clause.children().map_or(0, |children| children.len()) != 2 {
+                    bail!("fp_text user font thickness must contain exactly one value");
+                }
+                let value = clause
+                    .get_f64(1)
+                    .context("fp_text user font thickness is invalid")?;
+                if !value.is_finite() || value <= 0.0 {
+                    bail!("fp_text user font thickness must be finite and positive");
+                }
+                thickness = Some(value);
+            }
+            unsupported => {
+                bail!("fp_text user font clause '{unsupported}' is not supported losslessly");
+            }
+        }
+    }
+    size.context("fp_text user font is missing its size")?;
+    thickness.context("fp_text user font is missing its thickness")?;
     Ok(())
 }
 
@@ -1296,12 +1451,14 @@ fn mirror_graphic(
             rotation,
             layer,
             size,
+            stroke_width,
         } => Graphic::Text {
             text: text.clone(),
             position: point(*position),
             rotation: 180.0 - rotation,
             layer: flip_layer_name(layer)?,
             size: *size,
+            stroke_width: *stroke_width,
         },
     })
 }
@@ -1617,7 +1774,29 @@ mod tests {
         let library = parse_library_footprint("Konnect:Socket", source)
             .expect("KiCad's own serialization of the fixture must parse");
         assert_eq!(library.pads.len(), 4, "two '1' variants plus '2' and '3'");
-        assert_eq!(library.graphics.len(), 2, "one fp_line and one fp_poly");
+        assert_eq!(
+            library.graphics.len(),
+            3,
+            "one fp_line, one fp_poly, and KiCad's standard fab reference text"
+        );
+        assert!(library.graphics.iter().any(|graphic| {
+            matches!(
+                graphic,
+                konnect_ipc::IpcGraphicDefinition::Text {
+                    text,
+                    position,
+                    rotation,
+                    layer,
+                    size,
+                    stroke_width,
+                } if text == "${REFERENCE}"
+                    && *position == (0.0, 1.5)
+                    && *rotation == 0.0
+                    && layer == "F.Fab"
+                    && *size == 1.0
+                    && *stroke_width == 0.15
+            )
+        }));
         assert_eq!(library.datasheet.as_deref(), Some("new-datasheet.pdf"));
         assert_eq!(library.models.len(), 1);
 
@@ -1732,6 +1911,9 @@ mod tests {
     (effects (font (size 1 1) (thickness 0.15))))
   (fp_text value "Socket" (at 0 4 0) (layer "F.Fab")
     (effects (font (size 1 1) (thickness 0.15))))
+  (fp_text user "${REFERENCE}" (at 0 1.5 0) (layer "F.Fab")
+    (uuid "f96c2efe-5925-4f74-81d2-f89a56f57e13")
+    (effects (font (size 0.8 0.8) (thickness 0.11))))
   (property "Datasheet" "new-datasheet.pdf" (at 0 0) (layer "F.Fab") (hide yes))
   (property "Description" "new field description" (at 0 0) (layer "F.Fab") (hide yes))
   (model "../models/Socket.step"
@@ -1863,7 +2045,16 @@ mod tests {
             "keyboard socket"
         );
         assert_eq!(library.pads.len(), 4);
-        assert_eq!(library.graphics.len(), 2);
+        assert_eq!(library.graphics.len(), 3);
+        assert!(library.graphics.iter().any(|graphic| matches!(
+            graphic,
+            konnect_ipc::IpcGraphicDefinition::Text {
+                text,
+                size,
+                stroke_width,
+                ..
+            } if text == "${REFERENCE}" && *size == 0.8 && *stroke_width == 0.11
+        )));
         assert_eq!(library.models.len(), 1);
         let model = &library.models[0];
         assert_eq!(model.filename, "../models/Socket.step");
@@ -2050,6 +2241,41 @@ mod tests {
             error.to_string().contains("solder_mask_margin"),
             "{error:#}"
         );
+    }
+
+    #[test]
+    fn parser_rejects_lossy_user_text_variants() {
+        for (from, to, expected) in [
+            (
+                "(at 0 1.5 0) (layer \"F.Fab\")",
+                "(at 0 1.5 0) (unlocked yes) (layer \"F.Fab\")",
+                "unlocked",
+            ),
+            (
+                "(effects (font (size 0.8 0.8) (thickness 0.11)))",
+                "(effects (font (size 0.8 0.7) (thickness 0.11)))",
+                "non-square",
+            ),
+            (
+                "(effects (font (size 0.8 0.8) (thickness 0.11)))",
+                "(effects (font (size 0.8 0.8) (thickness 0.11)) (justify left))",
+                "justify",
+            ),
+            (
+                "(effects (font (size 0.8 0.8) (thickness 0.11)))",
+                "(effects (font (size 0.8 0.8) (thickness 0.11) (italic yes)))",
+                "italic",
+            ),
+            (
+                "(effects (font (size 0.8 0.8) (thickness 0.11)))",
+                "(effects (font (size 0.8 0.8)))",
+                "missing its thickness",
+            ),
+        ] {
+            let unsupported = LIBRARY_FOOTPRINT.replacen(from, to, 1);
+            let error = parse_library_footprint("Test:Socket", &unsupported).unwrap_err();
+            assert!(error.to_string().contains(expected), "{error:#}");
+        }
     }
 
     #[test]

--- a/crates/konnect-core/src/tools/pcb_sync.rs
+++ b/crates/konnect-core/src/tools/pcb_sync.rs
@@ -1847,7 +1847,7 @@ mod tests {
                     rotation: 0.0,
                     layer: silk(),
                     size: 1.0,
-                    stroke_width: 0.15,
+                    stroke_width_mm: 0.15,
                 },
             ],
             &konnect_ipc::IpcFieldPlacement::default(),

--- a/crates/konnect-core/src/tools/pcb_sync.rs
+++ b/crates/konnect-core/src/tools/pcb_sync.rs
@@ -1847,6 +1847,7 @@ mod tests {
                     rotation: 0.0,
                     layer: silk(),
                     size: 1.0,
+                    stroke_width: 0.15,
                 },
             ],
             &konnect_ipc::IpcFieldPlacement::default(),

--- a/crates/konnect-core/tests/fixtures/socket_kicad10.kicad_mod
+++ b/crates/konnect-core/tests/fixtures/socket_kicad10.kicad_mod
@@ -73,6 +73,17 @@
 		(layer "B.CrtYd")
 		(uuid "565a35da-55fa-4694-a0ae-23ca11f8f7b0")
 	)
+	(fp_text user "${REFERENCE}"
+		(at 0 1.5 0)
+		(layer "F.Fab")
+		(uuid "f96c2efe-5925-4f74-81d2-f89a56f57e13")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+		)
+	)
 	(pad "1" smd roundrect
 		(at -2 0 15)
 		(size 2 1)

--- a/crates/konnect-ipc/src/builders.rs
+++ b/crates/konnect-ipc/src/builders.rs
@@ -607,6 +607,30 @@ pub fn board_text(
     rotation_deg: f64,
     mirror: bool,
 ) -> kiapi::board::types::BoardText {
+    board_text_with_stroke_width(
+        layer,
+        text,
+        x,
+        y,
+        size_mm,
+        size_mm * 0.15,
+        rotation_deg,
+        mirror,
+    )
+}
+
+/// Build a BoardText while preserving an explicit font stroke width.
+#[allow(clippy::too_many_arguments)]
+pub fn board_text_with_stroke_width(
+    layer: &str,
+    text: &str,
+    x: f64,
+    y: f64,
+    size_mm: f64,
+    stroke_width_mm: f64,
+    rotation_deg: f64,
+    mirror: bool,
+) -> kiapi::board::types::BoardText {
     kiapi::board::types::BoardText {
         id: None,
         text: Some(kiapi::common::types::Text {
@@ -621,7 +645,7 @@ pub fn board_text(
                     value_degrees: rotation_deg,
                 }),
                 line_spacing: 1.0,
-                stroke_width: Some(distance(size_mm * 0.15)),
+                stroke_width: Some(distance(stroke_width_mm)),
                 italic: false,
                 bold: false,
                 underlined: false,
@@ -984,8 +1008,23 @@ pub(crate) mod tests {
         assert_eq!(text.position.unwrap().x_nm, 12_000_000);
         let attrs = text.attributes.expect("attrs");
         assert_eq!(attrs.size.unwrap().x_nm, 1_500_000);
+        assert!((attrs.stroke_width.unwrap().value_nm - 225_000).abs() <= 1);
         assert_eq!(attrs.angle.unwrap().value_degrees, 90.0);
         assert!(!attrs.mirrored);
+
+        let explicit =
+            board_text_with_stroke_width("F.Fab", "${REFERENCE}", 0.0, 0.0, 0.8, 0.11, 0.0, false);
+        assert_eq!(
+            explicit
+                .text
+                .unwrap()
+                .attributes
+                .unwrap()
+                .stroke_width
+                .unwrap()
+                .value_nm,
+            110_000
+        );
     }
 
     #[test]

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -2265,7 +2265,7 @@ fn build_graphic_child(
             rotation: text_rotation,
             layer,
             size,
-            stroke_width,
+            stroke_width_mm,
         } => {
             let (tx, ty) = xf(*position);
             builders::pack_any(
@@ -2275,7 +2275,7 @@ fn build_graphic_child(
                     tx,
                     ty,
                     *size,
-                    *stroke_width,
+                    *stroke_width_mm,
                     readable_text_angle(text_rotation + rotation),
                     false,
                 ),
@@ -2456,7 +2456,7 @@ mod footprint_graphics_tests {
                 rotation: 0.0,
                 layer: "F.Fab".to_string(),
                 size: 0.5,
-                stroke_width: 0.075,
+                stroke_width_mm: 0.075,
             },
         ];
         let fp = build(&graphics, 100.0, 50.0, 90.0);
@@ -2521,7 +2521,7 @@ mod footprint_graphics_tests {
             rotation: 0.0,
             layer: "F.Fab".to_string(),
             size: 0.5,
-            stroke_width: 0.075,
+            stroke_width_mm: 0.075,
         }];
         let fp = build(&graphics, 0.0, 0.0, 180.0);
         let texts = texts(&fp);
@@ -2673,7 +2673,7 @@ mod footprint_graphics_tests {
                 rotation: 0.0,
                 layer: "Dwgs.User".to_string(),
                 size: 1.0,
-                stroke_width: 0.15,
+                stroke_width_mm: 0.15,
             },
         ];
         let any = KiCadIpcClient::build_footprint_item(

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -2265,15 +2265,17 @@ fn build_graphic_child(
             rotation: text_rotation,
             layer,
             size,
+            stroke_width,
         } => {
             let (tx, ty) = xf(*position);
             builders::pack_any(
-                &builders::board_text(
+                &builders::board_text_with_stroke_width(
                     layer,
                     text,
                     tx,
                     ty,
                     *size,
+                    *stroke_width,
                     readable_text_angle(text_rotation + rotation),
                     false,
                 ),
@@ -2454,6 +2456,7 @@ mod footprint_graphics_tests {
                 rotation: 0.0,
                 layer: "F.Fab".to_string(),
                 size: 0.5,
+                stroke_width: 0.075,
             },
         ];
         let fp = build(&graphics, 100.0, 50.0, 90.0);
@@ -2518,6 +2521,7 @@ mod footprint_graphics_tests {
             rotation: 0.0,
             layer: "F.Fab".to_string(),
             size: 0.5,
+            stroke_width: 0.075,
         }];
         let fp = build(&graphics, 0.0, 0.0, 180.0);
         let texts = texts(&fp);
@@ -2669,6 +2673,7 @@ mod footprint_graphics_tests {
                 rotation: 0.0,
                 layer: "Dwgs.User".to_string(),
                 size: 1.0,
+                stroke_width: 0.15,
             },
         ];
         let any = KiCadIpcClient::build_footprint_item(

--- a/crates/konnect-ipc/src/types.rs
+++ b/crates/konnect-ipc/src/types.rs
@@ -128,7 +128,7 @@ pub enum IpcGraphicDefinition {
         /// Glyph size (width and height) in mm.
         size: f64,
         /// Font stroke width in mm.
-        stroke_width: f64,
+        stroke_width_mm: f64,
     },
 }
 

--- a/crates/konnect-ipc/src/types.rs
+++ b/crates/konnect-ipc/src/types.rs
@@ -127,6 +127,8 @@ pub enum IpcGraphicDefinition {
         layer: String,
         /// Glyph size (width and height) in mm.
         size: f64,
+        /// Font stroke width in mm.
+        stroke_width: f64,
     },
 }
 

--- a/crates/konnect-ipc/tests/mock_server_test.rs
+++ b/crates/konnect-ipc/tests/mock_server_test.rs
@@ -443,6 +443,7 @@ fn place_footprint_sends_graphics_children() {
             rotation: 0.0,
             layer: "F.Fab".to_string(),
             size: 0.26,
+            stroke_width: 0.04,
         },
     ];
 

--- a/crates/konnect-ipc/tests/mock_server_test.rs
+++ b/crates/konnect-ipc/tests/mock_server_test.rs
@@ -443,7 +443,7 @@ fn place_footprint_sends_graphics_children() {
             rotation: 0.0,
             layer: "F.Fab".to_string(),
             size: 0.26,
-            stroke_width: 0.04,
+            stroke_width_mm: 0.04,
         },
     ];
 

--- a/crates/konnect/tests/live_kicad_tools.rs
+++ b/crates/konnect/tests/live_kicad_tools.rs
@@ -173,6 +173,24 @@ fn footprint_models(
         .collect()
 }
 
+fn footprint_text_stroke_widths(footprint: &kiapi::board::types::FootprintInstance) -> Vec<i64> {
+    footprint
+        .definition
+        .as_ref()
+        .unwrap()
+        .items
+        .iter()
+        .filter(|item| item.type_url.ends_with("kiapi.board.types.BoardText"))
+        .map(|item| kiapi::board::types::BoardText::decode(item.value.as_slice()).unwrap())
+        .filter_map(|text| {
+            text.text
+                .and_then(|text| text.attributes)
+                .and_then(|attributes| attributes.stroke_width)
+                .map(|width| width.value_nm)
+        })
+        .collect()
+}
+
 #[test]
 #[ignore = "requires a running KiCad GUI, API socket, and standard footprint libraries"]
 fn place_component_loads_real_library_geometry() {
@@ -420,6 +438,18 @@ fn footprint_library_update_apply_then_dry_run_is_noop() {
             }
         }),
     );
+    let mut footprint_source = std::fs::read_to_string(&footprint_path).unwrap();
+    let root_end = footprint_source
+        .rfind("\n)")
+        .expect("created footprint must have a closing root");
+    footprint_source.insert_str(
+        root_end,
+        r#"
+  (fp_text user "${REFERENCE}" (at 0 1.5 0) (layer "F.Fab")
+    (uuid "f96c2efe-5925-4f74-81d2-f89a56f57e13")
+    (effects (font (size 0.8 0.8) (thickness 0.11))))"#,
+    );
+    std::fs::write(&footprint_path, footprint_source).unwrap();
     mcp.tool(
         "register_footprint_library",
         json!({
@@ -536,6 +566,10 @@ fn footprint_library_update_apply_then_dry_run_is_noop() {
         footprint_models(&after)[0].filename,
         "../models/revision-b.step"
     );
+    assert!(
+        footprint_text_stroke_widths(&after).contains(&110_000),
+        "explicit fab text thickness was not preserved"
+    );
 
     let converged = mcp.tool(
         "update_footprints_from_library",
@@ -550,6 +584,20 @@ fn footprint_library_update_apply_then_dry_run_is_noop() {
     assert_eq!(converged["status"], "noop", "{converged}");
 
     ipc.save_board().unwrap();
+    let saved_converged = mcp.tool(
+        "update_footprints_from_library",
+        json!({
+            "board": board,
+            "references": [reference],
+            "dry_run": true
+        }),
+    );
+    let saved_converged: Value =
+        serde_json::from_str(saved_converged["content"][0]["text"].as_str().unwrap()).unwrap();
+    assert_eq!(
+        saved_converged["status"], "noop",
+        "KiCad save changed the rebuilt fab text: {saved_converged}"
+    );
     mcp.tool("load_toolset", json!({"name": "verification"}));
     let drc = mcp.tool(
         "run_drc",


### PR DESCRIPTION
Closes #331.

## Problem

`update_footprints_from_library` rejected the `fp_text user` blocks emitted by ordinary KiCad 10 footprint libraries. A sample of the installed official footprint corpus found user text in 15,238 of 15,447 files, which made the safety validator refuse most real library refreshes.

The parser already extracted those text blocks, but the typed IPC representation did not retain their explicit font stroke width. Simply allowing them would therefore make refresh lossy.

## Change

- accept the conservative, losslessly representable `fp_text user` shape produced by KiCad
- preserve explicit font stroke width through parsing, mirroring, and IPC construction
- continue to fail closed for unsupported modifiers such as justification, italic text, unlocked placement, non-square fonts, or missing thickness
- add a KiCad-serialized fixture plus positive and negative regression coverage
- extend the ignored live-KiCad test to verify explicit thickness, save the board, and prove a subsequent dry run converges to `noop`

No MCP tool schema or public command surface changes.

## Verification

- `cargo test --workspace --locked --lib --tests`
- `cargo test --workspace --locked --doc`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- live KiCad 10 PCB Editor: `footprint_library_update_apply_then_dry_run_is_noop` passed against a disposable board through the API socket, including save and post-save no-op verification
- installed official KiCad corpus scan: 14,921 of 15,447 footprints fit the deliberately narrow supported shape; uncommon variants remain structured conflicts instead of being silently altered