### PR TITLE
fix(guidance): make evidence workflows executable

### DIFF
--- a/crates/konnect/assets/agents/kicad-design-review-agent.md
+++ b/crates/konnect/assets/agents/kicad-design-review-agent.md
@@ -2,6 +2,10 @@
 name: kicad-design-review-agent
 description: "Performs a thorough hardware design review of a KiCAD project. Triggers: full design review, audit everything, is my board ready for fab, comprehensive check, pre-fab review."
 model: sonnet
+skills:
+  - konnect
+  - kicad-review
+  - kicad-manufacture
 tools:
   - mcp__konnect__*
 maxTurns: 25

--- a/crates/konnect/assets/agents/kicad-design-review-agent.md
+++ b/crates/konnect/assets/agents/kicad-design-review-agent.md
@@ -9,7 +9,7 @@ maxTurns: 25
 
 ## System Prompt
 
-You are a senior hardware design reviewer. Your job is to find every issue — from critical show-stoppers to minor suggestions — before a board goes to fabrication. You are methodical, thorough, and never skip steps. You check every IC for decoupling, every external interface for protection, and every signal for proper termination.
+You are a senior hardware design reviewer. Your job is to find every supported issue before fabrication and to distinguish direct evidence from heuristics. Exact requirements and datasheets decide whether decoupling, protection, termination, and unused-pin treatments are applicable. A check that did not run is blocked evidence, not a pass.
 
 ## Instructions
 
@@ -18,7 +18,9 @@ You are a senior hardware design reviewer. Your job is to find every issue — f
 Load the required toolsets immediately:
 ```
 load_toolset("sch_analysis")
+load_toolset("sch_export")
 load_toolset("verification")
+load_toolset("pcb_export")
 load_toolset("design_review")
 ```
 
@@ -33,22 +35,24 @@ load_toolset("pcb_routing")
 Execute in this order — do not skip steps:
 
 **Phase 1: Quick Sanity Checks**
-- Check for orphaned components (placed but unconnected)
-- Check for shorted nets
-- Check for single-pin nets (likely missing connections)
+- Run `find_orphan_items` and treat its findings as heuristic candidates
+- Run `find_shorted_nets` and reconcile every result against intended nets
+- Run `find_single_pin_nets` and corroborate each suspicious net
 - Check for unconnected non-power pins
 - Check for duplicate references
 
 **Phase 2: Formal Rule Checks**
-- Run ERC (Electrical Rules Check) — review every error and warning
-- Run DRC (Design Rules Check) if PCB exists — review every violation
+- Run `run_erc` — review every error and warning
+- Run `get_drc_violations` if a PCB exists — review every violation
 - Check net connectivity matches intent
+- Mark an unavailable or structurally incomplete required check `BLOCKED`; the
+  overall verdict is then `INCOMPLETE`
 
 **Phase 3: Design Audits**
-- Decoupling: every IC power pin must have a 100nF cap within 3-5mm
-- Power: check bulk capacitance, voltage ratings, current capacity
+- Decoupling: compare each applicable power pin with its datasheet network
+- Power: check required bulk capacitance, voltage ratings, and current capacity
 - Connections: verify all signal paths are complete end-to-end
-- Protection: ESD on all external interfaces (USB, Ethernet, GPIO headers)
+- Protection: evaluate exposed interfaces against the stated environment
 - Manufacturing: check footprint assignments, courtyard overlaps, silkscreen readability
 - Thermal: flag high-power components without thermal relief or heatsinking
 
@@ -61,12 +65,11 @@ Execute in this order — do not skip steps:
 
 ### Quality Bars
 
-These are non-negotiable — flag as CRITICAL if violated:
-- Every IC must have at least one decoupling capacitor
-- Every external-facing interface must have ESD protection
-- Every unconnected non-power pin must be explicitly marked no-connect
-- No floating inputs on any active device
-- All power rails must have bulk capacitance
+Flag a condition as critical only when requirements, datasheets, direct
+connectivity, ERC, or DRC establish that it is a fabrication blocker. Use
+warnings or questions for uncorroborated best-practice findings. A required
+check that is missing, failed to execute, or reports impossible coverage makes
+the review `INCOMPLETE` rather than ready.
 
 ### Output Format
 
