### PR TITLE
fix(claude): make PCB hooks structured and registry-backed

### DIFF
--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -58,9 +58,37 @@ pub struct ToolDef {
     pub description: &'static str,
     pub input_schema: Value,
     pub handler: ToolHandlerFn,
+    /// How the tool interacts with a board held by KiCad. Client guidance can
+    /// derive warnings from this runtime contract instead of maintaining a
+    /// second list of tool names.
+    pub board_access: BoardAccess,
+}
+
+/// The board-state contract of a tool.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum BoardAccess {
+    /// The tool does not need board-state guidance.
+    #[default]
+    None,
+    /// The requested board must be open in a reachable KiCad instance.
+    LiveOnly,
+    /// Live IPC is preferred, with a guarded file fallback only when KiCad is
+    /// unreachable and the board is safe to edit offline.
+    LivePreferredWithFallback,
+    /// The operation writes the file directly and therefore requires KiCad to
+    /// have the board closed.
+    ClosedBoardOnly,
+    /// Planning is non-mutating, while applying has a stricter board-state
+    /// requirement described by the tool itself.
+    ApplyModeDependent,
 }
 
 impl ToolDef {
+    pub fn with_board_access(mut self, board_access: BoardAccess) -> Self {
+        self.board_access = board_access;
+        self
+    }
+
     pub fn to_mcp_description(&self) -> McpToolDescription {
         McpToolDescription {
             name: self.name.to_string(),
@@ -262,6 +290,7 @@ macro_rules! tool {
             description: $desc,
             input_schema: $schema,
             handler: h,
+            board_access: $crate::tools::BoardAccess::None,
         }
     }};
 }

