### PR TITLE
fix(guidance): require physical pin-map evidence

### DIFF
--- a/crates/konnect/assets/skills/kicad-library/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-library/SKILL.md
@@ -120,6 +120,54 @@ Before creating or wiring a package-sensitive part:
 7. **Refuse to use the part in a real schematic** while any mirror,
    reversal, duplicate, missing lead or view ambiguity is unresolved.
 
+### Physical pin-map acceptance contract
+
+For every custom or package-sensitive part, complete this record before the
+symbol and footprint are accepted. "Looks sequential" and a matching pin
+count are not evidence.
+
+Record the manufacturer, exact MPN and package suffix, datasheet document
+number/revision, source URL, relevant page numbers, symbol library ID, and
+footprint library ID. Then add one row for **every physical lead**:
+
+| Datasheet lead | Function | Symbol pin / name / type | Footprint pad | X/Y (mm) | Drawing view / direction | Evidence |
+|---|---|---|---|---|---|---|
+| 1 | Example only | 1 / NAME / passive | 1 | 0.00 / 0.00 | bottom view, clockwise from key | datasheet p. N, figure M |
+
+Apply these rules to the table:
+
+- Walk from the datasheet's documented key, notch, dot, flat, bevel, or other
+  datum in the stated direction. State top, bottom, component, solder, pin, or
+  mating view in every row; never silently translate between views.
+- Give repeated physical leads separate rows even when they share one
+  electrical function. List exposed pads, shields, mounting tabs, and
+  mechanical holes separately and state whether each is an electrical pad,
+  a duplicated connection, or intentionally absent from the symbol.
+- Reconcile and record the datasheet physical-lead count, symbol electrical-pin
+  count, footprint electrical-pad count, duplicate-pad count, and
+  mechanical-only feature count. Explain every difference.
+- Treat a symbol pin number and footprint pad number as the same physical lead
+  only when the evidence row proves it. Names such as A/K, G/D/S, B/C/E, COM,
+  or VCC do not establish the physical number.
+
+Acceptance procedure:
+
+1. Create or select the exact symbol and footprint only after completing the
+   source columns above.
+2. Query the symbol back with `get_symbol_info` and the footprint with
+   `get_footprint_info`. Compare every returned pin/pad number, name, type,
+   coordinate, drill, size, and layer set to the table and datasheet.
+3. Place a **disposable** symbol and footprint in a scratch project. Render the
+   schematic and board, then inspect the pin-1/key marker, numbering direction,
+   top/bottom orientation, pad geometry, drill/slot geometry, courtyard, fab,
+   and silkscreen. For mating parts, inspect the mating view as well.
+4. Read the disposable instances back; do not accept only the values requested
+   during creation as proof they were written.
+5. **Refuse acceptance** and keep the part out of a real schematic or PCB if
+   any lead is missing, duplicated without explanation, mirrored, reversed,
+   assigned to a different function, or ambiguous in view/direction. Record an
+   unavailable datasheet figure, query, or render as `BLOCKED`, never as pass.
+
 The rows below are *starting hypotheses for generic parts only*. Verify each
 against the actual symbol with `get_symbol_info` before relying on it.
 

--- a/crates/konnect/assets/skills/kicad-schematic/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-schematic/SKILL.md
@@ -44,6 +44,21 @@ Always call `get_active_toolsets()` first to see what is already loaded.
 3. Place on the 1.27mm grid (KiCAD default schematic grid)
 4. Verify placement with `list_schematic_components`
 
+### Package-sensitive and custom parts
+
+Before placing or wiring a custom symbol, a manufacturer-specific discrete,
+or any package whose view can be mirrored, require the `kicad-library` skill's
+**accepted physical pin map** for the exact MPN and package suffix. The map must
+join each datasheet lead to the symbol pin and footprint pad, identify the
+drawing view/direction, reconcile duplicate and mechanical pads, and include
+query-back plus disposable rendered inspection. `get_symbol_info` proves the
+library data that exists; it does not prove that data matches the package.
+
+If the accepted physical pin map is missing, incomplete, based on a different
+suffix, or ambiguous about top/bottom/mating view, stop before real schematic
+placement. Do not infer physical numbering from a generic symbol name or from
+the order pins appear on screen.
+
 ### Common Library IDs
 
 | Component       | lib_id                         |

--- a/crates/konnect/assets/skills/kicad-schematic/references/common-lib-ids.md
+++ b/crates/konnect/assets/skills/kicad-schematic/references/common-lib-ids.md
@@ -1,5 +1,17 @@
 # Common KiCAD Library Identifiers
 