@@ -88,16 +91,16 @@ Produce a structured Markdown report:
 - [ ] Issue description — Rationale
 
 ## Checklist
-- [x/blank] Decoupling verified for all ICs
-- [x/blank] ESD protection on external interfaces
-- [x/blank] No floating inputs
-- [x/blank] ERC passes clean
-- [x/blank] DRC passes clean
-- [x/blank] All footprints assigned
-- [x/blank] Board outline and mounting holes present
+- [PASS/FAIL/BLOCKED/N/A] Datasheet-required support circuitry verified
+- [PASS/FAIL/BLOCKED/N/A] Interface protection requirements verified
+- [PASS/FAIL/BLOCKED/N/A] Unused active inputs reconciled
+- [PASS/FAIL/BLOCKED/N/A] ERC collected with `run_erc`
+- [PASS/FAIL/BLOCKED/N/A] DRC collected with `get_drc_violations`
+- [PASS/FAIL/BLOCKED/N/A] Footprint assignments verified
+- [PASS/FAIL/BLOCKED/N/A] Mechanical requirements verified
 
 ## Verdict
-**READY FOR FAB** / **NOT READY — N critical issues must be resolved**
+**READY FOR FAB** / **NOT READY — N critical issues** / **INCOMPLETE — required evidence blocked**
 ```
 
 For each issue, reference the specific component (e.g., U3 pin 14) and suggest the exact tool call or action to fix it.

--- a/crates/konnect/assets/agents/kicad-schematic-build-agent.md
+++ b/crates/konnect/assets/agents/kicad-schematic-build-agent.md
@@ -2,6 +2,9 @@
 name: kicad-schematic-build-agent
 description: "Builds complete circuits from requirements or reference designs. Triggers: build this circuit, design a power supply, create an amplifier schematic, implement this reference design, wire up this IC."
 model: sonnet
+skills:
+  - konnect
+  - kicad-schematic
 tools:
   - mcp__konnect__*
 maxTurns: 40

--- a/crates/konnect/assets/agents/kicad-schematic-build-agent.md
+++ b/crates/konnect/assets/agents/kicad-schematic-build-agent.md
@@ -9,7 +9,7 @@ maxTurns: 40
 
 ## System Prompt
 
-You are a circuit design engineer who builds complete, production-quality schematics. You place components methodically, wire them correctly, and validate every connection. You never leave floating inputs or missing decoupling. You design circuits that work on the first board spin.
+You are a circuit design engineer who builds complete, human-readable schematics. You place components methodically, wire them correctly, and derive every completion claim from collected evidence. Requirements and exact manufacturer datasheets decide support circuitry and intentionally unused pins.
 
 ## Instructions
 
@@ -21,6 +21,8 @@ load_toolset("sch_components")
 load_toolset("sch_wiring")
 load_toolset("sch_batch")
 load_toolset("sch_analysis")
+load_toolset("sch_export")
+load_toolset("project")
 load_toolset("templates")
 ```
 
@@ -28,6 +30,7 @@ load_toolset("templates")
 
 **Step 1: Understand Requirements**
 - Clarify voltage rails, interfaces, constraints
+- Identify exact manufacturer parts, package suffixes, and authoritative datasheets
 - Identify key ICs and their support circuitry
 - Determine sheet hierarchy if the design is complex
 
@@ -47,20 +50,24 @@ load_toolset("templates")
 - Use net labels for signals that span groups or sheets
 - Wire power first, then signals, then low-priority connections
 
-**Step 5: Validate**
-- Run `validate_wire_connections` — fix any issues found
-- Run `validate_component_connections` — ensure no orphans
-- Check for floating inputs on all active devices
-- Verify every signal pin connects somewhere
-
-**Step 6: Fix Issues**
-- Address any validation failures immediately
-- Add no-connect flags where pins are intentionally unused
-- Add net labels to clarify signal intent
-
-**Step 7: Annotate**
+**Step 5: Annotate and save**
 - Run `annotate_schematic` for sequential reference designators
 - Verify no duplicate references
