### PR TITLE
fix(schematic): parse remaining mutation targets structurally

### DIFF
--- a/crates/konnect-core/src/tools/integration.rs
+++ b/crates/konnect-core/src/tools/integration.rs
@@ -15,12 +15,17 @@
 //! lookups within a session. Responses carry a `"cached"` field so callers
 //! can see whether a given result came from cache.
 
-use crate::mcp::protocol::CallToolResult;
+use crate::mcp::{error::ToolErrorKind, protocol::CallToolResult};
 use crate::tool;
 use crate::tools::{get_path, require_str, ToolContext, ToolDef};
-use konnect_sexp::writer::{read_consistent, write_atomic_if_unchanged};
+use konnect_sexp::{
+    command::{commit_command, prepare_command, ItemId, SchematicCommand},
+    parse_sexp,
+    writer::{find_direct_child_blocks, read_consistent},
+    SexpError, SexpNode,
+};
 use serde_json::json;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::{self, BufWriter};
 use std::path::{Path, PathBuf};
 use tokio::io::AsyncWriteExt;
@@ -838,16 +843,17 @@ async fn handle_enrich_datasheets(
     let read_path = sch_path.clone();
     let content = tokio::task::spawn_blocking(move || read_consistent(&read_path)).await??;
 
-    // Find all LCSC property values in the schematic
-    let mut lcsc_ids: Vec<String> = Vec::new();
-    let mut search = content.as_str();
-    while let Some(pos) = search.find("(property \"LCSC\" \"") {
-        let after = &search[pos + 18..];
-        if let Some(end) = after.find('"') {
-            lcsc_ids.push(after[..end].to_string());
-        }
-        search = &search[pos + 1..];
-    }
+    // Only placed, top-level symbol instances are enrichment targets. Library
+    // definitions, quoted text, and nested decoys must not enter the target
+    // set merely because they contain the same property spelling.
+    let symbols = match validated_datasheet_symbols(&content) {
+        Ok(symbols) => symbols,
+        Err(error) => return Ok(error.into_result()),
+    };
+    let mut lcsc_ids: Vec<String> = symbols
+        .iter()
+        .map(|symbol| symbol.lcsc_id.clone())
+        .collect();
     lcsc_ids.sort();
     lcsc_ids.dedup();
 
@@ -866,8 +872,7 @@ async fn handle_enrich_datasheets(
         .timeout(std::time::Duration::from_secs(30))
         .build()?;
 
-    let mut enriched = 0usize;
-    let mut new_content = content.clone();
+    let mut urls = HashMap::new();
 
     for lcsc_id in &lcsc_ids {
         let url = format!(
@@ -881,57 +886,378 @@ async fn handle_enrich_datasheets(
                         .pointer("/result/dataManualUrl")
                         .and_then(|v| v.as_str())
                     {
-                        // Find components with this LCSC ID and update their Datasheet property.
-                        // Pattern: find (property "LCSC" "CxxxID") → walk back to symbol block →
-                        // find (property "Datasheet" "...") and replace the URL.
-                        let lcsc_pat = format!(r#"(property "LCSC" "{}")"#, lcsc_id);
-                        let mut search_from = 0usize;
-                        while let Some(lcsc_pos) = new_content[search_from..]
-                            .find(&lcsc_pat)
-                            .map(|i| i + search_from)
-                        {
-                            // Find the enclosing symbol block
-                            let before = &new_content[..lcsc_pos];
-                            if let Some(sym_start) = before.rfind("\n  (symbol") {
-                                let sym_block = &new_content[sym_start..];
-                                // Find Datasheet property within this symbol
-                                let ds_pat = r#"(property "Datasheet" ""#;
-                                if let Some(ds_offset) = sym_block.find(ds_pat) {
-                                    let ds_abs = sym_start + ds_offset + ds_pat.len();
-                                    if let Some(ds_end) = new_content[ds_abs..].find('"') {
-                                        let existing = &new_content[ds_abs..ds_abs + ds_end];
-                                        if overwrite || existing == "~" || existing.is_empty() {
-                                            new_content = format!(
-                                                "{}{}{}",
-                                                &new_content[..ds_abs],
-                                                datasheet_url,
-                                                &new_content[ds_abs + ds_end..]
-                                            );
-                                            enriched += 1;
-                                        }
-                                    }
-                                }
-                            }
-                            search_from = lcsc_pos + 1;
-                        }
+                        urls.insert(lcsc_id.clone(), datasheet_url.to_owned());
                     }
                 }
             }
         }
     }
 
-    // Write back if anything changed
-    if enriched > 0 {
-        write_atomic_if_unchanged(&sch_path, &content, &new_content)?;
-    }
+    let plan = match plan_datasheet_enrichment(&content, &urls, overwrite) {
+        Ok(plan) => plan,
+        Err(error) => return Ok(error.into_result()),
+    };
+
+    let observed_updates = if let Some((command, planned)) = plan {
+        if let Err(error) = commit_command(&sch_path, &command) {
+            if let Some(refusal) = datasheet_commit_refusal(&sch_path, &error) {
+                return Ok(refusal);
+            }
+            return Err(error.into());
+        }
+        let committed = read_consistent(&sch_path)?;
+        match observe_datasheet_updates(&committed, &planned) {
+            Ok(observed) => observed,
+            Err(error) => return Ok(error.into_result()),
+        }
+    } else {
+        Vec::new()
+    };
 
     Ok(CallToolResult::text(
         serde_json::to_string(&json!({
             "lcsc_ids_found": lcsc_ids.len(),
-            "datasheets_enriched": enriched,
+            "datasheets_enriched": observed_updates.len(),
             "schematic": sch_path.to_str().unwrap_or("")
         }))
         .unwrap(),
+    ))
+}
+
+#[derive(Debug, Clone)]
+struct DatasheetSymbolTarget {
+    uuid: String,
+    reference: String,
+    unit: u32,
+    lcsc_id: String,
+    datasheet: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct PlannedDatasheetUpdate {
+    target: DatasheetSymbolTarget,
+    datasheet_url: String,
+}
+
+#[derive(Debug)]
+enum DatasheetTargetError {
+    Ambiguous {
+        target: String,
+        candidates: Vec<String>,
+    },
+    Stale {
+        target: String,
+        reason: String,
+    },
+}
+
+impl DatasheetTargetError {
+    fn stale(target: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::Stale {
+            target: target.into(),
+            reason: reason.into(),
+        }
+    }
+
+    fn from_sexp(target: impl Into<String>, error: SexpError) -> Self {
+        Self::stale(target, error.to_string())
+    }
+
+    fn into_result(self) -> CallToolResult {
+        match self {
+            Self::Ambiguous { target, candidates } => {
+                let reason = format!(
+                    "more than one candidate was observed: {}",
+                    candidates.join(", ")
+                );
+                CallToolResult::error_kind(
+                    ToolErrorKind::StaleTarget {
+                        target: target.clone(),
+                        reason: reason.clone(),
+                    },
+                    format!("cannot safely enrich {target}: {reason}"),
+                )
+            }
+            Self::Stale { target, reason } => CallToolResult::error_kind(
+                ToolErrorKind::StaleTarget {
+                    target: target.clone(),
+                    reason: reason.clone(),
+                },
+                format!("cannot safely enrich {target}: {reason}"),
+            ),
+        }
+    }
+}
+
+fn direct_property_values(node: &SexpNode, name: &str) -> Vec<String> {
+    node.find_all("property")
+        .into_iter()
+        .filter(|property| property.get(1).and_then(SexpNode::as_str) == Some(name))
+        .filter_map(|property| property.get(2).and_then(SexpNode::as_str))
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn one_identity_value(
+    values: Vec<String>,
+    field: &str,
+    item: &str,
+) -> Result<String, DatasheetTargetError> {
+    match values.as_slice() {
+        [value] if !value.trim().is_empty() => Ok(value.clone()),
+        [] | [_] => Err(DatasheetTargetError::stale(
+            item,
+            format!("{field} is missing or empty"),
+        )),
+        _ => Err(DatasheetTargetError::Ambiguous {
+            target: format!("{field} on {item}"),
+            candidates: values,
+        }),
+    }
+}
+
+fn validated_datasheet_symbols(
+    content: &str,
+) -> Result<Vec<DatasheetSymbolTarget>, DatasheetTargetError> {
+    let ranges = find_direct_child_blocks(content, "kicad_sch");
+    if ranges.is_empty() {
+        return Err(DatasheetTargetError::stale(
+            "schematic document",
+            "the kicad_sch root is missing or malformed",
+        ));
+    }
+
+    let mut uuid_owners: HashMap<String, Vec<String>> = HashMap::new();
+    let mut symbols = Vec::new();
+    for (start, end) in ranges {
+        let node = parse_sexp(&content[start..end])
+            .map_err(|error| DatasheetTargetError::from_sexp("schematic item", error))?;
+        let kind = node.head().unwrap_or("unknown");
+        if let Some(uuid) = node
+            .find("uuid")
+            .and_then(|uuid| uuid.get(1))
+            .and_then(SexpNode::as_str)
+        {
+            uuid_owners
+                .entry(uuid.to_owned())
+                .or_default()
+                .push(format!("{kind} at byte {start}"));
+        }
+        if kind != "symbol" {
+            continue;
+        }
+
+        let lcsc = direct_property_values(&node, "LCSC");
+        if lcsc.is_empty() {
+            continue;
+        }
+        let item = format!("symbol at byte {start}");
+        let lcsc_id = one_identity_value(lcsc, "LCSC", &item)?;
+        let reference = one_identity_value(
+            direct_property_values(&node, "Reference"),
+            "Reference",
+            &item,
+        )?;
+        let uuid = node
+            .find("uuid")
+            .and_then(|uuid| uuid.get(1))
+            .and_then(SexpNode::as_str)
+            .filter(|uuid| !uuid.trim().is_empty())
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| DatasheetTargetError::stale(&item, "UUID is missing or empty"))?;
+        let units = node.find_all("unit");
+        let unit = match units.as_slice() {
+            [] => 1,
+            [unit] => unit
+                .get(1)
+                .and_then(SexpNode::as_str)
+                .and_then(|unit| unit.parse::<u32>().ok())
+                .filter(|unit| *unit > 0)
+                .ok_or_else(|| DatasheetTargetError::stale(&item, "unit is invalid"))?,
+            _ => {
+                return Err(DatasheetTargetError::Ambiguous {
+                    target: format!("unit on {item}"),
+                    candidates: units
+                        .iter()
+                        .filter_map(|unit| unit.get(1).and_then(SexpNode::as_str))
+                        .map(ToOwned::to_owned)
+                        .collect(),
+                })
+            }
+        };
+        let datasheets = direct_property_values(&node, "Datasheet");
+        let datasheet = match datasheets.as_slice() {
+            [] => None,
+            [value] => Some(value.clone()),
+            _ => {
+                return Err(DatasheetTargetError::Ambiguous {
+                    target: format!("Datasheet on {reference} unit {unit}"),
+                    candidates: datasheets,
+                })
+            }
+        };
+        symbols.push(DatasheetSymbolTarget {
+            uuid,
+            reference,
+            unit,
+            lcsc_id,
+            datasheet,
+        });
+    }
+
+    for symbol in &symbols {
+        if let Some(owners) = uuid_owners
+            .get(&symbol.uuid)
+            .filter(|owners| owners.len() > 1)
+        {
+            return Err(DatasheetTargetError::Ambiguous {
+                target: format!("schematic UUID {}", symbol.uuid),
+                candidates: owners.clone(),
+            });
+        }
+    }
+
+    let mut placed: HashMap<(String, u32), Vec<String>> = HashMap::new();
+    for symbol in &symbols {
+        placed
+            .entry((symbol.reference.clone(), symbol.unit))
+            .or_default()
+            .push(symbol.uuid.clone());
+    }
+    if let Some(((reference, unit), uuids)) = placed.iter().find(|(_, uuids)| uuids.len() > 1) {
+        return Err(DatasheetTargetError::Ambiguous {
+            target: format!("symbol {reference} unit {unit}"),
+            candidates: uuids.clone(),
+        });
+    }
+
+    Ok(symbols)
+}
+
+fn plan_datasheet_enrichment(
+    content: &str,
+    urls: &HashMap<String, String>,
+    overwrite: bool,
+) -> Result<Option<(SchematicCommand, Vec<PlannedDatasheetUpdate>)>, DatasheetTargetError> {
+    let symbols = validated_datasheet_symbols(content)?;
+    let mut edited = content.to_owned();
+    let mut planned = Vec::new();
+    let path = Path::new("datasheet-enrichment.kicad_sch");
+
+    for symbol in symbols {
+        let Some(datasheet_url) = urls.get(&symbol.lcsc_id) else {
+            continue;
+        };
+        let Some(existing) = &symbol.datasheet else {
+            continue;
+        };
+        if (!overwrite && existing != "~" && !existing.is_empty()) || existing == datasheet_url {
+            continue;
+        }
+        let id = ItemId::new(symbol.uuid.clone())
+            .map_err(|error| DatasheetTargetError::from_sexp(&symbol.reference, error))?;
+        let command = SchematicCommand::set_property(
+            &edited,
+            id,
+            "Datasheet",
+            datasheet_url,
+            format!(
+                "enrich datasheet for {} unit {}",
+                symbol.reference, symbol.unit
+            ),
+        )
+        .map_err(|error| DatasheetTargetError::from_sexp(&symbol.reference, error))?;
+        edited = prepare_command(path, &edited, &command)
+            .map_err(|error| DatasheetTargetError::from_sexp(&symbol.reference, error))?
+            .0;
+        planned.push(PlannedDatasheetUpdate {
+            target: symbol,
+            datasheet_url: datasheet_url.clone(),
+        });
+    }
+
+    if planned.is_empty() {
+        return Ok(None);
+    }
+    let ids = planned
+        .iter()
+        .map(|update| ItemId::new(update.target.uuid.clone()))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| DatasheetTargetError::from_sexp("datasheet targets", error))?;
+    let command = SchematicCommand::replace_items_from_document(
+        content,
+        &edited,
+        ids,
+        "enrich schematic datasheets",
+    )
+    .map_err(|error| DatasheetTargetError::from_sexp("datasheet targets", error))?
+    .requiring_unchanged_document();
+    Ok(Some((command, planned)))
+}
+
+fn observe_datasheet_updates(
+    content: &str,
+    planned: &[PlannedDatasheetUpdate],
+) -> Result<Vec<serde_json::Value>, DatasheetTargetError> {
+    let symbols = validated_datasheet_symbols(content)?;
+    let mut observed = Vec::with_capacity(planned.len());
+    for update in planned {
+        let target = symbols
+            .iter()
+            .find(|symbol| symbol.uuid == update.target.uuid)
+            .ok_or_else(|| {
+                DatasheetTargetError::stale(
+                    format!("symbol UUID {}", update.target.uuid),
+                    "the committed symbol is missing",
+                )
+            })?;
+        if target.reference != update.target.reference
+            || target.unit != update.target.unit
+            || target.lcsc_id != update.target.lcsc_id
+        {
+            return Err(DatasheetTargetError::stale(
+                format!("symbol UUID {}", update.target.uuid),
+                "committed identity differs from the planned reference, unit, or LCSC ID",
+            ));
+        }
+        if target.datasheet.as_deref() != Some(&update.datasheet_url) {
+            return Err(DatasheetTargetError::stale(
+                format!("symbol {} unit {}", target.reference, target.unit),
+                format!(
+                    "committed Datasheet was {:?}, expected {}",
+                    target.datasheet, update.datasheet_url
+                ),
+            ));
+        }
+        observed.push(json!({
+            "uuid": target.uuid,
+            "reference": target.reference,
+            "unit": target.unit,
+            "lcsc_id": target.lcsc_id,
+            "datasheet_url": target.datasheet
+        }));
+    }
+    Ok(observed)
+}
+
+fn datasheet_commit_refusal(path: &Path, error: &SexpError) -> Option<CallToolResult> {
+    let reason = match error {
+        SexpError::Conflict { .. } => "the schematic changed after enrichment was planned",
+        SexpError::ItemConflict { reason, .. } => reason,
+        SexpError::KiCadEditorLocked { .. } => {
+            "KiCad owns the schematic; use a live editor mutation or close the document"
+        }
+        _ => return None,
+    };
+    Some(CallToolResult::error_kind(
+        ToolErrorKind::StaleTarget {
+            target: path.display().to_string(),
+            reason: reason.to_owned(),
+        },
+        format!(
+            "cannot commit datasheet enrichment for {}: {reason}",
+            path.display()
+        ),
     ))
 }
 
@@ -1173,6 +1499,201 @@ fn command_output(output: &std::process::Output) -> String {
         .filter(|part| !part.is_empty())
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+#[cfg(test)]
+mod datasheet_enrichment_tests {
+    use super::*;
+    use crate::mcp::error::extract_error_kind;
+    use std::io::Write;
+
+    const KICAD_STRUCTURAL_FIXTURE: &str =
+        include_str!("../../tests/fixtures/structural_scans_kicad10.kicad_sch");
+
+    fn symbol(reference: &str, unit: u32, uuid: Option<&str>, lcsc: &str) -> String {
+        let uuid = uuid
+            .map(|uuid| format!("\r\n\t\t(uuid \"{uuid}\")"))
+            .unwrap_or_default();
+        format!(
+            "\t(symbol\r\n\t\t(lib_id \"Device:R\")\r\n\t\t(at 10 20 0)\r\n\t\t(unit {unit})\r\n\t\t(property \"Reference\" \"{reference}\")\r\n\t\t(property \"Datasheet\" \"~\")\r\n\t\t(property \"Notes\" \"decoy\"\r\n\t\t\t(property \"LCSC\" \"C-DECOY\")\r\n\t\t)\r\n\t\t(property \"LCSC\" \"{lcsc}\"){uuid}\r\n\t)\r\n"
+        )
+    }
+
+    fn schematic(body: &str) -> String {
+        format!("(kicad_sch\r\n\t(version 20231120)\r\n{body})\r\n")
+    }
+
+    fn urls(entries: &[(&str, &str)]) -> HashMap<String, String> {
+        entries
+            .iter()
+            .map(|(id, url)| ((*id).to_owned(), (*url).to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn tab_crlf_multi_unit_symbols_update_atomically_and_read_back() {
+        let decoy = "\t(lib_symbols\r\n\t\t(symbol \"decoy\"\r\n\t\t\t(property \"LCSC\" \"C-LIBRARY\")\r\n\t\t)\r\n\t)\r\n";
+        let original = schematic(&format!(
+            "{decoy}{}{}",
+            symbol("U1", 1, Some("unit-1"), "C1"),
+            symbol("U1", 2, Some("unit-2"), "C1")
+        ));
+        let Some((command, planned)) = plan_datasheet_enrichment(
+            &original,
+            &urls(&[("C1", "https://example.com/u1.pdf")]),
+            false,
+        )
+        .unwrap() else {
+            panic!("expected enrichment plan");
+        };
+        assert_eq!(planned.len(), 2);
+
+        let mut file = tempfile::NamedTempFile::with_suffix(".kicad_sch").unwrap();
+        file.write_all(original.as_bytes()).unwrap();
+        file.flush().unwrap();
+        let outcome = commit_command(file.path(), &command).unwrap();
+        assert!(outcome.changed);
+
+        let committed = std::fs::read_to_string(file.path()).unwrap();
+        let observed = observe_datasheet_updates(&committed, &planned).unwrap();
+        assert_eq!(observed.len(), 2);
+        assert_eq!(observed[0]["reference"], "U1");
+        assert_eq!(observed[0]["unit"], 1);
+        assert_eq!(observed[1]["unit"], 2);
+        assert!(observed
+            .iter()
+            .all(|update| update["datasheet_url"] == "https://example.com/u1.pdf"));
+        assert!(committed.contains("\r\n\t\t(property \"Notes\" \"decoy\"\r\n"));
+        assert!(committed.contains("(property \"LCSC\" \"C-LIBRARY\")"));
+        assert!(committed.contains("(property \"LCSC\" \"C-DECOY\")"));
+    }
+
+    #[test]
+    fn kicad_authored_symbol_is_enriched_structurally_and_read_back() {
+        let Some((command, planned)) = plan_datasheet_enrichment(
+            KICAD_STRUCTURAL_FIXTURE,
+            &urls(&[("C25804", "https://example.com/c25804.pdf")]),
+            false,
+        )
+        .unwrap() else {
+            panic!("expected enrichment plan");
+        };
+        assert_eq!(planned.len(), 1);
+        assert_eq!(planned[0].target.reference, "R1");
+
+        let mut file = tempfile::NamedTempFile::with_suffix(".kicad_sch").unwrap();
+        file.write_all(KICAD_STRUCTURAL_FIXTURE.as_bytes()).unwrap();
+        file.flush().unwrap();
+        let outcome = commit_command(file.path(), &command).unwrap();
+        assert!(outcome.changed);
+
+        let committed = std::fs::read_to_string(file.path()).unwrap();
+        let observed = observe_datasheet_updates(&committed, &planned).unwrap();
+        assert_eq!(observed.len(), 1);
+        assert_eq!(observed[0]["reference"], "R1");
+        assert_eq!(observed[0]["lcsc_id"], "C25804");
+        assert_eq!(
+            observed[0]["datasheet_url"],
+            "https://example.com/c25804.pdf"
+        );
+        parse_sexp(&committed).expect("enriched KiCad fixture must still parse");
+    }
+
+    #[test]
+    fn nested_or_library_lcsc_text_is_not_a_symbol_target() {
+        let content = schematic(
+            "\t(lib_symbols\n\t\t(symbol \"X\" (property \"LCSC\" \"C1\"))\n\t)\n\t(text \"(property LCSC C1)\" (at 0 0) (uuid \"text-1\"))\n",
+        );
+        assert!(validated_datasheet_symbols(&content).unwrap().is_empty());
+        assert!(plan_datasheet_enrichment(
+            &content,
+            &urls(&[("C1", "https://example.com/decoy.pdf")]),
+            false
+        )
+        .unwrap()
+        .is_none());
+    }
+
+    #[test]
+    fn missing_uuid_is_a_stale_target() {
+        let content = schematic(&symbol("R1", 1, None, "C1"));
+        let error = validated_datasheet_symbols(&content).unwrap_err();
+        assert!(matches!(error, DatasheetTargetError::Stale { .. }));
+    }
+
+    #[test]
+    fn duplicate_reference_and_unit_is_a_stale_refusal() {
+        let content = schematic(&format!(
+            "{}{}",
+            symbol("U1", 1, Some("first"), "C1"),
+            symbol("U1", 1, Some("second"), "C2")
+        ));
+        let error = validated_datasheet_symbols(&content).unwrap_err();
+        assert!(matches!(&error, DatasheetTargetError::Ambiguous { .. }));
+        assert_eq!(
+            extract_error_kind(&error.into_result()).as_deref(),
+            Some("stale_target")
+        );
+    }
+
+    #[test]
+    fn duplicate_uuid_is_a_stale_refusal_even_across_item_kinds() {
+        let content = schematic(&format!(
+            "{}\t(junction (at 1 2) (uuid \"shared\"))\r\n",
+            symbol("R1", 1, Some("shared"), "C1")
+        ));
+        let error = validated_datasheet_symbols(&content).unwrap_err();
+        assert!(matches!(&error, DatasheetTargetError::Ambiguous { .. }));
+        assert_eq!(
+            extract_error_kind(&error.into_result()).as_deref(),
+            Some("stale_target")
+        );
+    }
+
+    #[test]
+    fn stale_document_revision_refuses_without_overwriting() {
+        let original = schematic(&symbol("R1", 1, Some("r1"), "C1"));
+        let Some((command, _)) = plan_datasheet_enrichment(
+            &original,
+            &urls(&[("C1", "https://example.com/r1.pdf")]),
+            false,
+        )
+        .unwrap() else {
+            panic!("expected enrichment plan");
+        };
+        let mut file = tempfile::NamedTempFile::with_suffix(".kicad_sch").unwrap();
+        let newer = original.replace("(at 10 20 0)", "(at 11 20 0)");
+        file.write_all(newer.as_bytes()).unwrap();
+        file.flush().unwrap();
+
+        let error = commit_command(file.path(), &command).unwrap_err();
+        let refusal = datasheet_commit_refusal(file.path(), &error).unwrap();
+        assert_eq!(
+            extract_error_kind(&refusal).as_deref(),
+            Some("stale_target")
+        );
+        assert_eq!(std::fs::read_to_string(file.path()).unwrap(), newer);
+    }
+
+    #[test]
+    fn overwrite_policy_and_noop_counts_are_truthful() {
+        let original = schematic(&symbol("R1", 1, Some("r1"), "C1")).replace(
+            "(property \"Datasheet\" \"~\")",
+            "(property \"Datasheet\" \"https://existing.example/r1.pdf\")",
+        );
+        let replacements = urls(&[("C1", "https://new.example/r1.pdf")]);
+        assert!(plan_datasheet_enrichment(&original, &replacements, false)
+            .unwrap()
+            .is_none());
+        assert!(plan_datasheet_enrichment(&original, &replacements, true)
+            .unwrap()
+            .is_some());
+
+        let same = urls(&[("C1", "https://existing.example/r1.pdf")]);
+        assert!(plan_datasheet_enrichment(&original, &same, true)
+            .unwrap()
+            .is_none());
+    }
 }
 
 async fn run_java_command(

--- a/crates/konnect-core/src/tools/sch_export.rs
+++ b/crates/konnect-core/src/tools/sch_export.rs
@@ -4,18 +4,18 @@
 //! `export_netlist_summary` and `fix_connectivity` operate directly on
 //! S-expression file content so they work without a running KiCAD instance.
 
-use crate::mcp::protocol::CallToolResult;
+use crate::mcp::{error::ToolErrorKind, protocol::CallToolResult};
 use crate::tool;
 use crate::tools::{get_path, placed_pins, placed_pins_by_reference, ToolContext, ToolDef};
 use konnect_sexp::{
     geometry::{point_on_segment, points_coincident},
+    parser::{parse_sexp, SexpNode},
     schematic::{
         extract_all_net_labels, extract_labels, extract_symbol_instances, extract_wires,
         pin_endpoint, read_schematic,
     },
-    writer::{
-        apply_edits, find_block_with_leading_whitespace, write_atomic_if_unchanged, SexpEdit,
-    },
+    writer::{apply_edits, find_direct_child_blocks, write_atomic_if_unchanged, SexpEdit},
+    SexpError,
 };
 use serde_json::json;
 use std::path::{Path, PathBuf};
@@ -729,8 +729,7 @@ async fn handle_fix_connectivity(
         snap_targets.push((w.x2, w.y2));
     }
 
-    let mut fixes: Vec<serde_json::Value> = Vec::new();
-    let mut file_edits: Vec<SexpEdit> = Vec::new();
+    let mut fixes = Vec::new();
 
     for w in &wires {
         for (is_start, (px, py)) in &[(true, (w.x1, w.y1)), (false, (w.x2, w.y2))] {
@@ -755,65 +754,403 @@ async fn handle_fix_connectivity(
                 continue; // T-junction — already connected
             }
 
-            // Look for a near-miss snap target within snap_tol
-            let near = snap_targets.iter().find(|(tx, ty)| {
+            // A geometric near miss is still ambiguous when two distinct
+            // destinations are in range. Refuse instead of depending on file
+            // order to choose one.
+            let mut raw_near = Vec::new();
+            for &(tx, ty) in &snap_targets {
                 let dist = ((px - tx).powi(2) + (py - ty).powi(2)).sqrt();
-                dist > exact_tol && dist <= snap_tol
-            });
-
-            if let Some(&(tx, ty)) = near {
-                fixes.push(json!({
-                    "wire_uuid": w.uuid,
-                    "endpoint": if *is_start { "start" } else { "end" },
-                    "from": { "x": px, "y": py },
-                    "to":   { "x": tx, "y": ty }
-                }));
-
-                if !dry_run {
-                    // Find the wire block by UUID and replace the coordinate
-                    if let Some(uuid_str) = &w.uuid {
-                        let uuid_pat = format!(r#"(uuid "{uuid_str}")"#);
-                        if let Some(uuid_pos) = content.find(&uuid_pat) {
-                            let before = &content[..uuid_pos];
-                            if let Some(ws) = before.rfind("\n  (wire").map(|p| p + 1) {
-                                if let Some((wbs, wbe)) =
-                                    find_block_with_leading_whitespace(&content, ws)
-                                {
-                                    let wire_block = &content[wbs..wbe];
-                                    let coord_prefix = if *is_start { "(start " } else { "(end " };
-                                    if let Some(coord_rel) = wire_block.find(coord_prefix) {
-                                        let vals_abs = wbs + coord_rel + coord_prefix.len();
-                                        let close_rel =
-                                            wire_block[coord_rel..].find(')').unwrap_or(0);
-                                        let vals_end = wbs + coord_rel + close_rel;
-                                        file_edits.push(SexpEdit::replace(
-                                            vals_abs,
-                                            vals_end,
-                                            format!("{tx} {ty}"),
-                                        ));
-                                    }
-                                }
-                            }
-                        }
-                    }
+                let own_other_endpoint = if *is_start {
+                    (w.x2, w.y2)
+                } else {
+                    (w.x1, w.y1)
+                };
+                if dist > exact_tol
+                    && dist <= snap_tol
+                    && !points_coincident(
+                        tx,
+                        ty,
+                        own_other_endpoint.0,
+                        own_other_endpoint.1,
+                        exact_tol,
+                    )
+                {
+                    raw_near.push((tx, ty));
                 }
+            }
+            let near = distinct_geometric_destinations(&raw_near, exact_tol);
+            if near.len() > 1 {
+                let target = format!(
+                    "wire {} {} endpoint at ({px}, {py})",
+                    w.uuid.as_deref().unwrap_or("without UUID"),
+                    if *is_start { "start" } else { "end" }
+                );
+                let candidates = near
+                    .iter()
+                    .map(|(x, y)| format!("({x}, {y})"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return Ok(stale_connectivity_target(
+                    target,
+                    format!("more than one snap destination was observed: {candidates}"),
+                ));
+            }
+
+            if let Some(&(tx, ty)) = near.first() {
+                let Some(uuid) = &w.uuid else {
+                    let target = format!("wire endpoint at ({px}, {py})");
+                    return Ok(stale_connectivity_target(
+                        target,
+                        "the wire has no UUID and cannot be identified after a concurrent edit",
+                    ));
+                };
+                fixes.push(PlannedWireFix {
+                    uuid: uuid.clone(),
+                    endpoint: if *is_start {
+                        WireEndpoint::Start
+                    } else {
+                        WireEndpoint::End
+                    },
+                    from: (px, py),
+                    to: (tx, ty),
+                });
             }
         }
     }
 
-    let applied_count = if dry_run { 0 } else { file_edits.len() };
-    if applied_count > 0 {
-        let expected = content.clone();
-        let new_content = apply_edits(content, file_edits);
-        write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
+    // When two loose wire ends see only each other, the independently planned
+    // fixes point in opposite directions. Applying both would merely swap the
+    // coordinates and leave the wires disconnected. Keep the target with the
+    // lexicographically smaller stable item key stationary and move only its
+    // peer onto it.
+    let mut keep = vec![true; fixes.len()];
+    for left in 0..fixes.len() {
+        for right in (left + 1)..fixes.len() {
+            if points_coincident(
+                fixes[left].from.0,
+                fixes[left].from.1,
+                fixes[right].to.0,
+                fixes[right].to.1,
+                exact_tol,
+            ) && points_coincident(
+                fixes[left].to.0,
+                fixes[left].to.1,
+                fixes[right].from.0,
+                fixes[right].from.1,
+                exact_tol,
+            ) {
+                if fixes[left].stable_key() <= fixes[right].stable_key() {
+                    keep[left] = false;
+                } else {
+                    keep[right] = false;
+                }
+            }
+        }
+    }
+    fixes = fixes
+        .into_iter()
+        .zip(keep)
+        .filter_map(|(fix, keep)| keep.then_some(fix))
+        .collect();
+
+    // Resolve every target structurally before constructing a replacement. A
+    // failure refuses the whole operation and leaves the document unchanged.
+    let mut file_edits = Vec::with_capacity(fixes.len());
+    for fix in &fixes {
+        let (start, end) = match wire_endpoint_block(&content, &fix.uuid, fix.endpoint) {
+            Ok(range) => range,
+            Err(error) => return Ok(error.into_result()),
+        };
+        let tag = parse_sexp(&content[start..end])
+            .ok()
+            .and_then(|node| node.head().map(ToOwned::to_owned))
+            .unwrap_or_else(|| "xy".to_owned());
+        file_edits.push(SexpEdit::replace(
+            start,
+            end,
+            format!("({tag} {} {})", fix.to.0, fix.to.1),
+        ));
+    }
+
+    if dry_run || fixes.is_empty() {
+        return Ok(CallToolResult::json(&json!({
+            "fixes_found": fixes.len(),
+            "applied": false,
+            "dry_run": dry_run,
+            "fixes": fixes.iter().map(PlannedWireFix::as_json).collect::<Vec<_>>()
+        })));
+    }
+
+    let new_content = apply_edits(content.clone(), file_edits);
+    if let Err(error) = write_atomic_if_unchanged(&sch_path, &content, &new_content) {
+        if let Some(refusal) = connectivity_write_refusal(&sch_path, &error) {
+            return Ok(refusal);
+        }
+        return Err(error.into());
+    }
+
+    // Never report the requested coordinates as though they were committed.
+    // Reparse the saved document and derive every returned endpoint from it.
+    let (committed, _) = read_schematic(&sch_path)?;
+    let mut observed = Vec::with_capacity(fixes.len());
+    for fix in &fixes {
+        let actual = match observed_wire_endpoint(&committed, &fix.uuid, fix.endpoint) {
+            Ok(point) => point,
+            Err(error) => return Ok(error.into_result()),
+        };
+        if !points_coincident(actual.0, actual.1, fix.to.0, fix.to.1, 1e-9) {
+            return Ok(stale_connectivity_target(
+                format!("wire {} {} endpoint", fix.uuid, fix.endpoint.name()),
+                format!(
+                    "committed readback was ({}, {}) instead of ({}, {})",
+                    actual.0, actual.1, fix.to.0, fix.to.1
+                ),
+            ));
+        }
+        observed.push(json!({
+            "wire_uuid": fix.uuid,
+            "endpoint": fix.endpoint.name(),
+            "from": { "x": fix.from.0, "y": fix.from.1 },
+            "to": { "x": actual.0, "y": actual.1 }
+        }));
     }
 
     Ok(CallToolResult::json(&json!({
-        "fixes_found": fixes.len(),
-        "applied": !dry_run && !fixes.is_empty(),
-        "dry_run": dry_run,
-        "fixes": fixes
+        "fixes_found": observed.len(),
+        "applied": !observed.is_empty(),
+        "dry_run": false,
+        "fixes": observed
     })))
+}
+
+/// Collapse different schematic objects that identify the same geometric
+/// destination. Ambiguity is about coordinates, not how many pins, labels, or
+/// wire endpoints happen to coexist there.
+fn distinct_geometric_destinations(candidates: &[(f64, f64)], tolerance: f64) -> Vec<(f64, f64)> {
+    let mut destinations = Vec::new();
+    for &(x, y) in candidates {
+        if !destinations
+            .iter()
+            .any(|&(dx, dy)| points_coincident(x, y, dx, dy, tolerance))
+        {
+            destinations.push((x, y));
+        }
+    }
+    destinations
+}
+
+#[derive(Clone, Copy, Debug)]
+enum WireEndpoint {
+    Start,
+    End,
+}
+
+impl WireEndpoint {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Start => "start",
+            Self::End => "end",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PlannedWireFix {
+    uuid: String,
+    endpoint: WireEndpoint,
+    from: (f64, f64),
+    to: (f64, f64),
+}
+
+impl PlannedWireFix {
+    fn stable_key(&self) -> (&str, &'static str) {
+        (&self.uuid, self.endpoint.name())
+    }
+
+    fn as_json(&self) -> serde_json::Value {
+        json!({
+            "wire_uuid": self.uuid,
+            "endpoint": self.endpoint.name(),
+            "from": { "x": self.from.0, "y": self.from.1 },
+            "to": { "x": self.to.0, "y": self.to.1 }
+        })
+    }
+}
+
+#[derive(Debug)]
+enum ConnectivityTargetError {
+    Ambiguous {
+        target: String,
+        candidates: Vec<String>,
+    },
+    Stale {
+        target: String,
+        reason: String,
+    },
+}
+
+impl ConnectivityTargetError {
+    fn into_result(self) -> CallToolResult {
+        match self {
+            Self::Ambiguous { target, candidates } => stale_connectivity_target(
+                target,
+                format!(
+                    "more than one schematic item identifies the target: {}",
+                    candidates.join(", ")
+                ),
+            ),
+            Self::Stale { target, reason } => stale_connectivity_target(target, reason),
+        }
+    }
+}
+
+fn stale_connectivity_target(
+    target: impl Into<String>,
+    reason: impl Into<String>,
+) -> CallToolResult {
+    let target = target.into();
+    let reason = reason.into();
+    CallToolResult::error_kind(
+        ToolErrorKind::StaleTarget {
+            target: target.clone(),
+            reason: reason.clone(),
+        },
+        format!("cannot safely edit {target}: {reason}"),
+    )
+}
+
+fn connectivity_write_refusal(path: &Path, error: &SexpError) -> Option<CallToolResult> {
+    let reason = match error {
+        SexpError::Conflict { .. } => {
+            "the schematic changed after connectivity fixes were planned; reload and retry"
+        }
+        SexpError::KiCadEditorLocked { .. } => {
+            "KiCad owns the schematic; use a live editor mutation or close the document"
+        }
+        _ => return None,
+    };
+    Some(stale_connectivity_target(
+        path.display().to_string(),
+        reason,
+    ))
+}
+
+fn node_uuid(node: &SexpNode) -> Option<&str> {
+    node.find("uuid")
+        .and_then(|uuid| uuid.get(1))
+        .and_then(SexpNode::as_str)
+}
+
+fn wire_block(content: &str, uuid: &str) -> Result<(usize, usize), ConnectivityTargetError> {
+    let target = format!("wire UUID {uuid}");
+    let mut matches = Vec::new();
+    for (start, end) in find_direct_child_blocks(content, "kicad_sch") {
+        let Ok(node) = parse_sexp(&content[start..end]) else {
+            continue;
+        };
+        if node_uuid(&node) == Some(uuid) {
+            matches.push((start, end, node.head().unwrap_or("unknown").to_owned()));
+        }
+    }
+
+    match matches.as_slice() {
+        [] => Err(ConnectivityTargetError::Stale {
+            target,
+            reason: "no top-level schematic item has that UUID".to_owned(),
+        }),
+        [(start, end, kind)] if kind == "wire" => Ok((*start, *end)),
+        [(_, _, kind)] => Err(ConnectivityTargetError::Stale {
+            target,
+            reason: format!("the UUID identifies a {kind}, not a wire"),
+        }),
+        _ => Err(ConnectivityTargetError::Ambiguous {
+            target,
+            candidates: matches
+                .iter()
+                .map(|(start, _, kind)| format!("{kind} at byte {start}"))
+                .collect(),
+        }),
+    }
+}
+
+fn direct_children_with_tag(source: &str, parent: &str, tag: &str) -> Vec<(usize, usize)> {
+    find_direct_child_blocks(source, parent)
+        .into_iter()
+        .filter(|(start, end)| {
+            parse_sexp(&source[*start..*end])
+                .ok()
+                .is_some_and(|node| node.head() == Some(tag))
+        })
+        .collect()
+}
+
+fn wire_endpoint_block(
+    content: &str,
+    uuid: &str,
+    endpoint: WireEndpoint,
+) -> Result<(usize, usize), ConnectivityTargetError> {
+    let (wire_start, wire_end) = wire_block(content, uuid)?;
+    let wire = &content[wire_start..wire_end];
+    let pts = direct_children_with_tag(wire, "wire", "pts");
+    let legacy_start = direct_children_with_tag(wire, "wire", "start");
+    let legacy_end = direct_children_with_tag(wire, "wire", "end");
+    let target = format!("wire UUID {uuid} {} endpoint", endpoint.name());
+
+    if pts.len() == 1 && legacy_start.is_empty() && legacy_end.is_empty() {
+        let (pts_start, pts_end) = pts[0];
+        let pts_source = &wire[pts_start..pts_end];
+        let xy = direct_children_with_tag(pts_source, "pts", "xy");
+        if xy.len() != 2 {
+            return Err(ConnectivityTargetError::Stale {
+                target,
+                reason: format!("expected exactly two xy points, observed {}", xy.len()),
+            });
+        }
+        let (start, end) = xy[match endpoint {
+            WireEndpoint::Start => 0,
+            WireEndpoint::End => 1,
+        }];
+        return Ok((wire_start + pts_start + start, wire_start + pts_start + end));
+    }
+
+    if pts.is_empty() && legacy_start.len() == 1 && legacy_end.len() == 1 {
+        let (start, end) = match endpoint {
+            WireEndpoint::Start => legacy_start[0],
+            WireEndpoint::End => legacy_end[0],
+        };
+        return Ok((wire_start + start, wire_start + end));
+    }
+
+    Err(ConnectivityTargetError::Stale {
+        target,
+        reason: "wire endpoint representation is missing or structurally ambiguous".to_owned(),
+    })
+}
+
+fn observed_wire_endpoint(
+    content: &str,
+    uuid: &str,
+    endpoint: WireEndpoint,
+) -> Result<(f64, f64), ConnectivityTargetError> {
+    let (start, end) = wire_endpoint_block(content, uuid, endpoint)?;
+    let node =
+        parse_sexp(&content[start..end]).map_err(|error| ConnectivityTargetError::Stale {
+            target: format!("wire UUID {uuid} {} endpoint", endpoint.name()),
+            reason: error.to_string(),
+        })?;
+    let x = node
+        .get_f64(1)
+        .ok_or_else(|| ConnectivityTargetError::Stale {
+            target: format!("wire UUID {uuid} {} endpoint", endpoint.name()),
+            reason: "x coordinate is missing".to_owned(),
+        })?;
+    let y = node
+        .get_f64(2)
+        .ok_or_else(|| ConnectivityTargetError::Stale {
+            target: format!("wire UUID {uuid} {} endpoint", endpoint.name()),
+            reason: "y coordinate is missing".to_owned(),
+        })?;
+    Ok((x, y))
 }
 
 #[cfg(test)]
@@ -998,6 +1335,201 @@ mod multi_unit_connectivity_tests {
         };
         let response: serde_json::Value = serde_json::from_str(text).unwrap();
         assert_eq!(response["fixes_found"], 0, "phantom pin snap: {response}");
+    }
+}
+
+#[cfg(test)]
+mod connectivity_edit_tests {
+    use super::*;
+    use crate::mcp::error::extract_error_kind;
+    use crate::tools::ServerConfig;
+    use std::io::Write;
+    use std::sync::Arc;
+
+    const KICAD_STRUCTURAL_FIXTURE: &str =
+        include_str!("../../tests/fixtures/structural_scans_kicad10.kicad_sch");
+
+    fn fixture(uuid: Option<&str>, decoy: &str, labels: &str) -> String {
+        let uuid = uuid
+            .map(|uuid| format!("\r\n\t\t(uuid \"{uuid}\")"))
+            .unwrap_or_default();
+        format!(
+            "(kicad_sch\r\n\t(version 20231120)\r\n{decoy}\t(wire\r\n\t\t(pts\r\n\t\t\t(xy 0 0)\r\n\t\t\t(xy 10.04 0)\r\n\t\t)\r\n\t\t(stroke (width 0) (type default)){uuid}\r\n\t)\r\n{labels})\r\n"
+        )
+    }
+
+    fn label(name: &str, x: f64, uuid: &str) -> String {
+        format!("\t(label \"{name}\"\r\n\t\t(at {x} 0 0)\r\n\t\t(uuid \"{uuid}\")\r\n\t)\r\n")
+    }
+
+    async fn run_fix(content: &str) -> (CallToolResult, tempfile::NamedTempFile) {
+        let mut file = tempfile::NamedTempFile::with_suffix(".kicad_sch").unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+        let context = ToolContext::new(
+            ServerConfig::default(),
+            Arc::new(crate::router::ToolRouter::new()),
+        );
+        let result = handle_fix_connectivity(
+            &json!({
+                "schematic": file.path().to_str().unwrap(),
+                "snap_tolerance": 0.05,
+                "dry_run": false
+            }),
+            &context,
+        )
+        .await
+        .unwrap();
+        (result, file)
+    }
+
+    fn response(result: &CallToolResult) -> serde_json::Value {
+        let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text response");
+        };
+        serde_json::from_str(text).unwrap()
+    }
+
+    #[tokio::test]
+    async fn tab_crlf_kicad10_wire_is_edited_structurally_and_read_back() {
+        let decoy = "\t(symbol\r\n\t\t(property \"decoy\" \"nested\"\r\n\t\t\t(uuid \"wire-1\")\r\n\t\t)\r\n\t\t(uuid \"symbol-1\")\r\n\t)\r\n";
+        let original = fixture(Some("wire-1"), decoy, &label("N", 10.0, "label-1"));
+        let (result, file) = run_fix(&original).await;
+
+        assert!(!result.is_error, "{result:?}");
+        let body = response(&result);
+        assert_eq!(body["fixes_found"], 1);
+        assert_eq!(body["applied"], true);
+        assert_eq!(body["fixes"][0]["wire_uuid"], "wire-1");
+        assert_eq!(body["fixes"][0]["endpoint"], "end");
+        assert_eq!(body["fixes"][0]["to"], json!({ "x": 10.0, "y": 0.0 }));
+
+        let committed = std::fs::read_to_string(file.path()).unwrap();
+        assert!(committed.contains("\r\n\t\t\t(xy 0 0)\r\n"));
+        assert!(committed.contains("\r\n\t\t\t(xy 10 0)\r\n"));
+        assert!(committed.contains("(property \"decoy\" \"nested\""));
+        assert_eq!(
+            observed_wire_endpoint(&committed, "wire-1", WireEndpoint::End).unwrap(),
+            (10.0, 0.0)
+        );
+    }
+
+    #[tokio::test]
+    async fn coincident_kicad_pin_and_label_are_one_snap_destination() {
+        let tree = parse_sexp(KICAD_STRUCTURAL_FIXTURE).unwrap();
+        let destination = (190.5, 193.04);
+        assert!(extract_labels(&tree).iter().any(|label| points_coincident(
+            label.x,
+            label.y,
+            destination.0,
+            destination.1,
+            1e-9
+        )));
+        assert!(placed_pins(&tree).into_iter().any(|(pin, transform)| {
+            let endpoint = pin_endpoint(&pin, transform);
+            points_coincident(endpoint.0, endpoint.1, destination.0, destination.1, 1e-9)
+        }));
+
+        let (result, file) = run_fix(KICAD_STRUCTURAL_FIXTURE).await;
+
+        assert!(!result.is_error, "{result:?}");
+        let body = response(&result);
+        assert_eq!(body["fixes_found"], 1);
+        assert_eq!(
+            body["fixes"][0]["wire_uuid"],
+            "11111111-2222-4333-8444-555555555555"
+        );
+        assert_eq!(body["fixes"][0]["to"], json!({ "x": 190.5, "y": 193.04 }));
+        let committed = std::fs::read_to_string(file.path()).unwrap();
+        assert_eq!(
+            observed_wire_endpoint(
+                &committed,
+                "11111111-2222-4333-8444-555555555555",
+                WireEndpoint::Start,
+            )
+            .unwrap(),
+            destination
+        );
+    }
+
+    #[tokio::test]
+    async fn wire_without_uuid_is_a_stale_refusal_and_does_not_write() {
+        let original = fixture(None, "", &label("N", 10.0, "label-1"));
+        let (result, file) = run_fix(&original).await;
+
+        assert_eq!(extract_error_kind(&result).as_deref(), Some("stale_target"));
+        assert_eq!(std::fs::read_to_string(file.path()).unwrap(), original);
+    }
+
+    #[tokio::test]
+    async fn two_distinct_snap_destinations_are_refused_without_writing() {
+        let labels = format!(
+            "{}{}",
+            label("LEFT", 10.0, "label-1"),
+            label("RIGHT", 10.08, "label-2")
+        );
+        let original = fixture(Some("wire-1"), "", &labels);
+        let (result, file) = run_fix(&original).await;
+
+        assert_eq!(extract_error_kind(&result).as_deref(), Some("stale_target"));
+        assert_eq!(std::fs::read_to_string(file.path()).unwrap(), original);
+    }
+
+    #[tokio::test]
+    async fn reciprocal_wire_endpoints_coalesce_to_one_observed_connection() {
+        let original = "(kicad_sch\r\n\t(version 20231120)\r\n\t(wire\r\n\t\t(pts (xy 0 0) (xy 10 0))\r\n\t\t(uuid \"wire-a\")\r\n\t)\r\n\t(wire\r\n\t\t(pts (xy 10.04 0) (xy 20 0))\r\n\t\t(uuid \"wire-b\")\r\n\t)\r\n)\r\n";
+        let (result, file) = run_fix(original).await;
+
+        assert!(!result.is_error, "{result:?}");
+        let body = response(&result);
+        assert_eq!(body["fixes_found"], 1);
+        assert_eq!(body["fixes"][0]["wire_uuid"], "wire-b");
+        assert_eq!(body["fixes"][0]["to"], json!({ "x": 10.0, "y": 0.0 }));
+
+        let committed = std::fs::read_to_string(file.path()).unwrap();
+        let left = observed_wire_endpoint(&committed, "wire-a", WireEndpoint::End).unwrap();
+        let right = observed_wire_endpoint(&committed, "wire-b", WireEndpoint::Start).unwrap();
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn duplicate_top_level_uuid_is_a_stale_refusal() {
+        let content = "(kicad_sch\n  (wire (start 0 0) (end 1 0) (uuid \"dup\"))\n  (wire (start 2 0) (end 3 0) (uuid \"dup\"))\n)";
+        let error = wire_endpoint_block(content, "dup", WireEndpoint::Start).unwrap_err();
+        assert!(matches!(&error, ConnectivityTargetError::Ambiguous { .. }));
+        assert_eq!(
+            extract_error_kind(&error.into_result()).as_deref(),
+            Some("stale_target")
+        );
+    }
+
+    #[test]
+    fn uuid_on_wrong_item_kind_is_stale() {
+        let content =
+            "(kicad_sch\n  (junction (at 1 2) (diameter 0) (color 0 0 0 0) (uuid \"not-wire\"))\n)";
+        let error = wire_endpoint_block(content, "not-wire", WireEndpoint::Start).unwrap_err();
+        assert!(matches!(error, ConnectivityTargetError::Stale { .. }));
+    }
+
+    #[test]
+    fn legacy_endpoint_keeps_its_structural_tag() {
+        let content = "(kicad_sch\n  (wire (start 1 2) (end 3 4) (uuid \"legacy\"))\n)";
+        let (start, end) = wire_endpoint_block(content, "legacy", WireEndpoint::End).unwrap();
+        assert_eq!(&content[start..end], "(end 3 4)");
+        assert_eq!(
+            observed_wire_endpoint(content, "legacy", WireEndpoint::End).unwrap(),
+            (3.0, 4.0)
+        );
+    }
+
+    #[test]
+    fn stale_revision_maps_to_structured_refusal() {
+        let path = Path::new("design.kicad_sch");
+        let error = SexpError::Conflict {
+            path: path.to_path_buf(),
+        };
+        let result = connectivity_write_refusal(path, &error).unwrap();
+        assert_eq!(extract_error_kind(&result).as_deref(), Some("stale_target"));
     }
 }
 

--- a/crates/konnect-core/src/tools/schematic_builder.rs
+++ b/crates/konnect-core/src/tools/schematic_builder.rs
@@ -13,14 +13,23 @@
 //!   6. Labels (net_label, global_label, hierarchical_label)
 //!   7. Symbol instances (ALWAYS LAST)
 
-use konnect_sexp::writer::{read_consistent, write_atomic_if_unchanged, write_new_atomic};
+use konnect_sexp::{
+    parse_sexp,
+    writer::{
+        find_balanced_block, find_block_starts, find_direct_child_blocks, read_consistent,
+        write_atomic_if_unchanged, write_new_atomic,
+    },
+    SexpError,
+};
 use std::path::{Path, PathBuf};
-use tracing::debug;
 
 /// Structured representation of a .kicad_sch file.
 /// Each section holds raw S-expression strings that are written in order.
 pub struct SchematicBuilder {
     source_revision: Option<(PathBuf, String)>,
+    lib_symbol_extras: Vec<String>,
+    preserved_before_symbols: Vec<String>,
+    preserved_after_symbols: Vec<String>,
     /// Everything before lib_symbols: version, generator, uuid, paper, title_block
     pub header: String,
     /// Contents inside (lib_symbols ...) — each entry is a complete (symbol "Lib:Name" ...) block
@@ -55,6 +64,9 @@ impl SchematicBuilder {
         let uuid = konnect_sexp::writer::new_uuid();
         SchematicBuilder {
             source_revision: None,
+            lib_symbol_extras: Vec::new(),
+            preserved_before_symbols: Vec::new(),
+            preserved_after_symbols: Vec::new(),
             header: format!(
                 "(kicad_sch\n\t(version 20250610)\n\t(generator \"konnect\")\n\t(generator_version \"10.0\")\n\t(uuid \"{}\")\n\t(paper \"A4\")",
                 uuid
@@ -83,6 +95,9 @@ impl SchematicBuilder {
     pub fn parse(content: &str) -> anyhow::Result<Self> {
         let mut builder = SchematicBuilder {
             source_revision: None,
+            lib_symbol_extras: Vec::new(),
+            preserved_before_symbols: Vec::new(),
+            preserved_after_symbols: Vec::new(),
             header: String::new(),
             lib_symbols: Vec::new(),
             junctions: Vec::new(),
@@ -95,158 +110,111 @@ impl SchematicBuilder {
             symbols: Vec::new(),
         };
 
-        // Extract header (everything up to and including the line before lib_symbols or first element)
-        let header_end = content
-            .find("\n\t(lib_symbols")
-            .or_else(|| content.find("\n  (lib_symbols"))
-            .or_else(|| content.find("\n  (wire"))
-            .or_else(|| content.find("\n  (symbol"))
-            .unwrap_or(content.len());
-        builder.header = content[..header_end].to_string();
-
-        // Extract lib_symbols contents
-        if let Some(ls_start) = content.find("(lib_symbols") {
-            let mut depth = 0i32;
-            let mut ls_end = ls_start;
-            for (i, ch) in content[ls_start..].char_indices() {
-                match ch {
-                    '(' => depth += 1,
-                    ')' => {
-                        depth -= 1;
-                        if depth == 0 {
-                            ls_end = ls_start + i + 1;
-                            break;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            let ls_content = &content[ls_start..ls_end];
-
-            // Extract individual symbol definitions from inside lib_symbols
-            let inner_start = ls_content.find('\n').unwrap_or(0) + 1;
-            let inner_end = ls_content.rfind(')').unwrap_or(ls_content.len());
-            let inner = &ls_content[inner_start..inner_end];
-
-            // Split into individual (symbol ...) blocks
-            let mut pos = 0;
-            while let Some(sym_start) = inner[pos..]
-                .find("\t\t(symbol ")
-                .or_else(|| inner[pos..].find("(symbol "))
-            {
-                let abs = pos + sym_start;
-                // Find the matching close paren
-                let block_start = if inner[abs..].starts_with('\t') {
-                    abs + inner[abs..].find('(').unwrap_or(0)
-                } else {
-                    abs
-                };
-                let mut d = 0i32;
-                let mut block_end = block_start;
-                for (i, ch) in inner[block_start..].char_indices() {
-                    match ch {
-                        '(' => d += 1,
-                        ')' => {
-                            d -= 1;
-                            if d == 0 {
-                                block_end = block_start + i + 1;
-                                break;
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-                builder
-                    .lib_symbols
-                    .push(inner[block_start..block_end].trim().to_string());
-                pos = block_end;
-            }
+        let root_start = find_block_starts(content, "kicad_sch")
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("missing kicad_sch root"))?;
+        let (root_start, root_end) = find_balanced_block(content, root_start)
+            .ok_or_else(|| anyhow::anyhow!("unbalanced kicad_sch root"))?;
+        if !content[..root_start].trim().is_empty() || !content[root_end..].trim().is_empty() {
+            anyhow::bail!("schematic must contain exactly one kicad_sch root");
+        }
+        let root = parse_sexp(&content[root_start..root_end])?;
+        if root.head() != Some("kicad_sch") {
+            anyhow::bail!("schematic root is not kicad_sch");
         }
 
-        // Scan the entire file for top-level elements.
-        // Top-level elements start with "\n  (" (newline + 2 spaces + open paren).
-        // We skip anything inside (lib_symbols ...) since those are already extracted above.
+        let direct = find_direct_child_blocks(content, "kicad_sch");
+        let tagged = direct
+            .iter()
+            .map(|&(start, end)| {
+                let node = parse_sexp(&content[start..end])?;
+                let tag = node
+                    .head()
+                    .ok_or_else(|| anyhow::anyhow!("top-level item at byte {start} has no tag"))?;
+                Ok((start, end, tag.to_owned()))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let lib_ranges = tagged
+            .iter()
+            .filter(|(_, _, tag)| tag == "lib_symbols")
+            .collect::<Vec<_>>();
+        if lib_ranges.len() > 1 {
+            anyhow::bail!("schematic has more than one top-level lib_symbols block");
+        }
 
-        // Find the end of lib_symbols to know what to skip
-        let ls_end = if let Some(ls) = content.find("(lib_symbols") {
-            let mut depth = 0i32;
-            let mut end = ls;
-            for (i, ch) in content[ls..].char_indices() {
-                match ch {
-                    '(' => depth += 1,
-                    ')' => {
-                        depth -= 1;
-                        if depth == 0 {
-                            end = ls + i + 1;
-                            break;
-                        }
-                    }
-                    _ => {}
+        const HEADER_TAGS: &[&str] = &[
+            "version",
+            "generator",
+            "generator_version",
+            "uuid",
+            "paper",
+            "title_block",
+        ];
+        let first_body = tagged
+            .iter()
+            .find(|(_, _, tag)| !HEADER_TAGS.contains(&tag.as_str()));
+        if let Some(body) = first_body {
+            if tagged
+                .iter()
+                .any(|(start, _, tag)| *start > body.0 && HEADER_TAGS.contains(&tag.as_str()))
+            {
+                anyhow::bail!("schematic header item appears after a body item");
+            }
+        }
+        if let Some(lib) = lib_ranges.first() {
+            if first_body.is_some_and(|body| body.0 != lib.0) {
+                anyhow::bail!("lib_symbols must precede schematic body items");
+            }
+        }
+        let header_end = lib_ranges
+            .first()
+            .map(|range| range.0)
+            .or_else(|| first_body.map(|range| range.0))
+            .unwrap_or(root_end - 1);
+        builder.header = content[..header_end].trim_end().to_owned();
+
+        let body_start = if let Some((start, end, _)) = lib_ranges.first().copied() {
+            let lib_source = &content[*start..*end];
+            for (child_start, child_end) in find_direct_child_blocks(lib_source, "lib_symbols") {
+                let child = &lib_source[child_start..child_end];
+                let node = parse_sexp(child)?;
+                if node.head() == Some("symbol") {
+                    builder.lib_symbols.push(child.to_owned());
+                } else {
+                    builder.lib_symbol_extras.push(child.to_owned());
                 }
             }
-            end
+            *end
         } else {
-            0
+            header_end
         };
 
-        let mut pos = ls_end;
-        while pos < content.len() {
-            // Find next "\n  (" pattern
-            let next = content[pos..].find("\n  (").map(|i| pos + i + 1);
-
-            if let Some(elem_start) = next {
-                // Extract element type from "(type_name ..." or "(type_name\n..."
-                let paren_pos = content[elem_start..].find('(').unwrap_or(0) + elem_start;
-                let after_paren = paren_pos + 1;
-                let type_end = content[after_paren..]
-                    .find(|c: char| c.is_whitespace() || c == '(' || c == ')')
-                    .map(|i| after_paren + i)
-                    .unwrap_or(after_paren);
-                let elem_type = &content[after_paren..type_end];
-
-                // Find the balanced close paren
-                let mut depth = 0i32;
-                let mut elem_end = paren_pos;
-                for (i, ch) in content[paren_pos..].char_indices() {
-                    match ch {
-                        '(' => depth += 1,
-                        ')' => {
-                            depth -= 1;
-                            if depth == 0 {
-                                elem_end = paren_pos + i + 1;
-                                break;
-                            }
-                        }
-                        _ => {}
-                    }
+        let mut seen_symbol = false;
+        for (start, end, tag) in tagged {
+            if start < body_start || tag == "lib_symbols" || HEADER_TAGS.contains(&tag.as_str()) {
+                continue;
+            }
+            let block = content[start..end].to_owned();
+            match tag.as_str() {
+                "junction" => builder.junctions.push(block),
+                "no_connect" => builder.no_connects.push(block),
+                "wire" => builder.wires.push(block),
+                "bus" => builder.buses.push(block),
+                "bus_entry" => builder.bus_entries.push(block),
+                "text" | "text_box" => builder.texts.push(block),
+                "net_label" | "global_label" | "hierarchical_label" | "label" => {
+                    builder.labels.push(block)
                 }
-
-                let block = content[paren_pos..elem_end].to_string();
-
-                match elem_type {
-                    "junction" => builder.junctions.push(block),
-                    "no_connect" => builder.no_connects.push(block),
-                    "wire" => builder.wires.push(block),
-                    "bus" => builder.buses.push(block),
-                    "bus_entry" => builder.bus_entries.push(block),
-                    "text" => builder.texts.push(block),
-                    "net_label" | "global_label" | "hierarchical_label" | "label" => {
-                        builder.labels.push(block)
-                    }
-                    "symbol" => builder.symbols.push(block),
-                    _ => {
-                        debug!(
-                            "[SchematicBuilder] Unknown element type: '{}', block len: {}",
-                            elem_type,
-                            block.len()
-                        );
-                        builder.texts.push(block);
-                    }
+                "symbol" => {
+                    seen_symbol = true;
+                    builder.symbols.push(block);
                 }
-
-                pos = elem_end;
-            } else {
-                break;
+                "sheet_instances" | "symbol_instances" | "embedded_fonts" => {
+                    builder.preserved_after_symbols.push(block)
+                }
+                _ if seen_symbol => builder.preserved_after_symbols.push(block),
+                _ => builder.preserved_before_symbols.push(block),
             }
         }
 
@@ -320,6 +288,11 @@ impl SchematicBuilder {
             out.push_str(sym);
             out.push('\n');
         }
+        for item in &self.lib_symbol_extras {
+            out.push_str("\t\t");
+            out.push_str(item);
+            out.push('\n');
+        }
         out.push_str("\t)\n");
 
         // Junctions
@@ -371,8 +344,20 @@ impl SchematicBuilder {
             out.push('\n');
         }
 
+        for item in &self.preserved_before_symbols {
+            out.push_str("  ");
+            out.push_str(item);
+            out.push('\n');
+        }
+
         // Symbols — ALWAYS LAST
         for item in &self.symbols {
+            out.push_str("  ");
+            out.push_str(item);
+            out.push('\n');
+        }
+
+        for item in &self.preserved_after_symbols {
             out.push_str("  ");
             out.push_str(item);
             out.push('\n');
@@ -388,20 +373,89 @@ impl SchematicBuilder {
     /// new destination without replacing anything already present.
     pub fn save(&self, path: &Path) -> anyhow::Result<()> {
         let content = self.to_string();
+        Self::parse(&content)?;
         if let Some((source_path, expected)) = &self.source_revision {
             if source_path == path {
                 write_atomic_if_unchanged(path, expected, &content)?;
-                return Ok(());
+                return verify_saved_schematic(path, &content);
             }
         }
         write_new_atomic(path, &content)?;
-        Ok(())
+        verify_saved_schematic(path, &content)
     }
+}
+
+fn verify_saved_schematic(path: &Path, expected: &str) -> anyhow::Result<()> {
+    let observed = read_consistent(path)?;
+    if observed != expected {
+        return Err(SexpError::Conflict {
+            path: path.to_path_buf(),
+        }
+        .into());
+    }
+    SchematicBuilder::parse(&observed)?;
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const KICAD_STRUCTURAL_FIXTURE: &str =
+        include_str!("../../tests/fixtures/structural_scans_kicad10.kicad_sch");
+
+    fn hierarchical_fixture() -> String {
+        r#"(kicad_sch
+	(version 20250610)
+	(generator "eeschema")
+	(generator_version "10.0")
+	(uuid "root-id")
+	(paper "A4")
+	(title_block (title "Controller (rev A)"))
+	(lib_symbols
+		(symbol "Amplifier:DUAL"
+			(property "Value" "Dual (op amp)")
+		)
+		(future_library_metadata (payload "quoted ) text"))
+	)
+	(junction (at 10 10) (uuid "j1"))
+	(wire (pts (xy 10 10) (xy 20 10)) (uuid "w1"))
+	(text "note (do not split)" (at 5 5 0) (uuid "t1"))
+	(label "SIG" (at 20 10 0) (uuid "l1"))
+	(future_item (payload "unknown (direct) child") (uuid "future-1"))
+	(symbol
+		(lib_id "Amplifier:DUAL")
+		(at 30 30 0)
+		(unit 1)
+		(property "Reference" "U1")
+		(uuid "u1-unit-1")
+		(instances (project "root" (path "/sheet-a/u1" (reference "U1") (unit 1))))
+	)
+	(symbol
+		(lib_id "Amplifier:DUAL")
+		(at 40 30 0)
+		(unit 2)
+		(property "Reference" "U1")
+		(uuid "u1-unit-2")
+		(instances (project "root" (path "/sheet-a/u1" (reference "U1") (unit 2))))
+	)
+	(sheet
+		(at 60 40)
+		(size 25 20)
+		(property "Sheetname" "Child")
+		(property "Sheetfile" "child.kicad_sch")
+		(uuid "sheet-a")
+	)
+	(future_footer (payload "keep me") (uuid "future-footer"))
+	(sheet_instances (path "/" (page "1")) (path "/sheet-a" (page "2")))
+	(symbol_instances
+		(path "/sheet-a/u1" (reference "U1") (unit 1) (value "DUAL"))
+	)
+	(embedded_fonts no)
+)
+"#
+        .replace('\n', "\r\n")
+    }
 
     #[test]
     fn empty_builder_produces_valid_structure() {
@@ -482,5 +536,132 @@ mod tests {
         assert!(output.contains("(wire"));
         assert!(output.contains("(net_label"));
         assert!(output.contains("(symbol"));
+    }
+
+    #[test]
+    fn kicad_authored_sections_reload_after_builder_reserialization() {
+        let builder = SchematicBuilder::parse(KICAD_STRUCTURAL_FIXTURE).unwrap();
+        assert_eq!(builder.lib_symbols.len(), 1);
+        assert_eq!(builder.junctions.len(), 3);
+        assert_eq!(builder.no_connects.len(), 1);
+        assert_eq!(builder.wires.len(), 7);
+        assert_eq!(builder.buses.len(), 2);
+        assert_eq!(builder.labels.len(), 1);
+        assert_eq!(builder.symbols.len(), 2);
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("structural_scans.kicad_sch");
+        std::fs::write(&path, KICAD_STRUCTURAL_FIXTURE).unwrap();
+        let loaded = SchematicBuilder::from_file(&path).unwrap();
+        loaded.save(&path).unwrap();
+
+        let observed = std::fs::read_to_string(path).unwrap();
+        let reparsed = SchematicBuilder::parse(&observed).unwrap();
+        assert_eq!(reparsed.wires.len(), 7);
+        assert_eq!(reparsed.symbols.len(), 2);
+        for identity in [
+            "11111111-2222-4333-8444-555555555555",
+            "5bb775af-80e4-4b9f-b739-822ba959ac32",
+            "C25804",
+        ] {
+            assert!(observed.contains(identity), "missing {identity}");
+        }
+        parse_sexp(&observed).expect("builder output from KiCad fixture must reload");
+    }
+
+    #[test]
+    fn tab_crlf_hierarchy_multi_unit_and_unknown_children_round_trip_semantically() {
+        let input = hierarchical_fixture();
+        let builder = SchematicBuilder::parse(&input).unwrap();
+        assert_eq!(builder.lib_symbols.len(), 1);
+        assert_eq!(builder.wires.len(), 1);
+        assert_eq!(builder.texts.len(), 1);
+        assert_eq!(builder.symbols.len(), 2);
+        assert_eq!(builder.preserved_before_symbols.len(), 1);
+        assert_eq!(builder.preserved_after_symbols.len(), 5);
+        assert_eq!(builder.lib_symbol_extras.len(), 1);
+
+        let output = builder.to_string();
+        assert_eq!(parse_sexp(&output).unwrap(), parse_sexp(&input).unwrap());
+        for identity in [
+            "u1-unit-1",
+            "u1-unit-2",
+            "sheet-a",
+            "/sheet-a/u1",
+            "future-1",
+            "future-footer",
+            "future_library_metadata",
+        ] {
+            assert!(output.contains(identity), "missing {identity}");
+        }
+    }
+
+    #[test]
+    fn malformed_or_duplicate_structural_roots_are_refused() {
+        assert!(SchematicBuilder::parse("(kicad_sch (version 1)").is_err());
+        assert!(
+            SchematicBuilder::parse("(kicad_sch (version 1) (lib_symbols) (lib_symbols))").is_err()
+        );
+        assert!(
+            SchematicBuilder::parse("(kicad_sch (version 1)) (kicad_sch (version 2))").is_err()
+        );
+        assert!(SchematicBuilder::parse(
+            "(kicad_sch (lib_symbols) (wire (start 0 0) (end 1 1)) (paper \"A4\"))"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn loaded_builder_refuses_a_stale_source_without_overwriting_it() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("stale.kicad_sch");
+        let original = hierarchical_fixture();
+        std::fs::write(&path, &original).unwrap();
+        let mut builder = SchematicBuilder::from_file(&path).unwrap();
+        builder.add_wire("(wire (pts (xy 1 1) (xy 2 2)) (uuid \"new-wire\"))");
+
+        let newer = original.replace("Controller (rev A)", "Controller (rev B)");
+        std::fs::write(&path, &newer).unwrap();
+        let error = builder.save(&path).unwrap_err();
+
+        assert!(matches!(
+            error.downcast_ref::<SexpError>(),
+            Some(SexpError::Conflict { .. })
+        ));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), newer);
+    }
+
+    #[test]
+    fn loaded_builder_cannot_overwrite_a_different_document() {
+        let directory = tempfile::tempdir().unwrap();
+        let source = directory.path().join("source.kicad_sch");
+        let other = directory.path().join("other.kicad_sch");
+        let original = hierarchical_fixture();
+        std::fs::write(&source, &original).unwrap();
+        std::fs::write(&other, "keep other").unwrap();
+        let builder = SchematicBuilder::from_file(&source).unwrap();
+
+        let error = builder.save(&other).unwrap_err();
+
+        assert!(matches!(
+            error.downcast_ref::<SexpError>(),
+            Some(SexpError::Io(error)) if error.kind() == std::io::ErrorKind::AlreadyExists
+        ));
+        assert_eq!(std::fs::read_to_string(other).unwrap(), "keep other");
+        assert_eq!(std::fs::read_to_string(source).unwrap(), original);
+    }
+
+    #[test]
+    fn saved_result_is_reparsed_and_contains_new_items() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("observed.kicad_sch");
+        let mut builder = SchematicBuilder::new();
+        builder.add_wire("(wire (pts (xy 1 1) (xy 2 2)) (uuid \"observed-wire\"))");
+
+        builder.save(&path).unwrap();
+
+        let observed = std::fs::read_to_string(path).unwrap();
+        assert!(observed.contains("observed-wire"));
+        assert_eq!(SchematicBuilder::parse(&observed).unwrap().wires.len(), 1);
     }
 }

--- a/crates/konnect-core/tests/fixtures/structural_scans_kicad10.README.md
+++ b/crates/konnect-core/tests/fixtures/structural_scans_kicad10.README.md
@@ -1,0 +1,32 @@
+# Structural schematic scan fixture
+
+`structural_scans_kicad10.kicad_sch` is Eeschema-authored evidence for the
+three saved-schematic paths repaired by issue #84:
+
+- wire endpoint repair sees a loose wire at `(190.54, 193.04)` and one
+  geometric destination at `(190.5, 193.04)`, represented by both R3 pin 1
+  and the `SNAP` label;
+- datasheet enrichment sees R1's placed-instance `LCSC` property (`C25804`)
+  and empty `Datasheet` property;
+- `SchematicBuilder` sees the complete top-level KiCad section ordering and
+  full library/symbol records.
+
+The seed was the existing `junction_reconcile.kicad_sch` fixture, which was
+built through Konnect against KiCad's stock `Device:R` library. The deliberate
+wire, label, and custom-property cases were added, then the whole document was
+parsed and force-resaved by KiCad 10.0.5:
+
+```text
+kicad-cli sch upgrade --force structural_scans_kicad10.kicad_sch
+```
+
+That final Eeschema serialization is committed here. It was reload-checked
+with KiCad 10.0.5's netlist exporter:
+
+```text
+kicad-cli sch export netlist --output structural_scans.net structural_scans_kicad10.kicad_sch
+```
+
+The ignored real-KiCad E2E regression repeats the force-resave and netlist
+export. The three focused module tests copy this same fixture, exercise their
+respective mutation/serialization paths, and verify committed readback.

--- a/crates/konnect-core/tests/fixtures/structural_scans_kicad10.kicad_sch
+++ b/crates/konnect-core/tests/fixtures/structural_scans_kicad10.kicad_sch
@@ -1,0 +1,438 @@
+(kicad_sch
+	(version 20260306)
+	(generator "eeschema")
+	(generator_version "10.0")
+	(uuid "5a1d3bbf-65fe-4cc0-9d9e-4ec47d238186")
+	(paper "A4")
+	(lib_symbols
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(junction
+		(at 120.65 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5b951c2a-e9c2-4186-9549-1503f2a08233")
+	)
+	(junction
+		(at 260.35 140)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "817bc4b4-92d8-420d-ada3-60ba6f2710ff")
+	)
+	(junction
+		(at 120.65 139.7)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cbf6314c-c2eb-4f88-a40c-c624edd5e194")
+	)
+	(no_connect
+		(at 190.5 200.66)
+		(uuid "3f9dbc19-858e-4bf8-b937-b169159de4c8")
+	)
+	(wire
+		(pts
+			(xy 190.54 193.04) (xy 210.82 193.04)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "11111111-2222-4333-8444-555555555555")
+	)
+	(wire
+		(pts
+			(xy 190.5 119.38) (xy 190.5 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "18704fbf-0b66-4864-a63f-39e3ac9f5a5c")
+	)
+	(wire
+		(pts
+			(xy 170.18 139.7) (xy 210.82 139.7)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2ee88759-26d0-45cb-a6a4-03f8efbf9d02")
+	)
+	(bus
+		(pts
+			(xy 240.03 140) (xy 280.67 140)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "71ea7cc5-a805-44b4-b564-835c2051f745")
+	)
+	(wire
+		(pts
+			(xy 170.18 200.66) (xy 210.82 200.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "757f541f-d16e-4df4-abaa-041c4ecb9ebd")
+	)
+	(wire
+		(pts
+			(xy 100.33 139.7) (xy 140.97 139.7)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b853b3f1-7cc9-40e9-93b1-a1ff20973f4e")
+	)
+	(wire
+		(pts
+			(xy 100.33 170.18) (xy 140.97 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bef5cb4e-21cf-4ec3-b2f8-7ff1ab5e3ec5")
+	)
+	(wire
+		(pts
+			(xy 120.65 170.18) (xy 120.65 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e52b89e5-9b93-48fc-b706-9bac32fe327a")
+	)
+	(bus
+		(pts
+			(xy 260.35 140) (xy 260.35 160.32)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f4ac98a1-32e4-4586-b94a-ed7e966b5bb3")
+	)
+	(label "SNAP"
+		(at 190.5 193.04 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "5bb775af-80e4-4b9f-b739-822ba959ac32")
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 120.65 135.89 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "6f08a78f-7ec2-45e6-ba39-1d930be32b74")
+		(property "Reference" "R1"
+			(at 122.682 135.89 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1k"
+			(at 120.65 135.89 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 120.65 135.89 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 120.65 135.89 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 120.65 135.89 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "LCSC" "C25804"
+			(at 120.65 135.89 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "8026d02f-ff62-464a-9ce5-e55f42254b73")
+		)
+		(pin "2"
+			(uuid "1c69097d-37d8-4e8b-8a09-5bd6ab851371")
+		)
+		(instances
+			(project "probe"
+				(path "/701ab0b3-499b-4a08-9573-b9c925e9f72f/021eab14-9a79-4688-8da8-1f44fdf246e6"
+					(reference "R1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 190.5 196.85 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "d1a57d40-4f0f-47c4-b115-df592005a20b")
+		(property "Reference" "R3"
+			(at 192.532 196.85 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 190.5 196.85 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 190.5 196.85 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 190.5 196.85 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 190.5 196.85 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "1db0d7c4-0e95-4553-8ab6-b4d9e18309a8")
+		)
+		(pin "2"
+			(uuid "bc276eb1-76aa-4b7e-b844-6647c9b70f78")
+		)
+		(instances
+			(project "probe"
+				(path "/701ab0b3-499b-4a08-9573-b9c925e9f72f/021eab14-9a79-4688-8da8-1f44fdf246e6"
+					(reference "R3")
+					(unit 1)
+				)
+			)
+		)
+	)
+)

--- a/crates/konnect/tests/e2e_kicad.rs
+++ b/crates/konnect/tests/e2e_kicad.rs
@@ -139,6 +139,45 @@ fn body(result: &Value) -> Value {
 }
 
 #[test]
+#[ignore = "requires kicad-cli; run via e2e workflow"]
+fn structural_scan_fixture_reloads_through_real_kicad() {
+    let Some(kicad_cli) = find_kicad_cli() else {
+        panic!("kicad-cli not found — set KICAD_CLI or install KiCAD (this test is e2e-only)");
+    };
+    let source = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../konnect-core/tests/fixtures/structural_scans_kicad10.kicad_sch");
+    let directory = tempfile::tempdir().unwrap();
+    let schematic = directory.path().join("structural_scans.kicad_sch");
+    std::fs::copy(&source, &schematic).unwrap();
+
+    let upgrade = Command::new(&kicad_cli)
+        .args(["sch", "upgrade", "--force"])
+        .arg(&schematic)
+        .output()
+        .expect("failed to run KiCad schematic upgrade");
+    assert!(
+        upgrade.status.success(),
+        "KiCad could not reload and save the structural fixture: {}",
+        String::from_utf8_lossy(&upgrade.stderr)
+    );
+
+    let netlist = directory.path().join("structural_scans.net");
+    let export = Command::new(&kicad_cli)
+        .args(["sch", "export", "netlist", "--output"])
+        .arg(&netlist)
+        .arg(&schematic)
+        .output()
+        .expect("failed to run KiCad netlist export");
+    assert!(
+        export.status.success(),
+        "KiCad could not export the reloaded structural fixture: {}",
+        String::from_utf8_lossy(&export.stderr)
+    );
+    let netlist = std::fs::read_to_string(netlist).expect("KiCad wrote no netlist");
+    assert!(netlist.contains("R1") && netlist.contains("R3"));
+}
+
+#[test]
 #[ignore = "requires kicad-cli + symbol libraries; run via e2e workflow"]
 fn full_design_loop_with_real_kicad() {
     let Some(kicad_cli) = find_kicad_cli() else {


### PR DESCRIPTION
## Summary

Replace the three remaining indentation-sensitive schematic scans named by #84 with structural direct-child parsing. Tab indentation, CRLF, nested strings, and nested S-expressions can no longer silently change wire repair, datasheet enrichment, or builder insertion targets.

Closes #84. The separately filed footprint pad-count bug in #248 remains outside this schematic-only scope.

## Base and sequence

Rebuilt directly on current `main` at `dbd2948890eb6781d1df3a8343b2a813b33bbb10`, which includes #389. The branch contains exactly three #392-owned commits:

- `3197667` — structural wire-endpoint repair, geometric destination deduplication, and KiCad evidence;
- `fd33e23` — structural datasheet-enrichment targeting with the existing response shape preserved;
- `18e7d93` — structural schematic-builder section parsing.

This remains the next step in `#392 -> #393 -> #394`; #390 is a separate IPC lane.

## Approach

- Locate wire targets through structural direct-child spans and exact endpoint identity.
- Group nearby snap candidates by coordinate within the existing coincidence tolerance, so a pin plus label or coincident wire endpoints represent one geometric destination; refuse only when more than one distinct coordinate remains.
- Locate placed symbol targets for datasheet backfill structurally, refusing duplicate, missing, or stale targets instead of using `rfind`.
- Parse and rebuild top-level schematic sections through direct-child spans rather than newline/indent boundaries.
- Preserve original ordering and unrelated bytes, with typed target checks before each mutation.
- Map duplicate structural observations to current `main`'s existing `stale_target` contract; this PR does not introduce the `ambiguous_target` kind reserved for the later IPC lane.

## KiCad-authored evidence

Added one shared Eeschema-authored fixture plus provenance documentation. It was force-resaved by KiCad 10.0.5 and contains:

- a loose wire near a coordinate represented by both a real placed pin and a label;
- a placed R1 instance with an `LCSC` property and empty `Datasheet` property;
- complete KiCad top-level sections and full library/symbol records for builder parsing.

Focused tests exercise all three successful mutation/serialization paths against this checked-in fixture and verify committed readback. An ignored real-KiCad regression force-reloads the fixture and exports its netlist; it passed locally against KiCad 10.0.5 and is included in the weekly/manual E2E workflow.

## Compatibility and safety

No public tool, schema, response-field, CLI, configuration, or documented-path changes. The temporary `updates` response member from the earlier branch head was removed; `enrich_datasheets` retains its existing public response shape while deriving `datasheets_enriched` from committed readback.

Files formatted differently by Eeschema now follow the same mutation path as LF/two-space fixtures. Missing, duplicate, stale, or genuinely ambiguous structural targets refuse before mutation instead of silently no-oping or modifying the wrong block.

The issue could not be self-assigned or labeled `claimed` because this fork account has read-only repository permission.

## Effective diff

Implementation remains limited to the three affected modules. The additional files are the shared KiCad fixture, its provenance note, and the real-KiCad reload regression:

- `crates/konnect-core/src/tools/sch_export.rs`
- `crates/konnect-core/src/tools/integration.rs`
- `crates/konnect-core/src/tools/schematic_builder.rs`
- `crates/konnect-core/tests/fixtures/structural_scans_kicad10.kicad_sch`
- `crates/konnect-core/tests/fixtures/structural_scans_kicad10.README.md`
- `crates/konnect/tests/e2e_kicad.rs`

## Validation

On exact head `18e7d93c3a9173ebfdc75dde8c285445330a0e26`:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --locked --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked --lib --tests`
- [x] `cargo test --workspace --locked --doc`
- [x] Focused regressions: 9 wire-target tests, 8 datasheet-target tests, and 10 builder tests passed
- [x] Real KiCad evidence: `structural_scan_fixture_reloads_through_real_kicad` passed against KiCad 10.0.5
- [x] Negative controls: disabling geometric deduplication, distinct-destination refusal, duplicate wire-identity refusal, and duplicate datasheet-identity refusal made their respective regressions fail
- [x] Final ancestry/diff audit: merge base is current `main`; exactly three owned commits and the six intended files are present
- [x] All 10 hosted checks passed on the exact head

Environment-dependent Java/Freerouting and live KiCad GUI/IPC tests remain intentionally skipped; they are unrelated to these saved-schematic structural paths. The installed KiCad demo-conformance suite and the new CLI reload regression both ran successfully.

## Risk and rollback

Risk is limited to the three saved-schematic targeting paths above. The change refuses uncertain targets before mutation, uses revision-aware writes, and derives success from committed readback. Rollback is the three focused commits in reverse order; no migration or persisted-format change is involved.