### PR TITLE
fix(guidance): bind manufacturing claims to evidence

### DIFF
--- a/crates/konnect/assets/skills/kicad-manufacture/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-manufacture/SKILL.md
@@ -9,235 +9,160 @@ argument-hint: "[fab house or export task]"
 
 # KiCAD Manufacturing & Fabrication Workflow
 
-This skill guides Claude through preparing a KiCAD design for manufacturing using Konnect MCP tools.
-ALL modifications go through MCP tools — never edit project files directly.
+Prepare manufacturing outputs through Konnect MCP tools. Treat each tool result
+as evidence with a named scope: a successful request is not by itself proof of a
+complete, current, upload-ready package. A required check or artifact that cannot
+be established makes the manufacturing verdict `INCOMPLETE`.
 
----
+## Toolset loading
 
-## Toolset Loading
-
-Before any manufacturing work, load the required toolsets:
-
-```
-load_toolset('pcb_export')       # export_gerber, export_bom, export_position_file, get_drc_violations
-load_toolset('manufacturing')    # export_manufacturing_package, validate_for_manufacturing, estimate_cost
-```
-
-Load additional toolsets as needed:
+Load the required toolsets:
 
 ```
-load_toolset('sch_analysis')     # inspect nets, verify footprints assigned
-load_toolset('integration')      # search_jlcpcb_parts, suggest_jlcpcb_alternatives
-load_toolset('pcb_export')       # export_3d for visual verification
+load_toolset('pcb_export')       # Gerber, drill, BOM, position, 3D, and direct DRC evidence
+load_toolset('manufacturing')    # Package export, manufacturing preflight, and rough cost estimate
 ```
 
-Always call `get_active_toolsets()` first to see what is already loaded.
+Load additional toolsets only for the branch that needs them:
+
+```
+load_toolset('sch_analysis')     # schematic inventory and footprint assignment
+load_toolset('integration')      # local JLCPCB catalogue and alternatives
+```
+
+Call `get_active_toolsets()` before loading more.
 
 ### References by manufacturing branch
 
 - Read [`references/gerber-layers.md`](references/gerber-layers.md) when
-  selecting manual plot layers or checking the generated artifact inventory.
+  selecting plot layers or accepting a generated artifact inventory.
 - Read [`references/jlcpcb-rules.md`](references/jlcpcb-rules.md) only when
-  JLCPCB is the selected fabricator or assembler. Verify time-sensitive limits,
-  field names, pricing, and part categories against the current order contract.
+  JLCPCB is the selected fabricator or assembler. It defines how to capture the
+  current order contract without caching volatile limits, prices, categories,
+  or field names in this skill.
 
----
+## 1. Capture the order contract
 
-## Pre-Flight Checklist
+Before checking or exporting, record the selected fabricator, service tier,
+stackup, copper weight, finish, assembly sides, stencil requirement, quantity,
+and any controlled-impedance service. Record the source and retrieval date for
+every vendor-controlled requirement. Project rules and output acceptance are
+judged against that record.
 
-Run these checks BEFORE generating any manufacturing outputs. Stop and fix issues at each stage.
+Completion criterion: every applicable fabrication and assembly constraint has
+one current authority, and no decision rests on an undated table in this skill.
 
-### 1. DRC — Zero Errors Required
+## 2. Establish direct design evidence
+
+Run direct KiCad DRC against the saved target board and resolve every error or
+record a deliberate, reviewable waiver. Then run:
 
 ```
-get_drc_violations()
+validate_for_manufacturing(board, fab_house?)
 ```
 
-- All errors must be resolved. Warnings should be reviewed but may be waived.
-- Common blockers: unrouted nets, clearance violations, minimum width violations.
-- Do NOT proceed to export if any DRC errors remain.
+The current handler checks only:
 
-### 2. Manufacturing Validation
+- presence of at least one `Edge.Cuts` item;
+- presence of footprints;
+- the configured minimum trace width against its built-in fab profile;
+- the coarse case where several nets exist but no routed tracks exist; and
+- direct `kicad-cli` DRC evidence, which must be available and complete for a
+  `READY` verdict.
 
-```
-validate_for_manufacturing()
-```
+Read `verdict`, `issues`, and `drc` together. A null or incomplete `drc`, a
+`NOT READY` verdict, or an unadjudicated issue blocks release.
 
-- Checks board outline is closed
-- Checks all pads have copper
-- Checks drill sizes are within fabrication limits
-- Checks silkscreen does not overlap pads
+This preflight does not prove outline closure, copper on every pad, drill-size
+acceptance, silkscreen clearance, stackup compatibility, or assembly readiness.
+Establish those separately with direct DRC, the selected fabricator's current
+contract, Gerber/drill inspection, BOM/CPL review, and the order preview.
 
-### 3. Verify Footprints Assigned
+Completion criterion: direct DRC is complete, every reported issue is resolved
+or waived, and every check outside the handler's stated scope has named evidence.
 
-Every schematic symbol must have a footprint assigned. Check for:
-- Missing footprint assignments (shows as empty Footprint field)
-- Mismatched footprints (wrong pad count for the symbol)
-- Non-existent footprint references (library not found)
+## 3. Export into a fresh destination
 
----
+Prefer a new, empty output directory for each invocation. This makes stale files
+structurally unable to impersonate output from the current invocation.
 
-## Export Workflow
-
-### One-Shot Export (Recommended)
+For a package attempt:
 
 ```
 export_manufacturing_package(board, output_dir, fab_house?, schematic?)
 ```
 
