### PR TITLE
fix(schematic): preserve all hierarchical placement instances

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -260,6 +260,7 @@ Tool-call failures are typed via the `ToolErrorKind` enum in `crates/konnect-cor
 | `invalid_argument` | Required argument missing/malformed |
 | `file_not_found` | Referenced file or project-discovery directory does not exist or cannot be read |
 | `conflict` | The file changed, a write would replace existing paths, or schematic project ownership cannot be proven uniquely — carries the affected paths; ownership conflicts include the schematic directory and all candidate roots |
+| `stale_target` | Saved symbol instance metadata disagrees with the proven hierarchy, or placement readback lacks the expected document/symbol evidence — carries `target` and `reason`; preflight refuses before writing, while a readback failure may follow a committed write |
 | `handler_error` | Catch-all for unmigrated `anyhow::Error` returns |
 
 ### Producing structured errors in a handler

--- a/crates/konnect-core/src/mcp/error.rs
+++ b/crates/konnect-core/src/mcp/error.rs
@@ -52,6 +52,9 @@ pub enum ToolErrorKind {
     /// A mutation conflicts with filesystem state, or schematic ownership
     /// cannot be proven uniquely. Paths identify the conflicting evidence.
     Conflict { paths: Vec<String> },
+    /// The caller named a target, but its observed editor or document state
+    /// no longer agrees with the state required to mutate it safely.
+    StaleTarget { target: String, reason: String },
     /// A board was live earlier in this server process, but IPC is now gone;
     /// its saved file may be stale relative to lost editor state.
     UnsafeFileFallback { path: String },
@@ -71,6 +74,7 @@ impl ToolErrorKind {
             Self::InvalidArgument { .. } => "invalid_argument",
             Self::FileNotFound { .. } => "file_not_found",
             Self::Conflict { .. } => "conflict",
+            Self::StaleTarget { .. } => "stale_target",
             Self::UnsafeFileFallback { .. } => "unsafe_file_fallback",
             Self::HandlerError { .. } => "handler_error",
         }
@@ -170,6 +174,10 @@ mod tests {
             ToolErrorKind::FileNotFound { path: "p".into() },
             ToolErrorKind::Conflict {
                 paths: vec!["p".into()],
+            },
+            ToolErrorKind::StaleTarget {
+                target: "p".into(),
+                reason: "r".into(),
             },
             ToolErrorKind::UnsafeFileFallback { path: "p".into() },
             ToolErrorKind::HandlerError { reason: "r".into() },

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -27,6 +27,8 @@ pub mod sch_export;
 pub mod sch_hierarchy;
 pub mod sch_wiring;
 pub mod schematic_builder;
+#[cfg(test)]
+mod schematic_placement_tests;
 pub mod svg_import;
 pub mod templates;
 pub mod verification;
@@ -1332,6 +1334,10 @@ pub struct SheetInstanceContext {
     pub project_name: String,
     /// `/root-uuid[/sheet-uuid…]`, the path from the root down to this sheet.
     pub instance_path: String,
+    /// Every structurally observed path to this document. A reused child sheet
+    /// has one entry per hierarchy instance; document-wide edits affect all of
+    /// them and must never silently choose the first.
+    pub instance_paths: Vec<String>,
     /// Whether this sheet was reached from a root other than itself.
     pub is_child_sheet: bool,
 }
@@ -1362,6 +1368,10 @@ pub(crate) enum SchematicTargetError {
         target: std::path::PathBuf,
         roots: Vec<std::path::PathBuf>,
     },
+    StaleTarget {
+        target: std::path::PathBuf,
+        reason: String,
+    },
 }
 
 impl std::fmt::Display for SchematicTargetError {
@@ -1389,6 +1399,13 @@ impl std::fmt::Display for SchematicTargetError {
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
+            Self::StaleTarget { target, reason } => {
+                write!(
+                    formatter,
+                    "schematic '{}' is stale: {reason}",
+                    target.display()
+                )
+            }
         }
     }
 }
@@ -1414,6 +1431,17 @@ impl SchematicTargetError {
                     message,
                 )
             }
+            Self::StaleTarget { target, reason } => CallToolResult::error_kind(
+                crate::mcp::error::ToolErrorKind::StaleTarget {
+                    target: target.display().to_string(),
+                    reason: reason.clone(),
+                },
+                format!(
+                    "Schematic '{}' does not match its structurally observed target state: {}.",
+                    target.display(),
+                    reason
+                ),
+            ),
         }
     }
 }
@@ -1593,6 +1621,7 @@ pub(crate) fn sheet_instance_context(
     let standalone = SheetInstanceContext {
         project_name: project_name_for(sch_path),
         instance_path: format!("/{own_root}"),
+        instance_paths: vec![format!("/{own_root}")],
         is_child_sheet: false,
     };
 
@@ -1612,8 +1641,111 @@ pub(crate) fn sheet_instance_context(
             .unwrap_or_default()
             .to_string(),
         instance_path,
+        instance_paths: ownership.instance_paths,
         is_child_sheet: !same_schematic_document(&ownership.root_schematic, sch_path),
     })
+}
+
+/// Prove that every existing placed symbol is keyed to exactly the hierarchy
+/// identities observed from the parsed project root.
+///
+/// A missing, foreign, duplicate, or obsolete path means the file's saved
+/// instance metadata is stale. Adding another symbol in that state would
+/// produce a document where KiCad resolves different components against
+/// different hierarchy instances, so mutation fails closed before the in-memory
+/// schematic is changed.
+pub(crate) fn validate_sheet_instance_state(
+    sch_path: &std::path::Path,
+    schematic: &konnect_schematic_editor::Schematic,
+    context: &SheetInstanceContext,
+) -> Result<(), SchematicTargetError> {
+    let mut expected = context
+        .instance_paths
+        .iter()
+        .map(|path| (context.project_name.clone(), path.clone()))
+        .collect::<Vec<_>>();
+    expected.sort();
+
+    fn reference_prefix(reference: &str) -> &str {
+        reference.trim_end_matches(|character: char| character.is_ascii_digit() || character == '?')
+    }
+
+    let mut stale_symbols = Vec::new();
+    for symbol in &schematic.symbols {
+        let instances = symbol.instances();
+        let mut observed = instances
+            .iter()
+            .filter_map(|instance| Some((instance.project.clone()?, instance.path.clone()?)))
+            .collect::<Vec<_>>();
+        observed.sort();
+        let symbol_reference = symbol.reference().filter(|reference| !reference.is_empty());
+        let malformed = instances.iter().any(|instance| {
+            instance.project.as_deref().is_none_or(str::is_empty)
+                || instance.path.as_deref().is_none_or(str::is_empty)
+                || instance.reference.as_deref().is_none_or(str::is_empty)
+                || instance.unit.is_none()
+        });
+        let wrong_unit = instances
+            .iter()
+            .any(|instance| instance.unit != Some(symbol.unit));
+        let wrong_reference = symbol_reference.is_none_or(|reference| {
+            let prefix = reference_prefix(reference);
+            !instances
+                .iter()
+                .any(|instance| instance.reference.as_deref() == Some(reference))
+                || instances.iter().any(|instance| {
+                    instance
+                        .reference
+                        .as_deref()
+                        .is_none_or(|candidate| reference_prefix(candidate) != prefix)
+                })
+        });
+        if malformed || observed != expected || wrong_unit || wrong_reference {
+            let identity = symbol_reference.unwrap_or(symbol.uuid.as_str());
+            let format_paths = |paths: &[(String, String)]| {
+                paths
+                    .iter()
+                    .map(|(project, path)| format!("{project}:{path}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+            let mut reasons = Vec::new();
+            if malformed {
+                reasons
+                    .push("missing or malformed project/path/reference/unit metadata".to_string());
+            }
+            if observed != expected {
+                reasons.push(format!(
+                    "observed [{}], expected [{}]",
+                    format_paths(&observed),
+                    format_paths(&expected)
+                ));
+            }
+            if wrong_unit {
+                reasons.push(format!(
+                    "instance unit disagrees with symbol unit {}",
+                    symbol.unit
+                ));
+            }
+            if wrong_reference {
+                reasons.push("instance reference identity disagrees with the symbol".to_string());
+            }
+            stale_symbols.push(format!("{identity}: {}", reasons.join(", ")));
+        }
+    }
+
+    if stale_symbols.is_empty() {
+        Ok(())
+    } else {
+        Err(SchematicTargetError::StaleTarget {
+            target: sch_path.to_path_buf(),
+            reason: format!(
+                "placed-symbol instance metadata disagrees with project '{}': {}",
+                context.project_name,
+                stale_symbols.join("; ")
+            ),
+        })
+    }
 }
 
 #[cfg(test)]

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -8,8 +8,8 @@
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
 use crate::tools::{
-    find_all_symbol_instance_blocks, get_path, opt_str, project_name_for, require_array,
-    require_f64, require_str, ToolDef,
+    find_all_symbol_instance_blocks, get_path, opt_str, require_array, require_f64, require_str,
+    ToolDef,
 };
 use konnect_schematic_editor as cse;
 use konnect_sexp::{
@@ -29,7 +29,7 @@ use std::collections::HashSet;
 
 use super::sch_connectivity::{ConnectivityIndex, COINCIDENT_TOLERANCE};
 // Re-use the single-item component placer and pin-to-pin router.
-use super::sch_components::place_one_component;
+use super::sch_components::{place_one_component, placed_component_readback};
 use super::sch_wiring::{resolve_pin_endpoint, resolve_placed_pin, route_between};
 
 // ─── Tool definitions ─────────────────────────────────────────────────────────
@@ -64,7 +64,9 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "batch_place_components",
-            "Place multiple symbols from KiCAD libraries in a single file read/write cycle. \
+            "Place multiple symbols from KiCAD libraries in one write with committed-file \
+             readback. Preserves every saved hierarchy instance and preflights stale metadata \
+             before any placement. \
              Pass explicit references -- there is no auto-numbering; an omitted reference \
              becomes '?' like an eeschema-unannotated symbol, same as add_schematic_component.",
             json!({
@@ -479,15 +481,20 @@ async fn handle_batch_place_components(
     };
 
     let mut sch = cse::Schematic::load(&sch_path)?;
-    let root_uuid = crate::tools::ensure_root_uuid(&mut sch);
-    let project_name = project_name_for(&sch_path);
+    let context = match crate::tools::sheet_instance_context(&sch_path, &mut sch) {
+        Ok(context) => context,
+        Err(error) => return Ok(error.into_tool_result()),
+    };
+    if let Err(error) = crate::tools::validate_sheet_instance_state(&sch_path, &sch, &context) {
+        return Ok(error.into_tool_result());
+    }
     // Built once: the lib-table parse is memoised across the whole batch.
     let src = match crate::tools::library::KiCadSymbolSource::for_file(&sch_path) {
         Ok(source) => source,
         Err(error) => return Ok(error.into_tool_result()),
     };
 
-    let mut placed: Vec<serde_json::Value> = Vec::new();
+    let mut placed_uuids = Vec::new();
     let mut errors: Vec<String> = Vec::new();
 
     for comp in &components {
@@ -506,8 +513,8 @@ async fn handle_batch_place_components(
 
         match place_one_component(
             &mut sch,
-            &root_uuid,
-            &project_name,
+            &context.instance_paths,
+            &context.project_name,
             lib_id,
             x,
             y,
@@ -517,13 +524,21 @@ async fn handle_batch_place_components(
             unit,
             &src,
         ) {
-            Ok(v) => placed.push(v),
+            Ok(uuid) => placed_uuids.push(uuid),
             Err(e) => errors.push(error_text(&e)),
         }
     }
 
-    if !placed.is_empty() {
+    let mut placed = Vec::new();
+    if !placed_uuids.is_empty() {
         sch.overwrite()?;
+        let committed = cse::Schematic::load(&sch_path)?;
+        for uuid in &placed_uuids {
+            match placed_component_readback(&sch_path, &committed, uuid, &context) {
+                Ok(result) => placed.push(result),
+                Err(error) => return Ok(error),
+            }
+        }
     }
 
     let mut result = CallToolResult::json(&json!({

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -81,7 +81,9 @@ pub fn tools() -> Vec<ToolDef> {
         tool!(
             "add_schematic_component",
             "Add a symbol from a KiCAD library to the schematic. The symbol is snapped \
-             to the 1.27mm schematic grid. Specify position in schematic mm coordinates.",
+             to the 1.27mm schematic grid. Preserves every saved hierarchy instance, reports \
+             committed-file readback, and refuses stale instance metadata before writing. \
+             Specify position in schematic mm coordinates.",
             json!({
                 "type": "object",
                 "properties": {
@@ -546,17 +548,18 @@ async fn handle_add_schematic_component(
         Ok(context) => context,
         Err(error) => return Ok(error.into_tool_result()),
     };
-    let instance_path = context.instance_path.clone();
-    let project_name = context.project_name.clone();
+    if let Err(error) = crate::tools::validate_sheet_instance_state(&sch_path, &sch, &context) {
+        return Ok(error.into_tool_result());
+    }
     let source = match crate::tools::library::KiCadSymbolSource::for_file(&sch_path) {
         Ok(source) => source,
         Err(error) => return Ok(error.into_tool_result()),
     };
 
-    let result = match place_one_component(
+    let uuid = match place_one_component(
         &mut sch,
-        &instance_path,
-        &project_name,
+        &context.instance_paths,
+        &context.project_name,
         &lib_id,
         x,
         y,
@@ -566,7 +569,7 @@ async fn handle_add_schematic_component(
         unit,
         &source,
     ) {
-        Ok(v) => v,
+        Ok(uuid) => uuid,
         Err(e) => return Ok(e),
     };
 
@@ -576,8 +579,12 @@ async fn handle_add_schematic_component(
     // KiCad's netlister treats it as unconnected. Runs after the write because
     // it re-reads the saved file; `place_one_component` stays pure so the batch
     // path can do one junction pass for the whole batch instead of one per part.
-    let mut result = result;
     let junctions = crate::tools::add_pin_midwire_junctions(&sch_path, ref_str)?;
+    let committed = cse::Schematic::load(&sch_path)?;
+    let mut result = match placed_component_readback(&sch_path, &committed, &uuid, &context) {
+        Ok(result) => result,
+        Err(error) => return Ok(error),
+    };
     result["junctions_added"] = json!(junctions
         .iter()
         .map(|(x, y)| json!({ "x": x, "y": y }))
@@ -592,7 +599,7 @@ async fn handle_add_schematic_component(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn place_one_component(
     sch: &mut cse::Schematic,
-    instance_path: &str,
+    instance_paths: &[String],
     project_name: &str,
     lib_id: &str,
     x: f64,
@@ -602,7 +609,7 @@ pub(crate) fn place_one_component(
     value: Option<&str>,
     unit: u32,
     src: &dyn cse::library::SymbolLibrarySource,
-) -> Result<serde_json::Value, CallToolResult> {
+) -> Result<String, CallToolResult> {
     // Snap to 1.27mm grid
     let (x, y) = snap_point(x, y, 1.27);
     let val_str = value.unwrap_or(lib_id.split(':').next_back().unwrap_or("?"));
@@ -693,18 +700,88 @@ pub(crate) fn place_one_component(
 
     // Instance entry, keyed to the root sheet UUID like eeschema writes it:
     // (instances (project "<name>" (path "/<root-uuid>" (reference ...) (unit 1))))
-    sym.set_instance_path(project_name, instance_path, reference, unit);
+    for instance_path in instance_paths {
+        sym.set_instance_path(project_name, instance_path, reference, unit);
+    }
 
     let uuid = sym.uuid.clone();
     sch.add_symbol(sym);
 
+    Ok(uuid)
+}
+
+/// Build a placement response only from the committed schematic that was read
+/// back after the write. The UUID is the mutation's stable identity; requested
+/// coordinates, fields, and hierarchy paths are never echoed as proof.
+pub(crate) fn placed_component_readback(
+    sch_path: &std::path::Path,
+    committed: &cse::Schematic,
+    uuid: &str,
+    context: &crate::tools::SheetInstanceContext,
+) -> Result<serde_json::Value, CallToolResult> {
+    if !super::same_schematic_document(sch_path, committed.filepath()) {
+        return Err(crate::tools::SchematicTargetError::StaleTarget {
+            target: sch_path.to_path_buf(),
+            reason: "placement readback came from a different schematic".to_string(),
+        }
+        .into_tool_result());
+    }
+    if let Err(error) = crate::tools::validate_sheet_instance_state(sch_path, committed, context) {
+        return Err(error.into_tool_result());
+    }
+    let Some(symbol) = committed.symbols.iter().find(|symbol| symbol.uuid == uuid) else {
+        return Err(crate::tools::SchematicTargetError::StaleTarget {
+            target: sch_path.to_path_buf(),
+            reason: format!("placed symbol UUID '{uuid}' is absent from post-write readback"),
+        }
+        .into_tool_result());
+    };
+    let Some(reference) = symbol.reference() else {
+        return Err(crate::tools::SchematicTargetError::StaleTarget {
+            target: sch_path.to_path_buf(),
+            reason: format!(
+                "placed symbol UUID '{}' has no Reference in post-write readback",
+                symbol.uuid
+            ),
+        }
+        .into_tool_result());
+    };
+    let Some(value) = symbol.value_str() else {
+        return Err(crate::tools::SchematicTargetError::StaleTarget {
+            target: sch_path.to_path_buf(),
+            reason: format!(
+                "placed symbol UUID '{}' has no Value in post-write readback",
+                symbol.uuid
+            ),
+        }
+        .into_tool_result());
+    };
+    let observed_instances = symbol.instance_paths();
+    let Some((project, _)) = observed_instances.first() else {
+        return Err(crate::tools::SchematicTargetError::StaleTarget {
+            target: sch_path.to_path_buf(),
+            reason: format!("placed symbol UUID '{uuid}' has no project in post-write readback"),
+        }
+        .into_tool_result());
+    };
+    let mut instance_paths = observed_instances
+        .iter()
+        .map(|(_, path)| path.clone())
+        .collect::<Vec<_>>();
+    instance_paths.sort();
+
     Ok(json!({
-        "added": lib_id,
+        "schematic": committed.filepath().display().to_string(),
+        "added": symbol.lib_id,
         "reference": reference,
-        "value": val_str,
-        "x": x, "y": y,
-        "unit": unit,
-        "uuid": uuid
+        "value": value,
+        "x": symbol.at.x,
+        "y": symbol.at.y,
+        "rotation": symbol.at.rotation.unwrap_or(0.0),
+        "unit": symbol.unit,
+        "uuid": symbol.uuid,
+        "project": project,
+        "instance_paths": instance_paths
     }))
 }
 

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -6,8 +6,7 @@
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
 use crate::tools::{
-    get_path, opt_f64, opt_str, project_name_for, require_array, require_f64, require_str,
-    ToolContext, ToolDef,
+    get_path, opt_f64, opt_str, require_array, require_f64, require_str, ToolContext, ToolDef,
 };
 use konnect_schematic_editor as cse;
 use konnect_sexp::{
@@ -210,7 +209,9 @@ pub fn tools() -> Vec<ToolDef> {
         tool!(
             "add_power_symbol",
             "Add a power symbol (VCC, GND, etc.) to the schematic. Auto-numbers the \
-             internal #PWR reference to the lowest number free on the sheet.",
+             internal #PWR reference to the lowest number free on the sheet. Preserves every \
+             saved hierarchy instance and reports committed-file readback; refuses stale \
+             instance metadata before writing.",
             json!({
                 "type": "object",
                 "properties": {
@@ -1587,6 +1588,13 @@ async fn handle_add_power_symbol(
     let rotation = opt_f64(args, "rotation").unwrap_or(0.0);
 
     let mut sch = cse::Schematic::load(&sch_path)?;
+    let context = match crate::tools::sheet_instance_context(&sch_path, &mut sch) {
+        Ok(context) => context,
+        Err(error) => return Ok(error.into_tool_result()),
+    };
+    if let Err(error) = crate::tools::validate_sheet_instance_state(&sch_path, &sch, &context) {
+        return Ok(error.into_tool_result());
+    }
 
     let pwr_ref = format!("#PWR{:03}", next_pwr_number(&sch));
 
@@ -1673,27 +1681,31 @@ async fn handle_add_power_symbol(
     // Instance entry, keyed to the root sheet UUID like eeschema writes it —
     // without a resolvable "/<root-uuid>" path KiCAD's netlister drops the
     // symbol from net formation.
-    let root_uuid = crate::tools::ensure_root_uuid(&mut sch);
-    sym.set_instance_path(
-        &project_name_for(&sch_path),
-        &format!("/{}", root_uuid),
-        &pwr_ref,
-        1,
-    );
+    for instance_path in &context.instance_paths {
+        sym.set_instance_path(&context.project_name, instance_path, &pwr_ref, 1);
+    }
 
+    let uuid = sym.uuid.clone();
     sch.add_symbol(sym);
     sch.overwrite()?;
 
     // A power pin landing mid-segment on an existing wire needs a junction
     // dot, or KiCad ERC reports it as not connected.
     let junctions_added = crate::tools::add_pin_midwire_junctions(&sch_path, &pwr_ref)?;
+    let committed = cse::Schematic::load(&sch_path)?;
+    let mut observed = match super::sch_components::placed_component_readback(
+        &sch_path, &committed, &uuid, &context,
+    ) {
+        Ok(result) => result,
+        Err(error) => return Ok(error),
+    };
+    observed["added_power"] = observed["value"].clone();
+    observed["junctions_added"] = json!(junctions_added
+        .iter()
+        .map(|(x, y)| json!({"x": x, "y": y}))
+        .collect::<Vec<_>>());
 
-    Ok(CallToolResult::json(&json!({
-        "added_power": power_net,
-        "reference": pwr_ref,
-        "x": x, "y": y,
-        "junctions_added": junctions_added.iter().map(|(x, y)| json!({"x": x, "y": y})).collect::<Vec<_>>()
-    })))
+    Ok(CallToolResult::json(&observed))
 }
 
 async fn handle_add_no_connect(

--- a/crates/konnect-core/src/tools/schematic_placement_tests.rs
+++ b/crates/konnect-core/src/tools/schematic_placement_tests.rs
@@ -1,0 +1,407 @@
+//! Placement acceptance for #383, using the KiCad-authored complex-hierarchy demo.
+
+use super::*;
+use konnect_schematic_editor::{sexp::SexpNode, Schematic};
+use serde_json::json;
+use std::path::{Path, PathBuf};
+
+const PATH_A: &str = "/5b9623a5-6d01-41fc-9865-e1bc779418c8/00000000-0000-0000-0000-00004b3a1333";
+const PATH_B: &str = "/5b9623a5-6d01-41fc-9865-e1bc779418c8/00000000-0000-0000-0000-00004b3a13a4";
+const PLACERS: [&str; 3] = [
+    "add_schematic_component",
+    "batch_place_components",
+    "add_power_symbol",
+];
+
+fn fixture(reused: bool) -> (tempfile::TempDir, PathBuf, PathBuf) {
+    let directory = tempfile::tempdir().unwrap();
+    let (root, child) = schematic_target_tests::native_deep_project(directory.path());
+    let mut schematic = Schematic::load(&child).unwrap();
+    if !reused {
+        // Derive a unique-child case by removing one native sheet and its saved
+        // per-symbol entries. Do not synthesize the remaining instance metadata.
+        let mut parent = Schematic::load(&root).unwrap();
+        parent
+            .sheets
+            .remove_by_uuid("00000000-0000-0000-0000-00004b3a13a4")
+            .unwrap();
+        parent.overwrite().unwrap();
+        for symbol in schematic.symbols.iter_mut() {
+            let project = symbol
+                .raw_sub_nodes
+                .iter_mut()
+                .find(|node| node.tag() == Some("instances"))
+                .unwrap()
+                .find_mut("project")
+                .unwrap();
+            let SexpNode::List(children) = project else {
+                unreachable!()
+            };
+            children.retain(|node| node.tag() != Some("path") || node.value() != Some(PATH_B));
+        }
+    }
+    // Alias the demo's embedded GND definition under the power tool's library
+    // name. Geometry and properties remain KiCad-authored; no host library is needed.
+    let library = schematic
+        .raw_other
+        .iter_mut()
+        .find(|node| node.tag() == Some("lib_symbols"))
+        .unwrap();
+    // Unit validation also consults the library source. Export the native
+    // embedded definitions into a temporary project library, keeping their
+    // unit sub-symbols intact and only stripping the library namespace.
+    let mut exported = library
+        .find_all("symbol")
+        .into_iter()
+        .cloned()
+        .collect::<Vec<_>>();
+    for entry in &mut exported {
+        let name = entry
+            .value()
+            .unwrap()
+            .split(':')
+            .next_back()
+            .unwrap()
+            .to_string();
+        let SexpNode::List(fields) = entry else {
+            unreachable!()
+        };
+        fields[1] = SexpNode::Str(name);
+    }
+    let mut library_nodes = vec![
+        konnect_schematic_editor::sexp::atom("kicad_symbol_lib"),
+        konnect_schematic_editor::sexp::tagged(
+            "version",
+            vec![konnect_schematic_editor::sexp::atom("20241209")],
+        ),
+        konnect_schematic_editor::sexp::tagged(
+            "generator",
+            vec![SexpNode::Str("kicad_symbol_editor".to_string())],
+        ),
+    ];
+    library_nodes.extend(exported);
+    std::fs::write(
+        child.parent().unwrap().join("fixture.kicad_sym"),
+        konnect_schematic_editor::sexp::writer::write(&SexpNode::List(library_nodes)),
+    )
+    .unwrap();
+    std::fs::write(child.parent().unwrap().join("sym-lib-table"),
+        r#"(sym_lib_table (lib (name "complex_hierarchy") (type "KiCad") (uri "${KIPRJMOD}/fixture.kicad_sym") (options "") (descr "KiCad demo definitions")))"#).unwrap();
+    let mut power = library
+        .find_all("symbol")
+        .into_iter()
+        .find(|symbol| symbol.value() == Some("complex_hierarchy:GND"))
+        .unwrap()
+        .clone();
+    let SexpNode::List(power_children) = &mut power else {
+        unreachable!()
+    };
+    power_children[1] = SexpNode::Str("power:GND".to_string());
+    let SexpNode::List(library_children) = library else {
+        unreachable!()
+    };
+    library_children.push(power);
+    schematic.overwrite().unwrap();
+    (directory, root, child)
+}
+
+async fn place(name: &str, child: &Path) -> CallToolResult {
+    let component = json!({
+        "lib_id": "complex_hierarchy:LM358N", "reference": "U999",
+        "value": "placement readback", "x": 100.1, "y": 80.2,
+        "rotation": 90.0, "unit": 2
+    });
+    let mut args = match name {
+        "add_schematic_component" => component,
+        "batch_place_components" => json!({"components": [
+            component,
+            {"lib_id": "complex_hierarchy:R", "reference": "R999", "x": 110.1, "y": 80.2}
+        ]}),
+        "add_power_symbol" => json!({"power_net": "GND", "x": 100.1, "y": 80.2, "rotation": 90.0}),
+        _ => unreachable!(),
+    };
+    args["schematic"] = json!(child.display().to_string());
+    let context = Arc::new(ToolContext::new(
+        ServerConfig {
+            kicad_cli: String::new(),
+            kicad_binary: String::new(),
+            ipc_address: String::new(),
+            project_dir: None,
+            jlcpcb_db_path: None,
+            auto_load_toolsets: false,
+            eager_toolsets: false,
+        },
+        Arc::new(ToolRouter::new()),
+    ));
+    let mut tools = sch_components::tools();
+    tools.extend(sch_batch::tools());
+    tools.extend(sch_wiring::tools());
+    let tool = tools.iter().find(|tool| tool.name == name).unwrap();
+    (tool.handler)(&args, context).await.unwrap()
+}
+
+fn body(result: &CallToolResult) -> Value {
+    let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+        panic!("expected text result")
+    };
+    serde_json::from_str(text).unwrap()
+}
+
+#[tokio::test]
+async fn native_placement_preserves_unique_and_reused_paths_with_committed_readback() {
+    for reused in [false, true] {
+        for name in PLACERS {
+            let (_directory, root, child) = fixture(reused);
+            let root_before = std::fs::read(&root).unwrap();
+            let project_before = std::fs::read(root.with_extension("kicad_pro")).unwrap();
+            let existing = Schematic::load(&child).unwrap().symbols.into_vec();
+            let result = place(name, &child).await;
+            assert!(!result.is_error, "{name}, reused={reused}: {result:?}");
+            let response = body(&result);
+            let placed = if name == "batch_place_components" {
+                assert_eq!(response["placed_count"], 2);
+                assert_eq!(response["errors"], json!([]));
+                response["placed"].as_array().unwrap().clone()
+            } else {
+                vec![response]
+            };
+            let committed = Schematic::load(&child).unwrap();
+            assert_eq!(committed.symbols.len(), existing.len() + placed.len());
+            let expected = if reused {
+                vec![PATH_A, PATH_B]
+            } else {
+                vec![PATH_A]
+            };
+            for entry in placed {
+                let symbol = committed
+                    .symbols
+                    .iter()
+                    .find(|symbol| Some(symbol.uuid.as_str()) == entry["uuid"].as_str())
+                    .unwrap();
+                let mut identities = symbol.instance_paths();
+                identities.sort();
+                assert_eq!(
+                    identities,
+                    expected
+                        .iter()
+                        .map(|path| ("complex_hierarchy".to_string(), path.to_string()))
+                        .collect::<Vec<_>>()
+                );
+                assert_eq!(entry["instance_paths"], json!(expected));
+                assert_eq!(
+                    entry["schematic"],
+                    committed.filepath().display().to_string()
+                );
+                assert_eq!(entry["project"], "complex_hierarchy");
+                assert_eq!(entry["added"], symbol.lib_id);
+                assert_eq!(entry["reference"], symbol.reference().unwrap());
+                assert_eq!(entry["value"], symbol.value_str().unwrap());
+                assert_eq!(entry["x"].as_f64(), Some(symbol.at.x));
+                assert_eq!(entry["y"].as_f64(), Some(symbol.at.y));
+                assert_eq!(entry["rotation"].as_f64(), symbol.at.rotation);
+                assert_eq!(entry["unit"], symbol.unit);
+                if symbol.reference() == Some("U999") {
+                    assert_eq!(symbol.unit, 2);
+                    assert_ne!(
+                        symbol.at.x, 100.1,
+                        "response must report grid-snapped coordinates"
+                    );
+                }
+                if name == "add_power_symbol" {
+                    assert_eq!(entry["added_power"], symbol.value_str().unwrap());
+                }
+            }
+            for original in existing {
+                let saved = committed
+                    .symbols
+                    .iter()
+                    .find(|symbol| symbol.uuid == original.uuid)
+                    .unwrap();
+                assert_eq!(
+                    saved.to_sexp(),
+                    original.to_sexp(),
+                    "existing symbol changed"
+                );
+            }
+            assert_eq!(std::fs::read(&root).unwrap(), root_before);
+            assert_eq!(
+                std::fs::read(root.with_extension("kicad_pro")).unwrap(),
+                project_before
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn native_placement_refuses_stale_instance_metadata_without_writing() {
+    for corruption in [
+        "missing",
+        "foreign",
+        "duplicate",
+        "obsolete",
+        "malformed",
+        "missing-reference",
+        "wrong-reference",
+        "missing-unit",
+        "wrong-unit",
+    ] {
+        for name in PLACERS {
+            let (_directory, root, child) = fixture(true);
+            let mut schematic = Schematic::load(&child).unwrap();
+            let symbol = schematic.symbols.get_mut(0).unwrap();
+            let instances = symbol
+                .raw_sub_nodes
+                .iter_mut()
+                .find(|node| node.tag() == Some("instances"))
+                .unwrap();
+            let project = instances.find_mut("project").unwrap();
+            let path = project.find("path").unwrap().clone();
+            let SexpNode::List(children) = project else {
+                unreachable!()
+            };
+            let index = children
+                .iter()
+                .position(|node| node.tag() == Some("path"))
+                .unwrap();
+            match corruption {
+                "missing" => {
+                    children.remove(index);
+                }
+                "foreign" => children[1] = SexpNode::Str("foreign-project".to_string()),
+                "duplicate" => children.push(path),
+                "obsolete" => {
+                    let SexpNode::List(fields) = &mut children[index] else {
+                        unreachable!()
+                    };
+                    fields[1] = SexpNode::Str("/obsolete/sheet".to_string());
+                }
+                "malformed" => {
+                    let SexpNode::List(fields) = &mut children[index] else {
+                        unreachable!()
+                    };
+                    fields.remove(1);
+                }
+                "missing-reference" => {
+                    let SexpNode::List(fields) = &mut children[index] else {
+                        unreachable!()
+                    };
+                    fields.retain(|field| field.tag() != Some("reference"));
+                }
+                "wrong-reference" => {
+                    let SexpNode::List(fields) = children[index].find_mut("reference").unwrap()
+                    else {
+                        unreachable!()
+                    };
+                    fields[1] = SexpNode::Str("R999".to_string());
+                }
+                "missing-unit" => {
+                    let SexpNode::List(fields) = &mut children[index] else {
+                        unreachable!()
+                    };
+                    fields.retain(|field| field.tag() != Some("unit"));
+                }
+                "wrong-unit" => {
+                    let SexpNode::List(fields) = children[index].find_mut("unit").unwrap() else {
+                        unreachable!()
+                    };
+                    fields[1] = SexpNode::Atom("99".to_string());
+                }
+                _ => unreachable!(),
+            }
+            schematic.overwrite().unwrap();
+            let before = std::fs::read(&child).unwrap();
+            let root_before = std::fs::read(&root).unwrap();
+            let result = place(name, &child).await;
+            assert!(result.is_error, "{name}/{corruption}: {result:?}");
+            assert_eq!(
+                body(&result)["error"]["kind"],
+                "stale_target",
+                "{name}/{corruption}"
+            );
+            assert_eq!(
+                std::fs::read(&child).unwrap(),
+                before,
+                "{name}/{corruption} wrote the target"
+            );
+            assert_eq!(std::fs::read(&root).unwrap(), root_before);
+        }
+    }
+}
+
+#[tokio::test]
+async fn native_placement_refuses_ambiguous_ownership_without_writing() {
+    for name in PLACERS {
+        let (directory, root, child) = fixture(true);
+        let competing = directory.path().join("competing.kicad_sch");
+        std::fs::copy(&root, &competing).unwrap();
+        std::fs::copy(
+            root.with_extension("kicad_pro"),
+            competing.with_extension("kicad_pro"),
+        )
+        .unwrap();
+        let before = std::fs::read(&child).unwrap();
+        let root_before = std::fs::read(&root).unwrap();
+        let result = place(name, &child).await;
+        assert!(result.is_error, "{name}: {result:?}");
+        assert_eq!(body(&result)["error"]["kind"], "conflict");
+        assert_eq!(std::fs::read(&child).unwrap(), before);
+        assert_eq!(std::fs::read(&root).unwrap(), root_before);
+        assert_eq!(std::fs::read(&competing).unwrap(), root_before);
+    }
+}
+
+#[test]
+fn native_placement_readback_refuses_wrong_document_and_missing_evidence() {
+    for missing in [
+        "document",
+        "symbol",
+        "Reference",
+        "Value",
+        "instances",
+        "stale",
+    ] {
+        let (_directory, _root, child) = fixture(true);
+        let mut schematic = Schematic::load(&child).unwrap();
+        let context = sheet_instance_context(&child, &mut schematic).unwrap();
+        let uuid = schematic.symbols.get(0).unwrap().uuid.clone();
+        match missing {
+            "symbol" => {
+                schematic.symbols.remove_by_uuid(&uuid).unwrap();
+            }
+            "Reference" | "Value" => schematic
+                .symbols
+                .get_mut(0)
+                .unwrap()
+                .remove_property(missing),
+            "instances" => schematic
+                .symbols
+                .get_mut(0)
+                .unwrap()
+                .raw_sub_nodes
+                .retain(|node| node.tag() != Some("instances")),
+            "stale" => schematic
+                .symbols
+                .get_mut(0)
+                .unwrap()
+                .set_instance_path("foreign", "/foreign", "U999", 1),
+            "document" => {}
+            _ => unreachable!(),
+        }
+        schematic.overwrite().unwrap();
+        let other = child.with_file_name("other.kicad_sch");
+        std::fs::copy(&child, &other).unwrap();
+        let committed = Schematic::load(if missing == "document" {
+            &other
+        } else {
+            &child
+        })
+        .unwrap();
+        let result = sch_components::placed_component_readback(&child, &committed, &uuid, &context)
+            .expect_err("incomplete readback must not return success");
+        assert_eq!(body(&result)["error"]["kind"], "stale_target", "{missing}");
+        assert!(!body(&result)["message"]
+            .as_str()
+            .unwrap()
+            .contains("did not modify"));
+    }
+}

--- a/crates/konnect-schematic-editor/src/schematic/symbol.rs
+++ b/crates/konnect-schematic-editor/src/schematic/symbol.rs
@@ -12,6 +12,17 @@ fn bool_kw(v: bool) -> &'static str {
 
 // ---- Symbol -----------------------------------------------------------------
 
+/// One saved hierarchy identity from a placed symbol's `(instances ...)` block.
+/// Optional fields preserve malformed entries so callers can fail closed rather
+/// than silently dropping incomplete metadata while validating a mutation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SymbolInstance {
+    pub project: Option<String>,
+    pub path: Option<String>,
+    pub reference: Option<String>,
+    pub unit: Option<u32>,
+}
+
 #[derive(Debug, Clone)]
 pub struct Symbol {
     /// Name of the `lib_symbols` entry this instance actually resolves through,
@@ -286,16 +297,52 @@ impl Symbol {
     /// Whether this symbol already has an instance entry for the given
     /// project name and hierarchical path.
     pub fn has_instance_path(&self, project_name: &str, path: &str) -> bool {
-        self.raw_sub_nodes
+        self.instance_paths()
             .iter()
-            .find(|n| n.tag() == Some("instances"))
-            .map(|inst| {
-                inst.find_all("project").iter().any(|p| {
-                    p.value() == Some(project_name)
-                        && p.find_all("path").iter().any(|pp| pp.value() == Some(path))
-                })
-            })
-            .unwrap_or(false)
+            .any(|(project, candidate)| project == project_name && candidate == path)
+    }
+
+    /// Every project/path identity carried by this placed symbol.
+    ///
+    /// A child schematic file can be instantiated more than once in one root
+    /// hierarchy, so one placed symbol legitimately carries multiple paths.
+    /// Returning all of them lets callers compare the saved identity with the
+    /// structurally observed hierarchy instead of selecting the first entry.
+    pub fn instance_paths(&self) -> Vec<(String, String)> {
+        self.instances()
+            .into_iter()
+            .filter_map(|instance| Some((instance.project?, instance.path?)))
+            .collect()
+    }
+
+    /// Every saved hierarchy entry, including malformed entries with missing
+    /// project, path, reference, or unit fields.
+    pub fn instances(&self) -> Vec<SymbolInstance> {
+        let mut entries = Vec::new();
+        for instances in self
+            .raw_sub_nodes
+            .iter()
+            .filter(|node| node.tag() == Some("instances"))
+        {
+            for project in instances.find_all("project") {
+                let project_name = project.value().map(str::to_owned);
+                for path in project.find_all("path") {
+                    entries.push(SymbolInstance {
+                        project: project_name.clone(),
+                        path: path.value().map(str::to_owned),
+                        reference: path
+                            .find("reference")
+                            .and_then(SexpNode::value)
+                            .map(str::to_owned),
+                        unit: path
+                            .find("unit")
+                            .and_then(SexpNode::value)
+                            .and_then(|value| value.parse().ok()),
+                    });
+                }
+            }
+        }
+        entries
     }
 
     // ---- position -----------------------------------------------------------
@@ -527,5 +574,24 @@ mod tests {
             "property must keep its offset"
         );
         assert_eq!((sym.at.x, sym.at.y), (110.0, 60.0));
+    }
+
+    #[test]
+    fn instance_paths_reports_every_reused_hierarchy_identity() {
+        let mut symbol = Symbol::new("Device:R", 100.0, 50.0);
+        symbol.set_instance_path("control", "/root/a", "R1", 1);
+        symbol.set_instance_path("control", "/root/b", "R1", 1);
+        symbol.set_instance_path("other", "/other/c", "R1", 1);
+
+        assert_eq!(
+            symbol.instance_paths(),
+            [
+                ("control".to_string(), "/root/a".to_string()),
+                ("control".to_string(), "/root/b".to_string()),
+                ("other".to_string(), "/other/c".to_string()),
+            ]
+        );
+        assert!(symbol.has_instance_path("control", "/root/b"));
+        assert!(!symbol.has_instance_path("control", "/root/missing"));
     }
 }

--- a/docs/API_MIGRATIONS.md
+++ b/docs/API_MIGRATIONS.md
@@ -3,6 +3,30 @@
 Konnect's tool schemas are public API. This file records intentional argument
 removals and the supported replacement workflow.
 
+## Unreleased: complete schematic placement instances (minor release)
+
+`add_schematic_component`, `batch_place_components`, and `add_power_symbol`
+preserve every instance path when the saved root reuses a child schematic.
+Existing inputs and response fields remain. Placement results now include
+`schematic`, `project`, `instance_paths`, and observed symbol fields (`uuid`,
+`added`, `reference`, `value`, `x`, `y`, `rotation`, `unit`). Batch results put
+these fields in each `placed` entry; power placement retains `added_power` and
+`junctions_added`. Values come from reloading the committed file.
+
+Missing, foreign, duplicate, malformed, or obsolete saved instance paths,
+references, or units return `stale_target` with `target` and `reason` before
+placement writes. Repair the saved hierarchy and its complete symbol instance
+metadata before retrying. Ambiguous
+project ownership continues to use the existing `conflict` kind from #189.
+If post-write readback cannot verify the target or symbol, `stale_target` may
+follow a committed write: inspect/reload the file before retrying to avoid a
+duplicate placement. This observes saved files only and does not claim an
+atomic snapshot of the complete hierarchy or unsaved editor state.
+
+See [Schematic project ownership](PROJECT_OWNERSHIP.md#placement-instance-validation)
+for the acceptance matrix and limits. This additive response change is planned
+for the next minor release; no tool or argument was renamed or removed.
+
 ## Unreleased: schematic ownership conflicts (minor release)
 
 Symbol-loading operations and ERC root detection now refuse unproven or ambiguous

--- a/docs/PROJECT_OWNERSHIP.md
+++ b/docs/PROJECT_OWNERSHIP.md
@@ -29,6 +29,29 @@ placement does so once before processing any entries, so ownership conflicts
 cannot leave partially placed components. A local library table establishes
 library authority, not proof of hierarchy membership for placement metadata.
 
+## Placement instance validation
+
+Single component, batch component, and power-symbol placement share the same
+saved hierarchy context. A document-wide placement into a reused child writes
+every observed project/path entry, then reloads the committed target and derives
+the successful response from that symbol.
+
+| Observed saved state | Placement result |
+| --- | --- |
+| Unique child with matching saved symbol metadata | Write its exact hierarchy path. |
+| Reused child with matching metadata | Write every hierarchy path; preserve existing symbols and other documents. |
+| Loose schematic with no candidate project and matching local instance metadata | Use its own project name and root UUID. |
+| Missing, foreign, duplicate, malformed, or obsolete symbol paths, references, or units | Return `stale_target` before writing; never silently repair or pick one entry. References must retain the symbol's designator identity, at least one hierarchy entry must match the symbol Reference, and every saved unit must match the placed unit. |
+| Unproven or ambiguous project ownership | Preserve #189's `conflict` refusal before writing. |
+| Readback has the wrong document, missing symbol/fields, or inconsistent instance metadata | Return `stale_target` instead of success; the placement may already have been written. |
+
+The saved root sheet tree supplies expected paths. Existing symbol instance
+entries supply preflight evidence. Reloaded symbol fields supply the UUID,
+library identity, reference, value, coordinates, rotation, unit, project and
+paths in the response. Correct the root links and saved symbol metadata together
+before retrying a stale preflight. After a readback failure, inspect the file
+first to avoid adding the same symbol twice.
+
 ## Unreleased notes (next minor release)
 
 Schematics that previously inherited an unrelated ancestor project's libraries,
@@ -36,7 +59,12 @@ or silently fell back to projectless operation despite an unproven candidate,
 now return `conflict`. Repair the saved root-to-child sheet references, restore
 unreadable project schematics, or place a genuinely independent document outside
 the unrelated project. An explicit library table beside a schematic continues
-to select its library context. No tool, argument, or new error kind is added.
+to select its library context. Ownership uses the existing `conflict` kind.
+
+Placement adds `stale_target` and observed hierarchy/readback fields without
+removing existing tools, inputs, or response fields. These response changes are
+also part of the next minor release (#383/#389); see
+[API migrations](API_MIGRATIONS.md#unreleased-complete-schematic-placement-instances-minor-release).
 
 This behavior change belongs in the next minor release, as agreed in #189.
 Existing `conflict` clients should inspect `error.paths` and the message before
@@ -50,8 +78,11 @@ directories, unrelated candidates, and explicit corruptions of temporary copies.
 
 Resolution observes saved files, not unsaved editor state. Traversal is
 cycle-safe and bounded by `MAX_HIERARCHY_DEPTH`; it does not establish ownership
-through an untraversable hierarchy. This change does not implement the later
-all-placement-instances work in #389 or live-editor navigation.
+through an untraversable hierarchy. Placement tests use this same KiCad-authored
+fixture for unique/reused children, real multi-unit symbols, all three placement
+handlers, stale path/reference/unit and ambiguous no-write refusals, and
+committed-file readback.
+This does not implement live-editor navigation.
 
 Ownership evidence is read during preflight; it is not an atomic snapshot of
 every project file. Target-file writes retain their existing revision checks.

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -73,7 +73,7 @@ Seven tools, grouped into *discovery/routing*, *observability*, and *runtime dia
 |------|-------------|
 | `create_schematic` | Create a new blank `.kicad_sch` schematic file, on A4 unless another paper size is given. Use `set_schematic_page` to change it later. |
 | `set_schematic_page` | Set the sheet's paper size (A0–A5, A–E, US Letter/Legal/Ledger) and orientation. Returns the size in mm — content outside the frame still exports and still nets up, so a too-small page is a silent defect. |
-| `add_schematic_component` | Add a symbol from a KiCAD library to the schematic. Snaps to the 1.27mm grid. |
+| `add_schematic_component` | Add a symbol from a KiCAD library to the schematic. Snaps to the 1.27mm grid, preserves every saved hierarchy instance, and reports committed-file readback. Refuses stale instance metadata before writing. |
 | `delete_schematic_component` | Remove a component and all of its placed units by reference designator. |
 | `edit_schematic_component` | Update shared fields consistently across every placed unit of a component. |
 | `get_schematic_component` | Get shared properties and every placed unit's position for a component. |
@@ -108,7 +108,7 @@ Seven tools, grouped into *discovery/routing*, *observability*, and *runtime dia
 | `rotate_schematic_label` | Rotate a net label to a new angle and update its justify direction. |
 | `move_labels_by_offset` | Move all labels matching a net name by a given X/Y offset. |
 | `batch_rotate_labels` | Rotate multiple labels by net name in a single file read/write cycle. |
-| `add_power_symbol` | Add a power symbol (VCC, GND, etc.). Auto-numbers the internal `#PWR` reference to the lowest number free on the sheet. |
+| `add_power_symbol` | Add a power symbol (VCC, GND, etc.). Auto-numbers the internal `#PWR` reference to the lowest number free on the sheet. Preserves every saved hierarchy instance and reports committed-file readback; refuses stale instance metadata before writing. |
 | `add_no_connect` | Add a no-connect flag (X marker) to an unconnected pin endpoint. |
 | `delete_no_connect` | Remove a no-connect flag at a given position. |
 | `batch_delete_no_connect` | Delete multiple no-connect flags in a single file read/write cycle. |