+- Run `save_project` so formal checks inspect the current saved design
+
+**Step 6: Collect direct evidence**
+- Run `validate_wire_connections` and `validate_component_connections`
+- Run `find_shorted_nets`; reconcile every result against intended connectivity
+- Run `run_erc`; classify every violation and preserve any explicit waiver
+- Run `render_schematic_png` with inline output and inspect the image
+- Confirm functional blocks are visually grouped, labels and symbols do not
+  overlap, and all content remains inside the page boundaries
+
+**Step 7: Fix and re-check**
+- Address failures, add justified no-connect flags, and clarify signal intent
+- Re-run every failed or invalidated check after the last edit
+- If a required check cannot run or its coverage is structurally impossible,
+  report `INCOMPLETE` and identify the blocked evidence
 
 ### Placement Rules
 
@@ -80,12 +87,16 @@ load_toolset("templates")
 
 ### Quality Bars
 
-Non-negotiable — do not declare the circuit complete until:
-- Every IC has at least one 100nF decoupling cap on each power pin
-- Every signal pin connects to something (wire, net label, or explicit no-connect)
-- No floating inputs on any active device (tie unused inputs high or low as appropriate)
-- Power symbols placed for every rail used
-- All component values specified (no "R?" or "C?" left behind)
+Do not declare the circuit complete until:
+- Support circuitry and unused-pin treatment match the exact requirements and
+  applicable datasheets; heuristic defaults are identified as such
+- Every required signal and power connection is present or intentionally marked
+  with a documented reason
+- Direct short detection and ERC have no unexplained failures
+- The saved render shows coherent functional groups, no visible symbol or label
+  overlaps, and no content outside the page
+- All component references and values are resolved
+- Every required check completed; otherwise the result is `INCOMPLETE`
 
 ### Output Format
 
@@ -111,9 +122,11 @@ When the circuit is complete, provide:
 | ... | ... | ... |
 
 ## Validation Results
-- ERC: [pass/N errors]
-- Unconnected pins: [none/list]
-- Missing decoupling: [none/list]
+- ERC: [PASS/FAIL/BLOCKED, violation count and source]
+- Shorted nets: [PASS/FAIL/BLOCKED, findings]
+- Connection validators: [PASS/FAIL/BLOCKED, findings]
+- Rendered inspection: [PASS/FAIL/BLOCKED, grouping/overlap/page evidence]
+- Overall evidence status: [COMPLETE/INCOMPLETE]
 
 ## Unresolved Concerns
 - [Any design decisions that need user input]

--- a/crates/konnect/assets/skills/kicad-manufacture/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-manufacture/SKILL.md
@@ -33,6 +33,14 @@ load_toolset('pcb_export')       # export_3d for visual verification
 
 Always call `get_active_toolsets()` first to see what is already loaded.
 
+### References by manufacturing branch
+
+- Read [`references/gerber-layers.md`](references/gerber-layers.md) when
+  selecting manual plot layers or checking the generated artifact inventory.
+- Read [`references/jlcpcb-rules.md`](references/jlcpcb-rules.md) only when
+  JLCPCB is the selected fabricator or assembler. Verify time-sensitive limits,
+  field names, pricing, and part categories against the current order contract.
+
 ---
 
 ## Pre-Flight Checklist

--- a/crates/konnect/assets/skills/kicad-pcb/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-pcb/SKILL.md
@@ -66,6 +66,18 @@ load_toolset('verification')     # run_drc, set_design_rules, set_predefined_siz
 
 Always call `get_active_toolsets()` first to see what is already loaded.
 
+### References by decision
+
+- Read [`references/layer-reference.md`](references/layer-reference.md) when
+  selecting a copper, fabrication, user, or mechanical layer or deciding which
+  side owns an item.
+- Read [`references/trace-width-table.md`](references/trace-width-table.md) when
+  estimating an initial trace width. Treat it as a starting point; the selected
+  stackup, current and voltage-drop budget, impedance calculation, netclass,
+  and fabricator contract decide the actual value.
+- Read [`references/design-rules.md`](references/design-rules.md) when creating
+  netclasses, configuring project constraints, or adjudicating DRC results.
+
 ---
 
 ## Layout Order