-`fab_house` selects the house profile (there is no `format` argument). Pass
-`schematic` when you want the BOM generated as part of the package.
+Pass `schematic` when assembly output requires a BOM. The tool attempts Gerber,
+drill, position, and BOM exports according to the request; individual failures
+can still leave a partial directory.
 
-Generates all manufacturing files in one call:
-- Gerbers (all copper layers + mask + silkscreen + edge cuts)
-- Drill files (Excellon format)
-- BOM (CSV)
-- Pick-and-place / component position file (CPL)
-- Job file (optional, fab-house specific)
+### Artifact acceptance gate
 
-### Manual Export (When You Need Control)
+1. Inspect `warnings` and `files_generated`. Any warning or missing requested
+   artifact type keeps the result `INCOMPLETE`.
+2. Reconcile the requested copper, mask, silkscreen, paste, and `Edge.Cuts`
+   layers against the actual files in the fresh output directory.
+3. Confirm every required artifact is a regular, non-empty file produced by the
+   current invocation. A directory entry, reported path, or zero exit status is
+   not enough.
+4. Confirm the required plated and non-plated drill outputs for the actual board
+   hole inventory. Absence is acceptable only when the design proves that output
+   is inapplicable.
+5. Open the Gerbers and drills in a viewer. Inspect layer registration, outline,
+   apertures, holes/slots, mask, paste, and silkscreen.
+6. For assembly, inspect BOM contents, DNP handling, designator coverage, CPL
+   side/units/origin/rotation, and the fabricator's export preview.
 
-Use individual tools when you need specific settings per file:
+The current `files` field is a directory listing and can include pre-existing
+entries; `files_generated` records successful export calls but does not prove
+that every reported output is fresh and non-empty. If a later tool response
+provides an explicit verified artifact manifest, accept that stronger evidence
+only for the artifacts and postconditions it names. Preserve the viewer and
+order-preview checks.
 
-#### Step 1: Gerbers
+Completion criterion: an accepted manifest accounts for every required output,
+every accepted path is fresh and non-empty, and visual/order previews agree with
+the saved design.
+
+## 4. Use manual exports when control is required
+
+Use the individual tools when a package needs explicit layer, BOM, side, unit,
+or filename choices:
 
 ```
 export_gerber(board, output_dir, layers?, drill_file?)
-```
-
-Standard layers to export:
-- F.Cu, B.Cu (and inner layers if present)
-- F.Mask, B.Mask
-- F.SilkS, B.SilkS
-- F.Paste, B.Paste (for stencils)
-- Edge.Cuts (board outline)
-
-#### Step 2: Bill of Materials
-
-```
 export_bom(schematic, output, format?, fields?, group_by?, labels?, exclude_dnp?)
-```
-
-Include fields: Reference, Value, Footprint, LCSC (if targeting JLCPCB).
-
-#### Step 3: Component Position File
-
-```
 export_position_file(board, output, format?, side?, units?)
 ```
 
-Required for SMT assembly. Contains X/Y/Rotation for each component.
-Export separately for top and bottom if double-sided assembly.
+Apply the same fresh-destination and artifact acceptance gate. A manual sequence
+does not lower the evidence requirement.
 
----
-
-## JLCPCB-Specific Guidance
-
-### Part Sourcing
-
-```
-search_jlcpcb_parts(query)                     # Find LCSC part numbers
-suggest_jlcpcb_alternatives(value, footprint)  # Find alternatives for OOS parts
-```
-
-### Part Categories
-
-| Category           | Description                              | Extra Cost             |
-|--------------------|------------------------------------------|------------------------|
-| **Basic**          | ~700 common parts, pre-loaded on machine | None                   |
-| **Preferred Ext.** | Popular extended parts                   | No feeder loading fee  |
-| **Extended**       | 300k+ parts, loaded on demand            | $3 per unique part     |
-
-**Strategy**: Use basic parts wherever possible. Every extended part adds $3 to assembly cost.
-Search with `search_jlcpcb_parts` and filter by `basic: true` when looking for alternatives.
-
-### Minimum Design Rules (JLCPCB Standard Process)
-
-| Parameter              | Minimum Value |
-|------------------------|---------------|
-| Trace width            | 0.127mm (5mil)  |
-| Trace spacing          | 0.127mm (5mil)  |
-| Via drill              | 0.3mm          |
-| Via annular ring       | 0.15mm (6mil)   |
-| Min hole size          | 0.3mm          |
-| Pad-to-pad clearance   | 0.254mm (10mil) |
-| Silkscreen line width  | 0.15mm         |
-| Board thickness        | 0.8-2.0mm (1.6 default) |
-| Min board size         | 10x10mm        |
-
-Use `add_design_rule` or `list_design_rules` to configure project rules to match.
-
-### JLCPCB BOM Requirements
-
-- Column headers must be exactly: `Designator`, `Comment`, `Footprint`, `LCSC Part #`
-- LCSC Part # format: `Cxxxxxx` (e.g., C14663)
-- Group identical parts on one row with comma-separated designators
-
-### JLCPCB CPL (Position File) Requirements
-
-- Columns: `Designator`, `Mid X`, `Mid Y`, `Layer`, `Rotation`
-- Coordinates in millimeters
-- Rotation in degrees (0-360)
-- Layer values: `Top` or `Bottom`
-
----
-
-## Cost Estimation
+## 5. Treat cost output as a heuristic
 
 ```
 estimate_cost(board, quantity?, layers?, fab_house?)
 ```
 
-Factors that increase cost:
-- Layer count (2 vs 4 vs 6+)
-- Board size
-- Number of unique extended parts
-- Double-sided assembly
-- Special finishes (ENIG vs HASL)
-- Tight tolerances below standard minimums
-- Expedited turnaround
+`estimate_cost` is an indicative heuristic built from fixed assumptions and
+rough average component costs. Use it only for coarse comparisons. It is not a
+vendor quote and does not know the selected finish, service, complete BOM,
+shipping, taxes, coupons, or current pricing. Budget and purchasing decisions
+require a current quote from the selected fabricator.
 