@@ -168,7 +168,7 @@ Seven tools, grouped into *discovery/routing*, *observability*, and *runtime dia
 | `get_schematic_layout` | Return component positions and transformed drawing/pin bounds (excluding free text), reporting unresolved geometry; optionally include wires and labels. |
 | `validate_wire_connections` | Check all wire endpoints for floating ends not connected to a pin, label, or another wire. |
 | `validate_component_connections` | Check that every non-passive pin has at least one wire or label connected. Reports unconnected pins. |
-| `batch_place_components` | Place multiple symbols from KiCAD libraries in a single file read/write cycle. Pass explicit references -- there is no auto-numbering; an omitted reference becomes '?' like an eeschema-unannotated symbol, same as `add_schematic_component`. |
+| `batch_place_components` | Place multiple symbols from KiCAD libraries in one write with committed-file readback. Preserves every saved hierarchy instance and preflights stale metadata before any placement. Pass explicit references -- there is no auto-numbering; an omitted reference becomes '?' like an eeschema-unannotated symbol, same as `add_schematic_component`. |
 | `batch_connect_pins` | Connect multiple component pin pairs by reference and pin number, in a single file read/write cycle. |
 
 ### `sch_export` · 10 tools


### PR DESCRIPTION
## Summary

Preserve every hierarchical instance path when placing a component or power
symbol into a reused child schematic, and derive placement results from the
committed child document.

