### PR TITLE
fix(schematic): resolve analysis pins by placed unit

### DIFF
--- a/crates/konnect-core/src/tools/sch_analysis.rs
+++ b/crates/konnect-core/src/tools/sch_analysis.rs
@@ -6,7 +6,9 @@
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
 use crate::tools::sch_connectivity::{net_graph_for, pt_key, ConnectivityIndex};
-use crate::tools::{get_path, opt_f64, require_f64, require_str, ToolContext, ToolDef};
+use crate::tools::{
+    get_path, opt_f64, placed_pins_by_reference, require_f64, require_str, ToolContext, ToolDef,
+};
 use konnect_schematic_editor as cse;
 use konnect_sexp::{
     geometry::{point_on_segment, points_coincident},
@@ -324,21 +326,18 @@ async fn handle_get_pin_connections(
     let instances = extract_symbol_instances(&tree);
     let wires = extract_wires(&tree);
     let labels = extract_all_net_labels(&tree);
-    let inst = instances
+    if !instances
         .iter()
-        .find(|i| i.reference == reference)
-        .ok_or_else(|| anyhow::anyhow!("Component '{}' not found", reference))?;
-    let lib_syms = tree
-        .find("lib_symbols")
-        .map(|n| n.find_all("symbol"))
-        .unwrap_or_default();
-    let lib_sym = find_lib_symbol(&lib_syms, inst);
-    let pin_ep = lib_sym.and_then(|sym| {
-        konnect_sexp::schematic::extract_lib_pins(sym)
-            .iter()
-            .find(|p| p.number == pin_number)
-            .map(|p| konnect_sexp::schematic::pin_endpoint(p, inst.pin_transform()))
-    });
+        .any(|instance| instance.reference == reference)
+    {
+        return Err(anyhow::anyhow!("Component '{}' not found", reference));
+    }
+    let pin_ep = placed_pins_by_reference(&tree)
+        .into_iter()
+        .filter(|(instance, _)| instance.reference == reference)
+        .flat_map(|(_, pins)| pins)
+        .find(|(pin, _)| pin.number == pin_number)
+        .map(|(pin, transform)| konnect_sexp::schematic::pin_endpoint(&pin, transform));
     let (px, py) = match pin_ep {
         Some(ep) => ep,
         None => {
@@ -367,25 +366,22 @@ async fn handle_get_component_nets(
     let instances = extract_symbol_instances(&tree);
     let wires = extract_wires(&tree);
     let labels = extract_all_net_labels(&tree);
-    let inst = instances
+    if !instances
         .iter()
-        .find(|i| i.reference == reference)
-        .ok_or_else(|| anyhow::anyhow!("Component '{}' not found", reference))?;
-    let lib_syms = tree
-        .find("lib_symbols")
-        .map(|n| n.find_all("symbol"))
-        .unwrap_or_default();
-    let lib_sym = find_lib_symbol(&lib_syms, inst);
+        .any(|instance| instance.reference == reference)
+    {
+        return Err(anyhow::anyhow!("Component '{}' not found", reference));
+    }
     let mut g = net_graph_for(&tree, &wires, &labels);
-    let pins: Vec<serde_json::Value> = if let Some(sym) = lib_sym {
-        let t = inst.pin_transform();
-        konnect_sexp::schematic::extract_lib_pins(sym).iter().map(|p| {
-            let (px, py) = konnect_sexp::schematic::pin_endpoint(p, t);
-            json!({ "pin": p.number, "name": p.name, "x": px, "y": py, "net": g.net_at(px, py) })
-        }).collect()
-    } else {
-        Vec::new()
-    };
+    let pins: Vec<serde_json::Value> = placed_pins_by_reference(&tree)
+        .into_iter()
+        .filter(|(instance, _)| instance.reference == reference)
+        .flat_map(|(_, pins)| pins)
+        .map(|(pin, transform)| {
+            let (px, py) = konnect_sexp::schematic::pin_endpoint(&pin, transform);
+            json!({ "pin": pin.number, "name": pin.name, "x": px, "y": py, "net": g.net_at(px, py) })
+        })
+        .collect();
     Ok(CallToolResult::json(
         &json!({ "reference": reference, "pins": pins }),
     ))
@@ -401,26 +397,19 @@ async fn handle_get_net_components(
         Err(e) => return Ok(e),
     };
     let (_, tree) = read_schematic(&sch_path)?;
-    let instances = extract_symbol_instances(&tree);
     let wires = extract_wires(&tree);
     let labels = extract_all_net_labels(&tree);
-    let lib_syms = tree
-        .find("lib_symbols")
-        .map(|n| n.find_all("symbol"))
-        .unwrap_or_default();
     let mut g = net_graph_for(&tree, &wires, &labels);
     let net_pts: HashSet<(i64, i64)> = g.points_on_net(&net).into_iter().collect();
-    let result: Vec<serde_json::Value> = instances
-        .iter()
-        .filter_map(|inst| {
-            let ls = find_lib_symbol(&lib_syms, inst)?;
-            let t = inst.pin_transform();
-            let connected: Vec<_> = konnect_sexp::schematic::extract_lib_pins(ls)
-                .iter()
-                .filter_map(|p| {
-                    let (px, py) = konnect_sexp::schematic::pin_endpoint(p, t);
+    let result: Vec<serde_json::Value> = placed_pins_by_reference(&tree)
+        .into_iter()
+        .filter_map(|(instance, pins)| {
+            let connected: Vec<_> = pins
+                .into_iter()
+                .filter_map(|(pin, transform)| {
+                    let (px, py) = konnect_sexp::schematic::pin_endpoint(&pin, transform);
                     if net_pts.contains(&pt_key(px, py)) {
-                        Some(json!({ "pin": p.number, "name": p.name }))
+                        Some(json!({ "pin": pin.number, "name": pin.name }))
                     } else {
                         None
                     }
@@ -429,7 +418,7 @@ async fn handle_get_net_components(
             if connected.is_empty() {
                 None
             } else {
-                Some(json!({ "reference": inst.reference, "value": inst.value, "pins": connected }))
+                Some(json!({ "reference": instance.reference, "value": instance.value, "pins": connected }))
             }
         })
         .collect();
@@ -622,30 +611,26 @@ async fn handle_get_connected_items(
     let instances = extract_symbol_instances(&tree);
     let wires = extract_wires(&tree);
     let labels = extract_all_net_labels(&tree);
-    let lib_syms = tree
-        .find("lib_symbols")
-        .map(|n| n.find_all("symbol"))
-        .unwrap_or_default();
-
-    let inst = match instances.iter().find(|i| i.reference == reference) {
-        Some(i) => i,
-        None => {
-            return Ok(CallToolResult::error(format!(
-                "Component '{}' not found",
-                reference
-            )))
-        }
-    };
-
-    let lib_sym = find_lib_symbol(&lib_syms, inst);
+    if !instances
+        .iter()
+        .any(|instance| instance.reference == reference)
+    {
+        return Ok(CallToolResult::error(format!(
+            "Component '{}' not found",
+            reference
+        )));
+    }
+    let placed_pins = placed_pins_by_reference(&tree);
     let mut g = net_graph_for(&tree, &wires, &labels);
 
     // Get nets for each pin
     let mut connected_nets: HashSet<String> = HashSet::new();
-    if let Some(sym) = lib_sym {
-        let t = inst.pin_transform();
-        for p in konnect_sexp::schematic::extract_lib_pins(sym) {
-            let (px, py) = konnect_sexp::schematic::pin_endpoint(&p, t);
+    for (_, pins) in placed_pins
+        .iter()
+        .filter(|(instance, _)| instance.reference == reference)
+    {
+        for (pin, transform) in pins {
+            let (px, py) = konnect_sexp::schematic::pin_endpoint(pin, *transform);
             if let Some(net) = g.net_at(px, py) {
                 connected_nets.insert(net);
             }
@@ -675,20 +660,26 @@ async fn handle_get_connected_items(
         .collect();
 
     // Find other components on the same nets (excluding the queried one)
-    let connected_components: Vec<serde_json::Value> = instances.iter()
-        .filter(|i| i.reference != reference)
-        .filter_map(|i| {
-            let ls = find_lib_symbol(&lib_syms, i)?;
-            let t = i.pin_transform();
-            let matching_pins: Vec<_> = konnect_sexp::schematic::extract_lib_pins(ls).iter()
-                .filter_map(|p| {
-                    let (px, py) = konnect_sexp::schematic::pin_endpoint(p, t);
+    let connected_components: Vec<serde_json::Value> = placed_pins
+        .iter()
+        .filter(|(instance, _)| instance.reference != reference)
+        .filter_map(|(instance, pins)| {
+            let matching_pins: Vec<_> = pins
+                .iter()
+                .filter_map(|(pin, transform)| {
+                    let (px, py) = konnect_sexp::schematic::pin_endpoint(pin, *transform);
                     if all_net_pts.contains(&pt_key(px, py)) {
-                        Some(json!({ "pin": p.number, "name": p.name }))
-                    } else { None }
-                }).collect();
-            if matching_pins.is_empty() { None }
-            else { Some(json!({ "reference": i.reference, "value": i.value, "connected_pins": matching_pins })) }
+                        Some(json!({ "pin": pin.number, "name": pin.name }))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            if matching_pins.is_empty() {
+                None
+            } else {
+                Some(json!({ "reference": instance.reference, "value": instance.value, "connected_pins": matching_pins }))
+            }
         })
         .collect();
 
@@ -1227,5 +1218,133 @@ mod power_symbol_net_tests {
         );
         let s = call(&shorted, "find_shorted_nets", json!({})).await;
         assert_eq!(s["short_count"], 1, "SIG and GND share one wire: {s}");
+    }
+}
+
+#[cfg(test)]
+mod multi_unit_tool_tests {
+    use super::*;
+    use crate::tools::ServerConfig;
+    use std::io::Write;
+    use std::sync::Arc;
+
+    const ECC83: &str = include_str!("../../tests/fixtures/ecc83_multiunit.kicad_sch");
+
+    async fn call_content(
+        content: &str,
+        tool: &str,
+        mut args: serde_json::Value,
+    ) -> serde_json::Value {
+        let mut schematic = tempfile::NamedTempFile::with_suffix(".kicad_sch").unwrap();
+        schematic.write_all(content.as_bytes()).unwrap();
+        schematic.flush().unwrap();
+
+        args["schematic"] = json!(schematic.path().to_str().unwrap());
+        let definition = tools()
+            .into_iter()
+            .find(|tool_def| tool_def.name == tool)
+            .unwrap();
+        let context = ToolContext::new(
+            ServerConfig::default(),
+            Arc::new(crate::router::ToolRouter::new()),
+        );
+        let result = (definition.handler)(&args, Arc::new(context))
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{tool} failed");
+        let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text content");
+        };
+        serde_json::from_str(text).unwrap()
+    }
+
+    async fn call(tool: &str, args: serde_json::Value) -> serde_json::Value {
+        call_content(ECC83, tool, args).await
+    }
+
+    #[tokio::test]
+    async fn pin_lookup_uses_the_unit_that_owns_the_pin() {
+        let result = call(
+            "get_pin_connections",
+            json!({ "reference": "U1", "pin_number": "4" }),
+        )
+        .await;
+
+        let pin_x = result["pin_x"].as_f64().unwrap();
+        let pin_y = result["pin_y"].as_f64().unwrap();
+        assert!((pin_x - 60.96).abs() < 1e-9, "wrong unit x: {pin_x}");
+        assert!((pin_y - 86.36).abs() < 1e-9, "wrong unit y: {pin_y}");
+    }
+
+    #[tokio::test]
+    async fn component_nets_use_each_pins_own_unit_placement() {
+        let result = call("get_component_nets", json!({ "reference": "U1" })).await;
+        let pins = result["pins"].as_array().unwrap();
+        assert_eq!(pins.len(), 9, "ECC83 must expose all three units: {pins:?}");
+
+        let pin_four = pins
+            .iter()
+            .find(|pin| pin["pin"] == "4")
+            .expect("heater pin 4");
+        let pin_x = pin_four["x"].as_f64().unwrap();
+        let pin_y = pin_four["y"].as_f64().unwrap();
+        assert!((pin_x - 60.96).abs() < 1e-9, "wrong unit x: {pin_x}");
+        assert!((pin_y - 86.36).abs() < 1e-9, "wrong unit y: {pin_y}");
+    }
+
+    #[tokio::test]
+    async fn net_components_ignore_pins_from_unplaced_units() {
+        // Applying the heater unit's pin 5 geometry to unit 2's placement
+        // invents a pin at (160.02, 119.38); no placed ECC83 unit owns it.
+        let phantom_label =
+            "\t(label \"PHANTOM_TEST\" (at 160.02 119.38 0) (uuid \"00000000-0000-4000-8000-000000000183\"))\n";
+        let content = ECC83.replacen(
+            "\t(sheet_instances",
+            &format!("{phantom_label}\t(sheet_instances"),
+            1,
+        );
+        assert_ne!(content, ECC83, "fixture insertion point changed");
+
+        let result = call_content(
+            &content,
+            "get_net_components",
+            json!({ "net": "PHANTOM_TEST" }),
+        )
+        .await;
+        assert!(
+            result["components"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|component| component["reference"] != "U1"),
+            "unit 2 must not invent heater pin 5: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn connected_items_include_nets_from_every_placed_unit() {
+        let heater_label =
+            "\t(label \"HEATER_TEST\" (at 66.04 86.36 0) (uuid \"00000000-0000-4000-8000-000000000184\"))\n";
+        let content = ECC83.replacen(
+            "\t(sheet_instances",
+            &format!("{heater_label}\t(sheet_instances"),
+            1,
+        );
+        assert_ne!(content, ECC83, "fixture insertion point changed");
+
+        let result = call_content(
+            &content,
+            "get_connected_items",
+            json!({ "reference": "U1" }),
+        )
+        .await;
+        assert!(
+            result["nets"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|net| net == "HEATER_TEST"),
+            "heater unit net missing: {result}"
+        );
     }
 }

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -2232,6 +2232,152 @@ mod multi_unit_field_tests {
 }
 
 #[cfg(test)]
+mod multi_unit_handler_tests {
+    use super::*;
+    use crate::tools::{ServerConfig, ToolContext};
+    use konnect_sexp::schematic::{extract_symbol_instances, read_schematic, SymbolInstance};
+    use std::io::Write;
+    use std::sync::Arc;
+
+    const ECC83: &str = include_str!("../../tests/fixtures/ecc83_multiunit.kicad_sch");
+
+    fn fixture_file() -> tempfile::NamedTempFile {
+        let mut schematic = tempfile::NamedTempFile::with_suffix(".kicad_sch").unwrap();
+        schematic.write_all(ECC83.as_bytes()).unwrap();
+        schematic.flush().unwrap();
+        schematic
+    }
+
+    fn instances(path: &std::path::Path) -> Vec<SymbolInstance> {
+        let (_, tree) = read_schematic(path).unwrap();
+        extract_symbol_instances(&tree)
+    }
+
+    async fn call(
+        path: &std::path::Path,
+        tool: &str,
+        mut args: serde_json::Value,
+    ) -> serde_json::Value {
+        args["schematic"] = json!(path.to_str().unwrap());
+        let definition = tools()
+            .into_iter()
+            .find(|tool_def| tool_def.name == tool)
+            .unwrap();
+        let context = ToolContext::new(
+            ServerConfig::default(),
+            Arc::new(crate::router::ToolRouter::new()),
+        );
+        let result = (definition.handler)(&args, Arc::new(context))
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{tool} failed: {result:?}");
+        let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text content");
+        };
+        serde_json::from_str(text).unwrap()
+    }
+
+    #[tokio::test]
+    async fn bulk_move_moves_every_ecc83_unit_and_no_neighbor() {
+        let schematic = fixture_file();
+        let before = instances(schematic.path());
+        let result = call(
+            schematic.path(),
+            "bulk_move_schematic_components",
+            json!({ "references": ["U1"], "dx": 12.7, "dy": 2.54 }),
+        )
+        .await;
+        assert_eq!(result["moved_count"], 1);
+        assert_eq!(result["moved"][0]["units"], 3);
+
+        let after = instances(schematic.path());
+        for old in before.iter().filter(|instance| instance.reference == "U1") {
+            let new = after
+                .iter()
+                .find(|instance| instance.uuid == old.uuid)
+                .expect("every ECC83 unit remains placed");
+            assert!((new.x - old.x - 12.7).abs() < 1e-9, "unit {} x", old.unit);
+            assert!((new.y - old.y - 2.54).abs() < 1e-9, "unit {} y", old.unit);
+        }
+        let old_r1 = before
+            .iter()
+            .find(|instance| instance.reference == "R1")
+            .unwrap();
+        let new_r1 = after
+            .iter()
+            .find(|instance| instance.reference == "R1")
+            .unwrap();
+        assert_eq!((new_r1.x, new_r1.y), (old_r1.x, old_r1.y));
+    }
+
+    #[tokio::test]
+    async fn batch_edit_updates_every_ecc83_unit() {
+        let schematic = fixture_file();
+        let original_r1 = instances(schematic.path())
+            .into_iter()
+            .find(|instance| instance.reference == "R1")
+            .unwrap()
+            .value;
+        let result = call(
+            schematic.path(),
+            "batch_edit_schematic_components",
+            json!({
+                "edits": [{
+                    "reference": "U1",
+                    "value": "ECC83-TEST",
+                    "footprint": "Package_DIP:DIP-9_W7.62mm"
+                }]
+            }),
+        )
+        .await;
+        assert_eq!(result["updated_count"], 1);
+
+        let after = instances(schematic.path());
+        let units: Vec<_> = after
+            .iter()
+            .filter(|instance| instance.reference == "U1")
+            .collect();
+        assert_eq!(units.len(), 3);
+        assert!(units.iter().all(|instance| instance.value == "ECC83-TEST"));
+        assert!(units
+            .iter()
+            .all(|instance| instance.footprint == "Package_DIP:DIP-9_W7.62mm"));
+        assert_eq!(
+            after
+                .iter()
+                .find(|instance| instance.reference == "R1")
+                .unwrap()
+                .value,
+            original_r1
+        );
+    }
+
+    #[tokio::test]
+    async fn both_reference_delete_tools_remove_every_ecc83_unit() {
+        for tool in ["batch_delete", "batch_delete_schematic_components"] {
+            let schematic = fixture_file();
+            let result = call(schematic.path(), tool, json!({ "references": ["U1"] })).await;
+            assert_eq!(result["deleted_count"], 1, "{tool}: {result}");
+
+            let after = instances(schematic.path());
+            assert!(
+                after.iter().all(|instance| instance.reference != "U1"),
+                "{tool} left an ECC83 unit"
+            );
+            assert!(
+                after.iter().any(|instance| instance.reference == "R1"),
+                "{tool} removed a neighbor"
+            );
+            let content = std::fs::read_to_string(schematic.path()).unwrap();
+            assert!(
+                content.contains(r#"(symbol "ecc83-pp:ECC83""#),
+                "{tool} removed the embedded library definition"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
 mod add_text_placement_tests {
     use super::{schematic_text_justify, tools};
     use crate::mcp::protocol::CallToolResult;

--- a/crates/konnect-core/src/tools/sch_export.rs
+++ b/crates/konnect-core/src/tools/sch_export.rs
@@ -6,12 +6,12 @@
 
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
-use crate::tools::{get_path, ToolContext, ToolDef};
+use crate::tools::{get_path, placed_pins, placed_pins_by_reference, ToolContext, ToolDef};
 use konnect_sexp::{
     geometry::{point_on_segment, points_coincident},
     schematic::{
-        extract_all_net_labels, extract_labels, extract_lib_pins, extract_symbol_instances,
-        extract_wires, find_lib_symbol, pin_endpoint, read_schematic,
+        extract_all_net_labels, extract_labels, extract_symbol_instances, extract_wires,
+        pin_endpoint, read_schematic,
     },
     writer::{
         apply_edits, find_block_with_leading_whitespace, write_atomic_if_unchanged, SexpEdit,
@@ -533,10 +533,7 @@ async fn handle_export_netlist_summary(
     let instances = extract_symbol_instances(&tree);
     let wires = extract_wires(&tree);
     let labels = extract_all_net_labels(&tree);
-    let lib_syms = tree
-        .find("lib_symbols")
-        .map(|n| n.find_all("symbol"))
-        .unwrap_or_default();
+    let placed = placed_pins_by_reference(&tree);
 
     let mut g = net_graph_for(&tree, &wires, &labels);
 
@@ -549,26 +546,35 @@ async fn handle_export_netlist_summary(
     let components: Vec<serde_json::Value> = instances
         .iter()
         .map(|inst| {
-            let lib_sym = find_lib_symbol(&lib_syms, inst);
-
-            let pins: Vec<serde_json::Value> = if let Some(sym) = lib_sym {
-                let t = inst.pin_transform();
-                extract_lib_pins(sym)
-                    .iter()
-                    .map(|p| {
-                        let (px, py) = pin_endpoint(p, t);
-                        let net = g.net_at(px, py).unwrap_or_else(|| "~".to_string());
-                        json!({
-                            "number": p.number,
-                            "name": p.name,
-                            "net": net,
-                            "x": px, "y": py
+            let pins: Vec<serde_json::Value> = placed
+                .iter()
+                .find(
+                    |(placed_instance, _)| match (&placed_instance.uuid, &inst.uuid) {
+                        (Some(placed_uuid), Some(uuid)) => placed_uuid == uuid,
+                        _ => {
+                            placed_instance.reference == inst.reference
+                                && placed_instance.unit == inst.unit
+                                && placed_instance.x == inst.x
+                                && placed_instance.y == inst.y
+                                && placed_instance.lib_symbol_name() == inst.lib_symbol_name()
+                        }
+                    },
+                )
+                .map(|(_, pins)| {
+                    pins.iter()
+                        .map(|(pin, transform)| {
+                            let (px, py) = pin_endpoint(pin, *transform);
+                            let net = g.net_at(px, py).unwrap_or_else(|| "~".to_string());
+                            json!({
+                                "number": pin.number,
+                                "name": pin.name,
+                                "net": net,
+                                "x": px, "y": py
+                            })
                         })
-                    })
-                    .collect()
-            } else {
-                Vec::new()
-            };
+                        .collect()
+                })
+                .unwrap_or_default();
 
             json!({
                 "reference": inst.reference,
@@ -704,23 +710,12 @@ async fn handle_fix_connectivity(
     let (content, tree) = read_schematic(&sch_path)?;
     let wires = extract_wires(&tree);
     let labels = extract_labels(&tree);
-    let instances = extract_symbol_instances(&tree);
-    let lib_syms = tree
-        .find("lib_symbols")
-        .map(|n| n.find_all("symbol"))
-        .unwrap_or_default();
 
     // Collect all valid snap targets: pin endpoints + label positions + wire endpoints
     let mut snap_targets: Vec<(f64, f64)> = Vec::new();
 
-    for inst in &instances {
-        let lib_sym = find_lib_symbol(&lib_syms, inst);
-        if let Some(sym) = lib_sym {
-            let t = inst.pin_transform();
-            for pin in extract_lib_pins(sym) {
-                snap_targets.push(pin_endpoint(&pin, t));
-            }
-        }
+    for (pin, transform) in placed_pins(&tree) {
+        snap_targets.push(pin_endpoint(&pin, transform));
     }
     for l in &labels {
         snap_targets.push((l.x, l.y));
@@ -827,6 +822,7 @@ mod netlist_summary_tests {
     /// R1 with pin 2 wired to a `power:GND` symbol, and pin 1 on a plain label.
     /// The rail is the case that used to disappear.
     const SCH: &str = include_str!("../../tests/fixtures/power_rail.kicad_sch");
+    const ECC83: &str = include_str!("../../tests/fixtures/ecc83_multiunit.kicad_sch");
 
     async fn summary(content: &str) -> serde_json::Value {
         let mut f = tempfile::NamedTempFile::with_suffix(".kicad_sch").unwrap();
@@ -904,6 +900,100 @@ mod netlist_summary_tests {
         let s = summary(&sch).await;
         assert_eq!(net_of(&s, "R1", "2"), "~");
         assert!(s["nets"].as_array().unwrap().iter().any(|n| n == "GND"));
+    }
+
+    #[tokio::test]
+    async fn multi_unit_summary_reports_only_the_pins_placed_by_each_unit() {
+        let result = summary(ECC83).await;
+        let mut pin_sets: Vec<Vec<String>> = result["components"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|component| component["reference"] == "U1")
+            .map(|component| {
+                let mut pins: Vec<String> = component["pins"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|pin| pin["number"].as_str().unwrap().to_string())
+                    .collect();
+                pins.sort();
+                pins
+            })
+            .collect();
+        pin_sets.sort();
+
+        assert_eq!(
+            pin_sets,
+            vec![
+                vec!["1".to_string(), "2".to_string(), "3".to_string()],
+                vec!["4".to_string(), "5".to_string(), "9".to_string()],
+                vec!["6".to_string(), "7".to_string(), "8".to_string()],
+            ]
+        );
+    }
+}
+
+#[cfg(test)]
+mod multi_unit_connectivity_tests {
+    use super::*;
+    use crate::tools::ServerConfig;
+    use std::io::Write;
+    use std::sync::Arc;
+
+    const ECC83: &str = include_str!("../../tests/fixtures/ecc83_multiunit.kicad_sch");
+
+    #[tokio::test]
+    async fn connectivity_fix_does_not_snap_to_a_pin_from_an_unplaced_unit() {
+        // Unit 1 is placed at (160.02, 64.77). Applying that transform to the
+        // heater unit's pin 5 invents a phantom target at (162.56, 76.20).
+        // Keep a loose wire end 0.02 mm from that point: the old all-unit
+        // extraction proposed a destructive snap, while the placed-unit view
+        // correctly leaves it alone.
+        let probe_wire = r#"
+	(wire
+		(pts
+			(xy 162.56 76.22) (xy 170 80)
+		)
+		(stroke (width 0) (type default))
+		(uuid "00000000-0000-4000-8000-000000000182")
+	)
+"#;
+        let content = ECC83.replacen(
+            "\t(sheet_instances",
+            &format!("{probe_wire}\t(sheet_instances"),
+            1,
+        );
+        assert_ne!(content, ECC83, "fixture insertion point changed");
+
+        let mut schematic = tempfile::NamedTempFile::with_suffix(".kicad_sch").unwrap();
+        schematic.write_all(content.as_bytes()).unwrap();
+        schematic.flush().unwrap();
+
+        let definition = tools()
+            .into_iter()
+            .find(|tool_def| tool_def.name == "fix_connectivity")
+            .unwrap();
+        let context = ToolContext::new(
+            ServerConfig::default(),
+            Arc::new(crate::router::ToolRouter::new()),
+        );
+        let result = (definition.handler)(
+            &json!({
+                "schematic": schematic.path().to_str().unwrap(),
+                "snap_tolerance": 0.05,
+                "dry_run": true
+            }),
+            Arc::new(context),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error);
+        let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text content");
+        };
+        let response: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(response["fixes_found"], 0, "phantom pin snap: {response}");
     }
 }
 


### PR DESCRIPTION
## Summary

Multi-unit symbols are now resolved through the unit actually placed on the sheet. This prevents analysis and connectivity repair from reporting or snapping to phantom pins, while allowing component queries to see nets on later units.

The PR also completes the requested `sch_batch` audit with handler-level tests against the real KiCad ECC83 fixture: bulk move, shared-field edit, and both reference-delete tools operate on all three units without changing a neighboring component or the embedded library definition.

Part of #182.

## Approach

The affected analysis and export handlers now reuse the existing shared `placed_pins_by_reference` / `placed_pins` path, which selects common pins plus the placed unit before applying that unit's transform. This removes the duplicated `extract_lib_pins` logic that superimposed every library unit on every placement.

`export_netlist_summary` still emits one entry per placed symbol instance and preserves unresolved instances with an empty pin list. `fix_connectivity` changes only its candidate pin endpoints; labels and wire endpoints are unchanged.

`design_review.rs` is intentionally excluded because PR #336 owns that file. Its author has been asked to make the same unit-aware correction and add ECC83 coverage.

## Compatibility and safety

No tool names, schemas, response fields, configuration, IPC, or file formats change. Existing single-unit behavior is preserved; multi-unit coordinates, connectivity, and per-placement pin counts are corrected.

The only mutating production path touched is `fix_connectivity`; its existing dry-run behavior, conditional atomic write, and stale-file protection are unchanged. The narrower target set prevents a wire from being moved to an unplaced unit's phantom pin. Rollback is one commit.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --locked --lib --tests`
- [x] `cargo test --workspace --locked --doc`
- [x] `cargo clippy --workspace --locked --all-targets -- -D warnings`
- [x] `cargo test -p konnect-core --locked multi_unit_ -- --nocapture` (34 passed)
- [x] Real KiCad ECC83 schematic fixture exercised through registered MCP tool handlers
- [ ] Live KiCad GUI/e2e checks were not run; these S-expression paths do not require a running editor, and the relevant environment-dependent tests remain ignored as designed

## Review checklist

- [x] The diff is focused and contains no generated output, personal data, or unrelated cleanup.
- [x] No new public names or renames.
- [x] New behavior and failure paths have regression coverage.
- [x] File mutations retain the existing atomic-write and stale-source protections.
- [x] No IPC mutation changes.
- [x] No tools were added or removed, so tool counts and directory documentation are unchanged.