### PR TITLE
fix(pcb): block stale file fallback after IPC loss

### DIFF
--- a/crates/konnect-core/src/mcp/error.rs
+++ b/crates/konnect-core/src/mcp/error.rs
@@ -51,6 +51,9 @@ pub enum ToolErrorKind {
     FileNotFound { path: String },
     /// A mutation would replace one or more existing filesystem targets.
     Conflict { paths: Vec<String> },
+    /// A board was live earlier in this server process, but IPC is now gone;
+    /// its saved file may be stale relative to lost editor state.
+    UnsafeFileFallback { path: String },
     /// Catch-all for handler `anyhow::Error` that hasn't been migrated yet.
     /// Eventually each variant above subsumes a subset of these.
     HandlerError { reason: String },
@@ -67,6 +70,7 @@ impl ToolErrorKind {
             Self::InvalidArgument { .. } => "invalid_argument",
             Self::FileNotFound { .. } => "file_not_found",
             Self::Conflict { .. } => "conflict",
+            Self::UnsafeFileFallback { .. } => "unsafe_file_fallback",
             Self::HandlerError { .. } => "handler_error",
         }
     }
@@ -166,6 +170,7 @@ mod tests {
             ToolErrorKind::Conflict {
                 paths: vec!["p".into()],
             },
+            ToolErrorKind::UnsafeFileFallback { path: "p".into() },
             ToolErrorKind::HandlerError { reason: "r".into() },
         ];
         for kind in kinds {

--- a/crates/konnect-core/src/tools/board_session.rs
+++ b/crates/konnect-core/src/tools/board_session.rs
@@ -1,0 +1,92 @@
+//! Process-lifetime safety memory for boards positively observed through KiCad IPC.
+//!
+//! An unreachable transport is ambiguous after a board was live: KiCad may have
+//! crashed with unsaved state. Remembering that observation lets file-fallback
+//! tools fail closed instead of editing a potentially stale save (#240).
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Default)]
+pub(crate) struct BoardSessionMemory {
+    observed_live: Arc<Mutex<HashSet<PathBuf>>>,
+}
+
+impl BoardSessionMemory {
+    pub(crate) fn observe_live(&self, board: &Path) {
+        self.observed_live
+            .lock()
+            .expect("board-session memory poisoned")
+            .insert(board_key(board));
+    }
+
+    pub(crate) fn was_observed_live(&self, board: &Path) -> bool {
+        self.observed_live
+            .lock()
+            .expect("board-session memory poisoned")
+            .contains(&board_key(board))
+    }
+}
+
+/// Prefer filesystem identity. If the path cannot be canonicalized, retain a
+/// stable absolute lexical spelling instead of silently dropping the safety
+/// observation.
+fn board_key(board: &Path) -> PathBuf {
+    board.canonicalize().unwrap_or_else(|_| {
+        if board.is_absolute() {
+            board.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .map(|cwd| cwd.join(board))
+                .unwrap_or_else(|_| board.to_path_buf())
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observations_are_sticky_idempotent_and_board_specific() {
+        let dir = tempfile::tempdir().unwrap();
+        let board_a = dir.path().join("a.kicad_pcb");
+        let board_b = dir.path().join("b.kicad_pcb");
+        std::fs::write(&board_a, "").unwrap();
+        std::fs::write(&board_b, "").unwrap();
+        let memory = BoardSessionMemory::default();
+
+        assert!(!memory.was_observed_live(&board_a));
+        memory.observe_live(&board_a);
+        memory.observe_live(&board_a);
+
+        assert!(memory.was_observed_live(&board_a));
+        assert!(!memory.was_observed_live(&board_b));
+    }
+
+    #[test]
+    fn canonical_equivalent_paths_share_one_observation() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = dir.path().join("board.kicad_pcb");
+        std::fs::write(&board, "").unwrap();
+        let equivalent = dir.path().join("subdir").join("..").join("board.kicad_pcb");
+        std::fs::create_dir(dir.path().join("subdir")).unwrap();
+        let memory = BoardSessionMemory::default();
+
+        memory.observe_live(&equivalent);
+
+        assert!(memory.was_observed_live(&board));
+    }
+
+    #[test]
+    fn fresh_memory_does_not_inherit_observations() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = dir.path().join("board.kicad_pcb");
+        std::fs::write(&board, "").unwrap();
+        let first = BoardSessionMemory::default();
+        first.observe_live(&board);
+
+        assert!(!BoardSessionMemory::default().was_observed_live(&board));
+    }
+}

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -1,5 +1,6 @@
 //! Tool trait definitions, ToolContext, and all toolset modules.
 
+mod board_session;
 pub mod cli;
 pub mod config;
 pub mod design_review;
@@ -90,6 +91,9 @@ pub struct ToolContext {
     pub observer: crate::observability::CallObserver,
     /// In-memory TTL cache for repeated JLCPCB parts-database queries.
     pub jlcpcb_cache: QueryCache,
+    /// Boards positively observed open through IPC during this server process.
+    /// Sticky state prevents an unsafe file fallback after KiCad disappears.
+    pub(crate) board_session: board_session::BoardSessionMemory,
 }
 
 impl ToolContext {
@@ -101,6 +105,7 @@ impl ToolContext {
             router,
             observer: crate::observability::CallObserver::new(None),
             jlcpcb_cache: QueryCache::default(),
+            board_session: board_session::BoardSessionMemory::default(),
         }
     }
 
@@ -116,6 +121,7 @@ impl ToolContext {
             router,
             observer,
             jlcpcb_cache: QueryCache::default(),
+            board_session: board_session::BoardSessionMemory::default(),
         }
     }
 }
@@ -287,6 +293,30 @@ where
         Ok(result) => Ok(result),
         Err(e) => Err(anyhow::anyhow!("Thread error: {}", e)),
     }
+}
+
+/// Run a board-targeted IPC call and remember the requested board as soon as
+/// KiCad positively identifies it. Observation happens before `f`, so a later
+/// command rejection, timeout, or editor crash cannot make the next file
+/// fallback treat this board as never having been live.
+pub(crate) async fn with_board_ipc_classified<T, F>(
+    ctx: &ToolContext,
+    board_path: &std::path::Path,
+    f: F,
+) -> anyhow::Result<Result<T, konnect_ipc::IpcFailure>>
+where
+    T: Send + 'static,
+    F: FnOnce(&konnect_ipc::client::KiCadIpcClient) -> anyhow::Result<T> + Send + 'static,
+{
+    let requested = board_path.to_path_buf();
+    let observation = requested.clone();
+    let memory = ctx.board_session.clone();
+    with_ipc_classified(ctx.config.ipc_address.clone(), move |client| {
+        client.ensure_board_is_active(&requested)?;
+        memory.observe_live(&observation);
+        f(client)
+    })
+    .await
 }
 
 // ─── Argument helpers ─────────────────────────────────────────────────────────

--- a/crates/konnect-core/src/tools/pcb_board.rs
+++ b/crates/konnect-core/src/tools/pcb_board.rs
@@ -10,7 +10,8 @@ use crate::mcp::error::ToolErrorKind;
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
 use crate::tools::{
-    get_path, opt_str_list, require_f64, require_str, with_ipc_classified, ToolContext, ToolDef,
+    get_path, opt_str_list, require_f64, require_str, with_board_ipc_classified, ToolContext,
+    ToolDef,
 };
 use konnect_ipc::builders;
 use konnect_sexp::{
@@ -181,33 +182,14 @@ fn outline_items(primitives: &[OutlinePrimitive], width: f64) -> Vec<prost_types
         .collect()
 }
 