Closes #383.

This is the next focused file-only PR after merged #388. The branch is rebuilt
from current `upstream/main` (`806277e`) and contains one unique commit,
`fix(schematic): bind placement to all sheet instances` (`7cb00de`). The agreed
sequence after this PR is #392 -> #393 -> #394; #390 remains a separate IPC lane.

## Behavior

- Resolve every hierarchy instance for the exact target before mutation.
- Use the same hierarchy identity for single component, batch component, and
  power-symbol placement.
- Refuse missing, foreign, duplicate, malformed, or obsolete existing instance
  metadata as structured `stale_target` before writing.
- Write every observed project/path entry for a unique or reused child.
- Reload the committed child and derive document, UUID, library identity,
  reference, value, coordinates, rotation, unit, project, and instance paths
  from the observed symbol.
- Return `stale_target` when post-write readback cannot prove the intended
  document or symbol. This may follow a committed write, so the error and
  migration notes tell callers to inspect/reload before retrying.

## Compatibility and release impact

Existing tools, inputs, and response fields remain. Successful placement
responses gain saved hierarchy and readback evidence. Inconsistent saved state
that could previously be written through now refuses. `DEV.md` documents the
new `stale_target` kind, and the tool directory, ownership guide, and API
migration notes record the additive response shape, repair path, limitations,
and next-minor-release obligation.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo test --workspace --locked --lib --tests`
- `cargo test --workspace --locked --doc`
- KiCad-authored complex-hierarchy fixture coverage for unique and reused
  children, a real multi-unit symbol, all three placement paths, stale and
  ambiguous no-write behavior, wrong-document isolation, and committed-file
  readback
- Every new preflight, all-instance write, and readback guard was individually
  disabled and its regression test failed; sources were restored afterward

The complete gate passed on `7cb00de`, based on exact current main `806277e`.
Ignored tests require live KiCad, Java, another operating system, or another
external runtime; this file-only behavior does not depend on unsaved editor
state. Hosted checks must pass on this rewritten head before merge.

## Risk and rollback

The change affects saved schematic instance metadata and placement response
JSON. It preserves inputs and existing fields, validates before mutation, and
uses revision-checked writes plus committed-file readback. Reverting the single
feature commit restores the earlier first-instance behavior.
