### PR TITLE
fix(guidance): connect skills, agents, and references

### DIFF
--- a/crates/konnect/assets/agents/kicad-design-review-agent.md
+++ b/crates/konnect/assets/agents/kicad-design-review-agent.md
@@ -2,6 +2,10 @@
 name: kicad-design-review-agent
 description: "Performs a thorough hardware design review of a KiCAD project. Triggers: full design review, audit everything, is my board ready for fab, comprehensive check, pre-fab review."
 model: sonnet
+skills:
+  - konnect
+  - kicad-review
+  - kicad-manufacture
 tools:
   - mcp__konnect__*
 maxTurns: 25

--- a/crates/konnect/assets/agents/kicad-schematic-build-agent.md
+++ b/crates/konnect/assets/agents/kicad-schematic-build-agent.md
@@ -2,6 +2,9 @@
 name: kicad-schematic-build-agent
 description: "Builds complete circuits from requirements or reference designs. Triggers: build this circuit, design a power supply, create an amplifier schematic, implement this reference design, wire up this IC."
 model: sonnet
+skills:
+  - konnect
+  - kicad-schematic
 tools:
   - mcp__konnect__*
 maxTurns: 40

--- a/crates/konnect/assets/skills/kicad-manufacture/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-manufacture/SKILL.md
@@ -33,6 +33,14 @@ load_toolset('pcb_export')       # export_3d for visual verification
 
 Always call `get_active_toolsets()` first to see what is already loaded.
 
+### References by manufacturing branch
+
+- Read [`references/gerber-layers.md`](references/gerber-layers.md) when
+  selecting manual plot layers or checking the generated artifact inventory.
+- Read [`references/jlcpcb-rules.md`](references/jlcpcb-rules.md) only when
+  JLCPCB is the selected fabricator or assembler. Verify time-sensitive limits,
+  field names, pricing, and part categories against the current order contract.
+
 ---
 
 ## Pre-Flight Checklist

--- a/crates/konnect/assets/skills/kicad-pcb/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-pcb/SKILL.md
@@ -66,6 +66,18 @@ load_toolset('verification')     # run_drc, set_design_rules, set_predefined_siz
 
 Always call `get_active_toolsets()` first to see what is already loaded.
 
+### References by decision
+
+- Read [`references/layer-reference.md`](references/layer-reference.md) when
+  selecting a copper, fabrication, user, or mechanical layer or deciding which
+  side owns an item.
+- Read [`references/trace-width-table.md`](references/trace-width-table.md) when
+  estimating an initial trace width. Treat it as a starting point; the selected
+  stackup, current and voltage-drop budget, impedance calculation, netclass,
+  and fabricator contract decide the actual value.
+- Read [`references/design-rules.md`](references/design-rules.md) when creating
+  netclasses, configuring project constraints, or adjudicating DRC results.
+
 ---
 
 ## Layout Order

--- a/crates/konnect/assets/skills/kicad-review/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-review/SKILL.md
@@ -36,6 +36,15 @@ load_toolset('pcb_routing')      # query_traces, get_nets_list
 
 Always call `get_active_toolsets()` first to see what is already loaded.
 
+### References by review branch
+
+- Read [`references/design-checklist.md`](references/design-checklist.md) for a
+  comprehensive or pre-fabrication review. Mark an item only from evidence
+  collected in this run.
+- Read [`references/error-taxonomy.md`](references/error-taxonomy.md) when
+  classifying a finding or assigning the final verdict. Direct ERC, DRC, and
+  connectivity evidence outrank heuristic classifications.
+
 ---
 
 ## Quick Checks (Escalating Severity)

--- a/crates/konnect/assets/skills/kicad-schematic/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-schematic/SKILL.md
@@ -37,6 +37,10 @@ Always call `get_active_toolsets()` first to see what is already loaded.
 
 ## Component Placement
 
+Read [`references/common-lib-ids.md`](references/common-lib-ids.md) when choosing
+a common generic KiCad symbol. It is a quick-start index, not an allowlist;
+search the active libraries when the required part is absent or package-specific.
+
 ### Workflow
 
 1. Search the library first: use `search_symbols` to find the correct lib_id