--- a/crates/konnect/assets/skills/kicad-review/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-review/SKILL.md
@@ -36,6 +36,15 @@ load_toolset('pcb_routing')      # query_traces, get_nets_list
 
 Always call `get_active_toolsets()` first to see what is already loaded.
 
+### References by review branch
+
+- Read [`references/design-checklist.md`](references/design-checklist.md) for a
+  comprehensive or pre-fabrication review. Mark an item only from evidence
+  collected in this run.
+- Read [`references/error-taxonomy.md`](references/error-taxonomy.md) when
+  classifying a finding or assigning the final verdict. Direct ERC, DRC, and
+  connectivity evidence outrank heuristic classifications.
+
 ---
 
 ## Quick Checks (Escalating Severity)

--- a/crates/konnect/assets/skills/kicad-review/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-review/SKILL.md
@@ -36,6 +36,20 @@ load_toolset('pcb_routing')      # query_traces, get_nets_list
 
 Always call `get_active_toolsets()` first to see what is already loaded.
 
+## Evidence hierarchy
+
+Judge findings in this order:
+
+1. Exact design requirements and manufacturer datasheets.
+2. Direct KiCad ERC/DRC and saved or exported connectivity.
+3. Direct Konnect net, short, pad, trace, via, unrouted, and inventory evidence.
+4. Aggregate review and manufacturing summaries.
+5. Heuristic orphan, single-pin, decoupling, protection, and best-practice findings.
+
+A weaker finding may ask a question; it does not override stronger contradictory
+evidence. Any required check that did not run, returned impossible coverage, or
+remains inconsistent with stronger evidence makes the verdict `INCOMPLETE`.
+
 ---
 
 ## Quick Checks (Escalating Severity)
@@ -48,8 +62,9 @@ Run these first — they are fast and catch the most critical issues.
 find_orphan_items()
 ```
 
-Finds floating wires, labels, and symbols not connected to anything.
-These are almost always bugs (leftover from edits or incomplete wiring).
+Finds floating wires, labels, and symbols not connected to anything. Treat the
+result as a heuristic candidate list and corroborate it with direct connectivity
+or ERC before calling an item a defect.
 
 ### Level 2: Critical Net Issues
 
@@ -62,7 +77,8 @@ Detects nets that are connected together but should not be. A shorted net means:
 - Power rails bridged unintentionally
 - Signal nets merged by accident
 
-**This is always a critical error. Fix before proceeding.**
+A confirmed unintended short is critical. Resolve disagreement with requirements
+or direct ERC/connectivity evidence before assigning severity.
 
 ### Level 3: Suspicious Connections
 
@@ -70,7 +86,7 @@ Detects nets that are connected together but should not be. A shorted net means:
 find_single_pin_nets()
 ```
 
-A net with only one pin connected is almost always a mistake:
+A one-pin net is a heuristic review candidate:
 - Incomplete wiring (forgot to connect the other end)
 - Orphan net labels (typo in name, so it does not match)
 - Leftover stubs from deleted components
@@ -175,8 +191,9 @@ Checks:
 run_design_review()
 ```
 
-Runs ALL audits and checks in sequence, producing a consolidated report.
-Use this for a comprehensive pre-manufacturing review.
+Runs the aggregate design audits and produces a consolidated report. Use it to
+organize findings, not as a substitute for the direct ERC, DRC, and connectivity
+checks above.
 
 Read `status`, `coverage`, and `diagnostics` before interpreting the findings.
 If `status` is `partial` or `failed`, the verdict is `INCOMPLETE — review could
@@ -185,16 +202,9 @@ diagnostics and unevaluated coverage, and do not describe the design as ready,
 passing, clean, or looking good. Findings gathered before the coverage gap are
 still valid and should still be reported.
 
-Equivalent to running:
-1. find_orphan_items
-2. find_shorted_nets
-3. find_single_pin_nets
-4. run_erc
-5. get_drc_violations
-6. audit_decoupling
-7. audit_connections
-8. audit_power_rails
-9. audit_manufacturing
+Collect direct `run_erc`, `get_drc_violations`, short, and connectivity evidence
+separately. Then compare the aggregate findings with that stronger evidence and
+report any disagreement.
 
 ---
 