+This is a non-exhaustive shortcut for common generic symbols, **not an allowlist**
+and not evidence that a symbol matches a manufacturer package. Verify every ID
+against the active KiCad libraries with `search_symbols` and inspect pins with
+`get_symbol_info`. If the required part is absent or uncertain, search rather
+than choosing the nearest name.
+
+Keep personal or project favorites in the user's/project's preference overlay,
+not in this shared upstream cache. For manufacturer-specific ICs, discrete
+semiconductors, connectors, displays, tubes, sockets, and other
+package-sensitive parts, the exact MPN/package datasheet and the
+`kicad-library` physical pin-map acceptance contract outrank this list.
+
 ## Passive Components (Device library)
 | lib_id | Description | Reference prefix |
 |--------|-------------|-----------------|

--- a/crates/konnect/tests/asset_references.rs
+++ b/crates/konnect/tests/asset_references.rs
@@ -431,6 +431,32 @@ fn snake_words(line: &str) -> Vec<String> {
 
 // ─── Library identifiers in guidance (skips without KiCad) ───────────────────
 
+/// Package-sensitive parts need a lead-by-lead electrical acceptance record,
+/// not only prose telling the agent to "check the datasheet". This pins the
+/// minimum evidence an agent must collect before using a custom symbol and
+/// footprint in a real design.
+#[test]
+fn package_sensitive_parts_require_a_physical_pin_map_and_visible_acceptance() {
+    let library_skill = include_str!("../assets/skills/kicad-library/SKILL.md");
+    let schematic_skill = include_str!("../assets/skills/kicad-schematic/SKILL.md");
+    let common_ids = include_str!("../assets/skills/kicad-schematic/references/common-lib-ids.md");
+
+    for marker in [
+        "Physical pin-map acceptance contract",
+        "Datasheet lead",
+        "Symbol pin / name / type",
+        "Footprint pad",
+        "Drawing view / direction",
+        "disposable",
+        "Refuse acceptance",
+    ] {
+        assert!(library_skill.contains(marker), "missing marker: {marker}");
+    }
+    assert!(schematic_skill.contains("accepted physical pin map"));
+    assert!(common_ids.contains("not an allowlist"));
+    assert!(common_ids.contains("personal or project favorites"));
+}
+
 /// Every `Lib:Symbol` identifier the bundled guidance quotes must resolve to a
 /// symbol in the installed KiCad libraries.
 ///


### PR DESCRIPTION
Closes #356 when merged after #362.

## Problem and scope

v0.10.1 already corrected the invalid KiCad IDs, reversed `Device:LED` example, and universal pin-number claims reported in #356. The remaining P0 gap is the physical acceptance contract: the guidance says to check the datasheet, but does not require the agent to prove that every physical lead maps to the intended symbol pin and footprint pad before using the part.

This PR changes only bundled Claude guidance and its asset regression test. It adds no MCP tools and changes no Rust symbol/footprint implementation.

## Design

- require exact manufacturer, MPN, package suffix, datasheet revision/URL/pages, and selected library identities;
- require one evidence row per physical lead, joining datasheet lead/function to symbol pin/name/type and footprint pad/X/Y;
- require every row to state drawing view and numbering direction from a documented key;
- separately account for repeated leads, exposed pads, shields, mounting tabs, and mechanical holes;
- reconcile physical-lead, symbol-pin, electrical-pad, duplicate-pad, and mechanical-feature counts;
- query symbol and footprint back through Konnect;
- require disposable placement plus rendered inspection of key/orientation/pads/drills/courtyard/fab/silkscreen;
- refuse real schematic/PCB use on any ambiguity and report unavailable evidence as `BLOCKED`;
- state that `common-lib-ids.md` is a shared generic shortcut, not an allowlist or personal-favorites store.

The schematic skill now requires an accepted physical pin map before placing or wiring package-sensitive/custom parts. #362 independently makes the two schematic references reachable from their parent skill; merge #362 before this PR to satisfy the complete #356 acceptance set.

## Evidence

Red baseline:

`cargo test -p konnect --test asset_references package_sensitive_parts_require_a_physical_pin_map_and_visible_acceptance`

failed with:

`missing marker: Physical pin-map acceptance contract`

After the guidance change, the focused test passes.

Local required gate:

- `cargo fmt --all -- --check` — PASS
- `cargo clippy --workspace --locked --all-targets -- -D warnings` — PASS
- `cargo test --workspace --locked --lib --tests` — PASS
- `cargo test --workspace --locked --doc` — PASS

The repository's explicitly ignored real-KiCad/live-IPC tests remain environment-dependent. This guidance-only PR does not alter KiCad runtime behavior.

## Risk and rollback

The risk is added workflow friction for package-sensitive parts. It is intentionally scoped away from ordinary generic passives and pays for itself at the symbol-to-physical-pad boundary, where a plausible-looking reversal can destroy hardware. Rollback is the single guidance commit.