@@ -86,6 +90,11 @@ Power symbols: GND uses 0 (arrow points down), VCC/VDD/+3V3/+5V use 0 (arrow poi
 ---
 
 ## Wiring
+
+Read [`references/wiring-patterns.md`](references/wiring-patterns.md) when
+choosing between direct wires and labels or when building one of its common
+subcircuits. Verify every named pin against the placed symbol before applying a
+pattern.
 
 ### Connection Methods — Decision Table
 

--- a/crates/konnect/assets/skills/konnect/SKILL.md
+++ b/crates/konnect/assets/skills/konnect/SKILL.md
@@ -90,13 +90,30 @@ unload_toolset("name")  → Remove a toolset when done
 |----------|----------|
 | Project | project |
 | Schematic | sch_components, sch_wiring, sch_bus, sch_analysis, sch_batch, sch_export, sch_hierarchy |
-| PCB | pcb_board, pcb_components, pcb_routing, pcb_export |
+| PCB | pcb_board, pcb_components, pcb_routing, pcb_export, placement |
 | Library | library |
 | Integration | integration (JLCPCB parts, Freerouting installation checks, datasheets) |
 | Verification & Review | verification, design_review |
 | Config | config |
 | Templates | templates |
 | Manufacturing | manufacturing |
+
+## Agent Routing and Mutation Ownership
+
+Use one design owner at a time. Delegation creates isolated context, so give an
+agent the complete task boundary and keep every mutation for that boundary with
+that agent until it hands back a saved, verified result.
+
+- Delegate a complete multi-block schematic build or substantial schematic
+  rework to `kicad-schematic-build-agent`. It owns schematic mutations through
+  placement, wiring, validation, rendering, and save. The caller does not make
+  concurrent schematic edits.
+- Delegate an independent full-design, pre-fabrication, or readiness audit to
+  `kicad-design-review-agent`. It gathers and reports evidence without mutating
+  the design. Return fixes to the current design owner, then run a fresh review.
+- Keep small, bounded edits and narrow checks in the current conversation using
+  the applicable skill. Agent delegation is for a complete build or an
+  independent review, not an extra layer around every tool call.
 
 ## Design Rules Quick Reference
 

--- a/crates/konnect/tests/asset_references.rs
+++ b/crates/konnect/tests/asset_references.rs
@@ -34,6 +34,139 @@ fn asset_files() -> Vec<PathBuf> {
     files
 }
 
+fn assets_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("assets")
+}
+
+/// Every installed reference is named by its parent skill. Copying a file into
+/// `references/` is not progressive disclosure unless the skill tells the
+/// agent that it exists and when to read it (#357).
+#[test]
+fn every_reference_is_reachable_from_its_parent_skill() {
+    let skills = assets_root().join("skills");
+    let mut unreachable = Vec::new();
+
+    for entry in std::fs::read_dir(&skills).unwrap().flatten() {
+        let skill_dir = entry.path();
+        let references = skill_dir.join("references");
+        if !references.is_dir() {
+            continue;
+        }
+        let skill = std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
+        for reference in std::fs::read_dir(references).unwrap().flatten() {
+            let path = reference.path();
+            let Some(filename) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if !skill.contains(filename) {
+                unreachable.push(format!(
+                    "{} does not name references/{filename}",
+                    display(&skill_dir.join("SKILL.md"))
+                ));
+            }
+        }
+    }
+
+    assert!(
+        unreachable.is_empty(),
+        "installed references have no parent-skill pointer:\n  {}",
+        unreachable.join("\n  ")
+    );
+}
+
+/// Every bundled Claude agent preloads at least one real bundled skill. Agent
+/// context is isolated, so relying on the caller to have read a skill leaves
+/// the agent running a stale condensed copy instead (#357).
+#[test]
+fn agents_preload_existing_skills() {
+    let skills_root = assets_root().join("skills");
+    let known: BTreeSet<String> = std::fs::read_dir(skills_root)
+        .unwrap()
+        .flatten()
+        .filter(|entry| entry.path().join("SKILL.md").is_file())
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .collect();
+    let mut bad = Vec::new();
+
+    for entry in std::fs::read_dir(assets_root().join("agents"))
+        .unwrap()
+        .flatten()
+    {
+        let path = entry.path();
+        let text = std::fs::read_to_string(&path).unwrap();
+        let normalized = text.replace("\r\n", "\n");
+        let frontmatter = normalized
+            .strip_prefix("---\n")
+            .and_then(|rest| rest.split_once("\n---\n"))
+            .map(|(head, _)| head)
+            .unwrap_or("");
+        let preloaded = yaml_list(frontmatter, "skills");
+        if preloaded.is_empty() {
+            bad.push(format!("{} preloads no skills", display(&path)));
+            continue;
+        }
+        for skill in preloaded {
+            if !known.contains(&skill) {
+                bad.push(format!(
+                    "{} preloads missing skill `{skill}`",
+                    display(&path)
+                ));
+            }
+        }
+    }
+
+    assert!(
+        bad.is_empty(),
+        "bundled agents do not preload valid bundled skills:\n  {}",
+        bad.join("\n  ")
+    );
+}
+
+/// The top-level router names every installed agent so a caller can delegate
+/// deliberately instead of leaving agents undiscoverable (#357).
+#[test]
+fn top_level_skill_routes_every_bundled_agent() {
+    let router = std::fs::read_to_string(assets_root().join("skills/konnect/SKILL.md")).unwrap();
+    let mut missing = Vec::new();
+    for entry in std::fs::read_dir(assets_root().join("agents"))
+        .unwrap()
+        .flatten()
+    {
+        let path = entry.path();
+        let Some(name) = path.file_stem().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if !router.contains(name) {
+            missing.push(name.to_string());
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "top-level konnect skill does not route bundled agent(s): {}",
+        missing.join(", ")
+    );
+}
+
+fn yaml_list(frontmatter: &str, key: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut in_list = false;
+    for line in frontmatter.lines() {
+        if line == format!("{key}:") {
+            in_list = true;
+            continue;
+        }
+        if in_list {
+            if let Some(value) = line.strip_prefix("  - ") {
+                values.push(value.trim().to_string());
+            } else if !line.trim().is_empty() {
+                break;
+            }
+        }
+    }
+    values
+}
+
 /// Every `load_toolset('name')` in the shipped prose names a real toolset.
 #[test]
 fn documented_toolsets_exist_in_the_registry() {


### PR DESCRIPTION
## Problem and scope

Konnect installs nine skill references and two Claude agents, but v0.11.0 gives the references no incoming pointers, gives the agents no skill preloads, and never routes tasks to those agents from the top-level skill. The files are present while the workflow that should disclose them is absent.

This is the first focused part of #357. It connects the released package; the separate evidence/workflow correction remains a follow-up PR.

## Design

- Link every reference from its parent skill at the decision that should trigger reading it.
- Preload `konnect` plus the applicable workflow skill in each Claude agent; the design reviewer also preloads manufacturing guidance because its trigger includes pre-fab readiness.
- Route complete schematic builds and independent reviews from the top-level `konnect` skill.
- Establish one mutation owner: the schematic builder owns its build boundary, while the reviewer gathers evidence without mutating.
- Add the missing `placement` toolset to the router's catalogue.
- Add mechanical tests for reference reachability, valid agent skill preloads, and top-level agent routing.

## Compatibility

This changes bundled Claude guidance only. It adds supported agent frontmatter and prose pointers; no MCP tool, response shape, file format, installer path, or Codex behavior changes.

## Validation

Red baseline was observed before the guidance edit:

- 9/9 references reported unreachable;
- 2/2 agents reported no skill preloads;
- 2/2 agents reported absent from the router.

After the change:

- `cargo test -p konnect --test asset_references`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo test --workspace --locked --lib --tests`
- `cargo test --workspace --locked --doc`

All pass. The real-KiCad GUI tests remain intentionally ignored outside their dedicated environment.

## Risk and rollback

Risk is limited to added Claude context and routing behavior. The generic tests prevent a future manifest reference, agent, or preload from becoming unreachable. Reverting this commit restores the previous package without data migration.

Part of #357.