--- a/crates/konnect-core/src/tools/pcb_board.rs
+++ b/crates/konnect-core/src/tools/pcb_board.rs
@@ -745,7 +745,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "width", "height"]
             }),
             |args, ctx| async move { handle_set_board_size(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LivePreferredWithFallback),
         tool!(
             "get_board_info",
             "Return metadata about the PCB: title, revision, company, layer count, paper size, \
@@ -800,7 +801,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "layer_name"]
             }),
             |args, ctx| async move { handle_add_layer(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::ClosedBoardOnly),
         tool!(
             "set_active_layer",
             "Set the active layer recorded in the board file's setup section.",
@@ -813,7 +815,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "layer"]
             }),
             |args, ctx| async move { handle_set_active_layer(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::ClosedBoardOnly),
         tool!(
             "add_board_outline",
             "Add a rectangular board outline on Edge.Cuts, optionally using circular rounded \
@@ -833,7 +836,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "x1", "y1", "x2", "y2"]
             }),
             |args, ctx| async move { handle_add_board_outline(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LivePreferredWithFallback),
         tool!(
             "delete_graphics",
             "Delete board graphics — lines, rectangles, arcs, circles, polygons, curves, text, \
@@ -870,7 +874,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board"]
             }),
             |args, ctx| async move { handle_delete_graphics(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LivePreferredWithFallback),
         tool!(
             "add_mounting_hole",
             "Add an NPTH mounting hole footprint at the specified position.",
@@ -886,7 +891,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "x", "y"]
             }),
             |args, ctx| async move { handle_add_mounting_hole(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LivePreferredWithFallback),
         tool!(
             "add_board_text",
             "Add a silkscreen or fabrication text string to the board.",
@@ -904,7 +910,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "text", "x", "y"]
             }),
             |args, ctx| async move { handle_add_board_text(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LivePreferredWithFallback),
         tool!(
             "add_zone",
             "Add a copper fill zone polygon on a specified layer and net. Tries KiCAD IPC \
@@ -916,7 +923,8 @@ pub fn tools() -> Vec<ToolDef> {
              declare rather than binding copper to net 0.",
             zone_schema(),
             |args, ctx| async move { handle_add_zone(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LivePreferredWithFallback),
         tool!(
             "import_svg_logo",
             "Import an SVG file as filled silkscreen or copper artwork (a logo, icon, or other \
@@ -936,7 +944,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "svg", "width_mm"]
             }),
             |args, ctx| async move { handle_import_svg_logo(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LivePreferredWithFallback),
     ]
 }
 

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -1745,7 +1745,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "footprint", "reference", "x", "y"]
             }),
             |args, ctx| async move { handle_place_component(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LivePreferredWithFallback),
         tool!(
             "move_component",
             "Move a placed footprint to a new X/Y position. Uses live KiCAD IPC when reachable; \
@@ -1761,7 +1762,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "reference", "x", "y"]
             }),
             |args, ctx| async move { handle_move_component(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LivePreferredWithFallback),
         tool!(
             "rotate_component",
             "Set the rotation angle of a placed footprint. Uses live KiCAD IPC when reachable; \
@@ -1776,7 +1778,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "reference", "rotation"]
             }),
             |args, ctx| async move { handle_rotate_component(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LivePreferredWithFallback),
         tool!(
             "set_component_placements",
             "Set X/Y positions and rotations for multiple existing footprints atomically. Uses one live KiCAD IPC update and one undo step when reachable; otherwise safely edits a closed board file once with revision checks.",
@@ -1802,7 +1805,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "placements"]
             }),
             |args, ctx| async move { handle_set_component_placements(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LivePreferredWithFallback),
         tool!(
             "flip_component",
             "Set a placed footprint to F.Cu or B.Cu with KiCAD-equivalent geometry mirroring. \
@@ -1818,7 +1822,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "reference", "layer"]
             }),
             |args, ctx| async move { handle_flip_component(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::ClosedBoardOnly),
         tool!(
             "delete_component",
             "Remove a footprint from the board via KiCAD IPC.",
@@ -1831,7 +1836,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "reference"]
             }),
             |args, ctx| async move { handle_delete_component(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
         tool!(
             "edit_component",
             "Update the value or other properties of a placed footprint via KiCAD IPC.",
@@ -1845,7 +1851,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "reference"]
             }),
             |args, ctx| async move { handle_edit_component(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
         tool!(
             "repair_corrupted_footprints",
             "Repair the exact legacy corruption from Konnect issue #244: footprint drawing \
@@ -1876,7 +1883,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board"]
             }),
             |args, ctx| async move { handle_repair_corrupted_footprints(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
         tool!(
             "find_component",
             "Find a footprint on the board by reference designator and return its position.",
@@ -1889,7 +1897,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "reference"]
             }),
             |args, ctx| async move { handle_find_component(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
         super::pcb_footprint_update::tool(),
         tool!(
             "list_board_footprint_graphics",
@@ -1904,7 +1913,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "reference"]
             }),
             |args, ctx| async move { handle_list_board_footprint_graphics(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
         tool!(
             "edit_board_footprint_graphic",
             "Replace the vertices of a polygon inside a footprint placed on the board, selected by UUID. Points are footprint-local millimetres, as the .kicad_mod shows them. Use this to bring one placed instance in line with a library change without re-placing the part. Only a single-outline polygon with no holes can be replaced; anything else is refused by name rather than flattened. Requires KiCAD running with the board open.",
@@ -1930,7 +1940,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "reference", "uuid", "points"]
             }),
             |args, ctx| async move { handle_edit_board_footprint_graphic(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
         tool!(
             "get_component_pads",
             "Return live board-space pad positions, layers and net assignments for a footprint. \
@@ -1949,7 +1960,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "reference"]
             }),
             |args, ctx| async move { handle_get_component_pads(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LivePreferredWithFallback),
         tool!(
             "get_pad_position",
             "Return the live board-space position, layers and net of a specific pad number on a footprint.",
@@ -1963,7 +1975,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "reference", "pad_number"]
             }),
             |args, ctx| async move { handle_get_pad_position(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LivePreferredWithFallback),
         tool!(
             "get_component_list",
             "List all footprints on the board with their positions, layers, and values.",
@@ -1975,7 +1988,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board"]
             }),
             |args, ctx| async move { handle_get_component_list(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
         tool!(
             "place_component_array",
             "Place multiple copies of a footprint in a grid or line array via KiCAD IPC.",
@@ -1996,7 +2010,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "footprint", "start_x", "start_y", "count_x", "spacing_x"]
             }),
             |args, ctx| async move { handle_place_array(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
         tool!(
             "align_components",
             "Align multiple footprints along a common X or Y axis via KiCAD IPC.",
@@ -2011,7 +2026,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "references", "value"]
             }),
             |args, ctx| async move { handle_align_components(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
         tool!(
             "duplicate_component",
             "Duplicate an existing footprint at a new position via KiCAD IPC.",
@@ -2027,7 +2043,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "reference", "new_reference", "x", "y"]
             }),
             |args, ctx| async move { handle_duplicate_component(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
         tool!(
             "get_board_2d_view",
             "Render the board with kicad-cli and return it as a base64 PNG. Note this is              kicad-cli's 3-D board render viewed from the top, not a layer plot -- there is              no layer selection. Use export_svg for layer-aware 2-D output.",

--- a/crates/konnect-core/src/tools/pcb_footprint_update.rs
+++ b/crates/konnect-core/src/tools/pcb_footprint_update.rs
@@ -196,6 +196,7 @@ pub(crate) fn tool() -> ToolDef {
         }),
         |args, ctx| async move { handle_update_footprints_from_library(args, ctx).await }
     )
+    .with_board_access(crate::tools::BoardAccess::LiveOnly)
 }
 
 pub(crate) async fn handle_update_footprints_from_library(

--- a/crates/konnect-core/src/tools/pcb_routing.rs
+++ b/crates/konnect-core/src/tools/pcb_routing.rs
@@ -62,7 +62,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "net_name", "layer", "x1", "y1", "x2", "y2"]
             }),
             |args, ctx| async move { handle_route_trace(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
         tool!(
             "route_pad_to_pad",
             "Route a direct trace between two pads of named components (L-bend routing) via KiCAD IPC.",
@@ -81,7 +82,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "net_name", "ref1", "pad1", "ref2", "pad2"]
             }),
             |args, ctx| async move { handle_route_pad_to_pad(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
         tool!(
             "add_via",
             "Add a through-hole via at a given position and assign it to a net via KiCAD IPC.",
@@ -98,7 +100,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "net_name", "x", "y"]
             }),
             |args, ctx| async move { handle_add_via(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
         tool!(
             "add_copper_pour",
             "Alias of pcb_board's add_zone, kept for compatibility: identical arguments, \
@@ -107,7 +110,8 @@ pub fn tools() -> Vec<ToolDef> {
              only when no live KiCAD answers.",
             crate::tools::pcb_board::zone_schema(),
             |args, ctx| async move { handle_add_copper_pour(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LivePreferredWithFallback),
         tool!(
             "delete_trace",
             "Delete a trace segment identified by its UUID via KiCAD IPC.",
@@ -120,7 +124,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "uuid"]
             }),
             |args, ctx| async move { handle_delete_trace(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
         tool!(
             "query_traces",
             "List trace segments on the board, optionally filtered by net and/or layer. \
@@ -135,7 +140,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board"]
             }),
             |args, ctx| async move { handle_query_traces(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
         tool!(
             "get_nets_list",
             "Return all nets defined on the PCB via KiCAD IPC.",
@@ -147,7 +153,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board"]
             }),
             |args, ctx| async move { handle_get_nets_list(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
         tool!(
             "modify_trace",
             "Modify a trace segment by deleting and re-adding it with new parameters.",
@@ -165,7 +172,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "uuid", "net_name", "layer", "x1", "y1", "x2", "y2"]
             }),
             |args, ctx| async move { handle_modify_trace(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
         tool!(
             "create_netclass",
             "Create or update a netclass in the project's design rules. Writes \
@@ -250,7 +258,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "net_pos", "net_neg", "x1", "y1", "x2", "y2"]
             }),
             |args, ctx| async move { handle_route_diff_pair(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
     ]
 }
 

--- a/crates/konnect-core/src/tools/placement.rs
+++ b/crates/konnect-core/src/tools/placement.rs
@@ -74,7 +74,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "ic_reference"]
             }),
             |args, ctx| async move { handle_place_decoupling(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::ApplyModeDependent),
         tool!(
             "plan_bga_fanout",
             "Plan a BGA fanout: outer-ring pads escape directly; each inner pad gets a via \
@@ -93,7 +94,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board", "reference"]
             }),
             |args, ctx| async move { handle_bga_fanout(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::ApplyModeDependent),
         tool!(
             "auto_place_from_schematic",
             "Deterministic first placement: cluster footprints by shared nets (union-find), \
@@ -112,7 +114,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board"]
             }),
             |args, ctx| async move { handle_auto_place(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::ApplyModeDependent),
         tool!(
             "refine_placement_force_directed",
             "Refine placement with a deterministic spring embedder: shared nets pull \
@@ -133,7 +136,8 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["board"]
             }),
             |args, ctx| async move { handle_force_directed(args, ctx).await }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::ApplyModeDependent),
     ]
 }
 

