### PR TITLE
fix(repo): restore text and binary attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
+* text=auto
+*.png binary
+*.ico binary
+*.icns binary
+
 # KiCad-authored fixtures are byte-evidence: never eol-normalize them.
 crates/konnect-sexp/tests/fixtures/** -text
 crates/konnect-core/tests/fixtures/** -text


### PR DESCRIPTION
Closes #352.

## Problem and scope

Konnect v0.10.0 added `-text` rules so KiCad-authored fixtures remain byte-for-byte evidence, but the change replaced the repository's existing general attributes. That removed repository-controlled text normalization and explicit binary handling for PNG, ICO, and ICNS files.

The result makes text checkout behavior more dependent on each contributor's Git configuration and leaves image handling to heuristics.

## Root cause and design

Commit `8472c1c` replaced `.gitattributes` instead of extending it. This PR restores the four prior repository-wide rules above the newer fixture exceptions:

```gitattributes
* text=auto
*.png binary
*.ico binary
*.icns binary
```

The later, more-specific fixture paths remain `-text`, so their byte-preserving behavior wins over the general `text=auto` rule.

## Compatibility and migration

This changes no Konnect tool, schema, configuration, IPC behavior, runtime format, or user project. No migration is required. The PR intentionally does not renormalize existing files.

## Verification

- `git check-attr text diff merge -- README.md packaging/resources/icon.png crates/schematic-viewer/icons/icon.icns crates/konnect-sexp/tests/fixtures/placement/placement_fixture.kicad_pcb crates/konnect-core/tests/fixtures/test.kicad_pcb crates/konnect-ipc/tests/fixtures/live_ipc.kicad_pcb`
  - ordinary text: `text=auto`
  - PNG/ICNS: `text`, `diff`, and `merge` unset by the binary macro
  - every KiCad fixture tree: `text` unset
- `git diff --cached --check`
- changed-file audit: `.gitattributes` only; no fixture or unrelated file changed
- Cargo tests, clippy, and formatting were not run locally because this is an attribute-only change with no Rust source or generated output; normal CI remains authoritative

## Risk and rollback

Risk is limited to Git checkout/diff/merge behavior and restores the repository's pre-v0.10 defaults. Rollback is a one-commit revert. The fixture exceptions remain unchanged.