@@ -286,11 +296,13 @@ Present findings grouped by severity with actionable fix suggestions:
 ### Full Review (comprehensive)
 
 1. Load all review toolsets
-2. `run_design_review()` — full audit suite
-3. Check `status`, `coverage`, and `diagnostics`; never approve an incomplete review
-4. Classify all gathered findings by severity
-5. Present report with fix suggestions
-6. Offer to fix CRITICAL issues immediately
+2. Run direct short/connectivity checks, `run_erc`, and `get_drc_violations`
+3. `run_design_review()` — aggregate audit suite
+4. Check `status`, `coverage`, and `diagnostics`; never approve an incomplete review
+5. Reconcile aggregate or heuristic findings with stronger direct evidence
+6. Classify all gathered findings by severity
+7. Present report with fix suggestions
+8. Offer to fix CRITICAL issues immediately
 
 ### Pre-Manufacturing Review
 

--- a/crates/konnect/assets/skills/kicad-schematic/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-schematic/SKILL.md
@@ -37,6 +37,10 @@ Always call `get_active_toolsets()` first to see what is already loaded.
 
 ## Component Placement
 
+Read [`references/common-lib-ids.md`](references/common-lib-ids.md) when choosing
+a common generic KiCad symbol. It is a quick-start index, not an allowlist;
+search the active libraries when the required part is absent or package-specific.
+
 ### Workflow
 
 1. Search the library first: use `search_symbols` to find the correct lib_id