--- a/crates/konnect-core/src/tools/sch_export.rs
+++ b/crates/konnect-core/src/tools/sch_export.rs
@@ -196,7 +196,8 @@ pub fn tools() -> Vec<ToolDef> {
             |args, ctx| async move {
                 super::pcb_sync::handle_update_pcb_from_schematic(args, ctx).await
             }
-        ),
+        )
+        .with_board_access(crate::tools::BoardAccess::LiveOnly),
     ]
 }
 

--- a/crates/konnect/src/install.rs
+++ b/crates/konnect/src/install.rs
@@ -5,6 +5,7 @@
 
 use crate::manifest::{AGENTS, HOOK_SKILLS, SKILLS};
 use anyhow::{bail, Context, Result};
+use std::collections::BTreeSet;
 use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -119,6 +120,74 @@ pub fn print_skill_content(name: &str) -> Result<()> {
     }
     eprintln!("Unknown skill: {}", name);
     std::process::exit(1);
+}
+
+/// Emit the structured response Claude consumes for a hook event. Stdout is
+/// intentionally one JSON object and nothing else.
+pub fn print_hook_output(name: &str) -> Result<()> {
+    let hook = HOOK_SKILLS
+        .iter()
+        .find(|hook| hook.name == name)
+        .with_context(|| format!("unknown hook: {name}"))?;
+    println!(
+        "{}",
+        serde_json::to_string(&serde_json::json!({
+            "hookSpecificOutput": {
+                "hookEventName": hook.event,
+                "additionalContext": hook.content
+            }
+        }))?
+    );
+    Ok(())
+}
+
+fn hook_tool_names(board_access: konnect_core::tools::BoardAccess) -> Vec<&'static str> {
+    let mut names = BTreeSet::new();
+    for toolset in konnect_core::router::registry::ALL_TOOLSETS {
+        if let Some(tools) = konnect_core::router::registry::tools_for(toolset.name) {
+            for tool in tools {
+                if tool.board_access == board_access {
+                    names.insert(tool.name);
+                }
+            }
+        }
+    }
+    names.into_iter().collect()
+}
+
+fn hook_matcher(hook: &crate::manifest::HookSkillManifest) -> Result<String> {
+    let names = hook_tool_names(hook.board_access);
+    if names.is_empty() {
+        anyhow::bail!("hook '{}' has no registered tool targets", hook.name);
+    }
+    Ok(format!("mcp__konnect__({})", names.join("|")))
+}
+
+fn quote_command_arg(argument: &str) -> String {
+    #[cfg(windows)]
+    {
+        format!("\"{}\"", argument.replace('"', "\\\""))
+    }
+    #[cfg(not(windows))]
+    {
+        format!("'{}'", argument.replace('\'', "'\\''"))
+    }
+}
+
+fn hook_command(exe_str: &str, subcommand: &str, hook_name: &str) -> String {
+    format!(
+        "{} {} {}",
+        quote_command_arg(exe_str),
+        subcommand,
+        quote_command_arg(hook_name)
+    )
+}
+
+/// Exact command representation written by releases before the structured
+/// hook subcommand. It was unquoted and doubled Windows backslashes before
+/// JSON serialization; retain this only for surgical migration/removal.
+fn legacy_hook_command(exe_str: &str, hook_name: &str) -> String {
+    format!("{} skill {}", exe_str.replace('\\', "\\\\"), hook_name)
 }
 
 /// Double-click behavior remains Claude-focused for backward compatibility.
