### PR TITLE
fix(schematic): preserve library metadata on placement

### DIFF
--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -604,6 +604,7 @@ pub(crate) fn place_one_component(
     if !cse::library::ensure_lib_symbol(sch, lib_id, src) {
         return Err(crate::tools::lib_symbol_not_found_error(lib_id, src));
     }
+    let metadata = cse::library::symbol_metadata(sch, lib_id);
 
     // Validate the unit against the resolved symbol BEFORE writing anything:
     // eeschema silently renders an out-of-range unit as unit 1 and the
@@ -623,7 +624,10 @@ pub(crate) fn place_one_component(
 
     // Reference and Value go where the library anchors them, carried through
     // the placement transform so they follow a rotated body (#101);
-    // Footprint/Datasheet stay hidden at the origin.
+    // Footprint/Datasheet/Description stay hidden at the origin. KiCad copies
+    // Datasheet and Description from the resolved library symbol onto every
+    // placed instance; without those copies its BOM exporter leaves both
+    // columns blank even though lib_symbols still carries the values (#226).
     // Power symbols get their Reference hidden too, matching eeschema: a
     // #PWR designator is never shown on the sheet.
     let hide_reference = lib_id.starts_with("power:") || reference.starts_with("#PWR");
@@ -661,8 +665,24 @@ pub(crate) fn place_one_component(
     ));
     sym.properties
         .push(positioned("Footprint", "", x, y, 0.0, true, centred));
-    sym.properties
-        .push(positioned("Datasheet", "", x, y, 0.0, true, centred));
+    sym.properties.push(positioned(
+        "Datasheet",
+        &metadata.datasheet,
+        x,
+        y,
+        0.0,
+        true,
+        centred,
+    ));
+    sym.properties.push(positioned(
+        "Description",
+        &metadata.description,
+        x,
+        y,
+        0.0,
+        true,
+        centred,
+    ));
 
     // Instance entry, keyed to the root sheet UUID like eeschema writes it:
     // (instances (project "<name>" (path "/<root-uuid>" (reference ...) (unit 1))))
@@ -2939,6 +2959,55 @@ mod tests {
         assert!(
             !reference.contains("justify"),
             "a centred library field must not gain a justify: {reference}"
+        );
+    }
+
+    #[tokio::test]
+    async fn placement_copies_library_datasheet_and_description() {
+        // Pre-seed two real KiCad field shapes so this remains independent of
+        // an installed symbol library: one URL and one no-datasheet sentinel.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("metadata.kicad_sch");
+        std::fs::write(
+            &path,
+            "(kicad_sch\n  (version 20250610)\n  (generator \"konnect\")\n  (uuid \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\")\n  (paper \"A4\")\n  (lib_symbols\n    (symbol \"Device:R\"\n      (property \"Reference\" \"R\" (at 2.032 0 90))\n      (property \"Value\" \"R\" (at 0 0 90))\n      (property \"Datasheet\" \"https://example.com/resistor.pdf\" (at 0 0 0))\n      (property \"Description\" \"Resistor\" (at 0 0 0))\n    )\n    (symbol \"Device:C\"\n      (property \"Reference\" \"C\" (at 2.032 0 90))\n      (property \"Value\" \"C\" (at 0 0 90))\n      (property \"Datasheet\" \"~\" (at 0 0 0))\n    )\n  )\n)\n",
+        )
+        .unwrap();
+
+        for (lib_id, reference, x) in [("Device:R", "R1", 100.0), ("Device:C", "C1", 120.0)] {
+            let result = handle_add_schematic_component(
+                &json!({
+                    "schematic": path.display().to_string(),
+                    "lib_id": lib_id,
+                    "reference": reference,
+                    "x": x,
+                    "y": 50.0
+                }),
+                &test_ctx(),
+            )
+            .await
+            .unwrap();
+            assert!(!result.is_error, "{result:?}");
+        }
+
+        let sch = cse::Schematic::load(&path).unwrap();
+        let field = |reference: &str, name: &str| {
+            sch.symbols
+                .iter()
+                .find(|symbol| symbol.reference() == Some(reference))
+                .and_then(|symbol| symbol.properties.iter().find(|p| p.name == name))
+                .map(|property| property.value.as_str())
+        };
+        assert_eq!(
+            field("R1", "Datasheet"),
+            Some("https://example.com/resistor.pdf")
+        );
+        assert_eq!(field("R1", "Description"), Some("Resistor"));
+        assert_eq!(field("C1", "Datasheet"), Some("~"));
+        assert_eq!(
+            field("C1", "Description"),
+            Some(""),
+            "KiCad writes the mandatory Description field even when empty"
         );
     }
 

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -1596,6 +1596,7 @@ async fn handle_add_power_symbol(
     if !cse::library::ensure_lib_symbol(&mut sch, &lib_id, &src) {
         return Ok(crate::tools::lib_symbol_not_found_error(&lib_id, &src));
     }
+    let metadata = cse::library::symbol_metadata(&sch, &lib_id);
 
     // Build the Symbol struct
     let mut sym = cse::Symbol::new(format!("power:{}", power_net), x, y);
@@ -1647,8 +1648,24 @@ async fn handle_add_power_symbol(
     ));
     sym.properties
         .push(positioned("Footprint", "", x, y, 0.0, true, centred));
-    sym.properties
-        .push(positioned("Datasheet", "", x, y, 0.0, true, centred));
+    sym.properties.push(positioned(
+        "Datasheet",
+        &metadata.datasheet,
+        x,
+        y,
+        0.0,
+        true,
+        centred,
+    ));
+    sym.properties.push(positioned(
+        "Description",
+        &metadata.description,
+        x,
+        y,
+        0.0,
+        true,
+        centred,
+    ));
 
     // Instance entry, keyed to the root sheet UUID like eeschema writes it —
     // without a resolvable "/<root-uuid>" path KiCAD's netlister drops the
@@ -3367,6 +3384,51 @@ mod power_symbol_tests {
         assert!(
             !after.contains("(property \"Reference\" \"#PWR001\")\n"),
             "must not write a bare Reference with no (at)"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_power_symbol_copies_library_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("power-metadata.kicad_sch");
+        std::fs::write(
+            &path,
+            "(kicad_sch\n  (version 20250610)\n  (generator \"konnect\")\n  (uuid \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\")\n  (paper \"A4\")\n  (lib_symbols\n    (symbol \"power:GND\"\n      (property \"Reference\" \"#PWR\" (at 0 -6.35 0))\n      (property \"Value\" \"GND\" (at 0 -3.81 0))\n      (property \"Datasheet\" \"https://example.com/gnd.pdf\" (at 0 0 0))\n      (property \"Description\" \"Ground power symbol\" (at 0 0 0))\n    )\n  )\n)\n",
+        )
+        .unwrap();
+
+        let result = handle_add_power_symbol(
+            &json!({
+                "schematic": path.display().to_string(),
+                "power_net": "GND",
+                "x": 100.0,
+                "y": 80.0
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error, "{result:?}");
+
+        let sch = cse::Schematic::load(&path).unwrap();
+        let sym = sch
+            .symbols
+            .iter()
+            .find(|s| s.reference() == Some("#PWR001"))
+            .expect("power symbol instance");
+        assert_eq!(
+            sym.properties
+                .iter()
+                .find(|p| p.name == "Datasheet")
+                .map(|p| p.value.as_str()),
+            Some("https://example.com/gnd.pdf")
+        );
+        assert_eq!(
+            sym.properties
+                .iter()
+                .find(|p| p.name == "Description")
+                .map(|p| p.value.as_str()),
+            Some("Ground power symbol")
         );
     }
 

--- a/crates/konnect-schematic-editor/src/library.rs
+++ b/crates/konnect-schematic-editor/src/library.rs
@@ -416,6 +416,40 @@ fn embedded_lib_symbol<'a>(schematic: &'a Schematic, lib_id: &str) -> Option<&'a
         .find(|s| s.value() == Some(lib_id))
 }
 
+/// Library-owned fields that KiCad copies onto each placed symbol instance.
+///
+/// Read these from the embedded definition rather than resolving the library
+/// again: the embedded copy is already flattened for derived symbols and is
+/// the exact definition the schematic instance refers to.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SymbolMetadata {
+    pub datasheet: String,
+    pub description: String,
+}
+
+/// Read the metadata fields of `lib_id` from the schematic's embedded symbol.
+/// Missing fields and an unknown symbol both produce empty values, matching
+/// KiCad's mandatory placed-field representation.
+pub fn symbol_metadata(schematic: &Schematic, lib_id: &str) -> SymbolMetadata {
+    let Some(symbol) = embedded_lib_symbol(schematic, lib_id) else {
+        return SymbolMetadata::default();
+    };
+    let value = |name: &str| {
+        symbol
+            .find_all("property")
+            .into_iter()
+            .find(|property| property.value() == Some(name))
+            .and_then(|property| property.args().get(1))
+            .and_then(SexpNode::text)
+            .unwrap_or_default()
+            .to_string()
+    };
+    SymbolMetadata {
+        datasheet: value("Datasheet"),
+        description: value("Description"),
+    }
+}
+
 /// [`FieldAnchors`] of a resolved symbol node.
 ///
 /// Only direct `(property …)` children count: a unit sub-symbol carries its
@@ -742,6 +776,11 @@ mod suggestion_tests {
             out.contains("lm2904.pdf"),
             "properties the child lacks are inherited:\n{out}"
         );
+        assert_eq!(
+            symbol_metadata(&sch, "Amp:NE5532").datasheet,
+            "lm2904.pdf",
+            "placed-instance metadata must follow the flattened definition"
+        );
         // Pins from both units present exactly once.
         assert_eq!(out.matches("(number \"1\"").count(), 1);
         assert_eq!(out.matches("(number \"7\"").count(), 1);
@@ -913,6 +952,21 @@ mod field_anchor_tests {
         let anchors = field_anchors(&sch, "Device:R");
         assert_eq!(anchors.reference_at, Some((2.032, 0.0, 90.0)));
         assert_eq!(anchors.value_at, Some((0.0, 0.0, 90.0)));
+    }
+
+    #[test]
+    fn reads_instance_metadata_from_direct_library_properties_only() {
+        let (sch, _dir) = schematic_with(
+            "(symbol \"Device:R\" (property \"Datasheet\" \"~\" (at 0 0 0)) (property \"Description\" \"Resistor\" (at 0 0 0)) (symbol \"R_0_1\" (property \"Description\" \"nested\" (at 0 0 0))))",
+        );
+        assert_eq!(
+            symbol_metadata(&sch, "Device:R"),
+            SymbolMetadata {
+                datasheet: "~".to_string(),
+                description: "Resistor".to_string(),
+            }
+        );
+        assert_eq!(symbol_metadata(&sch, "Device:C"), SymbolMetadata::default());
     }
 
     /// The anchor alone is not enough: `Regulator_Linear:AP2112K-3.3` puts

--- a/crates/konnect/tests/e2e_kicad.rs
+++ b/crates/konnect/tests/e2e_kicad.rs
@@ -182,6 +182,13 @@ fn full_design_loop_with_real_kicad() {
         }),
     );
     p.tool(
+        "add_schematic_component",
+        json!({
+            "schematic": sch.to_string_lossy(), "lib_id": "Regulator_Linear:LM7805_TO220",
+            "reference": "U1", "x": 140.0, "y": 100.0
+        }),
+    );
+    p.tool(
         "connect_pins",
         json!({
             "schematic": sch.to_string_lossy(),
@@ -209,7 +216,49 @@ fn full_design_loop_with_real_kicad() {
         .into_iter()
         .map(|s| s.reference)
         .collect();
-    assert!(refs.contains(&"R1".to_string()) && refs.contains(&"C1".to_string()));
+    assert!(
+        refs.contains(&"R1".to_string())
+            && refs.contains(&"C1".to_string())
+            && refs.contains(&"U1".to_string())
+    );
+
+    // KiCad's BOM exporter reads Datasheet and Description from the placed
+    // instance, not the embedded lib_symbols fallback. Both rows must retain
+    // the descriptions copied from the real Device library (#226).
+    let bom_file = proj.join("metadata.csv");
+    let bom_output = Command::new(&kicad_cli)
+        .args(["sch", "export", "bom", "--output"])
+        .arg(&bom_file)
+        .args([
+            "--fields",
+            "Reference,Datasheet,Description",
+            "--labels",
+            "Reference,Datasheet,Description",
+        ])
+        .arg(&sch)
+        .output()
+        .expect("failed to run KiCad BOM exporter");
+    assert!(
+        bom_output.status.success(),
+        "KiCad BOM export failed: {}",
+        String::from_utf8_lossy(&bom_output.stderr)
+    );
+    let bom = std::fs::read_to_string(&bom_file).expect("KiCad wrote no BOM");
+    for reference in ["R1", "C1", "U1"] {
+        let prefix = format!("\"{reference}\",");
+        let row = bom
+            .lines()
+            .find(|line| line.starts_with(&prefix))
+            .unwrap_or_else(|| panic!("BOM has no {reference} row:\n{bom}"));
+        assert!(
+            !row.ends_with(",\"\""),
+            "{reference} lost its library Description in KiCad's BOM:\n{bom}"
+        );
+    }
+    assert!(
+        !bom.lines().any(|line| line.starts_with("\"U1\",\"\",\"")),
+        "U1 lost the regulator library Datasheet in KiCad's BOM:\n{bom}"
+    );
 
     // ── ERC through real eeschema ────────────────────────────────────────
     p.load("sch_export");


### PR DESCRIPTION
## Summary

- copy `Datasheet` and `Description` from the schematic's resolved embedded library symbol onto each newly placed instance
- apply the same serialization to ordinary/batch placement and the separate power-symbol path
- add unit coverage for URLs, KiCad's `~` sentinel, missing descriptions, power symbols, and flattened derived symbols
- extend the real-KiCad end-to-end test to prove the metadata survives KiCad's BOM exporter

## Problem and root cause

`add_schematic_component` hard-coded an empty Datasheet and omitted Description. `add_power_symbol` repeated the same shape. KiCad keeps those values on the placed instance; its BOM exporter does not fall back to the copy under `lib_symbols`, so Konnect-authored schematics exported blank metadata even when the resolved library definition held a datasheet URL and description.

## Design

The schematic-editor library now exposes a typed metadata read from the already embedded symbol definition. That is the correct source because it is the exact definition the instance resolves through and derived symbols have already been flattened there. Placement copies the two values and emits both fields hidden at the symbol origin, matching KiCad's placed-symbol shape.

## Compatibility and migration

- No MCP tool names, arguments, or response fields change.
- Existing schematic files are not rewritten.
- New placements preserve library metadata instead of discarding it.
- Missing library fields remain empty; the `~` no-datasheet sentinel is preserved when the library carries it.
- Repairing metadata in existing Konnect-authored schematics is intentionally outside this PR.

## Verification

- `cargo test --workspace --locked --lib --tests`
- `cargo test --workspace --locked --doc`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `KICAD10_SYMBOL_DIR=<KiCad 10 symbols> cargo test -p konnect --test e2e_kicad full_design_loop_with_real_kicad --locked -- --ignored --nocapture`
  - passed with KiCad 10.0.5: BOM metadata, ERC, design review, Gerber export, and DRC

The live GUI/IPC-only tests remain ignored by the standard workspace command; this change does not touch IPC or PCB mutation.

## Risk and rollback

Risk is limited to the two additional/changed hidden properties on newly created symbol blocks. Structured parsing is used instead of text scanning. Reverting this commit restores the previous serialization; no migration or persistent schema change is involved.

Closes #226