-// ─── IPC helper ───────────────────────────────────────────────────────────────
-
-async fn with_ipc<T, F>(addr: String, f: F) -> anyhow::Result<Result<T, String>>
-where
-    T: Send + 'static,
-    F: FnOnce(&konnect_ipc::client::KiCadIpcClient) -> anyhow::Result<T> + Send + 'static,
-{
-    match tokio::task::spawn_blocking(move || {
-        let client = konnect_ipc::client::KiCadIpcClient::new(&addr);
-        f(&client)
-    })
-    .await
-    {
-        Ok(Ok(r)) => Ok(Ok(r)),
-        Ok(Err(e)) => Ok(Err(e.to_string())),
-        Err(e) => Err(anyhow::anyhow!("Thread error: {}", e)),
-    }
-}
-
 /// What a board-mutating tool should do after its IPC attempt.
 pub(crate) enum BoardWrite<T = ()> {
     /// KiCAD applied the change; report `"source": "ipc"`. Carries whatever the
     /// IPC call returned, for tools that echo it back — the placed footprint,
     /// for instance.
     Ipc(T),
-    /// No live KiCAD on this transport, so a direct file edit cannot race an
-    /// editor; proceed with the S-expression path.
+    /// No live KiCad on this transport and this board was not observed live
+    /// during the current server session; proceed with the S-expression path.
     File,
     /// KiCAD answered and refused. The caller must return this result and must
     /// NOT touch the file.
@@ -225,12 +207,11 @@ pub(crate) enum BoardWrite<T = ()> {
 ///   rejects that up front (issue: `add_board_outline` writing into the open board).
 /// * A file-only edit is invisible to a KiCAD holding this board open and is
 ///   discarded by its next save. So the fallback gate is the typed transport
-///   classification, never a text match: only a request that never reached a live
-///   KiCAD may edit the file; a KiCAD that answered — even with an error — fails
-///   closed. `handle_add_mounting_hole` established that rule; this is it made
-///   reusable, so every board-mutating tool decides the same way.
+///   classification, never a text match. A KiCad that answers — even with an
+///   error — fails closed. An unreachable transport permits the file path only
+///   when this server has never observed the requested board live.
 pub(crate) async fn attempt_ipc_write<T, F>(
-    addr: String,
+    ctx: &ToolContext,
     board_path: &std::path::Path,
     what: &str,
     f: F,
@@ -239,13 +220,7 @@ where
     T: Send + 'static,
     F: FnOnce(&konnect_ipc::client::KiCadIpcClient) -> anyhow::Result<T> + Send + 'static,
 {
-    let requested = board_path.to_path_buf();
-    match crate::tools::with_ipc_classified(addr, move |c| {
-        c.ensure_board_is_active(&requested)?;
-        f(c)
-    })
-    .await?
-    {
+    match with_board_ipc_classified(ctx, board_path, f).await? {
         Ok(value) => Ok(BoardWrite::Ipc(value)),
         Err(konnect_ipc::IpcFailure::Rejected(message)) => {
             Ok(BoardWrite::Refused(CallToolResult::error(format!(
@@ -254,8 +229,27 @@ where
                  board open, so editing the file directly could be silently overwritten."
             ))))
         }
-        Err(konnect_ipc::IpcFailure::Unreachable(_)) => Ok(BoardWrite::File),
+        Err(konnect_ipc::IpcFailure::Unreachable(_)) => {
+            if ctx.board_session.was_observed_live(board_path) {
+                Ok(BoardWrite::Refused(unsafe_file_fallback(board_path)))
+            } else {
+                Ok(BoardWrite::File)
+            }
+        }
     }
+}
+
+fn unsafe_file_fallback(board_path: &std::path::Path) -> CallToolResult {
+    CallToolResult::error_kind(
+        ToolErrorKind::UnsafeFileFallback {
+            path: board_path.display().to_string(),
+        },
+        "Konnect previously reached KiCad with this board open, but IPC is now unreachable. \
+         The saved board file may be older than unsaved editor state, so Konnect did not \
+         modify it. Reopen or recover the board in KiCad, reconcile it, and save the \
+         authoritative state. If KiCad was deliberately closed cleanly, restart Konnect \
+         only after confirming that the saved file is authoritative.",
+    )
 }
 
 /// Refuse a direct file edit when KiCAD is reachable AND holds this very
@@ -263,23 +257,25 @@ where
 /// be silently discarded on its next save — success reported, nothing kept
 /// (#192). For tools with no IPC implementation this guard is the honest
 /// alternative to [`attempt_ipc_write`]'s fallback. A reachable KiCAD holding
-/// a *different* board (or none) does not interfere with this file, and an
-/// unreachable one cannot race it — both proceed.
+/// a *different* board (or none) does not interfere with this file. An
+/// unreachable transport proceeds only when this server has never observed
+/// the requested board live.
 pub(crate) async fn refuse_if_board_open_in_kicad(
-    addr: String,
+    ctx: &ToolContext,
     board_path: &std::path::Path,
     what: &str,
 ) -> anyhow::Result<Option<CallToolResult>> {
-    let requested = board_path.to_path_buf();
-    match crate::tools::with_ipc_classified(addr, move |c| c.ensure_board_is_active(&requested))
-        .await?
-    {
+    match with_board_ipc_classified(ctx, board_path, |_| Ok(())).await? {
         Ok(()) => Ok(Some(CallToolResult::error(format!(
             "KiCAD currently holds this board open, and a {what} written to the file would \
              be discarded by KiCAD's next save. Close the board in KiCAD (or make the edit \
              there) and retry — this tool has no IPC path for a live board yet."
         )))),
-        Err(_) => Ok(None),
+        Err(konnect_ipc::IpcFailure::Rejected(_)) => Ok(None),
+        Err(konnect_ipc::IpcFailure::Unreachable(_)) => Ok(ctx
+            .board_session
+            .was_observed_live(board_path)
+            .then(|| unsafe_file_fallback(board_path))),
     }
 }
 
@@ -293,10 +289,11 @@ pub(crate) const DEFAULT_ZONE_MIN_WIDTH_MM: f64 = 0.2;
 
 /// What the caller gets back when no live KiCAD could be reached and the zone
 /// went into the file instead.
-pub(crate) const ZONE_FILE_FALLBACK_WARNING: &str =
-    "KiCAD was not reachable over IPC, so the zone was written straight into the board \
-     file. If KiCAD in fact has this board open (with the IPC API switched off, say), use \
-     File → Revert there before saving, or the zone will be discarded by KiCAD's next save.";
+pub(crate) const FILE_FALLBACK_WARNING: &str =
+    "KiCad IPC was unreachable and this board has not been observed live during the current \
+     Konnect server session, so Konnect edited the saved board file directly. If KiCad \
+     crashed or was force-quit before this server started, reconcile any unsaved work \
+     before relying on this change.";
 
 /// The `pad_connection` argument in both the representations it needs: the IPC
 /// enum and the token KiCad's `(connect_pads …)` takes.
@@ -1031,25 +1028,20 @@ async fn handle_set_board_size(
     // to Edge.Cuts and the board failed DRC with a self-intersecting outline
     // while the tool reported success (#314).
     let items = rect_outline_items(ox, oy, x2, y2, w);
-    match attempt_ipc_write(
-        ctx.config.ipc_address.clone(),
-        &board_path,
-        "board size",
-        move |c| {
-            let existing =
-                c.get_items(konnect_ipc::gen::kiapi::common::types::KiCadObjectType::KotPcbShape)?;
-            let (segment_ids, other_kinds) = partition_edge_cuts_shapes(&existing);
-            if !other_kinds.is_empty() {
-                return Ok(OutlineIpcOutcome::NotPlainSegments(other_kinds.join(", ")));
-            }
-            let removed = segment_ids.len();
-            c.run_commit("Set board size", |c| {
-                c.delete_items(segment_ids.clone())?;
-                c.create_items(items.clone()).map(|_| ())
-            })?;
-            Ok(OutlineIpcOutcome::Replaced(removed))
-        },
-    )
+    match attempt_ipc_write(ctx, &board_path, "board size", move |c| {
+        let existing =
+            c.get_items(konnect_ipc::gen::kiapi::common::types::KiCadObjectType::KotPcbShape)?;
+        let (segment_ids, other_kinds) = partition_edge_cuts_shapes(&existing);
+        if !other_kinds.is_empty() {
+            return Ok(OutlineIpcOutcome::NotPlainSegments(other_kinds.join(", ")));
+        }
+        let removed = segment_ids.len();
+        c.run_commit("Set board size", |c| {
+            c.delete_items(segment_ids.clone())?;
+            c.create_items(items.clone()).map(|_| ())
+        })?;
+        Ok(OutlineIpcOutcome::Replaced(removed))
+    })
     .await?
     {
         BoardWrite::Ipc(OutlineIpcOutcome::Replaced(removed)) => {
@@ -1116,7 +1108,8 @@ async fn handle_set_board_size(
         "width": width, "height": height,
         "x1": ox, "y1": oy, "x2": x2, "y2": y2,
         "replaced_segments": removed,
-        "source": "file"
+        "source": "file",
+        "warning": FILE_FALLBACK_WARNING
     })))
 }
 
@@ -1167,22 +1160,23 @@ async fn handle_get_board_info(
     // the IPC-backed writers in this toolset, most visibly as layer_count 0 /
     // net_count 0 on a board KiCad was showing fully populated.
     let ipc_board = board_path.clone();
-    if let Ok((title_block, enabled, nets)) = with_ipc(ctx.config.ipc_address.clone(), move |c| {
-        let document = c.find_open_board(&ipc_board)?;
-        Ok((
-            c.get_title_block_in(document.clone())?,
-            c.get_enabled_layers_in(document.clone())?,
-            // Net 0 is KiCad's unconnected pseudo-net and GetNets returns it.
-            // The tool description promises a count without it and the file
-            // path already excludes it (konnect_sexp::net::count_distinct_nets),
-            // so a board with nothing wired must not read as one net.
-            c.get_nets_in(document)?
-                .iter()
-                .filter(|net| net.netcode != 0)
-                .count(),
-        ))
-    })
-    .await?
+    if let Ok((title_block, enabled, nets)) =
+        with_board_ipc_classified(ctx, &board_path, move |c| {
+            let document = c.find_open_board(&ipc_board)?;
+            Ok((
+                c.get_title_block_in(document.clone())?,
+                c.get_enabled_layers_in(document.clone())?,
+                // Net 0 is KiCad's unconnected pseudo-net and GetNets returns it.
+                // The tool description promises a count without it and the file
+                // path already excludes it (konnect_sexp::net::count_distinct_nets),
+                // so a board with nothing wired must not read as one net.
+                c.get_nets_in(document)?
+                    .iter()
+                    .filter(|net| net.netcode != 0)
+                    .count(),
+            ))
+        })
+        .await?
     {
         // Paper always comes from the file — KiCad's API exposes no page
         // settings — through the same parsed-tree helpers the file path uses,
@@ -1279,7 +1273,7 @@ async fn handle_get_board_extents(
     // boards open, first-document targeting silently measures the other, and
     // ensure_board_is_active only checks it is open somewhere.
     let ipc_board = board_path.clone();
-    if let Ok(ext) = with_ipc(ctx.config.ipc_address.clone(), move |c| {
+    if let Ok(ext) = with_board_ipc_classified(ctx, &board_path, move |c| {
         c.get_board_extents_in(c.find_open_board(&ipc_board)?)
     })
     .await?
@@ -1549,12 +1543,9 @@ async fn handle_add_board_outline(
     let arc_count = primitives.len() - line_count;
 
     let items = outline_items(&primitives, w);
-    match attempt_ipc_write(
-        ctx.config.ipc_address.clone(),
-        &board_path,
-        "board outline",
-        move |c| c.create_items(items).map(|_| ()),
-    )
+    match attempt_ipc_write(ctx, &board_path, "board outline", move |c| {
+        c.create_items(items).map(|_| ())
+    })
     .await?
     {
         BoardWrite::Ipc(()) => {
@@ -1582,7 +1573,8 @@ async fn handle_add_board_outline(
         "width": (x2-x1).abs(), "height": (y2-y1).abs(),
         "corner_radius": corner_radius,
         "line_count": line_count, "arc_count": arc_count,
-        "source": "file"
+        "source": "file",
+        "warning": FILE_FALLBACK_WARNING
     })))
 }
 
@@ -1655,12 +1647,11 @@ async fn handle_delete_graphics(
     }
 
     // The board KiCad holds first. The fallback gate is the typed transport
-    // classification: only when the request never reached a live KiCad is it
-    // safe to edit the board file, since a file edited behind a live editor is
-    // silently overwritten on its next save.
+    // classification plus session memory: file mode is available only when
+    // this server has never observed the requested board live.
     let ipc_board = board_path.clone();
     let ipc_filter = filter.clone();
-    let attempt = with_ipc_classified(ctx.config.ipc_address.clone(), move |c| {
+    let attempt = attempt_ipc_write(ctx, &board_path, "graphic deletion", move |c| {
         let document = c.find_open_board(&ipc_board)?;
         let matched: Vec<konnect_ipc::IpcGraphic> = c
             .get_board_graphics_in(document.clone())?
@@ -1683,7 +1674,7 @@ async fn handle_delete_graphics(
     .await?;
 
     let (graphics, source) = match attempt {
-        Ok(matched) => (
+        BoardWrite::Ipc(matched) => (
             matched
                 .iter()
                 .map(|g| {
@@ -1697,14 +1688,8 @@ async fn handle_delete_graphics(
                 .collect::<Vec<_>>(),
             "ipc",
         ),
-        Err(konnect_ipc::IpcFailure::Rejected(message)) => {
-            return Ok(CallToolResult::error(format!(
-                "KiCad rejected the deletion over IPC: {message}. \
-                 The board file was not modified — KiCad is reachable and may hold this \
-                 board open, so editing the file directly could be silently overwritten."
-            )))
-        }
-        Err(konnect_ipc::IpcFailure::Unreachable(_)) => {
+        BoardWrite::Refused(result) => return Ok(result),
+        BoardWrite::File => {
             let content = std::fs::read_to_string(&board_path)?;
             let matched: Vec<FileGraphic> = read_file_graphics(&content)
                 .into_iter()
@@ -1731,7 +1716,12 @@ async fn handle_delete_graphics(
         "deleted": if dry_run { 0 } else { graphics.len() },
         "dry_run": dry_run,
         "graphics": graphics,
-        "source": source
+        "source": source,
+        "warning": if source == "file" && !dry_run {
+            Some(FILE_FALLBACK_WARNING)
+        } else {
+            None
+        }
     })))
 }
 
@@ -1760,29 +1750,24 @@ async fn handle_add_mounting_hole(
     let lib_id_ipc = lib_id.clone();
     let reference_ipc = reference.clone();
     let text_offset = mounting_hole_text_offset(drill_d);
-    let attempt = attempt_ipc_write(
-        ctx.config.ipc_address.clone(),
-        &board_path,
-        "mounting hole",
-        move |c| {
-            c.place_footprint(
-                &requested_board,
-                &lib_id_ipc,
-                &reference_ipc,
-                "MountingHole",
-                std::slice::from_ref(&mounting_hole_pad(drill_d)),
-                &[],
-                &konnect_ipc::IpcFieldPlacement {
-                    reference_at: Some((0.0, text_offset, 0.0)),
-                    value_at: Some((0.0, -text_offset, 0.0)),
-                },
-                x,
-                y,
-                0.0,
-                "F.Cu",
-            )
-        },
-    )
+    let attempt = attempt_ipc_write(ctx, &board_path, "mounting hole", move |c| {
+        c.place_footprint(
+            &requested_board,
+            &lib_id_ipc,
+            &reference_ipc,
+            "MountingHole",
+            std::slice::from_ref(&mounting_hole_pad(drill_d)),
+            &[],
+            &konnect_ipc::IpcFieldPlacement {
+                reference_at: Some((0.0, text_offset, 0.0)),
+                value_at: Some((0.0, -text_offset, 0.0)),
+            },
+            x,
+            y,
+            0.0,
+            "F.Cu",
+        )
+    })
     .await?;
 
     match attempt {
@@ -1793,8 +1778,8 @@ async fn handle_add_mounting_hole(
         }))),
         BoardWrite::Refused(err) => Ok(err),
         BoardWrite::File => {
-            // No live KiCad on the other end of this transport: editing the
-            // board file directly cannot race an editor.
+            // No live KiCad now, and this board was not observed live during
+            // the current server session: use the guarded file path.
             let fp_sexp = format_npth_footprint(x, y, drill_d, &reference);
             let content = std::fs::read_to_string(&board_path)?;
             let close_pos = content.rfind(')').unwrap_or(content.len());
@@ -1805,9 +1790,7 @@ async fn handle_add_mounting_hole(
                 "reference": reference, "x": x, "y": y, "drill_diameter": drill_d,
                 "footprint": lib_id,
                 "source": "file",
-                "warning": "KiCAD IPC was not reachable, so the board file was edited \
-                            directly. KiCAD will show this mounting hole when it next \
-                            loads the board."
+                "warning": FILE_FALLBACK_WARNING
             })))
         }
     }
@@ -1836,16 +1819,11 @@ async fn handle_add_board_text(
 
     let text_ipc = text.clone();
     let layer_ipc = layer.clone();
-    match attempt_ipc_write(
-        ctx.config.ipc_address.clone(),
-        &board_path,
-        "board text",
-        move |c| {
-            let bt = builders::board_text(&layer_ipc, &text_ipc, x, y, size, rotation, false);
-            let any = builders::pack_any(&bt, "kiapi.board.types.BoardText");
-            c.create_items(vec![any]).map(|_| ())
-        },
-    )
+    match attempt_ipc_write(ctx, &board_path, "board text", move |c| {
+        let bt = builders::board_text(&layer_ipc, &text_ipc, x, y, size, rotation, false);
+        let any = builders::pack_any(&bt, "kiapi.board.types.BoardText");
+        c.create_items(vec![any]).map(|_| ())
+    })
     .await?
     {
         BoardWrite::Ipc(()) => {
@@ -1866,7 +1844,8 @@ async fn handle_add_board_text(
 
     Ok(CallToolResult::json(&json!({
         "text": text, "x": x, "y": y, "layer": layer, "size": size,
-        "source": "file"
+        "source": "file",
+        "warning": FILE_FALLBACK_WARNING
     })))
 }
 
@@ -1932,23 +1911,18 @@ pub(crate) async fn add_zone_impl(
     let layer_ipc = layer.clone();
     let name_ipc = zone_name.clone();
     let points_ipc = points.clone();
-    let ipc_attempt = attempt_ipc_write(
-        ctx.config.ipc_address.clone(),
-        &board_path,
-        "zone",
-        move |c| {
-            c.add_zone(&konnect_ipc::builders::ZoneSpec {
-                layer: &layer_ipc,
-                net_name: &net_ipc,
-                points: &points_ipc,
-                clearance_mm: clearance,
-                min_thickness_mm: min_width,
-                name: &name_ipc,
-                priority,
-                connection: connection.as_ipc(),
-            })
-        },
-    )
+    let ipc_attempt = attempt_ipc_write(ctx, &board_path, "zone", move |c| {
+        c.add_zone(&konnect_ipc::builders::ZoneSpec {
+            layer: &layer_ipc,
+            net_name: &net_ipc,
+            points: &points_ipc,
+            clearance_mm: clearance,
+            min_thickness_mm: min_width,
+            name: &name_ipc,
+            priority,
+            connection: connection.as_ipc(),
+        })
+    })
     .await?;
 
     match ipc_attempt {
@@ -1986,7 +1960,7 @@ pub(crate) async fn add_zone_impl(
 
     let mut body = describe();
     body["source"] = json!("file");
-    body["warning"] = json!(ZONE_FILE_FALLBACK_WARNING);
+    body["warning"] = json!(FILE_FALLBACK_WARNING);
     Ok(CallToolResult::json(&body))
 }
 
@@ -2024,16 +1998,11 @@ async fn handle_import_svg_logo(
 
     let layer_ipc = layer.clone();
     let placed_ipc = placed.clone();
-    let ipc_attempt = attempt_ipc_write(
-        ctx.config.ipc_address.clone(),
-        &board_path,
-        "SVG logo",
-        move |c| {
-            let shape = builders::board_polygon(&layer_ipc, 0.0, true, &placed_ipc);
-            let any = builders::pack_any(&shape, "kiapi.board.types.BoardGraphicShape");
-            c.create_items(vec![any]).map(|_| ())
-        },
-    )
+    let ipc_attempt = attempt_ipc_write(ctx, &board_path, "SVG logo", move |c| {
+        let shape = builders::board_polygon(&layer_ipc, 0.0, true, &placed_ipc);
+        let any = builders::pack_any(&shape, "kiapi.board.types.BoardGraphicShape");
+        c.create_items(vec![any]).map(|_| ())
+    })
     .await?;
     if let BoardWrite::Refused(err) = ipc_attempt {
         return Ok(err);
@@ -2060,7 +2029,8 @@ async fn handle_import_svg_logo(
         "polygon_count": placed.len(),
         "layer": layer,
         "width_mm": width_mm,
-        "source": "file"
+        "source": "file",
+        "warning": FILE_FALLBACK_WARNING
     })))
 }
 
@@ -2260,6 +2230,187 @@ mod board_mock {
             }
         });
         url
+    }
+}
+
+#[cfg(test)]
+mod board_session_safety_tests {
+    use super::board_mock::ctx_talking_to;
+    use super::*;
+    use konnect_ipc::gen::kiapi;
+    use prost::Message;
+
+    fn spawn_one_document_response(
+        board: &std::path::Path,
+    ) -> (String, std::thread::JoinHandle<()>) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let url = format!("tcp://127.0.0.1:{port}");
+        let socket = nng::Socket::new(nng::Protocol::Rep0).expect("mock rep socket");
+        socket.listen(&url).expect("mock listen");
+        let board = board.display().to_string();
+        let handle = std::thread::spawn(move || {
+            let request = socket.recv().expect("GetOpenDocuments request");
+            let request = kiapi::common::ApiRequest::decode(request.as_slice()).unwrap();
+            assert!(request
+                .message
+                .as_ref()
+                .is_some_and(|message| message.type_url.ends_with("GetOpenDocuments")));
+            let document = kiapi::common::types::DocumentSpecifier {
+                r#type: kiapi::common::types::DocumentType::DoctypePcb as i32,
+                project: None,
+                identifier: Some(
+                    kiapi::common::types::document_specifier::Identifier::BoardFilename(board),
+                ),
+            };
+            let response = kiapi::common::ApiResponse {
+                status: Some(kiapi::common::ApiResponseStatus {
+                    status: kiapi::common::ApiStatusCode::AsOk as i32,
+                    error_message: String::new(),
+                }),
+                header: None,
+                message: Some(konnect_ipc::builders::pack_any(
+                    &kiapi::common::commands::GetOpenDocumentsResponse {
+                        documents: vec![document],
+                    },
+                    "kiapi.common.commands.GetOpenDocumentsResponse",
+                )),
+            };
+            socket
+                .send(nng::Message::from(response.encode_to_vec().as_slice()))
+                .expect("document response");
+        });
+        (url, handle)
+    }
+
+    #[tokio::test]
+    async fn live_then_dead_blocks_a_file_fallback_and_preserves_the_board() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let before = std::fs::read(&board).unwrap();
+        let (address, server) = spawn_one_document_response(&board);
+        let ctx = ctx_talking_to(address);
+
+        let observation = with_board_ipc_classified(&ctx, &board, |_| Ok(()))
+            .await
+            .unwrap();
+        assert!(observation.is_ok());
+        server.join().unwrap();
+
+        let result = super::handle_add_mounting_hole(
+            &json!({
+                "board": board.to_string_lossy(),
+                "x": 5.0,
+                "y": 6.0,
+                "reference": "H1"
+            }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_error);
+        assert_eq!(
+            crate::mcp::error::extract_error_kind(&result).as_deref(),
+            Some("unsafe_file_fallback")
+        );
+        let text = super::mounting_hole_tests::result_text(&result);
+        assert!(text.contains("Konnect previously reached KiCad"), "{text}");
+        assert!(text.contains("did not modify"), "{text}");
+        assert_eq!(std::fs::read(&board).unwrap(), before);
+    }
+
+    #[tokio::test]
+    async fn an_offline_board_never_observed_live_still_allows_file_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let ctx = ctx_talking_to(String::new());
+
+        let outcome = attempt_ipc_write(&ctx, &board, "test write", |_| Ok(()))
+            .await
+            .unwrap();
+
+        assert!(matches!(outcome, BoardWrite::File));
+    }
+
+    #[tokio::test]
+    async fn an_observed_board_does_not_taint_a_different_offline_board() {
+        let dir = tempfile::tempdir().unwrap();
+        let board_a = dir.path().join("a.kicad_pcb");
+        let board_b = dir.path().join("b.kicad_pcb");
+        std::fs::write(&board_a, "").unwrap();
+        std::fs::write(&board_b, "").unwrap();
+        let ctx = ctx_talking_to(String::new());
+        ctx.board_session.observe_live(&board_a);
+
+        let outcome = attempt_ipc_write(&ctx, &board_b, "test write", |_| Ok(()))
+            .await
+            .unwrap();
+
+        assert!(matches!(outcome, BoardWrite::File));
+    }
+
+    #[tokio::test]
+    async fn a_file_only_guard_blocks_a_previously_live_board_after_transport_loss() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let ctx = ctx_talking_to(String::new());
+        ctx.board_session.observe_live(&board);
+
+        let result = refuse_if_board_open_in_kicad(&ctx, &board, "test edit")
+            .await
+            .unwrap()
+            .expect("the edit must be refused");
+
+        assert_eq!(
+            crate::mcp::error::extract_error_kind(&result).as_deref(),
+            Some("unsafe_file_fallback")
+        );
+    }
+
+    #[tokio::test]
+    async fn an_operation_rejected_after_identification_still_protects_the_next_call() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let (address, server) = spawn_one_document_response(&board);
+        let ctx = ctx_talking_to(address);
+
+        let rejected = with_board_ipc_classified(&ctx, &board, |_| -> anyhow::Result<()> {
+            anyhow::bail!("mock mutation rejected after board identification")
+        })
+        .await
+        .unwrap();
+        assert!(matches!(
+            rejected,
+            Err(konnect_ipc::IpcFailure::Rejected(_))
+        ));
+        server.join().unwrap();
+
+        let next = attempt_ipc_write(&ctx, &board, "next write", |_| Ok(()))
+            .await
+            .unwrap();
+        let BoardWrite::Refused(result) = next else {
+            panic!("the next file fallback must be refused")
+        };
+        assert_eq!(
+            crate::mcp::error::extract_error_kind(&result).as_deref(),
+            Some("unsafe_file_fallback")
+        );
+    }
+
+    #[tokio::test]
+    async fn rejection_before_board_identification_does_not_create_an_observation() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let ctx = ctx_talking_to(super::mounting_hole_tests::spawn_rejecting_kicad());
+
+        let result = with_board_ipc_classified(&ctx, &board, |_| Ok(()))
+            .await
+            .unwrap();
+
+        assert!(matches!(result, Err(konnect_ipc::IpcFailure::Rejected(_))));
+        assert!(!ctx.board_session.was_observed_live(&board));
     }
 }
 
@@ -3178,8 +3329,11 @@ mod zone_net_format_tests {
         let body = body_of(&result);
         assert_eq!(body["source"], json!("file"));
         let warning = body["warning"].as_str().expect("a fallback must warn");
-        assert!(warning.contains("File → Revert"), "{warning}");
-        assert!(warning.contains("next save"), "{warning}");
+        assert!(
+            warning.contains("current Konnect server session"),
+            "{warning}"
+        );
+        assert!(warning.contains("crashed or was force-quit"), "{warning}");
     }
 
     #[tokio::test]

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -7,9 +7,9 @@
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
 use crate::tools::library::{footprint_lib_nickname_for_dir, is_lib_id, resolve_footprint_path};
-use crate::tools::pcb_board::{attempt_ipc_write, BoardWrite};
+use crate::tools::pcb_board::{attempt_ipc_write, BoardWrite, FILE_FALLBACK_WARNING};
 use crate::tools::{
-    get_path, require_array, require_f64, require_str, require_u64, with_ipc_classified,
+    get_path, require_array, require_f64, require_str, require_u64, with_board_ipc_classified,
     ToolContext, ToolDef,
 };
 use anyhow::Context;
@@ -25,30 +25,10 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::path::Path;
 
-// ─── IPC helper ───────────────────────────────────────────────────────────────
-
-async fn with_ipc<T, F>(addr: String, f: F) -> anyhow::Result<Result<T, String>>
-where
-    T: Send + 'static,
-    F: FnOnce(&KiCadIpcClient) -> anyhow::Result<T> + Send + 'static,
-{
-    match tokio::task::spawn_blocking(move || f(&KiCadIpcClient::new(&addr))).await {
-        Ok(Ok(r)) => Ok(Ok(r)),
-        Ok(Err(e)) => Ok(Err(format!("{e:#}"))),
-        Err(e) => Err(anyhow::anyhow!("Thread error: {}", e)),
-    }
-}
-
 macro_rules! ipc {
     ($ctx:expr, $args:expr, |$c:ident| $body:expr) => {{
-        let addr = $ctx.config.ipc_address.clone();
         let requested_board = get_path($args, "board")?;
-        match with_ipc_classified(addr, move |$c| {
-            $c.ensure_board_is_active(&requested_board)?;
-            $body
-        })
-        .await?
-        {
+        match with_board_ipc_classified($ctx, &requested_board, move |$c| $body).await? {
             Ok(v) => v,
             // Only an unreachable transport justifies "KiCAD must be running".
             // This used to say it for every failure, so a tool that refused a
@@ -936,7 +916,7 @@ enum FootprintPlacementUpdate {
 /// The handlers have to tell a caller's mistake — a reference that is not on
 /// this board — from a board Konnect declines to edit, from a genuine I/O
 /// failure, and report each differently. Deciding that by matching on the
-/// error's message text is exactly what [`with_ipc_classified`]'s contract
+/// error's message text is exactly what [`with_board_ipc_classified`]'s contract
 /// forbids two screens up, and it left every case except the missing
 /// reference surfacing as an unstructured `handler_error` (#194's class).
 #[derive(Debug)]
@@ -2120,16 +2100,14 @@ async fn handle_place_component(
         .to_string();
 
     // Try IPC first. The fallback gate is the typed transport classification:
-    // only when the request never reached a live KiCad (unconfigured socket,
-    // failed dial/send) is it safe to edit the board file directly. A KiCad
-    // that answered — even with an error — may hold this board open, and a
-    // file edited behind a live editor is silently overwritten on its next
-    // save, so a rejection fails closed with no fallback.
-    let requested_board = board.clone();
+    // only when the transport is unreachable and this server has never
+    // observed the requested board live is the guarded file path available.
+    // A KiCad that answered — even with an error — fails closed.
     let footprint_ipc = footprint.clone();
     let reference_ipc = reference.clone();
     let layer_ipc = layer.clone();
-    let attempt = with_ipc_classified(ctx.config.ipc_address.clone(), move |c| {
+    let requested_board = board.clone();
+    let attempt = attempt_ipc_write(ctx, &board, "placement", move |c| {
         c.place_footprint(
             &requested_board,
             &footprint_ipc,
@@ -2147,19 +2125,15 @@ async fn handle_place_component(
     .await?;
 
     match attempt {
-        Ok(fp) => Ok(CallToolResult::json(&json!({
+        BoardWrite::Ipc(fp) => Ok(CallToolResult::json(&json!({
             "placed": fp.reference,
             "footprint": fp.footprint,
             "x": fp.position.x, "y": fp.position.y,
             "rotation": fp.rotation, "layer": fp.layer,
             "source": "ipc"
         }))),
-        Err(konnect_ipc::IpcFailure::Rejected(message)) => Ok(CallToolResult::error(format!(
-            "KiCAD rejected the placement over IPC: {message}. \
-             The board file was not modified — KiCAD is reachable and may hold this \
-             board open, so editing the file directly could be silently overwritten."
-        ))),
-        Err(konnect_ipc::IpcFailure::Unreachable(_)) => {
+        BoardWrite::Refused(result) => Ok(result),
+        BoardWrite::File => {
             // No live KiCad on the other end of this transport: fall back to
             // editing the board file directly.
             if board_contains_reference(&board, &reference)? {
@@ -2191,9 +2165,7 @@ async fn handle_place_component(
                 "footprint": footprint,
                 "x": x, "y": y, "rotation": rotation, "layer": layer,
                 "source": "file",
-                "warning": "KiCAD IPC was not reachable, so the board file was edited \
-                            directly. KiCAD will show this footprint when it next loads \
-                            the board."
+                "warning": FILE_FALLBACK_WARNING
             })))
         }
     }
@@ -2218,7 +2190,7 @@ async fn handle_move_component(
     };
 
     let ref_ipc = reference.clone();
-    match attempt_ipc_write(ctx.config.ipc_address.clone(), &board, "move", move |c| {
+    match attempt_ipc_write(ctx, &board, "move", move |c| {
         c.move_footprint(&ref_ipc, x, y)
     })
     .await?
@@ -2238,7 +2210,7 @@ async fn handle_move_component(
                     "x": x,
                     "y": y,
                     "source": "file",
-                    "warning": "KiCAD IPC was not reachable, so the closed board file was edited directly."
+                    "warning": FILE_FALLBACK_WARNING
                 }))),
                 Err(error) => Ok(error.into_result()),
             }
@@ -2320,12 +2292,9 @@ async fn handle_rotate_component(
     };
 
     let ref_ipc = reference.clone();
-    match attempt_ipc_write(
-        ctx.config.ipc_address.clone(),
-        &board,
-        "rotation",
-        move |c| c.rotate_footprint(&ref_ipc, rotation),
-    )
+    match attempt_ipc_write(ctx, &board, "rotation", move |c| {
+        c.rotate_footprint(&ref_ipc, rotation)
+    })
     .await?
     {
         BoardWrite::Ipc(()) => Ok(CallToolResult::json(&json!({
@@ -2344,7 +2313,7 @@ async fn handle_rotate_component(
                     "rotated": reference,
                     "rotation": rotation,
                     "source": "file",
-                    "warning": "KiCAD IPC was not reachable, so the closed board file was edited directly."
+                    "warning": FILE_FALLBACK_WARNING
                 }))),
                 Err(error) => Ok(error.into_result()),
             }
@@ -2423,12 +2392,9 @@ async fn handle_set_component_placements(
     };
 
     let placements_ipc = placements.clone();
-    match attempt_ipc_write(
-        ctx.config.ipc_address.clone(),
-        &board,
-        "component placement batch",
-        move |client| client.set_footprint_placements(&placements_ipc),
-    )
+    match attempt_ipc_write(ctx, &board, "component placement batch", move |client| {
+        client.set_footprint_placements(&placements_ipc)
+    })
     .await?
     {
         BoardWrite::Ipc(applied) => Ok(CallToolResult::json(&json!({
@@ -2443,7 +2409,7 @@ async fn handle_set_component_placements(
                 "count": applied.len(),
                 "placements": applied,
                 "source": "file",
-                "warning": "KiCad IPC was not reachable, so the closed board file was edited once with a revision check."
+                "warning": FILE_FALLBACK_WARNING
             }))),
             Err(error) => Ok(error.into_result()),
         },
@@ -2495,12 +2461,9 @@ async fn handle_flip_component(
     // does not exist here — so the refusal is equally untested for
     // `add_zone` and the copper-pour path, this helper's two other callers.
     // Tracked as #241 rather than pretended away.
-    if let Some(refusal) = crate::tools::pcb_board::refuse_if_board_open_in_kicad(
-        ctx.config.ipc_address.clone(),
-        &board,
-        "footprint flip",
-    )
-    .await?
+    if let Some(refusal) =
+        crate::tools::pcb_board::refuse_if_board_open_in_kicad(ctx, &board, "footprint flip")
+            .await?
     {
         return Ok(refusal);
     }
@@ -2828,7 +2791,7 @@ async fn handle_repair_corrupted_footprints(
     let board_for_ipc = board.clone();
     let expected_for_ipc = expected_revision.clone();
     let outcome = attempt_ipc_write(
-        ctx.config.ipc_address.clone(),
+        ctx,
         &board,
         "legacy footprint repair",
         move |client| {
@@ -3146,7 +3109,7 @@ async fn handle_get_component_pads(
     // live one. The file stays the fallback for an offline session.
     let ipc_board = board_path.clone();
     let ipc_reference = reference.clone();
-    let live = with_ipc_classified(ctx.config.ipc_address.clone(), move |c| {
+    let live = with_board_ipc_classified(ctx, &board_path, move |c| {
         let document = c.find_open_board(&ipc_board)?;
         c.get_footprint_pads_in(document, &ipc_reference)
     })
@@ -3435,10 +3398,8 @@ async fn handle_place_array(
         }
     }
 
-    let requested_board = board.clone();
     let footprint_id = footprint.clone();
-    let placed = match with_ipc(ctx.config.ipc_address.clone(), move |c| {
-        c.ensure_board_is_active(&requested_board)?;
+    let placed = match with_board_ipc_classified(ctx, &board, move |c| {
         let existing = c
             .list_footprints()?
             .into_iter()
@@ -3498,7 +3459,7 @@ async fn handle_place_array(
     .await?
     {
         Ok(placed) => placed,
-        Err(error) => return Ok(CallToolResult::error(format!("IPC array error: {error:#}"))),
+        Err(error) => return Ok(CallToolResult::error(format!("IPC array error: {error}"))),
     };
     Ok(CallToolResult::json(
         &json!({ "placed_count": placed.len(), "components": placed }),
@@ -3535,9 +3496,7 @@ async fn handle_align_components(
         Err(e) => return Ok(e),
     };
 
-    let requested_board = board.clone();
-    let aligned = match with_ipc(ctx.config.ipc_address.clone(), move |c| {
-        c.ensure_board_is_active(&requested_board)?;
+    let aligned = match with_board_ipc_classified(ctx, &board, move |c| {
         c.run_commit("Align footprints", |c| {
             references
                 .iter()
@@ -3559,7 +3518,7 @@ async fn handle_align_components(
     .await?
     {
         Ok(aligned) => aligned,
-        Err(error) => return Ok(CallToolResult::error(format!("IPC align error: {error:#}"))),
+        Err(error) => return Ok(CallToolResult::error(format!("IPC align error: {error}"))),
     };
     Ok(CallToolResult::json(
         &json!({ "aligned_count": aligned.len(), "components": aligned }),
@@ -4192,8 +4151,8 @@ mod tests {
     #[tokio::test]
     async fn unreachable_ipc_falls_back_to_writing_the_board_file() {
         // ipc_address is empty in test_ctx, which classifies as
-        // transport-unreachable — the one condition under which editing the
-        // board file directly cannot race a live editor.
+        // transport-unreachable, and this fresh context has never observed the
+        // board live, so the guarded file path is available.
         let tmp = tempfile::tempdir().unwrap();
         let board = fallback_fixture(tmp.path());
 
@@ -4212,7 +4171,8 @@ mod tests {
         assert!(
             out["warning"]
                 .as_str()
-                .is_some_and(|w| w.contains("edited") && w.contains("loads")),
+                .is_some_and(|w| w.contains("current Konnect server session")
+                    && w.contains("crashed or was force-quit")),
             "the fallback must warn that the file was edited directly: {out}"
         );
 
@@ -4244,6 +4204,31 @@ mod tests {
             0,
             "board is no longer balanced:\n{written}"
         );
+    }
+
+    #[tokio::test]
+    async fn a_previously_live_board_blocks_place_components_file_fallback() {
+        let tmp = tempfile::tempdir().unwrap();
+        let board = fallback_fixture(tmp.path());
+        let before = std::fs::read(&board).unwrap();
+        let ctx = test_ctx();
+        ctx.board_session.observe_live(&board);
+        let args = json!({
+            "board": board.to_string_lossy(),
+            "footprint": "Resistor_SMD:R_0805_2012Metric",
+            "reference": "R7",
+            "x": 50.0,
+            "y": 60.0,
+        });
+
+        let result = handle_place_component(&args, &ctx).await.unwrap();
+
+        assert!(result.is_error);
+        assert_eq!(
+            crate::mcp::error::extract_error_kind(&result).as_deref(),
+            Some("unsafe_file_fallback")
+        );
+        assert_eq!(std::fs::read(&board).unwrap(), before);
     }
 
     #[tokio::test]

--- a/crates/konnect-core/src/tools/pcb_footprint_update.rs
+++ b/crates/konnect-core/src/tools/pcb_footprint_update.rs
@@ -245,7 +245,7 @@ pub(crate) async fn handle_update_footprints_from_library(
         "footprint library update apply"
     };
     let result = attempt_ipc_write(
-        ctx.config.ipc_address.clone(),
+        ctx,
         &board_path,
         operation,
         move |client| {

--- a/crates/konnect-core/src/tools/pcb_routing.rs
+++ b/crates/konnect-core/src/tools/pcb_routing.rs
@@ -5,40 +5,21 @@
 
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
-use crate::tools::{get_path, opt_f64, require_f64, require_str, ToolContext, ToolDef};
-use konnect_ipc::client::KiCadIpcClient;
+use crate::tools::{
+    get_path, opt_f64, require_f64, require_str, with_board_ipc_classified, ToolContext, ToolDef,
+};
 use konnect_sexp::writer::{apply_edits, write_atomic, SexpEdit};
 use serde_json::json;
 
-// ─── IPC helper ───────────────────────────────────────────────────────────────
-
-async fn with_ipc<T, F>(addr: String, f: F) -> anyhow::Result<Result<T, String>>
-where
-    T: Send + 'static,
-    F: FnOnce(&KiCadIpcClient) -> anyhow::Result<T> + Send + 'static,
-{
-    match tokio::task::spawn_blocking(move || f(&KiCadIpcClient::new(&addr))).await {
-        Ok(Ok(r)) => Ok(Ok(r)),
-        Ok(Err(e)) => Ok(Err(e.to_string())),
-        Err(e) => Err(anyhow::anyhow!("Thread error: {}", e)),
-    }
-}
-
 macro_rules! ipc {
     ($ctx:expr, $args:expr, |$c:ident| $body:expr) => {{
-        let addr = $ctx.config.ipc_address.clone();
         let requested_board = get_path($args, "board")?;
-        match with_ipc(addr, move |$c| {
-            $c.ensure_board_is_active(&requested_board)?;
-            $body
-        })
-        .await?
-        {
+        match with_board_ipc_classified($ctx, &requested_board, move |$c| $body).await? {
             Ok(v) => v,
-            Err(msg) => {
+            Err(error) => {
                 return Ok(CallToolResult::error(format!(
                     "KiCAD must be running with the board loaded (IPC error: {})",
-                    msg
+                    error.message()
                 )))
             }
         }
@@ -2146,7 +2127,7 @@ mod zone_net_format_tests {
         assert_eq!(body["source"], json!("file"));
         assert!(body["warning"]
             .as_str()
-            .is_some_and(|w| w.contains("File → Revert")));
+            .is_some_and(|w| w.contains("current Konnect server session")));
     }
 
     /// The new arguments reach the alias too — it is the same handler, and a

--- a/crates/konnect-core/src/tools/pcb_sync.rs
+++ b/crates/konnect-core/src/tools/pcb_sync.rs
@@ -245,7 +245,7 @@ pub(crate) async fn handle_update_pcb_from_schematic(
     let ipc_board = board.clone();
     let library_board = board.clone();
     let result = attempt_ipc_write(
-        ctx.config.ipc_address.clone(),
+        ctx,
         &board,
         what,
         move |client| {

--- a/crates/konnect-core/src/tools/placement.rs
+++ b/crates/konnect-core/src/tools/placement.rs
@@ -544,12 +544,9 @@ async fn handle_place_decoupling(
     }
 
     // Applying: never edit a board a live KiCad holds open.
-    if let Some(refusal) = super::pcb_board::refuse_if_board_open_in_kicad(
-        ctx.config.ipc_address.clone(),
-        &board,
-        "place_decoupling_caps",
-    )
-    .await?
+    if let Some(refusal) =
+        super::pcb_board::refuse_if_board_open_in_kicad(ctx, &board, "place_decoupling_caps")
+            .await?
     {
         return Ok(refusal);
     }
@@ -726,10 +723,7 @@ async fn handle_bga_fanout(
             )
         })
         .collect();
-    let addr = ctx.config.ipc_address.clone();
-    let requested_board = board.clone();
-    let created = match super::with_ipc_classified(addr, move |c| {
-        c.ensure_board_is_active(&requested_board)?;
+    let created = match super::with_board_ipc_classified(ctx, &board, move |c| {
         c.apply_fanout(
             &net_stubs,
             &via_list,
@@ -1006,12 +1000,9 @@ async fn handle_auto_place(
         })));
     }
 
-    if let Some(refusal) = super::pcb_board::refuse_if_board_open_in_kicad(
-        ctx.config.ipc_address.clone(),
-        &board,
-        "auto_place_from_schematic",
-    )
-    .await?
+    if let Some(refusal) =
+        super::pcb_board::refuse_if_board_open_in_kicad(ctx, &board, "auto_place_from_schematic")
+            .await?
     {
         return Ok(refusal);
     }
@@ -1326,7 +1317,7 @@ async fn handle_force_directed(
     }
 
     if let Some(refusal) = super::pcb_board::refuse_if_board_open_in_kicad(
-        ctx.config.ipc_address.clone(),
+        ctx,
         &board,
         "refine_placement_force_directed",
     )

--- a/crates/konnect-core/src/tools/project.rs
+++ b/crates/konnect-core/src/tools/project.rs
@@ -313,12 +313,15 @@ async fn handle_open_project(
     };
     let (requested_path, requested_board, requested_open, requested_check_error) = match requested {
         Some((project_or_board, board)) if connected => match ipc.find_open_board(&board) {
-            Ok(_) => (
-                Some(project_or_board),
-                Some(board.display().to_string()),
-                Some(true),
-                None,
-            ),
+            Ok(_) => {
+                ctx.board_session.observe_live(&board);
+                (
+                    Some(project_or_board),
+                    Some(board.display().to_string()),
+                    Some(true),
+                    None,
+                )
+            }
             Err(error) => (
                 Some(project_or_board),
                 Some(board.display().to_string()),

--- a/crates/konnect-core/src/tools/verification.rs
+++ b/crates/konnect-core/src/tools/verification.rs
@@ -643,7 +643,7 @@ async fn handle_set_predefined_sizes(
     }
 
     if let Some(refusal) = crate::tools::pcb_board::refuse_if_board_open_in_kicad(
-        ctx.config.ipc_address.clone(),
+        ctx,
         &board,
         "Pre-defined Sizes list",
     )

--- a/crates/konnect/assets/skills/kicad-pcb/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-pcb/SKILL.md
@@ -19,14 +19,23 @@ ALL modifications go through MCP tools — never edit .kicad_pcb files directly.
 Most PCB layout operations require KiCAD to be running with the board file open. The IPC
 connection communicates with the running KiCAD instance in real-time.
 
-`place_component`, `move_component`, `rotate_component`, and `flip_component` are
-narrow exceptions for closed boards. Placement, move, and rotation fall back when
-IPC is unreachable. Flip intentionally requires IPC to be unreachable because KiCAD's
-typed IPC API has no native footprint-flip command. The file paths use revision-aware
-atomic writes: placement preserves pads, graphics, attributes, and models; moves
-preserve the existing angle; rotations update the footprint and its child angles;
-flips mirror supported geometry and swap front/back layers. If KiCAD is reachable and
-rejects a request, the fallback stays disabled to avoid racing a live editor.
+Some board-construction and component tools have guarded closed-board paths. IPC-first
+tools fall back to the file only when the transport is unreachable and the target board
+has not been observed live during this server session. File-only operations such as
+`flip_component` proceed only when KiCad does not hold the target board open. These
+paths use revision-aware atomic writes: placement preserves pads, graphics, attributes,
+and models; moves preserve the existing angle; rotations update the footprint and its
+child angles; flips mirror supported geometry and swap front/back layers. A reachable
+KiCad rejection stays closed instead of racing the editor.
+
+`unsafe_file_fallback` is a stop condition. It means Konnect reached this board live
+earlier in the current server session but IPC is now unreachable, so the saved file may
+be older than lost editor state. Pause mutation work, tell the user that Konnect left
+the file unchanged, and ask them to reopen/recover, reconcile, and save the board in
+KiCad. Continue through live IPC afterward. Preserve the guard: do not retry-loop,
+restart Konnect automatically, or edit `.kicad_pcb` directly. If the user confirms a
+clean close and an authoritative saved file, they may restart Konnect to deliberately
+begin a new closed-board session.
 
 If connection fails:
 - Tell the user to open KiCAD and load the project
@@ -260,8 +269,9 @@ add_zone(board, net_name, layer, points, clearance?, min_width?,
 - With KiCad running on this board the zone is created over IPC and refilled
   for you, so it appears at once and is in KiCad's undo stack. Without a live
   KiCad it goes into the file instead, and the result says so (`source: file`)
-  and carries a `warning` — a file-only edit is invisible to an open pcbnew
-  and is lost on its next save
+  and carries a `warning` describing the process-local evidence and cold-start
+  limitation. A board observed live earlier in this server session fails with
+  `unsafe_file_fallback` instead of writing the file.
 
 ### refill_zones
 
@@ -335,9 +345,9 @@ Common DRC errors and fixes:
 4. **Refill zones after changes** — stale zone fills cause phantom DRC errors
 5. **Check DRC before finishing** — run `run_drc()` and resolve all errors
 6. **Use netclasses for consistency** — define track widths per net type, not per trace
-7. **KiCAD normally must be running** — `place_component`, `move_component`, and
-   `rotate_component` have safe IPC-unreachable file fallbacks; `flip_component`
-   requires a closed board; other PCB edits still require the live IPC connection
+7. **KiCAD normally must be running** — use guarded closed-board paths only when a
+   tool explicitly offers them. Treat `unsafe_file_fallback` as a human recovery
+   boundary; other PCB edits still require the live IPC connection.
 8. **Save frequently** — call `save_project` after major operations
 9. **Load toolsets first** — check `get_active_toolsets()` and load what you need
 10. **Copper pour last** — add zones only after routing is substantially complete

--- a/crates/konnect/tests/asset_references.rs
+++ b/crates/konnect/tests/asset_references.rs
@@ -350,6 +350,8 @@ fn backticked_tool_names_in_prose_exist_in_the_registry() {
         "match_all",
         "replace_existing",
         "roundrect_rratio",
+        // Structured MCP error discriminant, not a callable tool.
+        "unsafe_file_fallback",
     ];
 
     let mut phantom = Vec::new();

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -74,18 +74,31 @@ names the layer and the item.
 `Connector:BJB_Pico_46.110.1001_Receptacle_Horizontal` can kill KiCAD outright.
 Update to v0.6.1 or later.
 
-## A closed-board edit landed after KiCAD crashed
+## `unsafe_file_fallback` after KiCad disappears
 
-`place_component`, `move_component` and `rotate_component` edit the board file
-directly when the IPC transport is unreachable, which is safe when KiCAD was
-never running.
+Konnect remembers each board it positively observes open through IPC during the
+current server process. If IPC later becomes unreachable, a board-file mutation
+for that same board fails with `error.kind: "unsafe_file_fallback"` instead of
+editing the saved file. KiCad may have crashed or been force-quit with unsaved
+state, so the saved `.kicad_pcb` is not known to be authoritative. The error
+confirms that Konnect left it unchanged
+([#240](https://github.com/mixelpixx/Konnect/issues/240)).
 
-They cannot currently tell that from "KiCAD died a second ago holding this
-board" — the transport looks identical
-([#240](https://github.com/mixelpixx/Konnect/issues/240)). If KiCAD crashes or
-is force-quit mid-session, the next such call may edit the file behind it and
-report success. Reopen the board and check before continuing, and prefer
-reopening KiCAD first.
+Recover deliberately:
+
+1. Reopen or recover the board in KiCad.
+2. Reconcile any recovered/unsaved work and save the authoritative board.
+3. Continue through live IPC.
+
+If KiCad was intentionally closed cleanly and closed-board mode is desired,
+first confirm that the saved file is authoritative, then restart Konnect to
+begin a new server session. Repeating the tool call does not clear the safety
+memory, and an agent must not restart Konnect or edit `.kicad_pcb` directly to
+bypass the refusal.
+
+This memory is intentionally process-local. It cannot detect a KiCad crash that
+happened before the current Konnect process started. File-fallback success
+therefore carries a warning describing that cold-start limitation.
 
 ## An older schematic-to-PCB sync left extra unnamed pads
 


### PR DESCRIPTION
## Summary

- add process-lifetime, per-board memory once KiCad positively identifies a requested board through IPC
- fail closed with structured `unsafe_file_fallback` when that board was live earlier but IPC is now unreachable
- route IPC-first writes, file-only guards, common PCB reads, routing, sync, refresh, placement, and project inspection through the shared board-aware observation seam
- replace overconfident file-fallback messages with one warning that states the current-session evidence and cold-start limitation
- document the human recovery boundary in troubleshooting and the shipped `kicad-pcb` skill

## Safety behavior

A board starts unobserved in each `ToolContext`. After `GetOpenDocuments` positively identifies the exact requested board, the observation is sticky for that server process and is recorded before the caller's IPC operation runs. If transport later becomes unreachable:

- IPC-first mutations return `error.kind = unsafe_file_fallback`
- file-only mutation guards return the same refusal
- the saved `.kicad_pcb` remains unchanged
- a different board remains eligible for its normal closed-board path
- a fresh server context starts without inherited observations

There is deliberately no force flag or automatic clear. The recovery path is to reopen/recover, reconcile, and save in KiCad; a deliberate closed-board session can begin only after the user confirms the saved file is authoritative and restarts Konnect.

## Verification

- deterministic live-board -> transport loss -> refused mutation with byte-identical board
- observation before a rejected operation still protects the next call
- rejection before board identification does not create state
- board isolation, canonical path identity, idempotence, fresh-context reset, and never-observed offline fallback
- `place_component` regression coverage for its former bespoke fallback
- `cargo test --workspace --locked --lib --tests`
- `cargo test --workspace --locked --doc`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Closes #240