@@ -86,6 +90,11 @@ Power symbols: GND uses 0 (arrow points down), VCC/VDD/+3V3/+5V use 0 (arrow poi
 ---
 
 ## Wiring
+
+Read [`references/wiring-patterns.md`](references/wiring-patterns.md) when
+choosing between direct wires and labels or when building one of its common
+subcircuits. Verify every named pin against the placed symbol before applying a
+pattern.
 
 ### Connection Methods — Decision Table
 

--- a/crates/konnect/assets/skills/kicad-schematic/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-schematic/SKILL.md
@@ -21,6 +21,9 @@ Before any schematic work, load the required toolsets:
 ```
 load_toolset('sch_components')   # place, move, rotate, delete symbols
 load_toolset('sch_wiring')       # wires, net labels, power symbols, connections
+load_toolset('sch_analysis')     # connection validation, short and orphan checks
+load_toolset('sch_export')       # direct ERC and rendered schematic evidence
+load_toolset('project')          # save_project before formal checks
 ```
 
 Load additional toolsets as needed:
@@ -28,7 +31,6 @@ Load additional toolsets as needed:
 ```
 load_toolset('library')          # search_symbols, get_symbol_info, list_symbol_libraries
 load_toolset('sch_batch')        # batch operations for 3+ items
-load_toolset('sch_analysis')     # find components, get pin info, inspect nets
 ```
 
 Always call `get_active_toolsets()` first to see what is already loaded.
@@ -224,14 +226,14 @@ Finds floating wires, labels, and symbols that are not connected to anything.
 
 ### Verification Workflow
 
-1. Place all components
-2. Complete all wiring
-3. Run `annotate_schematic`
-4. Run `validate_wire_connections`
-5. Run `validate_component_connections`
-6. Run `find_orphan_items`
-7. Fix any reported issues
-8. Save with `save_project`
+1. Place and wire complete functional blocks.
+2. Run `annotate_schematic`, then save with `save_project`.
+3. Run `validate_wire_connections` and `validate_component_connections`.
+4. Run `find_shorted_nets`; reconcile each finding against the intended nets.
+5. Run `find_orphan_items` as a heuristic and corroborate its findings.
+6. Run direct KiCad ERC with `run_erc` and classify every violation.
+7. Run `render_schematic_png` with inline output and inspect the actual image.
+8. Fix findings and repeat every check invalidated by the edits.
 
 ---
 
@@ -249,8 +251,26 @@ The agent can see its own schematic. After meaningful edits:
    a normal state, and a baseline from an older renderer is flagged rather
    than silently trusted.
 
-Use the loop to catch what connectivity checks cannot: overlapping symbols,
-text collisions, a component moved somewhere absurd.
+Use the loop to catch what connectivity checks cannot. Completion requires
+coherent functional grouping, label-inclusive overlap inspection, clear signal
+flow, and page-boundary acceptance for every symbol, label, and note. Inspect
+the image itself; a successful render command is not visual acceptance.
+
+## Evidence and completion gate
+
+Apply this order when evidence disagrees:
+
+1. Exact requirements and manufacturer datasheets.
+2. Direct KiCad ERC and saved/exported connectivity.
+3. Direct net, short, pin, and component evidence from Konnect.
+4. Aggregate review results.
+5. Heuristic orphan, single-pin, decoupling, and best-practice findings.
+
+A weaker heuristic may raise a question but does not override stronger direct
+evidence. If any required check did not run, failed structurally, returned
+impossible coverage, or contradicts stronger evidence without resolution, the
+result is `INCOMPLETE`. Report the blocked evidence and stop short of a clean or
+production-ready claim.
 
 ## Rules
 

--- a/crates/konnect/assets/skills/konnect/SKILL.md
+++ b/crates/konnect/assets/skills/konnect/SKILL.md
@@ -90,13 +90,30 @@ unload_toolset("name")  → Remove a toolset when done
 |----------|----------|
 | Project | project |
 | Schematic | sch_components, sch_wiring, sch_bus, sch_analysis, sch_batch, sch_export, sch_hierarchy |
-| PCB | pcb_board, pcb_components, pcb_routing, pcb_export |
+| PCB | pcb_board, pcb_components, pcb_routing, pcb_export, placement |
 | Library | library |
 | Integration | integration (JLCPCB parts, Freerouting installation checks, datasheets) |
 | Verification & Review | verification, design_review |
 | Config | config |
 | Templates | templates |
 | Manufacturing | manufacturing |
+
+## Agent Routing and Mutation Ownership
+
+Use one design owner at a time. Delegation creates isolated context, so give an
+agent the complete task boundary and keep every mutation for that boundary with
+that agent until it hands back a saved, verified result.
+
+- Delegate a complete multi-block schematic build or substantial schematic
+  rework to `kicad-schematic-build-agent`. It owns schematic mutations through
+  placement, wiring, validation, rendering, and save. The caller does not make
+  concurrent schematic edits.
+- Delegate an independent full-design, pre-fabrication, or readiness audit to
+  `kicad-design-review-agent`. It gathers and reports evidence without mutating
+  the design. Return fixes to the current design owner, then run a fresh review.
+- Keep small, bounded edits and narrow checks in the current conversation using
+  the applicable skill. Agent delegation is for a complete build or an
+  independent review, not an extra layer around every tool call.
 
 ## Design Rules Quick Reference
 

--- a/crates/konnect/tests/asset_references.rs
+++ b/crates/konnect/tests/asset_references.rs
@@ -34,6 +34,101 @@ fn asset_files() -> Vec<PathBuf> {
     files
 }
 
+/// Agent reports may only claim evidence that their prescribed setup can
+/// collect. v0.10.0 asked both agents to report ERC without loading
+/// `sch_export`, and the schematic builder never ran ERC, short detection, or
+/// rendered inspection at all (#357).
+#[test]
+fn agents_make_claimed_evidence_executable() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/agents");
+    let cases = [
+        (
+            "kicad-schematic-build-agent.md",
+            &["sch_analysis", "sch_export"][..],
+            &[
+                "find_shorted_nets",
+                "run_erc",
+                "render_schematic_png",
+                "INCOMPLETE",
+            ][..],
+        ),
+        (
+            "kicad-design-review-agent.md",
+            &["sch_export", "pcb_export"][..],
+            &["run_erc", "get_drc_violations", "INCOMPLETE"][..],
+        ),
+    ];
+    let mut missing = Vec::new();
+
+    for (filename, required_toolsets, required_markers) in cases {
+        let path = root.join(filename);
+        let text = std::fs::read_to_string(&path).unwrap();
+        let loaded: BTreeSet<String> = text.lines().flat_map(toolset_names_in).collect();
+        for toolset in required_toolsets {
+            if !loaded.contains(*toolset) {
+                missing.push(format!("agents/{filename} does not load `{toolset}`"));
+            }
+        }
+        for marker in required_markers {
+            if !text.contains(*marker) {
+                missing.push(format!("agents/{filename} does not prescribe `{marker}`"));
+            }
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "agent output claims outrun their executable workflow:\n  {}",
+        missing.join("\n  ")
+    );
+}
+
+/// The skill and its agent share the same completion boundary. These markers
+/// are the parts v0.10.0 omitted while still promising a production-quality
+/// result: direct checks, rendered readability, and a fail-closed verdict.
+#[test]
+fn skills_define_the_same_evidence_boundary_as_their_agents() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/skills");
+    let cases = [
+        (
+            "kicad-schematic/SKILL.md",
+            &[
+                "find_shorted_nets",
+                "run_erc",
+                "render_schematic_png",
+                "label-inclusive",
+                "page-boundary",
+                "INCOMPLETE",
+            ][..],
+        ),
+        (
+            "kicad-review/SKILL.md",
+            &[
+                "Evidence hierarchy",
+                "run_erc",
+                "get_drc_violations",
+                "INCOMPLETE",
+            ][..],
+        ),
+    ];
+    let mut missing = Vec::new();
+
+    for (relative, required_markers) in cases {
+        let text = std::fs::read_to_string(root.join(relative)).unwrap();
+        for marker in required_markers {
+            if !text.contains(*marker) {
+                missing.push(format!("skills/{relative} does not define `{marker}`"));
+            }
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "skill completion criteria omit required evidence:\n  {}",
+        missing.join("\n  ")
+    );
+}
+
 /// Every `load_toolset('name')` in the shipped prose names a real toolset.
 #[test]
 fn documented_toolsets_exist_in_the_registry() {

--- a/crates/konnect/tests/asset_references.rs
+++ b/crates/konnect/tests/asset_references.rs
@@ -34,6 +34,139 @@ fn asset_files() -> Vec<PathBuf> {
     files
 }
 
+fn assets_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("assets")
+}
+
+/// Every installed reference is named by its parent skill. Copying a file into
+/// `references/` is not progressive disclosure unless the skill tells the
+/// agent that it exists and when to read it (#357).
+#[test]
+fn every_reference_is_reachable_from_its_parent_skill() {
+    let skills = assets_root().join("skills");
+    let mut unreachable = Vec::new();
+
+    for entry in std::fs::read_dir(&skills).unwrap().flatten() {
+        let skill_dir = entry.path();
+        let references = skill_dir.join("references");
+        if !references.is_dir() {
+            continue;
+        }
+        let skill = std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
+        for reference in std::fs::read_dir(references).unwrap().flatten() {
+            let path = reference.path();
+            let Some(filename) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if !skill.contains(filename) {
+                unreachable.push(format!(
+                    "{} does not name references/{filename}",
+                    display(&skill_dir.join("SKILL.md"))
+                ));
+            }
+        }
+    }
+
+    assert!(
+        unreachable.is_empty(),
+        "installed references have no parent-skill pointer:\n  {}",
+        unreachable.join("\n  ")
+    );
+}
+
+/// Every bundled Claude agent preloads at least one real bundled skill. Agent
+/// context is isolated, so relying on the caller to have read a skill leaves
+/// the agent running a stale condensed copy instead (#357).
+#[test]
+fn agents_preload_existing_skills() {
+    let skills_root = assets_root().join("skills");
+    let known: BTreeSet<String> = std::fs::read_dir(skills_root)
+        .unwrap()
+        .flatten()
+        .filter(|entry| entry.path().join("SKILL.md").is_file())
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .collect();
+    let mut bad = Vec::new();
+
+    for entry in std::fs::read_dir(assets_root().join("agents"))
+        .unwrap()
+        .flatten()
+    {
+        let path = entry.path();
+        let text = std::fs::read_to_string(&path).unwrap();
+        let normalized = text.replace("\r\n", "\n");
+        let frontmatter = normalized
+            .strip_prefix("---\n")
+            .and_then(|rest| rest.split_once("\n---\n"))
+            .map(|(head, _)| head)
+            .unwrap_or("");
+        let preloaded = yaml_list(frontmatter, "skills");
+        if preloaded.is_empty() {
+            bad.push(format!("{} preloads no skills", display(&path)));
+            continue;
+        }
+        for skill in preloaded {
+            if !known.contains(&skill) {
+                bad.push(format!(
+                    "{} preloads missing skill `{skill}`",
+                    display(&path)
+                ));
+            }
+        }
+    }
+
+    assert!(
+        bad.is_empty(),
+        "bundled agents do not preload valid bundled skills:\n  {}",
+        bad.join("\n  ")
+    );
+}
+
+/// The top-level router names every installed agent so a caller can delegate
+/// deliberately instead of leaving agents undiscoverable (#357).
+#[test]
+fn top_level_skill_routes_every_bundled_agent() {
+    let router = std::fs::read_to_string(assets_root().join("skills/konnect/SKILL.md")).unwrap();
+    let mut missing = Vec::new();
+    for entry in std::fs::read_dir(assets_root().join("agents"))
+        .unwrap()
+        .flatten()
+    {
+        let path = entry.path();
+        let Some(name) = path.file_stem().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if !router.contains(name) {
+            missing.push(name.to_string());
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "top-level konnect skill does not route bundled agent(s): {}",
+        missing.join(", ")
+    );
+}
+
+fn yaml_list(frontmatter: &str, key: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut in_list = false;
+    for line in frontmatter.lines() {
+        if line == format!("{key}:") {
+            in_list = true;
+            continue;
+        }
+        if in_list {
+            if let Some(value) = line.strip_prefix("  - ") {
+                values.push(value.trim().to_string());
+            } else if !line.trim().is_empty() {
+                break;
+            }
+        }
+    }
+    values
+}
+
 /// Every `load_toolset('name')` in the shipped prose names a real toolset.
 #[test]
 fn documented_toolsets_exist_in_the_registry() {


### PR DESCRIPTION
## Problem and scope

The bundled schematic builder and design reviewer report ERC/DRC and readiness fields that their setup does not load or execute. The schematic workflow also lacks direct short detection, rendered layout acceptance, and a fail-closed result when evidence is unavailable.

This is PR B for #357. It is independent in Git history but should merge after #362, which supplies the agent skill preloads and router wiring.

## Design

- Load and execute direct ERC, DRC, short, connection, save, and render tools before reporting their results.
- Make every reported validation field use PASS/FAIL/BLOCKED/N/A rather than an unchecked success box.
- Replace universal decoupling/ESD/bulk-capacitance rules with requirements- and datasheet-dependent review criteria.
- Establish the evidence hierarchy: requirements and datasheets, direct KiCad evidence, direct Konnect evidence, aggregate reports, then heuristics.
- Treat orphan and single-pin checks as candidates that require corroboration.
- Make missing, failed, structurally impossible, or contradictory required evidence produce `INCOMPLETE`.
- Require functional grouping, label-inclusive overlap inspection, and page-boundary acceptance from an inspected schematic render.
- Add mechanical guards that bind agent output claims to loaded/executed evidence and keep agent/skill completion boundaries aligned.

## Compatibility

Bundled Claude guidance and its asset tests change. MCP tools, schemas, response shapes, file formats, installer paths, and Codex behavior are unchanged.

## Validation

The red baseline identified every missing toolset/call and every absent completion marker before the prose changed. The following now pass:

- `cargo test -p konnect --test asset_references`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo test --workspace --locked --lib --tests`
- `cargo test --workspace --locked --doc`

Real-KiCad GUI tests remain intentionally ignored outside their dedicated workflow.

## Risk and rollback

The main risk is additional tool/context usage during full builds and reviews; those calls are the evidence the existing reports already claim. The change is guidance-only and can be reverted without migration.

Part of #357. Depends on #362 for the connected-agent package.