----
+## 6. Record manufacturing acceptance
 
-## 3D Verification
+The final report must include:
 
-Before submitting to fab, always generate a 3D view:
+- saved design revision or hash;
+- direct DRC status and any explicit waivers;
+- `validate_for_manufacturing` verdict, issues, and DRC coverage;
+- selected fabricator/order contract with source and retrieval date;
+- accepted artifact manifest with file type, path, and non-empty evidence;
+- Gerber/drill viewer result;
+- BOM/CPL and order-preview result when assembly is in scope;
+- 3D/enclosure inspection status when mechanically relevant; and
+- final `READY`, `NOT READY`, or `INCOMPLETE` verdict.
 
-```
-export_3d(board, output, format?, include_unspecified?)
-```
-
-Visual checks:
-- Component clearance (tall parts near board edges)
-- Connector accessibility and orientation
-- Mounting hole alignment
-- Heatsink/thermal pad clearance
-- Enclosure fit (if applicable)
-
----
-
-## Common Mistakes
-
-1. **Exporting with DRC errors** — Always run DRC first. A clearance violation can short traces on the fab board.
-2. **Wrong drill file format** — JLCPCB expects Excellon format. PTH and NPTH in separate files.
-3. **Missing board outline** — Edge.Cuts layer must be a closed polygon. Open outlines cause fab rejection.
-4. **Silkscreen on pads** — Silkscreen ink on exposed copper pads prevents soldering. Remove overlaps.
-5. **Wrong position file origin** — CPL origin must match board origin. Use board center or bottom-left corner consistently.
-6. **Forgetting paste layer** — If ordering stencils, F.Paste/B.Paste must be exported.
-7. **Out-of-stock parts in BOM** — Always verify availability with `search_jlcpcb_parts` before ordering.
-8. **Rotation offsets** — JLCPCB may apply rotation corrections. Review their orientation guide for ICs and polarized components.
-9. **Panelization not accounted for** — If panelizing, export from the panel file, not the individual board.
-10. **Missing fiducials** — SMT assembly with fine-pitch parts requires at least 2 fiducial marks on each assembly side.
-
----
-
-## Rules
-
-1. **Never export without passing DRC** — zero errors required
-2. **Never skip validate_for_manufacturing** — catches issues DRC misses
-3. **Always verify part availability** before finalizing BOM for assembly
-4. **Export 3D model** before submitting order — visual sanity check
-5. **Save project before export** — ensures exported files match current state
-6. **Load toolsets first** — check `get_active_toolsets()` and load what you need
-7. **Use one-shot export when possible** — `export_manufacturing_package` ensures consistency
-8. **Double-check fab house requirements** — each house has slightly different file format expectations
+Only `READY` permits upload. Preserve the accepted manifest rather than telling
+the user to upload every entry found in a reused directory.

--- a/crates/konnect/assets/skills/kicad-manufacture/references/gerber-layers.md
+++ b/crates/konnect/assets/skills/kicad-manufacture/references/gerber-layers.md
@@ -1,6 +1,9 @@
 # Gerber Layer Mapping
 
-## Standard Gerber File Extensions
+## Common Gerber File Extensions
+
+Filenames and extensions vary with KiCad and exporter options. Accept files by
+their plotted layer and content, not by suffix alone.
 
 | KiCAD Layer | Gerber Extension | Purpose |
 |-------------|-----------------|---------|
@@ -24,35 +27,30 @@
 | Non-plated holes | `-NPTH.drl` | Mounting holes, slots |
 | Drill map | `.drl.map` | Visual drill reference |
 
-## What `export_gerber` Produces
+## What `export_gerber` Attempts
 
-The `export_gerber` tool generates all required files in one call:
-- All copper layers present in the design
-- Both mask layers
-- Both silkscreen layers
-- Both paste layers
-- Edge.Cuts (board outline)
-- Drill file(s)
+With no explicit layer list, `export_gerber` selects enabled copper layers,
+front/back mask and silkscreen, and `Edge.Cuts`. Paste is not in that default
+selection. With `drill_file` enabled, drill export is a separate best-effort
+step. The returned directory listing may contain older entries and does not
+prove that the current invocation created a complete, non-empty set.
 
-## What Fab Houses Expect
-
-### JLCPCB Upload
-Upload a single `.zip` containing all Gerber + drill files.
-JLCPCB auto-detects layers by extension or content.
-
-### PCBWay Upload
-Same as JLCPCB — single zip with all Gerbers.
-
-### OSH Park Upload
-Upload the `.kicad_pcb` file directly (they parse it themselves).
-Or upload Gerber zip.
+Choose layers from the saved board and the selected fabricator's current order
+contract. Use a fresh output directory and apply the manufacturing skill's
+artifact acceptance gate.
 
 ## Verification Checklist
 
 Before uploading Gerbers:
-1. `get_drc_violations` — zero errors
-2. `export_3d` — visual check of the 3D model
-3. Open Gerbers in a viewer (KiCAD's built-in, or gerbv)
-4. Verify board outline is closed (no gaps in Edge.Cuts)
-5. Verify drill file has correct hole count
-6. Verify silkscreen doesn't overlap pads
+
+1. Re-run direct DRC against the saved board and adjudicate every result.
+2. Confirm each requested artifact is a regular, non-empty file from the fresh
+   invocation.
+3. Reconcile every expected copper, mask, silkscreen, paste, and outline layer
+   with the accepted manifest.
+4. Open Gerbers and drills in a viewer and inspect registration, outline,
+   apertures, mask, paste, silkscreen, holes, and slots.
+5. Compare the viewer and upload preview with the selected fabricator's current
+   order contract.
+
+Any missing, stale, empty, or unexplained artifact makes the package `INCOMPLETE`.

--- a/crates/konnect/assets/skills/kicad-manufacture/references/jlcpcb-rules.md
+++ b/crates/konnect/assets/skills/kicad-manufacture/references/jlcpcb-rules.md
@@ -1,93 +1,76 @@
-# JLCPCB Manufacturing Reference
+# JLCPCB Order-Contract Verification
 
-## Part Categories
+Use this reference only for a JLCPCB fabrication or assembly branch. JLCPCB
+controls its capabilities, prices, part categories, templates, and portal
+validation. The current order contract is authoritative; this file deliberately
+does not cache those volatile values.
 
-| Category | Assembly fee | Notes |
-|----------|-------------|-------|
-| **Basic** | Included in standard fee | ~350 common parts, no setup charge |
-| **Extended** | +$3 per unique part | Thousands of parts, requires setup |
-| **Consigned** | User-supplied parts | You ship parts to JLCPCB |
+## 1. Pin the selected service
 
-Use `search_jlcpcb_parts` and check the `category` field in results.
-Prefer **Basic** parts for cost optimization.
+Record the exact selected service before configuring the board:
 
-## BOM Format Requirements
+- fabrication versus fabrication plus assembly;
+- economic/standard or other service tier shown by the current portal;
+- layer count, stackup, copper weight, thickness, finish, colour, and quantity;
+- assembly side(s), stencil choice, panelization, and special processes; and
+- controlled-impedance, via, slot, castellated, edge-plating, or other options.
 
-CSV with columns:
-```
-Comment, Designator, Footprint, LCSC Part Number
-100nF, C1;C2;C3, 0402, C1525
-10k, R1;R2, 0402, C25744
-```
+For every copied limit or template requirement, record the source and retrieval date.
+A generic capability page does not override the selected service's order-page
+constraints.
 
-- Multiple designators separated by `;`
-- LCSC part number is the `C######` identifier
-- Use `export_bom` then enrich with `search_jlcpcb_parts`
+Completion criterion: the order record names one selected service and contains
+the current limits for every feature the design uses.
 
-## Component Placement File (CPL)
+## 2. Verify parts against the live assembly branch
 
-CSV with columns:
-```
-Designator, Mid X, Mid Y, Layer, Rotation
-C1, 10.5, 20.3, top, 0
-U1, 25.0, 15.0, top, 90
-```
+Use `search_jlcpcb_parts` and `suggest_jlcpcb_alternatives` to produce candidates,
+then verify each candidate in the current assembly order:
 
-- Coordinates in mm from board origin
-- Layer: "top" or "bottom"
-- Rotation: degrees, counter-clockwise from file
-- Use `export_position_file` to generate
+- exact manufacturer part number and package;
+- current category, availability, and quantity;
+- feeder/setup or special-handling effects; and
+- lifecycle or substitution constraints.
 
-## Rotation Offsets
+The downloaded catalogue is useful discovery evidence, not a live stock or price
+guarantee. Record the catalogue date and recheck the order before payment.
 
-JLCPCB may rotate components differently than KiCAD's orientation.
-Common offsets (add to KiCAD rotation):
+## 3. Bind BOM and CPL to current templates
 
-| Package | Offset |
-|---------|--------|
-| 0402/0603/0805 passives | 0° (usually correct) |
-| SOT-23 | 180° |
-| SOIC-8 | 0° |
-| QFP | 0° |
-| QFN | 0° |
-| USB-C receptacle | Verify visually |
-| Electrolytic caps | Check polarity dot |
+Generate BOM and position data through Konnect, then compare the exported headers,
+units, side names, origin, delimiter, and designator grouping with the templates
+offered by the selected service. Map the project supplier field deliberately;
+do not assume one historical column spelling remains mandatory.
 
-*Always verify rotation in JLCPCB's preview tool before confirming order.*
+In the export preview, account for every placed designator and every intentional
+DNP. Inspect pin 1, polarity, side, rotation, and footprint/package agreement for
+each orientation-sensitive part. The preview, datasheet, footprint, and physical
+pin-map evidence must agree.
 
-## Design Rules Summary
+Completion criterion: the portal accepts both files and the export preview has
+no unexplained missing, extra, rotated, mirrored, or substituted component.
 
-| Rule | JLCPCB Minimum | Recommended |
-|------|---------------|-------------|
-| Trace width | 0.127mm | 0.15mm |
-| Trace space | 0.127mm | 0.15mm |
-| Via drill | 0.30mm | 0.40mm |
-| Annular ring | 0.15mm | 0.20mm |
-| Hole to hole | 0.50mm | 0.60mm |
-| Hole to edge | 0.30mm | 0.50mm |
-| Min silkscreen | 0.15mm wide | 0.20mm wide |
-| Pad to pad | 0.127mm | 0.15mm |
+## 4. Apply current fabrication constraints
 
-## Assembly Constraints
+Copy trace/space, annular-ring, drill, slot, copper-to-edge, mask, silkscreen,
+stackup, and impedance constraints from the selected service into project rules
+and netclasses. Use the stricter applicable value when the component datasheet,
+electrical calculation, or enclosure imposes a stronger requirement.
 
-### Economic Assembly (cheaper)
-- Single-side only (top OR bottom)
-- Max 1000 unique parts per board
-- No parts in slots or cutouts
-- Component size: 0201 to 40x40mm
+Re-run KiCad DRC after applying the contract and after every routing or placement
+change. Inspect the Gerber and drill outputs in a viewer; a rule table alone does
+not prove the exported geometry.
 
-### Standard Assembly (full capability)
-- Both sides
-- Fine-pitch down to 0.35mm
-- BGA support
-- Odd-form components
+## 5. Accept the package
 
-## Order Workflow with Konnect
+Create a fresh export destination and apply the manufacturing skill's artifact
+acceptance gate. Upload only the accepted manifest. In the order portal:
 
-1. `get_drc_violations` — ensure zero errors
-2. `validate_for_manufacturing` — pre-flight
-3. `export_manufacturing_package` — generates all files
-4. `search_jlcpcb_parts` for each component — get LCSC numbers
-5. `suggest_jlcpcb_alternatives` for any out-of-stock parts
-6. `estimate_cost` — get price breakdown
-7. Upload Gerber zip + BOM CSV + CPL CSV to jlcpcb.com
+- confirm every copper, mask, silkscreen, paste, and outline layer;
+- confirm plated/non-plated holes, slots, cutouts, dimensions, and layer count;
+- review warnings and the rendered board preview;
+- verify assembly mapping and rotations when assembly is selected; and
+- save the final quote and order configuration as the purchasing record.
+
+Any unexplained difference between the saved design, artifact manifest, and
+export preview makes the result `INCOMPLETE`.

--- a/crates/konnect/assets/skills/kicad-pcb/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-pcb/SKILL.md
@@ -72,9 +72,8 @@ Always call `get_active_toolsets()` first to see what is already loaded.
   selecting a copper, fabrication, user, or mechanical layer or deciding which
   side owns an item.
 - Read [`references/trace-width-table.md`](references/trace-width-table.md) when
-  estimating an initial trace width. Treat it as a starting point; the selected
-  stackup, current and voltage-drop budget, impedance calculation, netclass,
-  and fabricator contract decide the actual value.
+  sizing a current-carrying trace, via, or controlled-impedance route. It defines
+  the required calculation inputs and acceptance record; it is not a lookup table.
 - Read [`references/design-rules.md`](references/design-rules.md) when creating
   netclasses, configuring project constraints, or adjudicating DRC results.
 
@@ -188,7 +187,7 @@ route_pad_to_pad(board, net_name, ref1, pad1, ref2, pad2, layer?, width?)
 ```
 
 - Emits one segment when the pads already share an X or Y, two otherwise
-- Specify width in mm (e.g., 0.25 for signal, 0.5 for power)
+- Specify the width in mm from the accepted project netclass or sizing record.
 - Routes entirely on `layer` (default `F.Cu`) — it does not add a via. To
   change layer mid-route, place the via yourself with `add_via` and route each
   side separately
@@ -232,16 +231,11 @@ create_netclass(board, name, trace_width?, clearance?, via_drill?, via_diameter?
 The class is written to the project's `.kicad_pro` file, which is where KiCad
 has kept netclasses since v7 — the board file is not modified.
 
-Common netclass configurations:
-- Signal: 0.25mm track, 0.2mm clearance
-- Power: 0.5-1.0mm track, 0.3mm clearance
-- USB: 0.3mm track, 0.15mm spacing (90 ohm differential)
-
-### Via Defaults
-
-- Standard signal via: 0.4mm drill, 0.8mm pad diameter
-- Power via: 0.6mm drill, 1.0mm pad diameter
-- Micro via (HDI): 0.1mm drill, 0.3mm pad diameter
+Before creating or updating a class, read `get_netclasses` and the applicable
+design-rule/trace-sizing references. Derive width, clearance, gap, drill, and
+diameter from the selected fabrication contract, stackup, and electrical
+calculation. Read the classes back after the write and confirm every special net
+resolves through the intended class. Missing inputs make the rule `INCOMPLETE`.
 
 ### Pre-defined sizes
 

--- a/crates/konnect/assets/skills/kicad-pcb/references/design-rules.md
+++ b/crates/konnect/assets/skills/kicad-pcb/references/design-rules.md
@@ -1,56 +1,48 @@
-# Design Rules by Fab House
+# Project Design-Rule Workflow
 
-## JLCPCB (Standard Process)
+Design rules are project evidence, not generic prose defaults. Derive them from
+the exact design requirements, component datasheets, the selected fabricator's current contract,
+ordered stackup, and accepted electrical calculations.
 
-| Parameter | Minimum | Notes |
-|-----------|---------|-------|
-| Trace width | 0.127mm (5mil) | 0.09mm available with "advanced" |
-| Trace spacing | 0.127mm (5mil) | |
-| Via drill | 0.30mm | |
-| Via pad diameter | 0.50mm min | Annular ring ≥ 0.15mm |
-| Min hole size | 0.30mm | |
-| Board thickness | 0.4–2.4mm | 1.6mm standard |
-| Copper weight | 1oz or 2oz | 1oz default |
-| Min board size | 10x10mm | |
-| Max board size | 400x500mm | |
-| Slots min width | 0.80mm | |
-| Castellated holes | 0.60mm min | Edge-plated |
-| Silkscreen min | 0.15mm width, 0.80mm height | |
-| Board edge clearance | 0.30mm | Copper to edge |
+## 1. Capture rule provenance
 
-## PCBWay (Standard Process)
+Record the source and retrieval date for:
 
-| Parameter | Minimum |
-|-----------|---------|
-| Trace width | 0.10mm (4mil) |
-| Trace spacing | 0.10mm (4mil) |
-| Via drill | 0.20mm |
-| Via pad diameter | 0.40mm min |
-| Board thickness | 0.2–6.0mm |
-| Copper weight | 0.5–13oz |
+- trace, space, annular-ring, drill, slot, and copper-to-edge limits;
+- mask, paste, silkscreen, and courtyard constraints;
+- layer count, copper thickness, dielectric stackup, and impedance service;
+- voltage-clearance, creepage, current, thermal, and mechanical requirements;
+- assembly, test, panelization, and enclosure constraints.
 
-## OSH Park (2-layer)
+Use the strictest applicable requirement. A capability advertised for another
+service tier or stackup does not authorize the selected order.
 
-| Parameter | Minimum |
-|-----------|---------|
-| Trace width | 0.152mm (6mil) |
-| Trace spacing | 0.152mm (6mil) |
-| Via drill | 0.254mm (10mil) |
-| Annular ring | 0.102mm (4mil) |
-| Board thickness | 1.6mm (fixed) |
+Completion criterion: every configured rule has a current source or calculation,
+and every applicable requirement has a project rule or explicit review check.
 
-## Netclass Setup for Design Rules
+## 2. Encode the accepted values
 
-Use `create_netclass` to apply different rules per net type:
+Use `set_design_rules` for board-wide minima and `get_design_rules` to read back
+what was stored. Use `create_netclass` for electrical groups and
+`assign_net_to_class` for exact net membership. Use `set_predefined_sizes` for
+the accepted trace/via palette.
 
-```
-Default:    clearance 0.20mm, trace_width 0.20mm, via_drill 0.40mm
-Power:      clearance 0.25mm, trace_width 0.50mm, via_drill 0.50mm
-HighSpeed:  clearance 0.15mm, trace_width 0.15mm, via_drill 0.30mm
-USB:        clearance 0.15mm, trace_width 0.15mm, via_drill 0.30mm
-```
+The project netclasses are the source of truth for routing widths, clearances, and
+via geometry. Name classes by purpose—ordinary signal, current-carrying rail,
+controlled-impedance interface, high-voltage isolation—rather than copying an
+undated vendor table.
 
-Then use `assign_net_to_class` to assign nets:
-- Power nets (+3V3, +5V, VCC) → "Power"
-- USB_DP, USB_DM → "USB"
-- Clock nets → "HighSpeed"
+Completion criterion: readback matches the accepted rule record, and every
+special net is assigned to the intended class.
+
+## 3. Verify the effective design
+
+After encoding the values, re-run DRC after rule changes and after placement, routing, zone, or outline
+changes. Resolve every error or record a deliberate waiver tied to the governing
+requirement. For controlled impedance and current-carrying nets, reconcile DRC
+with the calculation record; DRC only proves compliance with the values it was
+given.
+
+Before manufacturing, compare project rules with the final selected order and
+stackup again. Any missing source, mismatched readback, unreviewed DRC result, or
+contract drift makes the rule set `INCOMPLETE`.

--- a/crates/konnect/assets/skills/kicad-pcb/references/trace-width-table.md
+++ b/crates/konnect/assets/skills/kicad-pcb/references/trace-width-table.md
@@ -1,70 +1,69 @@
-# Trace Width Reference
+# Trace, Via, and Impedance Sizing
 
-## Current Capacity (1oz/ft² copper, 10°C rise, external layer)
+This reference defines the sizing process, not universal dimensions. Store the
+accepted results in project netclasses and predefined sizes so routing tools use
+the same values that were reviewed.
 
-| Current (A) | Min Width (mm) | Recommended Width (mm) |
-|-------------|---------------|----------------------|
-| 0.1 | 0.05 | 0.15 |
-| 0.25 | 0.10 | 0.20 |
-| 0.5 | 0.15 | 0.30 |
-| 1.0 | 0.30 | 0.50 |
-| 2.0 | 0.70 | 1.00 |
-| 3.0 | 1.10 | 1.50 |
-| 5.0 | 2.00 | 2.50 |
+## Current-carrying traces
 
-**For internal layers**: multiply width by 1.5x (less cooling)
-**For 2oz copper**: divide width by ~0.7x
+For each current-carrying net, capture:
 
-## Standard Trace Widths by Application
+- continuous and transient current;
+- copper thickness and plating assumptions;
+- external or internal layer;
+- ambient and temperature-rise budget;
+- trace length and voltage-drop budget;
+- available routing width and thermal environment; and
+- the selected fabricator's current minimums and stackup.
 
-| Application | Width (mm) | Netclass name |
-|-------------|-----------|--------------|
-| Signal (general) | 0.15–0.25 | Default |
-| High-speed digital | 0.10–0.15 | HighSpeed |
-| Power (< 1A) | 0.30–0.50 | Power |
-| Power (1–3A) | 0.50–1.50 | PowerHigh |
-| USB 2.0 differential | 0.15 (90Ω diff) | USB |
-| USB 3.0 differential | 0.10 (85Ω diff) | USB3 |
-| Antenna / RF | per impedance calc | RF |
+Use an accepted current-capacity method or calculator with those inputs. Record
+the method, inputs, result, and chosen margin. Changing copper weight, layer,
+temperature, length, or allowed drop requires a new calculation; a scale factor
+is not sufficient acceptance evidence.
 
-## Via Sizing
+Completion criterion: the selected width satisfies both thermal and voltage-drop
+limits and is no narrower than the current fabrication contract.
 
-| Application | Drill (mm) | Pad (mm) | Current capacity |
-|-------------|-----------|---------|-----------------|
-| Signal via | 0.30 | 0.60 | ~0.5A |
-| Standard via | 0.40 | 0.80 | ~1A |
-| Power via | 0.50 | 1.00 | ~1.5A |
-| Thermal via | 0.30 | 0.60 | Array of 4-9 for heat |
+## Ordinary signals
 
-## Clearance Rules
+For an ordinary, non-impedance-controlled signal, choose a width and clearance
+that the selected process can fabricate reliably and the available geometry can
+route. Keep one project netclass as the source of truth. A prose default is only
+a candidate until it is written to the project and passes DRC.
 
-| Item pair | Minimum (mm) | Recommended (mm) |
-|-----------|-------------|-----------------|
-| Trace-to-trace | 0.15 | 0.20 |
-| Trace-to-pad | 0.15 | 0.20 |
-| Trace-to-edge | 0.25 | 0.50 |
-| Via-to-via | 0.20 | 0.30 |
-| Via-to-trace | 0.15 | 0.20 |
-| Component-to-edge | 1.00 | 2.00 |
+## Controlled impedance
 
-## JLCPCB Minimums (standard process)
+Obtain the actual stackup before choosing geometry. An external microstrip and
+an internal stripline have different fields; an internal conductor is not a
+microstrip. A differential pair additionally depends on spacing, reference
+planes, copper thickness, dielectric properties, solder mask, and the
+fabricator's impedance-control process.
 
-| Parameter | Minimum |
-|-----------|---------|
-| Trace width | 0.127mm (5mil) |
-| Trace spacing | 0.127mm (5mil) |
-| Via drill | 0.30mm |
-| Via annular ring | 0.15mm |
-| Hole-to-hole | 0.50mm |
-| Board edge clearance | 0.30mm |
+Use a field solver or the fabricator's stackup calculator. Record:
 
-## Impedance Reference (FR4, 1.6mm, 1oz)
+- target single-ended or differential impedance and tolerance;
+- layer and reference plane(s);
+- dielectric thickness and material assumptions;
+- copper thickness, finished trace width, and etch assumptions;
+- pair spacing and solder-mask treatment; and
+- solver/tool version and result.
 
-| Target | Trace width | Gap | Layer |
-|--------|------------|-----|-------|
-| 50Ω single-ended | 0.30mm | — | External |
-| 90Ω differential (USB 2.0) | 0.15mm | 0.15mm | External |
-| 100Ω differential (Ethernet) | 0.12mm | 0.18mm | External |
-| 50Ω microstrip (internal) | 0.18mm | — | Internal |
+Apply the solved width and gap to the project netclass. Re-solve whenever the
+stackup or fabricator changes, and verify the ordered impedance service matches
+the calculation.
 
-*Note: These are approximate. Use a proper impedance calculator for production designs.*
+## Vias
+
+Choose via drill and finished diameter from the selected fabricator's current
+capability, required annular ring, board thickness/aspect ratio, current, and
+reliability target. Power and thermal paths may require parallel vias; justify
+their count with electrical/thermal evidence rather than a fixed lookup table.
+
+Use `set_predefined_sizes` to record accepted via choices and
+`get_predefined_sizes` to verify the stored palette before routing.
+
+## Acceptance record
+
+For every non-default netclass, preserve the sizing purpose, governing inputs,
+calculation or current contract, selected values, and DRC result. A required
+input that is unavailable makes the sizing decision `INCOMPLETE`.

--- a/crates/konnect/assets/skills/kicad-review/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-review/SKILL.md
@@ -316,7 +316,9 @@ Present findings grouped by severity with actionable fix suggestions:
 ### Pre-Manufacturing Review
 
 1. Full review (above)
-2. `validate_for_manufacturing()` — fab-specific checks
+2. Run `validate_for_manufacturing()`, then inspect `verdict`, `issues`, and
+   `drc` against the handler's limited contract; it does not replace outline,
+   drill, silkscreen, artifact, BOM/CPL, or order-preview acceptance
 3. Verify BOM completeness
 4. Check part availability (if targeting specific fab house)
 5. Final verdict: ready to manufacture or not

--- a/crates/konnect/tests/asset_references.rs
+++ b/crates/konnect/tests/asset_references.rs
@@ -262,6 +262,121 @@ fn skills_define_the_same_evidence_boundary_as_their_agents() {
     );
 }
 
+/// Manufacturing guidance must describe evidence the released tools actually
+/// return, and it must remain safe while artifact verification is implemented
+/// independently in #270. v0.10.0 claimed four validations the handler did not
+/// perform, treated a partial export as a complete package, and duplicated
+/// volatile vendor and impedance tables as if they were design authority
+/// (#357).
+#[test]
+fn manufacturing_guidance_is_contract_bound_and_fail_closed() {
+    let manufacture = include_str!("../assets/skills/kicad-manufacture/SKILL.md");
+    let jlcpcb = include_str!("../assets/skills/kicad-manufacture/references/jlcpcb-rules.md");
+    let design_rules = include_str!("../assets/skills/kicad-pcb/references/design-rules.md");
+    let trace_width = include_str!("../assets/skills/kicad-pcb/references/trace-width-table.md");
+
+    for marker in [
+        "presence of at least one `Edge.Cuts` item",
+        "`verdict`, `issues`, and `drc`",
+        "does not prove outline closure",
+        "`warnings` and `files_generated`",
+        "current invocation",
+        "regular, non-empty file",
+        "INCOMPLETE",
+        "indicative heuristic",
+        "current quote",
+    ] {
+        assert!(
+            manufacture.contains(marker),
+            "manufacturing skill is missing contract marker: {marker}"
+        );
+    }
+
+    for stale_claim in [
+        "Checks board outline is closed",
+        "Checks all pads have copper",
+        "Checks drill sizes are within fabrication limits",
+        "Checks silkscreen does not overlap pads",
+        "ensures consistency",
+        "~700 common parts",
+        "Every extended part adds $3",
+    ] {
+        assert!(
+            !manufacture.contains(stale_claim),
+            "manufacturing skill still claims `{stale_claim}`"
+        );
+    }
+
+    for marker in [
+        "current order contract",
+        "selected service",
+        "export preview",
+        "source and retrieval date",
+    ] {
+        assert!(
+            jlcpcb.contains(marker),
+            "JLCPCB reference is missing current-contract marker: {marker}"
+        );
+    }
+    for stale_value in [
+        "~350 common parts",
+        "+$3 per unique part",
+        "0.127mm",
+        "0.35mm",
+    ] {
+        assert!(
+            !jlcpcb.contains(stale_value),
+            "JLCPCB reference still caches volatile value `{stale_value}`"
+        );
+    }
+
+    for marker in [
+        "selected fabricator's current contract",
+        "project netclasses",
+        "re-run DRC",
+    ] {
+        assert!(
+            design_rules.contains(marker),
+            "design-rule reference is missing authority marker: {marker}"
+        );
+    }
+    for stale_heading in [
+        "JLCPCB (Standard Process)",
+        "PCBWay (Standard Process)",
+        "OSH Park (2-layer)",
+    ] {
+        assert!(
+            !design_rules.contains(stale_heading),
+            "design-rule reference still duplicates vendor table `{stale_heading}`"
+        );
+    }
+
+    for marker in [
+        "copper thickness",
+        "temperature-rise budget",
+        "voltage-drop budget",
+        "external microstrip",
+        "internal stripline",
+        "field solver",
+    ] {
+        assert!(
+            trace_width.contains(marker),
+            "trace-width reference is missing calculation input: {marker}"
+        );
+    }
+    for stale_value in [
+        "divide width by ~0.7x",
+        "50Ω single-ended | 0.30mm",
+        "90Ω differential (USB 2.0) | 0.15mm",
+        "50Ω microstrip (internal)",
+    ] {
+        assert!(
+            !trace_width.contains(stale_value),
+            "trace-width reference still presents unsafe fixed advice `{stale_value}`"
+        );
+    }
+}
+
 /// Every `load_toolset('name')` in the shipped prose names a real toolset.
 #[test]
 fn documented_toolsets_exist_in_the_registry() {
@@ -580,6 +695,8 @@ fn backticked_tool_names_in_prose_exist_in_the_registry() {
         "roundrect_rratio",
         // Structured MCP error discriminant, not a callable tool.
         "unsafe_file_fallback",
+        // Structured manufacturing response field, not a callable tool.
+        "files_generated",
     ];
 
     let mut phantom = Vec::new();


### PR DESCRIPTION
## Problem and scope

PRs #362 and #363 connected the Claude package and made its claimed evidence executable, but the final #357 scope remained: manufacturing guidance still credited `validate_for_manufacturing` with checks it does not perform, treated partial exports as complete packages, duplicated conflicting vendor tables, and presented fixed trace/via/impedance geometry without the inputs required to justify it.

This is the focused guidance-only PR C. It closes the remaining #357 scope without depending on the conflicting #270 branch.

## Design

- Bind the manufacturing preflight to the handler's observed contract: Edge.Cuts presence, footprint presence, configured minimum trace width, the no-tracks heuristic, and direct DRC evidence.
- Require fresh export destinations plus an artifact acceptance gate covering warnings, generated-file records, actual regular/non-empty files, Gerber/drill viewing, BOM/CPL inspection, and order-preview reconciliation.
- Treat an unavailable or contradictory required check as `INCOMPLETE`.
- Label `estimate_cost` as an indicative fixed-assumption heuristic rather than a quote.
- Replace duplicated JLCPCB prices, categories, limits, and template claims with a current-order-contract workflow that records source and retrieval date.
- Replace current/width, via, and controlled-impedance lookup tables with calculation inputs, stackup/field-solver evidence, project netclasses, and readback/DRC acceptance.
- Correct the Gerber reference: paste is not in the default layer selection, drill export is best-effort, and a directory listing is not artifact proof.
- Add a mechanical asset test that prevents the false claims and unsafe fixed tables from returning.

The wording is deliberately forward-compatible with #270: if a future response exposes a verified artifact manifest, the skill accepts that stronger evidence only for the postconditions it names. The viewer and order-preview gates remain.

## Compatibility

Bundled Claude skills, references, and their asset tests change. MCP tools, schemas, response shapes, Rust export behavior, file formats, installer paths, and Codex behavior are unchanged. Because #270 edits Rust export modules while this PR edits bundled Markdown and `asset_references.rs`, there is no expected textual conflict.

## Validation

Red baseline before the guidance rewrite:

- `cargo test -p konnect --test asset_references manufacturing_guidance_is_contract_bound_and_fail_closed`
- failed on the first missing current-contract marker (`presence of at least one Edge.Cuts item`)

After the rewrite:

- `cargo test -p konnect --test asset_references`: 12/12 passed
- `cargo fmt --all -- --check`: passed
- `cargo clippy --workspace --locked --all-targets -- -D warnings`: passed
- `cargo test --workspace --locked --lib --tests`: passed
- `cargo test --workspace --locked --doc`: passed

Real-KiCad GUI, installed-library, Java/Freerouting, and dedicated E2E cases remain ignored where their existing tests require those environments. This PR changes guidance only and does not claim those environment-dependent paths were exercised.

## Risk and rollback

The workflow asks for more explicit evidence before manufacturing approval, which adds agent work to a full fabrication handoff. That work corresponds to checks the previous guidance already claimed had happened. The change can be reverted without data or API migration.

Closes #357.