@@ -305,7 +374,11 @@ fn run_uninstall_at(client: InstallClient, paths: &InstallPaths, verbose: bool) 
                 }
             }
         }
-        remove_hooks_from_settings(&paths.claude_settings_path())?;
+        let exe = std::env::current_exe()?;
+        remove_hooks_from_settings(
+            &paths.claude_settings_path(),
+            exe.to_string_lossy().as_ref(),
+        )?;
         if verbose {
             println!("  [-] Removed hook entries from settings.json");
         }
@@ -414,11 +487,17 @@ fn patch_claude_settings(path: &Path, exe_str: &str) -> Result<usize> {
 
     let mut added = 0;
     for hook in HOOK_SKILLS {
+        let command = hook_command(exe_str, "hook", hook.name);
+        let legacy_command = legacy_hook_command(exe_str, hook.name);
         let event_arr = hooks_obj
             .entry(hook.event)
             .or_insert_with(|| serde_json::json!([]))
             .as_array_mut()
             .context("hook event field is not an array")?;
+        // Migrate the exact handler installed by the old plain-stdout form.
+        // Do not use substring matching: user-authored neighboring handlers
+        // and unrelated commands containing "konnect" are not ours.
+        remove_exact_commands(event_arr, &[legacy_command.as_str()]);
         let already_exists = event_arr.iter().any(|entry| {
             entry
                 .get("hooks")
@@ -428,20 +507,16 @@ fn patch_claude_settings(path: &Path, exe_str: &str) -> Result<usize> {
                         hook_entry
                             .get("command")
                             .and_then(|command| command.as_str())
-                            .is_some_and(|command| {
-                                command.contains("konnect") && command.contains(hook.name)
-                            })
+                            .is_some_and(|candidate| candidate == command)
                     })
                 })
         });
         if !already_exists {
-            // Preserve the established Claude hook command representation.
-            let exe_escaped = exe_str.replace('\\', "\\\\");
             event_arr.push(serde_json::json!({
-                "matcher": hook.tool_matcher,
+                "matcher": hook_matcher(hook)?,
                 "hooks": [{
                     "type": "command",
-                    "command": format!("{} skill {}", exe_escaped, hook.name)
+                    "command": command
                 }]
             }));
             added += 1;
@@ -451,7 +526,29 @@ fn patch_claude_settings(path: &Path, exe_str: &str) -> Result<usize> {
     Ok(added)
 }
 
-fn remove_hooks_from_settings(path: &Path) -> Result<()> {
+fn remove_exact_commands(event_arr: &mut Vec<serde_json::Value>, commands: &[&str]) {
+    for entry in event_arr.iter_mut() {
+        if let Some(handlers) = entry
+            .get_mut("hooks")
+            .and_then(|hooks| hooks.as_array_mut())
+        {
+            handlers.retain(|handler| {
+                !handler
+                    .get("command")
+                    .and_then(|command| command.as_str())
+                    .is_some_and(|command| commands.contains(&command))
+            });
+        }
+    }
+    event_arr.retain(|entry| {
+        entry
+            .get("hooks")
+            .and_then(|hooks| hooks.as_array())
+            .is_none_or(|handlers| !handlers.is_empty())
+    });
+}
+
+fn remove_hooks_from_settings(path: &Path, exe_str: &str) -> Result<()> {
     if !path.exists() {
         return Ok(());
     }
@@ -466,19 +563,9 @@ fn remove_hooks_from_settings(path: &Path) -> Result<()> {
                 .get_mut(hook.event)
                 .and_then(|event| event.as_array_mut())
             {
-                event_arr.retain(|entry| {
-                    !entry
-                        .get("hooks")
-                        .and_then(|hooks| hooks.as_array())
-                        .is_some_and(|hooks| {
-                            hooks.iter().any(|hook_entry| {
-                                hook_entry
-                                    .get("command")
-                                    .and_then(|command| command.as_str())
-                                    .is_some_and(|command| command.contains("konnect"))
-                            })
-                        })
-                });
+                let current = hook_command(exe_str, "hook", hook.name);
+                let legacy = legacy_hook_command(exe_str, hook.name);
+                remove_exact_commands(event_arr, &[current.as_str(), legacy.as_str()]);
             }
         }
     }
@@ -624,9 +711,128 @@ mod tests {
         let settings: serde_json::Value =
             serde_json::from_str(&fs::read_to_string(settings_path).unwrap()).unwrap();
         assert_eq!(settings["theme"], "dark");
+        let entries = settings["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(entries.len(), HOOK_SKILLS.len());
         for hook in HOOK_SKILLS {
-            assert_eq!(settings["hooks"][hook.event].as_array().unwrap().len(), 1);
+            let expected_command = hook_command(
+                std::env::current_exe().unwrap().to_string_lossy().as_ref(),
+                "hook",
+                hook.name,
+            );
+            assert!(entries.iter().any(|entry| {
+                entry["matcher"] == hook_matcher(hook).unwrap()
+                    && entry["hooks"][0]["command"] == expected_command
+            }));
         }
+    }
+
+    #[test]
+    fn hook_matchers_are_derived_from_registered_board_contracts() {
+        let registered = konnect_core::router::registry::ALL_TOOLSETS
+            .iter()
+            .flat_map(|toolset| {
+                konnect_core::router::registry::tools_for(toolset.name).unwrap_or_default()
+            })
+            .map(|tool| (tool.name, tool.board_access))
+            .collect::<std::collections::HashMap<_, _>>();
+
+        for hook in HOOK_SKILLS {
+            let matcher = hook_matcher(hook).unwrap();
+            let targets = matcher
+                .strip_prefix("mcp__konnect__(")
+                .and_then(|value| value.strip_suffix(')'))
+                .unwrap()
+                .split('|')
+                .collect::<Vec<_>>();
+            assert!(!targets.is_empty());
+            for target in targets {
+                assert_eq!(registered.get(target), Some(&hook.board_access), "{target}");
+            }
+        }
+        assert!(!HOOK_SKILLS
+            .iter()
+            .any(|hook| hook_matcher(hook).unwrap().contains("refill_zones")));
+        assert_eq!(
+            registered.get("route_trace"),
+            Some(&konnect_core::tools::BoardAccess::LiveOnly)
+        );
+        assert_eq!(
+            registered.get("place_component"),
+            Some(&konnect_core::tools::BoardAccess::LivePreferredWithFallback)
+        );
+        assert_eq!(
+            registered.get("flip_component"),
+            Some(&konnect_core::tools::BoardAccess::ClosedBoardOnly)
+        );
+        assert_eq!(
+            registered.get("plan_bga_fanout"),
+            Some(&konnect_core::tools::BoardAccess::ApplyModeDependent)
+        );
+    }
+
+    #[test]
+    fn spaced_windows_executable_survives_settings_json_roundtrip() {
+        let temp = TempDir::new().unwrap();
+        let settings_path = temp.path().join("settings.json");
+        let exe = r"C:\Program Files\Konnect Tools\konnect.exe";
+
+        patch_claude_settings(&settings_path, exe).unwrap();
+        let settings: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(settings_path).unwrap()).unwrap();
+        let commands = settings["hooks"]["PreToolUse"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .flat_map(|entry| entry["hooks"].as_array().unwrap())
+            .map(|handler| handler["command"].as_str().unwrap())
+            .collect::<Vec<_>>();
+
+        for hook in HOOK_SKILLS {
+            assert!(commands.contains(&hook_command(exe, "hook", hook.name).as_str()));
+        }
+        #[cfg(windows)]
+        assert!(commands.iter().all(|command| command.starts_with('"')));
+    }
+
+    #[test]
+    fn install_migrates_the_exact_legacy_plain_stdout_handler() {
+        let temp = TempDir::new().unwrap();
+        let settings_path = temp.path().join("settings.json");
+        let exe = r"C:\Program Files\Konnect\konnect.exe";
+        let hook = &HOOK_SKILLS[0];
+        fs::write(
+            &settings_path,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "hooks": {
+                    hook.event: [{
+                        "matcher": "old-static-matcher",
+                        "hooks": [{
+                            "type": "command",
+                            "command": legacy_hook_command(exe, hook.name)
+                        }, {
+                            "type": "command",
+                            "command": "user-neighbor"
+                        }]
+                    }]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        patch_claude_settings(&settings_path, exe).unwrap();
+        let settings: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(settings_path).unwrap()).unwrap();
+        let commands = settings["hooks"][hook.event]
+            .as_array()
+            .unwrap()
+            .iter()
+            .flat_map(|entry| entry["hooks"].as_array().unwrap())
+            .map(|handler| handler["command"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert!(!commands.contains(&legacy_hook_command(exe, hook.name).as_str()));
+        assert!(commands.contains(&hook_command(exe, "hook", hook.name).as_str()));
+        assert!(commands.contains(&"user-neighbor"));
     }
 
     #[test]
@@ -687,5 +893,44 @@ mod tests {
         let entries = remaining["hooks"][HOOK_SKILLS[0].event].as_array().unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0]["hooks"][0]["command"], "other-tool");
+    }
+
+    #[test]
+    fn exact_uninstall_preserves_mixed_and_similarly_named_handlers() {
+        let temp = TempDir::new().unwrap();
+        let settings_path = temp.path().join("settings.json");
+        let exe = r"C:\Program Files\Konnect\konnect.exe";
+        patch_claude_settings(&settings_path, exe).unwrap();
+
+        let mut settings: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&settings_path).unwrap()).unwrap();
+        let entries = settings["hooks"]["PreToolUse"].as_array_mut().unwrap();
+        entries[0]["hooks"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!({
+                "type": "command",
+                "command": "user-board-check"
+            }));
+        entries.push(serde_json::json!({
+            "matcher": "Write",
+            "hooks": [{
+                "type": "command",
+                "command": "C:/tools/konnect-helper.exe audit"
+            }]
+        }));
+        fs::write(
+            &settings_path,
+            serde_json::to_string_pretty(&settings).unwrap(),
+        )
+        .unwrap();
+
+        remove_hooks_from_settings(&settings_path, exe).unwrap();
+        let remaining = fs::read_to_string(settings_path).unwrap();
+        assert!(remaining.contains("user-board-check"));
+        assert!(remaining.contains("konnect-helper.exe audit"));
+        for hook in HOOK_SKILLS {
+            assert!(!remaining.contains(&hook_command(exe, "hook", hook.name)));
+        }
     }
 }

--- a/crates/konnect/src/main.rs
+++ b/crates/konnect/src/main.rs
@@ -28,7 +28,14 @@ enum Cli<'a> {
 }
 
 /// Subcommands that take `--client`/`--help` rather than being server flags.
-const SUBCOMMANDS: &[&str] = &["init", "uninstall", "status", "skill", "transaction"];
+const SUBCOMMANDS: &[&str] = &[
+    "init",
+    "uninstall",
+    "status",
+    "skill",
+    "hook",
+    "transaction",
+];
 
 fn classify(args: &[String]) -> Cli<'_> {
     let subcommand = args
@@ -86,6 +93,10 @@ async fn main() -> Result<()> {
         Cli::Subcommand("skill") => {
             let name = args.get(2).map(String::as_str).unwrap_or("");
             return install::print_skill_content(name);
+        }
+        Cli::Subcommand("hook") => {
+            let name = args.get(2).map(String::as_str).unwrap_or("");
+            return install::print_hook_output(name);
         }
         Cli::Subcommand("transaction") => return transaction_cli::run(&args[2..]),
         Cli::Subcommand(_) | Cli::Server => {}
@@ -198,7 +209,11 @@ fn print_help_for(subcommand: Option<&str>) {
         }
         Some("skill") => {
             println!("konnect skill <name>\n");
-            println!("Print a bundled skill's content to stdout, for hooks. Writes nothing.");
+            println!("Print bundled guidance as human-readable text. Writes nothing.");
+        }
+        Some("hook") => {
+            println!("konnect hook <name>\n");
+            println!("Print one structured Claude hook response as JSON. Writes nothing.");
         }
         Some("transaction") => {
             println!("konnect transaction status <project-dir>");
@@ -221,6 +236,7 @@ fn print_help() {
     println!("  konnect uninstall [--client <client>]");
     println!("  konnect status [--client <client>]");
     println!("  konnect skill <name>     Print skill content (for hooks)");
+    println!("  konnect hook <name>      Print structured Claude hook JSON");
     println!("  konnect transaction status <project-dir>");
     println!("  konnect transaction recover <project-dir>");
     println!("  konnect transaction abandon <project-dir> <id> --force");
@@ -249,7 +265,14 @@ mod cli_dispatch_tests {
     /// `uninstall --help` was the same code path. The reporter did not run it.
     #[test]
     fn subcommand_help_is_help_and_never_the_subcommand() {
-        for name in ["init", "uninstall", "status", "skill", "transaction"] {
+        for name in [
+            "init",
+            "uninstall",
+            "status",
+            "skill",
+            "hook",
+            "transaction",
+        ] {
             for flag in ["--help", "-h"] {
                 assert_eq!(
                     classify(&cli(&[name, flag])),
@@ -295,6 +318,10 @@ mod cli_dispatch_tests {
         assert_eq!(
             classify(&cli(&["skill", "konnect"])),
             Cli::Subcommand("skill")
+        );
+        assert_eq!(
+            classify(&cli(&["hook", "pre-pcb-ipc"])),
+            Cli::Subcommand("hook")
         );
         assert_eq!(
             classify(&cli(&["transaction", "status", "dir"])),

--- a/crates/konnect/src/manifest.rs
+++ b/crates/konnect/src/manifest.rs
@@ -20,11 +20,11 @@ pub struct AgentManifest {
 
 /// A hook-bound skill: triggers before/after specific MCP tool calls.
 /// Installed as a hook entry in `~/.claude/settings.json` that runs
-/// `konnect.exe skill <name>` to emit the content to stdout.
+/// `konnect.exe hook <name>` to emit Claude's structured hook JSON.
 pub struct HookSkillManifest {
     pub name: &'static str,
     pub content: &'static str,
-    pub tool_matcher: &'static str,
+    pub board_access: konnect_core::tools::BoardAccess,
     pub event: &'static str, // "PreToolUse" or "PostToolUse"
 }
 
@@ -121,10 +121,26 @@ pub const AGENTS: &[AgentManifest] = &[
 pub const HOOK_SKILLS: &[HookSkillManifest] = &[
     HookSkillManifest {
         name: "pre-pcb-ipc",
-        content: "These PCB tools require KiCAD to be running with the board file open.\n\
-                  If you get a connection error, tell the user: \"Please open KiCAD and load\n\
-                  your .kicad_pcb file, then try again.\" Do not retry more than once.",
-        tool_matcher: "mcp__konnect__(place_component|move_component|rotate_component|route_trace|add_via|route_differential_pair|route_pad_to_pad|refill_zones)",
+        content: "This operation is live-IPC-only. KiCad must be running with the exact requested .kicad_pcb board open. If IPC or board identity fails, ask the user to open that board and retry once; do not bypass the server-side guard or edit the board file behind KiCad.",
+        board_access: konnect_core::tools::BoardAccess::LiveOnly,
+        event: "PreToolUse",
+    },
+    HookSkillManifest {
+        name: "pre-pcb-fallback",
+        content: "This operation prefers live KiCad IPC but has a guarded closed-board file fallback. Let the tool select the safe path. Never force a file edit while KiCad holds this board open, and treat the server-side board identity and revision checks as authoritative.",
+        board_access: konnect_core::tools::BoardAccess::LivePreferredWithFallback,
+        event: "PreToolUse",
+    },
+    HookSkillManifest {
+        name: "pre-pcb-closed",
+        content: "This operation requires the requested board to be closed in KiCad because it edits the saved file directly. Ask the user to close that board before applying the change; do not bypass the server-side open-board refusal.",
+        board_access: konnect_core::tools::BoardAccess::ClosedBoardOnly,
+        event: "PreToolUse",
+    },
+    HookSkillManifest {
+        name: "pre-pcb-conditional",
+        content: "This tool has different board-state requirements for planning and applying. Dry-run or planning is non-mutating; before apply, follow the tool description and returned plan exactly. Do not reuse a stale plan revision or bypass the server-side board-state guard.",
+        board_access: konnect_core::tools::BoardAccess::ApplyModeDependent,
         event: "PreToolUse",
     },
 ];

--- a/crates/konnect/tests/transaction_cli.rs
+++ b/crates/konnect/tests/transaction_cli.rs
@@ -28,6 +28,20 @@ fn client_scoped_installer_help_is_advertised() {
 }
 
 #[test]
+fn claude_pretooluse_hook_emits_only_structured_json() {
+    let output = konnect().args(["hook", "pre-pcb-ipc"]).output().unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    assert!(output.stderr.is_empty(), "{output:?}");
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["hookSpecificOutput"]["hookEventName"], "PreToolUse");
+    assert!(value["hookSpecificOutput"]["additionalContext"]
+        .as_str()
+        .is_some_and(|message| message.contains("live-IPC-only")));
+    assert_eq!(value.as_object().unwrap().len(), 1);
+}
+
+#[test]
 fn malformed_journal_requires_force_and_can_be_abandoned() {
     let project = tempfile::tempdir().unwrap();
     let active = project


### PR DESCRIPTION
Closes #358.

## Problem and scope

Claude's installed `PreToolUse` hook printed plain stdout, so its warning went to the debug log rather than Claude's context. Its hand-written matcher had also drifted (`refill_zones` is not a tool), the executable path was not shell-quoted, and uninstall could delete neighboring user handlers by substring.

This PR is limited to the Claude hook/runtime path. It does not install hooks for Codex and does not weaken any server-side board identity, liveness, or revision guard.

## Design

- add a neutral `BoardAccess` contract to registered tools;
- derive four deterministic Claude matchers from the live registry: live-only, guarded fallback, closed-board-only, and apply-mode-dependent;
- add `konnect hook <name>`, which writes exactly one structured `hookSpecificOutput.additionalContext` JSON object;
- retain `konnect skill <name>` as human-readable output;
- quote executable paths for the host shell, including Windows paths with spaces;
- migrate/remove only exact current or legacy handlers and preserve mixed neighbors;
- keep the server-side PCB guards authoritative.

## Compatibility and migration

A subsequent Claude install surgically replaces the exact legacy `skill pre-pcb-ipc` command from the current executable with the structured `hook` commands. User-authored handlers, including handlers in the same matcher group and commands merely containing `konnect`, are preserved. Codex installation behavior is unchanged.

## Evidence

Red baseline: the old idempotence assertion failed when the static one-hook shape was replaced (`left: 4`, `right: 1`). The final tests assert behavior rather than the old shape.

Guard-neuter proof: temporarily changing `route_trace` from `LiveOnly` to `None` made `hook_matchers_are_derived_from_registered_board_contracts` fail with `Some(None)` versus `Some(LiveOnly)`; the annotation was restored before this commit.

Local required gate:

- `cargo fmt --all -- --check` — PASS
- `cargo clippy --workspace --locked --all-targets -- -D warnings` — PASS
- `cargo test --workspace --locked --lib --tests` — PASS
- `cargo test --workspace --locked --doc` — PASS

Focused evidence:

- `cargo test -p konnect install::tests` — 14 passed
- `cargo test -p konnect --test transaction_cli claude_pretooluse_hook_emits_only_structured_json` — PASS

The repository's explicitly ignored real-KiCad/live-IPC tests remain environment-dependent and were not forced; this PR changes hook dispatch and metadata, not KiCad mutation behavior.

## Risk and rollback

The main risk is an incorrectly classified tool. Matchers are generated from the registry, canonical examples pin every class, and future tool renames/removals cannot leave a stale explicit matcher target. Rollback is the single commit; installed Claude settings can also be refreshed with `konnect init --client claude`.