### PR TITLE
fix(schematic): preserve connectivity on component delete

### DIFF
--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -19,17 +19,17 @@ use konnect_sexp::{
         find_lib_symbol, format_net_label, format_wire, pin_endpoint, pin_label_rotation,
         read_schematic, symbol_bounds_for_instance, SymbolBounds,
     },
-    writer::{
-        apply_edits, find_block_with_leading_whitespace, find_enclosing_direct_child_block,
-        new_uuid, read_consistent, write_atomic_if_unchanged, SexpEdit,
-    },
+    writer::{apply_edits, new_uuid, read_consistent, write_atomic_if_unchanged, SexpEdit},
 };
 use serde_json::json;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use super::sch_connectivity::{ConnectivityIndex, COINCIDENT_TOLERANCE};
 // Re-use the single-item component placer and pin-to-pin router.
-use super::sch_components::{place_one_component, placed_component_readback};
+use super::sch_components::{
+    commit_component_deletion, indexed_uuid_items, place_one_component, placed_component_readback,
+    plan_component_and_item_deletions, ComponentDeleteTargetError,
+};
 use super::sch_wiring::{resolve_pin_endpoint, resolve_placed_pin, route_between};
 
 // ─── Tool definitions ─────────────────────────────────────────────────────────
@@ -332,10 +332,13 @@ pub fn tools() -> Vec<ToolDef> {
 ///
 /// One entry per unit: deleting a multi-unit part means deleting all of them.
 /// Returns `(block_start, block_end)` byte offsets in `content`.
+#[cfg(test)]
 fn find_symbol_blocks(content: &str, reference: &str) -> Vec<(usize, usize)> {
     find_all_symbol_instance_blocks(content, reference)
         .into_iter()
-        .filter_map(|(sym_start, _)| find_block_with_leading_whitespace(content, sym_start))
+        .filter_map(|(sym_start, _)| {
+            konnect_sexp::writer::find_block_with_leading_whitespace(content, sym_start)
+        })
         .collect()
 }
 
@@ -612,110 +615,17 @@ async fn handle_batch_connect_pins(
 
 async fn handle_batch_delete(
     args: &serde_json::Value,
-    _ctx: &crate::tools::ToolContext,
+    ctx: &crate::tools::ToolContext,
 ) -> anyhow::Result<CallToolResult> {
-    let sch_path = get_path(args, "schematic")?;
-    let content = read_consistent(&sch_path)?;
-    let expected = content.clone();
-
-    let mut edits: Vec<SexpEdit> = Vec::new();
-    let mut deleted: Vec<String> = Vec::new();
-    let mut errors: Vec<String> = Vec::new();
-    let mut delete_ranges: HashSet<(usize, usize)> = HashSet::new();
-
-    // Delete by UUID — walk back from uuid node to enclosing top-level block
-    if let Some(uuids) = args["uuids"].as_array() {
-        for uuid_val in uuids {
-            let uuid = match uuid_val.as_str() {
-                Some(u) => u,
-                None => continue,
-            };
-            let pattern = format!(r#"(uuid "{}")"#, uuid);
-            match content.find(&pattern) {
-                Some(uuid_pos) => {
-                    match find_enclosing_direct_child_block(&content, "kicad_sch", uuid_pos) {
-                        Some((block_start, block_end)) => {
-                            let item = &content[block_start..block_end];
-                            if !is_deletable_schematic_item(item) {
-                                errors.push(format!(
-                                    "UUID '{}' belongs to protected schematic structure '{}'",
-                                    uuid,
-                                    sexp_tag(item)
-                                ));
-                                continue;
-                            }
-                            match find_block_with_leading_whitespace(&content, block_start) {
-                                Some((del_start, del_end)) => {
-                                    if delete_ranges.insert((del_start, del_end)) {
-                                        edits.push(SexpEdit::delete(del_start, del_end));
-                                        deleted.push(uuid.to_string());
-                                    }
-                                }
-                                None => {
-                                    errors.push(format!("Cannot parse block for UUID '{}'", uuid))
-                                }
-                            }
-                        }
-                        None => errors.push(format!("Cannot locate block for UUID '{}'", uuid)),
-                    }
-                }
-                None => errors.push(format!("UUID '{}' not found", uuid)),
-            }
-        }
-    }
-
-    // Delete by reference designator
-    if let Some(refs) = args["references"].as_array() {
-        for ref_val in refs {
-            let reference = match ref_val.as_str() {
-                Some(r) => r,
-                None => continue,
-            };
-            let blocks = find_symbol_blocks(&content, reference);
-            if blocks.is_empty() {
-                errors.push(format!("Component '{}' not found", reference));
-                continue;
-            }
-            // Every unit of a multi-unit part, or the whole component is not gone.
-            let mut any = false;
-            for (del_start, del_end) in blocks {
-                if delete_ranges.insert((del_start, del_end)) {
-                    edits.push(SexpEdit::delete(del_start, del_end));
-                    any = true;
-                }
-            }
-            if any {
-                deleted.push(reference.to_string());
-            }
-        }
-    }
-
-    let new_content = apply_edits(content, edits);
-    write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
-
-    Ok(CallToolResult::json(&json!({
-        "deleted_count": deleted.len(),
-        "deleted": deleted,
-        "errors": errors
-    })))
-}
-
-fn sexp_tag(block: &str) -> &str {
-    let Some(after_open) = block.strip_prefix('(') else {
-        return "";
-    };
-    let end = after_open
-        .find(|c: char| c.is_whitespace() || c == '(' || c == ')')
-        .unwrap_or(after_open.len());
-    &after_open[..end]
+    handle_structural_batch_delete(args, ctx, true).await
 }
 
 // Blocklist of structural forms, not an allowlist of item kinds: deleting a
 // drawing item (text, bus, sheet, image, polyline, …) by UUID has always
 // worked and must keep working — only the schematic's skeleton is protected.
-fn is_deletable_schematic_item(block: &str) -> bool {
+fn is_deletable_schematic_tag(tag: &str) -> bool {
     !matches!(
-        sexp_tag(block),
+        tag,
         "version"
             | "generator"
             | "generator_version"
@@ -1017,43 +927,182 @@ async fn handle_batch_edit(
 
 async fn handle_batch_delete_components(
     args: &serde_json::Value,
+    ctx: &crate::tools::ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    handle_structural_batch_delete(args, ctx, false).await
+}
+
+async fn handle_structural_batch_delete(
+    args: &serde_json::Value,
     _ctx: &crate::tools::ToolContext,
+    allow_uuids: bool,
 ) -> anyhow::Result<CallToolResult> {
     let sch_path = get_path(args, "schematic")?;
     let refs = match args["references"].as_array() {
         Some(a) => a.clone(),
+        None if allow_uuids => Vec::new(),
         None => return Ok(CallToolResult::error("Missing 'references' array")),
     };
 
     let content = read_consistent(&sch_path)?;
-    let expected = content.clone();
-    let mut edits: Vec<SexpEdit> = Vec::new();
-    let mut deleted: Vec<String> = Vec::new();
+    let tree = match konnect_sexp::parse_sexp(&content) {
+        Ok(tree) => tree,
+        Err(error) => {
+            return Ok(ComponentDeleteTargetError::Stale {
+                target: sch_path.display().to_string(),
+                reason: error.to_string(),
+            }
+            .into_result());
+        }
+    };
+    let instances = extract_symbol_instances(&tree);
+    let available_references = instances
+        .iter()
+        .map(|instance| instance.reference.clone())
+        .collect::<BTreeSet<_>>();
+    let mut reference_by_uuid: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for instance in &instances {
+        if let Some(uuid) = &instance.uuid {
+            reference_by_uuid
+                .entry(uuid.clone())
+                .or_default()
+                .insert(instance.reference.clone());
+        }
+    }
+    let indexed = match indexed_uuid_items(&sch_path, &content) {
+        Ok(indexed) => indexed,
+        Err(error) => return Ok(error.into_result()),
+    };
+
+    let mut selected_references = Vec::new();
+    let mut seen_references = HashSet::new();
+    let mut selected_item_uuids = Vec::new();
+    let mut seen_item_uuids = HashSet::new();
     let mut errors: Vec<String> = Vec::new();
 
     for ref_val in &refs {
         let reference = match ref_val.as_str() {
             Some(r) => r,
-            None => continue,
+            None => {
+                errors.push("Component reference must be a string".to_owned());
+                continue;
+            }
         };
-        let blocks = find_symbol_blocks(&content, reference);
-        if blocks.is_empty() {
+        if !available_references.contains(reference) {
             errors.push(format!("Component '{}' not found", reference));
             continue;
         }
-        // Every unit of a multi-unit part, or the whole component is not gone.
-        for (del_start, del_end) in blocks {
-            edits.push(SexpEdit::delete(del_start, del_end));
+        if seen_references.insert(reference.to_owned()) {
+            selected_references.push(reference.to_owned());
         }
-        deleted.push(reference.to_string());
     }
 
-    let new_content = apply_edits(content, edits);
-    write_atomic_if_unchanged(&sch_path, &expected, &new_content)?;
+    if allow_uuids {
+        if let Some(uuids) = args["uuids"].as_array() {
+            for uuid_value in uuids {
+                let Some(uuid) = uuid_value.as_str() else {
+                    errors.push("Schematic UUID must be a string".to_owned());
+                    continue;
+                };
+                let Some(item) = indexed.get(uuid) else {
+                    errors.push(format!("UUID '{}' not found", uuid));
+                    continue;
+                };
+                if !is_deletable_schematic_tag(&item.kind) {
+                    errors.push(format!(
+                        "UUID '{}' belongs to protected schematic structure '{}'",
+                        uuid, item.kind
+                    ));
+                    continue;
+                }
+                if item.kind == "symbol" {
+                    let Some(references) = reference_by_uuid.get(uuid) else {
+                        return Ok(ComponentDeleteTargetError::Stale {
+                            target: format!("schematic symbol UUID {uuid}"),
+                            reason: "the symbol has no structural reference identity".to_owned(),
+                        }
+                        .into_result());
+                    };
+                    if references.len() != 1 {
+                        return Ok(ComponentDeleteTargetError::Ambiguous {
+                            target: format!("schematic symbol UUID {uuid}"),
+                            candidates: references.iter().cloned().collect(),
+                        }
+                        .into_result());
+                    }
+                    let reference = references.iter().next().expect("one reference").clone();
+                    if seen_references.insert(reference.clone()) {
+                        selected_references.push(reference);
+                    }
+                } else if seen_item_uuids.insert(uuid.to_owned()) {
+                    selected_item_uuids.push(uuid.to_owned());
+                }
+            }
+        }
+    }
+
+    if selected_references.is_empty() && selected_item_uuids.is_empty() {
+        return Ok(ComponentDeleteTargetError::Stale {
+            target: sch_path.display().to_string(),
+            reason: if errors.is_empty() {
+                "no schematic items were selected".to_owned()
+            } else {
+                errors.join("; ")
+            },
+        }
+        .into_result());
+    }
+
+    let plan = match plan_component_and_item_deletions(
+        &sch_path,
+        &content,
+        &selected_references,
+        &selected_item_uuids,
+    ) {
+        Ok(plan) => plan,
+        Err(error) => return Ok(error.into_result()),
+    };
+    let outcome = match commit_component_deletion(&sch_path, plan)? {
+        Ok(outcome) => outcome,
+        Err(refusal) => return Ok(refusal),
+    };
+
+    let deleted_references = selected_references
+        .into_iter()
+        .filter(|reference| outcome.units_by_reference.contains_key(reference))
+        .collect::<Vec<_>>();
+    let deleted_items = selected_item_uuids
+        .into_iter()
+        .filter(|uuid| outcome.item_uuids.contains(uuid))
+        .collect::<Vec<_>>();
+    let deleted_components = deleted_references
+        .iter()
+        .map(|reference| {
+            let unit_uuids = &outcome.units_by_reference[reference];
+            json!({
+                "reference": reference,
+                "deleted_units": unit_uuids.len(),
+                "deleted_unit_uuids": unit_uuids
+            })
+        })
+        .collect::<Vec<_>>();
+    let deleted = deleted_references
+        .iter()
+        .cloned()
+        .chain(deleted_items.iter().cloned())
+        .collect::<Vec<_>>();
 
     Ok(CallToolResult::json(&json!({
         "deleted_count": deleted.len(),
         "deleted": deleted,
+        "deleted_components": deleted_components,
+        "deleted_item_uuids": deleted_items,
+        "removed_no_connects_count": outcome.marker_uuids.len(),
+        "removed_no_connect_uuids": outcome.marker_uuids,
+        "junctions_added_count": outcome.added_junctions.len(),
+        "junctions_added_uuids": outcome.added_junctions,
+        "junctions_pruned_count": outcome.pruned_junctions.len(),
+        "junctions_pruned_uuids": outcome.pruned_junctions,
         "errors": errors
     })))
 }
@@ -1595,6 +1644,208 @@ mod batch_delete_tests {
         assert!(after.contains("(uuid \"root\")"));
         assert!(after.contains("(sheet_instances"));
         assert!(konnect_sexp::parse_sexp(&after).is_ok());
+    }
+}
+
+#[cfg(test)]
+mod connectivity_safe_batch_delete_tests {
+    use super::*;
+    use crate::mcp::{error::extract_error_kind, protocol::ToolContent};
+    use crate::tools::{ServerConfig, ToolContext};
+    use std::sync::Arc;
+
+    const CONNECTIVITY: &str = include_str!("../../tests/fixtures/junction_reconcile.kicad_sch");
+    const ECC83: &str = include_str!("../../tests/fixtures/ecc83_multiunit.kicad_sch");
+
+    fn context() -> ToolContext {
+        ToolContext::new(
+            ServerConfig::default(),
+            Arc::new(crate::router::ToolRouter::new()),
+        )
+    }
+
+    fn fixture(content: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("batch-delete.kicad_sch");
+        std::fs::write(&path, content).unwrap();
+        (directory, path)
+    }
+
+    fn body(result: &CallToolResult) -> serde_json::Value {
+        assert!(!result.is_error, "{result:?}");
+        let ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text result");
+        };
+        serde_json::from_str(text).unwrap()
+    }
+
+    fn has_junction(content: &str, x: f64, y: f64) -> bool {
+        let tree = konnect_sexp::parse_sexp(content).unwrap();
+        konnect_sexp::schematic::extract_junctions(&tree)
+            .iter()
+            .any(|&(jx, jy)| konnect_sexp::geometry::points_coincident(x, y, jx, jy, 0.01))
+    }
+
+    #[test]
+    fn schematic_skeleton_tags_are_never_uuid_delete_targets() {
+        for tag in [
+            "version",
+            "generator",
+            "generator_version",
+            "uuid",
+            "paper",
+            "title_block",
+            "lib_symbols",
+            "sheet_instances",
+            "symbol_instances",
+            "embedded_fonts",
+        ] {
+            assert!(!is_deletable_schematic_tag(tag), "{tag}");
+        }
+        assert!(is_deletable_schematic_tag("text"));
+        assert!(is_deletable_schematic_tag("wire"));
+    }
+
+    #[tokio::test]
+    async fn both_aliases_dedupe_references_and_report_missing_without_partial_units() {
+        for generic in [true, false] {
+            let (_directory, path) = fixture(ECC83);
+            let args = json!({
+                "schematic": path,
+                "references": ["U1", "MISSING", "U1"]
+            });
+            let result = if generic {
+                handle_batch_delete(&args, &context()).await.unwrap()
+            } else {
+                handle_batch_delete_components(&args, &context())
+                    .await
+                    .unwrap()
+            };
+            let response = body(&result);
+
+            assert_eq!(response["deleted_count"], 1);
+            assert_eq!(response["deleted"], json!(["U1"]));
+            assert_eq!(response["deleted_components"][0]["deleted_units"], 3);
+            assert_eq!(response["errors"], json!(["Component 'MISSING' not found"]));
+            let after = konnect_sexp::schematic::read_schematic(&path).unwrap().1;
+            let instances = extract_symbol_instances(&after);
+            assert!(instances.iter().all(|instance| instance.reference != "U1"));
+            assert!(instances.iter().any(|instance| instance.reference == "R1"));
+        }
+    }
+
+    #[tokio::test]
+    async fn overlapping_reference_and_unit_uuid_delete_one_whole_component() {
+        let (_directory, path) = fixture(ECC83);
+        let tree = konnect_sexp::schematic::read_schematic(&path).unwrap().1;
+        let uuid = extract_symbol_instances(&tree)
+            .into_iter()
+            .find(|instance| instance.reference == "U1")
+            .and_then(|instance| instance.uuid)
+            .unwrap();
+        let result = handle_batch_delete(
+            &json!({
+                "schematic": path,
+                "references": ["U1"],
+                "uuids": [uuid, uuid]
+            }),
+            &context(),
+        )
+        .await
+        .unwrap();
+        let response = body(&result);
+
+        assert_eq!(response["deleted"], json!(["U1"]));
+        assert_eq!(response["deleted_components"][0]["deleted_units"], 3);
+        assert_eq!(response["deleted_item_uuids"], json!([]));
+    }
+
+    #[tokio::test]
+    async fn component_batch_reconciles_junctions_and_no_connects_once() {
+        for generic in [true, false] {
+            let (_directory, path) = fixture(CONNECTIVITY);
+            let args = json!({ "schematic": path, "references": ["R1", "R3"] });
+            let result = if generic {
+                handle_batch_delete(&args, &context()).await.unwrap()
+            } else {
+                handle_batch_delete_components(&args, &context())
+                    .await
+                    .unwrap()
+            };
+            let response = body(&result);
+
+            assert_eq!(response["deleted_count"], 2);
+            assert_eq!(response["removed_no_connects_count"], 1);
+            assert_eq!(response["junctions_pruned_count"], 1);
+            let committed = std::fs::read_to_string(&path).unwrap();
+            assert!(!has_junction(&committed, 120.65, 139.7));
+            assert!(has_junction(&committed, 120.65, 170.18));
+            assert!(!committed.contains("3f9dbc19-858e-4bf8-b937-b169159de4c8"));
+        }
+    }
+
+    #[tokio::test]
+    async fn total_missing_or_protected_selection_is_structured_stale_and_unchanged() {
+        let cases = [
+            json!({ "references": ["MISSING"] }),
+            json!({ "uuids": ["5a1d3bbf-65fe-4cc0-9d9e-4ec47d238186"] }),
+            json!({ "uuids": ["8026d02f-ff62-464a-9ce5-e55f42254b73"] }),
+        ];
+        for selection in cases {
+            let (_directory, path) = fixture(CONNECTIVITY);
+            let mut args = selection;
+            args["schematic"] = json!(path);
+            let result = handle_batch_delete(&args, &context()).await.unwrap();
+
+            assert_eq!(extract_error_kind(&result).as_deref(), Some("stale_target"));
+            assert_eq!(std::fs::read_to_string(&path).unwrap(), CONNECTIVITY);
+        }
+    }
+
+    #[tokio::test]
+    async fn duplicate_top_level_uuid_is_stale_and_unchanged() {
+        let closing = CONNECTIVITY.rfind("\n)").unwrap();
+        let duplicate =
+            "\t(junction\n\t\t(at 1 1)\n\t\t(uuid \"6f08a78f-7ec2-45e6-ba39-1d930be32b74\")\n\t)\n";
+        let original = format!(
+            "{}{}{}",
+            &CONNECTIVITY[..closing + 1],
+            duplicate,
+            &CONNECTIVITY[closing + 1..]
+        );
+        let (_directory, path) = fixture(&original);
+        let result = handle_batch_delete_components(
+            &json!({ "schematic": path, "references": ["R1"] }),
+            &context(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(extract_error_kind(&result).as_deref(), Some("stale_target"));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn stale_revision_refuses_the_whole_batch_without_overwriting() {
+        let (_directory, path) = fixture(CONNECTIVITY);
+        let plan = plan_component_and_item_deletions(
+            &path,
+            CONNECTIVITY,
+            &["R1".to_owned(), "R3".to_owned()],
+            &[],
+        )
+        .unwrap();
+        let newer = CONNECTIVITY.replace("(paper \"A4\")", "(paper \"A3\")");
+        std::fs::write(&path, &newer).unwrap();
+
+        let refusal = commit_component_deletion(&path, plan)
+            .unwrap()
+            .expect_err("stale batch must refuse");
+        assert_eq!(
+            extract_error_kind(&refusal).as_deref(),
+            Some("stale_target")
+        );
+        assert_eq!(std::fs::read_to_string(path).unwrap(), newer);
     }
 }
 

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -804,89 +804,55 @@ async fn handle_delete_schematic_component(
         Ok(plan) => plan,
         Err(error) => return Ok(error.into_result()),
     };
-    if let Err(error) = commit_command(&sch_path, &plan.command) {
-        if let Some(refusal) = component_delete_commit_refusal(&sch_path, &error) {
-            return Ok(refusal);
-        }
-        return Err(error.into());
-    }
-
-    let committed = read_consistent(&sch_path)?;
-    let after_items = match indexed_uuid_items(&sch_path, &committed) {
-        Ok(items) => items,
-        Err(error) => return Ok(error.into_result()),
+    let outcome = match commit_component_deletion(&sch_path, plan)? {
+        Ok(outcome) => outcome,
+        Err(refusal) => return Ok(refusal),
     };
-    let after_tree = parse_sexp(&committed)?;
-    let remaining = extract_symbol_instances(&after_tree)
-        .into_iter()
-        .filter(|instance| instance.reference == reference)
-        .collect::<Vec<_>>();
-    if !remaining.is_empty() {
-        return Ok(ComponentDeleteTargetError::stale(
-            &sch_path,
-            format!(
-                "post-write readback still contains {} unit(s) of {reference}",
-                remaining.len()
-            ),
-        )
-        .into_result());
-    }
-    for uuid in plan.unit_uuids.iter().chain(&plan.marker_uuids) {
-        if after_items.contains_key(uuid) {
-            return Ok(ComponentDeleteTargetError::stale(
-                &sch_path,
-                format!("post-write readback still contains deleted item UUID {uuid}"),
-            )
-            .into_result());
-        }
-    }
-
-    let before_junctions = plan
-        .before_items
-        .iter()
-        .filter_map(|(uuid, item)| (item.kind == "junction").then_some(uuid.clone()))
-        .collect::<BTreeSet<_>>();
-    let after_junctions = after_items
-        .iter()
-        .filter_map(|(uuid, item)| (item.kind == "junction").then_some(uuid.clone()))
-        .collect::<BTreeSet<_>>();
-    let pruned_junctions = before_junctions
-        .difference(&after_junctions)
+    let unit_uuids = outcome
+        .units_by_reference
+        .get(&reference)
         .cloned()
-        .collect::<Vec<_>>();
-    let added_junctions = after_junctions
-        .difference(&before_junctions)
-        .cloned()
-        .collect::<Vec<_>>();
+        .unwrap_or_default();
 
     Ok(CallToolResult::json(&json!({
         "deleted": reference,
-        "deleted_units": plan.unit_uuids.len(),
-        "deleted_unit_uuids": plan.unit_uuids,
-        "removed_no_connects_count": plan.marker_uuids.len(),
-        "removed_no_connect_uuids": plan.marker_uuids,
-        "junctions_added_count": added_junctions.len(),
-        "junctions_added_uuids": added_junctions,
-        "junctions_pruned_count": pruned_junctions.len(),
-        "junctions_pruned_uuids": pruned_junctions
+        "deleted_units": unit_uuids.len(),
+        "deleted_unit_uuids": unit_uuids,
+        "removed_no_connects_count": outcome.marker_uuids.len(),
+        "removed_no_connect_uuids": outcome.marker_uuids,
+        "junctions_added_count": outcome.added_junctions.len(),
+        "junctions_added_uuids": outcome.added_junctions,
+        "junctions_pruned_count": outcome.pruned_junctions.len(),
+        "junctions_pruned_uuids": outcome.pruned_junctions
     })))
 }
 
 #[derive(Debug, Clone)]
-struct IndexedSchematicItem {
-    kind: String,
+pub(crate) struct IndexedSchematicItem {
+    pub(crate) kind: String,
     source: String,
 }
 
-struct ComponentDeletePlan {
+pub(crate) struct ComponentDeletePlan {
     command: SchematicCommand,
     before_items: BTreeMap<String, IndexedSchematicItem>,
     unit_uuids: Vec<String>,
+    units_by_reference: BTreeMap<String, Vec<String>>,
     marker_uuids: Vec<String>,
+    item_uuids: Vec<String>,
 }
 
 #[derive(Debug)]
-enum ComponentDeleteTargetError {
+pub(crate) struct ComponentDeleteOutcome {
+    pub(crate) units_by_reference: BTreeMap<String, Vec<String>>,
+    pub(crate) marker_uuids: Vec<String>,
+    pub(crate) item_uuids: Vec<String>,
+    pub(crate) added_junctions: Vec<String>,
+    pub(crate) pruned_junctions: Vec<String>,
+}
+
+#[derive(Debug)]
+pub(crate) enum ComponentDeleteTargetError {
     Ambiguous {
         target: String,
         candidates: Vec<String>,
@@ -909,7 +875,7 @@ impl ComponentDeleteTargetError {
         Self::stale(path, error.to_string())
     }
 
-    fn into_result(self) -> CallToolResult {
+    pub(crate) fn into_result(self) -> CallToolResult {
         match self {
             Self::Ambiguous { target, candidates } => {
                 let reason = format!(
@@ -935,7 +901,7 @@ impl ComponentDeleteTargetError {
     }
 }
 
-fn indexed_uuid_items(
+pub(crate) fn indexed_uuid_items(
     path: &std::path::Path,
     content: &str,
 ) -> Result<BTreeMap<String, IndexedSchematicItem>, ComponentDeleteTargetError> {
@@ -985,28 +951,76 @@ fn plan_component_deletion(
     content: &str,
     reference: &str,
 ) -> Result<ComponentDeletePlan, ComponentDeleteTargetError> {
+    plan_component_deletions(path, content, &[reference.to_owned()])
+}
+
+pub(crate) fn plan_component_deletions(
+    path: &std::path::Path,
+    content: &str,
+    references: &[String],
+) -> Result<ComponentDeletePlan, ComponentDeleteTargetError> {
+    plan_component_and_item_deletions(path, content, references, &[])
+}
+
+pub(crate) fn plan_component_and_item_deletions(
+    path: &std::path::Path,
+    content: &str,
+    references: &[String],
+    item_uuids: &[String],
+) -> Result<ComponentDeletePlan, ComponentDeleteTargetError> {
+    let references = references.iter().cloned().collect::<BTreeSet<_>>();
+    let mut item_uuids = item_uuids.to_vec();
+    item_uuids.sort();
+    item_uuids.dedup();
+    if references.is_empty() && item_uuids.is_empty() {
+        return Err(ComponentDeleteTargetError::stale(
+            path,
+            "no schematic items were selected",
+        ));
+    }
+    let reference_label = if references.is_empty() {
+        "selected items".to_owned()
+    } else {
+        references.iter().cloned().collect::<Vec<_>>().join(", ")
+    };
     let tree =
         parse_sexp(content).map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?;
     let before_items = indexed_uuid_items(path, content)?;
+    for uuid in &item_uuids {
+        if !before_items.contains_key(uuid) {
+            return Err(ComponentDeleteTargetError::stale(
+                path,
+                format!("schematic item UUID {uuid} is not present"),
+            ));
+        }
+    }
     let instances = extract_symbol_instances(&tree);
     let selected = instances
         .iter()
-        .filter(|instance| instance.reference == reference)
+        .filter(|instance| references.contains(&instance.reference))
         .collect::<Vec<_>>();
-    if selected.is_empty() {
+    let found = selected
+        .iter()
+        .map(|instance| instance.reference.clone())
+        .collect::<BTreeSet<_>>();
+    if let Some(missing) = references.difference(&found).next() {
         return Err(ComponentDeleteTargetError::stale(
             path,
-            format!("component {reference} is not present"),
+            format!("component {missing} is not present"),
         ));
     }
 
-    let mut by_unit: BTreeMap<u32, Vec<String>> = BTreeMap::new();
+    let mut by_unit: BTreeMap<(String, u32), Vec<String>> = BTreeMap::new();
+    let mut units_by_reference: BTreeMap<String, Vec<String>> = BTreeMap::new();
     let mut unit_uuids = Vec::new();
     for instance in &selected {
         let uuid = instance.uuid.clone().ok_or_else(|| {
             ComponentDeleteTargetError::stale(
                 path,
-                format!("component {reference} unit {} has no UUID", instance.unit),
+                format!(
+                    "component {} unit {} has no UUID",
+                    instance.reference, instance.unit
+                ),
             )
         })?;
         if before_items
@@ -1018,20 +1032,31 @@ fn plan_component_deletion(
                 format!("UUID {uuid} no longer identifies a top-level symbol"),
             ));
         }
-        by_unit.entry(instance.unit).or_default().push(uuid.clone());
+        by_unit
+            .entry((instance.reference.clone(), instance.unit))
+            .or_default()
+            .push(uuid.clone());
+        units_by_reference
+            .entry(instance.reference.clone())
+            .or_default()
+            .push(uuid.clone());
         unit_uuids.push(uuid);
     }
-    if let Some((unit, uuids)) = by_unit.iter().find(|(_, uuids)| uuids.len() > 1) {
+    if let Some(((reference, unit), uuids)) = by_unit.iter().find(|(_, uuids)| uuids.len() > 1) {
         return Err(ComponentDeleteTargetError::Ambiguous {
             target: format!("component {reference} unit {unit}"),
             candidates: uuids.clone(),
         });
     }
+    for uuids in units_by_reference.values_mut() {
+        uuids.sort();
+        uuids.dedup();
+    }
     unit_uuids.sort();
     unit_uuids.dedup();
     if unit_uuids.len() != selected.len() {
         return Err(ComponentDeleteTargetError::Ambiguous {
-            target: format!("component {reference}"),
+            target: format!("components {reference_label}"),
             candidates: unit_uuids,
         });
     }
@@ -1039,13 +1064,18 @@ fn plan_component_deletion(
     // Require every placed symbol's library definition to resolve before
     // deciding marker ownership or junction validity. Unknown pins are stale
     // state, not evidence that no pin remains at a coordinate.
-    let grouped = crate::tools::placed_pins_by_reference(&tree);
-    if grouped.len() != instances.len() {
-        return Err(ComponentDeleteTargetError::stale(
-            path,
-            "one or more placed symbols have unresolved library pin geometry",
-        ));
-    }
+    let grouped = if selected.is_empty() {
+        Vec::new()
+    } else {
+        let grouped = crate::tools::placed_pins_by_reference(&tree);
+        if grouped.len() != instances.len() {
+            return Err(ComponentDeleteTargetError::stale(
+                path,
+                "one or more placed symbols have unresolved library pin geometry",
+            ));
+        }
+        grouped
+    };
     let selected_ids = unit_uuids.iter().cloned().collect::<BTreeSet<_>>();
     let mut affected = Vec::new();
     let mut remaining = Vec::new();
@@ -1095,10 +1125,15 @@ fn plan_component_deletion(
     marker_uuids.sort();
     marker_uuids.dedup();
 
-    let initial_ids = unit_uuids
+    let initial_uuid_set = unit_uuids
         .iter()
         .chain(&marker_uuids)
-        .map(|uuid| ItemId::new(uuid.clone()))
+        .chain(&item_uuids)
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let initial_ids = initial_uuid_set
+        .into_iter()
+        .map(ItemId::new)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?;
     let initial = SchematicCommand::delete_items(content, initial_ids, "prepare component delete")
@@ -1134,7 +1169,7 @@ fn plan_component_deletion(
                 .map(|uuid| ItemId::new(uuid.clone()))
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?,
-            format!("delete {reference} and dependent markers"),
+            format!("delete {reference_label} and dependent markers"),
         )
         .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?;
         changes.extend(command.changes);
@@ -1144,7 +1179,7 @@ fn plan_component_deletion(
             content,
             after_items[&uuid].source.clone(),
             ItemAnchor::EndOfDocument,
-            format!("restore junction after deleting {reference}"),
+            format!("restore junction after deleting {reference_label}"),
         )
         .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?;
         changes.extend(command.changes);
@@ -1155,15 +1190,18 @@ fn plan_component_deletion(
             ItemId::new(uuid.clone())
                 .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?,
             after_items[&uuid].source.clone(),
-            format!("reconcile {uuid} after deleting {reference}"),
+            format!("reconcile {uuid} after deleting {reference_label}"),
         )
         .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?;
         changes.extend(command.changes);
     }
-    let command =
-        SchematicCommand::from_changes(content, format!("delete component {reference}"), changes)
-            .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?
-            .requiring_unchanged_document();
+    let command = SchematicCommand::from_changes(
+        content,
+        format!("delete components {reference_label}"),
+        changes,
+    )
+    .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?
+    .requiring_unchanged_document();
     let prepared = prepare_command(path, content, &command)
         .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?
         .0;
@@ -1178,8 +1216,89 @@ fn plan_component_deletion(
         command,
         before_items,
         unit_uuids,
+        units_by_reference,
         marker_uuids,
+        item_uuids,
     })
+}
+
+pub(crate) fn commit_component_deletion(
+    path: &std::path::Path,
+    plan: ComponentDeletePlan,
+) -> anyhow::Result<Result<ComponentDeleteOutcome, CallToolResult>> {
+    if let Err(error) = commit_command(path, &plan.command) {
+        if let Some(refusal) = component_delete_commit_refusal(path, &error) {
+            return Ok(Err(refusal));
+        }
+        return Err(error.into());
+    }
+
+    let committed = read_consistent(path)?;
+    let after_items = match indexed_uuid_items(path, &committed) {
+        Ok(items) => items,
+        Err(error) => return Ok(Err(error.into_result())),
+    };
+    let after_tree = match parse_sexp(&committed) {
+        Ok(tree) => tree,
+        Err(error) => {
+            return Ok(Err(
+                ComponentDeleteTargetError::from_sexp(path, error).into_result()
+            ));
+        }
+    };
+    for reference in plan.units_by_reference.keys() {
+        let remaining = extract_symbol_instances(&after_tree)
+            .into_iter()
+            .filter(|instance| instance.reference == *reference)
+            .count();
+        if remaining != 0 {
+            return Ok(Err(ComponentDeleteTargetError::stale(
+                path,
+                format!("post-write readback still contains {remaining} unit(s) of {reference}"),
+            )
+            .into_result()));
+        }
+    }
+    for uuid in plan
+        .unit_uuids
+        .iter()
+        .chain(&plan.marker_uuids)
+        .chain(&plan.item_uuids)
+    {
+        if after_items.contains_key(uuid) {
+            return Ok(Err(ComponentDeleteTargetError::stale(
+                path,
+                format!("post-write readback still contains deleted item UUID {uuid}"),
+            )
+            .into_result()));
+        }
+    }
+
+    let before_junctions = plan
+        .before_items
+        .iter()
+        .filter_map(|(uuid, item)| (item.kind == "junction").then_some(uuid.clone()))
+        .collect::<BTreeSet<_>>();
+    let after_junctions = after_items
+        .iter()
+        .filter_map(|(uuid, item)| (item.kind == "junction").then_some(uuid.clone()))
+        .collect::<BTreeSet<_>>();
+    let pruned_junctions = before_junctions
+        .difference(&after_junctions)
+        .cloned()
+        .collect::<Vec<_>>();
+    let added_junctions = after_junctions
+        .difference(&before_junctions)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    Ok(Ok(ComponentDeleteOutcome {
+        units_by_reference: plan.units_by_reference,
+        marker_uuids: plan.marker_uuids,
+        item_uuids: plan.item_uuids,
+        added_junctions,
+        pruned_junctions,
+    }))
 }
 
 fn component_delete_commit_refusal(
@@ -4710,7 +4829,10 @@ mod component_delete_connectivity_tests {
     #[tokio::test]
     async fn kicad_lock_is_structured_stale_and_preserves_the_file() {
         let (_directory, path) = fixture(CONNECTIVITY);
-        let lock = konnect_sexp::writer::kicad_editor_lock_path(&path).unwrap();
+        let lock = path.with_file_name(format!(
+            "~{}.lck",
+            path.file_name().unwrap().to_string_lossy()
+        ));
         std::fs::write(&lock, "locked").unwrap();
         let result = handle_delete_schematic_component(
             &json!({ "schematic": path, "reference": "R1" }),

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -4,7 +4,7 @@
 //! round-trip parsing.  Pin coordinate math still delegates to
 //! `konnect_sexp::geometry::transform_pin`.
 
-use crate::mcp::protocol::CallToolResult;
+use crate::mcp::{error::ToolErrorKind, protocol::CallToolResult};
 use crate::tool;
 use crate::tools::{
     find_all_symbol_instance_blocks, get_path, opt_f64, opt_str, reembed_lib_symbols,
@@ -14,15 +14,19 @@ use konnect_schematic_editor as cse;
 use konnect_sexp::{
     commit_command,
     geometry::snap_point,
-    parse_sexp,
+    parse_sexp, prepare_command,
     schematic::{
         extract_lib_pins_for_unit, extract_symbol_instances, find_lib_symbol, pin_endpoint,
         pin_outward_direction, read_schematic,
     },
-    writer::{apply_edits, read_consistent, write_atomic_if_unchanged, write_new_atomic, SexpEdit},
-    ItemId, SchematicCommand,
+    writer::{
+        apply_edits, find_direct_child_blocks, read_consistent, write_atomic_if_unchanged,
+        write_new_atomic, SexpEdit,
+    },
+    ItemAnchor, ItemId, SchematicCommand, SexpError,
 };
 use serde_json::json;
+use std::collections::{BTreeMap, BTreeSet};
 
 pub fn tools() -> Vec<ToolDef> {
     vec![
@@ -795,24 +799,402 @@ async fn handle_delete_schematic_component(
         Err(e) => return Ok(e),
     };
 
-    let mut sch = cse::Schematic::load(&sch_path)?;
-
-    let before = sch.symbols.len();
-    sch.symbols
-        .retain(|symbol| symbol.reference() != Some(reference.as_str()));
-    let deleted_units = before - sch.symbols.len();
-    if deleted_units == 0 {
-        Ok(CallToolResult::error(format!(
-            "Component '{}' not found in schematic",
-            reference
-        )))
-    } else {
-        sch.overwrite()?;
-        Ok(CallToolResult::json(&json!({
-            "deleted": reference,
-            "deleted_units": deleted_units
-        })))
+    let content = read_consistent(&sch_path)?;
+    let plan = match plan_component_deletion(&sch_path, &content, &reference) {
+        Ok(plan) => plan,
+        Err(error) => return Ok(error.into_result()),
+    };
+    if let Err(error) = commit_command(&sch_path, &plan.command) {
+        if let Some(refusal) = component_delete_commit_refusal(&sch_path, &error) {
+            return Ok(refusal);
+        }
+        return Err(error.into());
     }
+
+    let committed = read_consistent(&sch_path)?;
+    let after_items = match indexed_uuid_items(&sch_path, &committed) {
+        Ok(items) => items,
+        Err(error) => return Ok(error.into_result()),
+    };
+    let after_tree = parse_sexp(&committed)?;
+    let remaining = extract_symbol_instances(&after_tree)
+        .into_iter()
+        .filter(|instance| instance.reference == reference)
+        .collect::<Vec<_>>();
+    if !remaining.is_empty() {
+        return Ok(ComponentDeleteTargetError::stale(
+            &sch_path,
+            format!(
+                "post-write readback still contains {} unit(s) of {reference}",
+                remaining.len()
+            ),
+        )
+        .into_result());
+    }
+    for uuid in plan.unit_uuids.iter().chain(&plan.marker_uuids) {
+        if after_items.contains_key(uuid) {
+            return Ok(ComponentDeleteTargetError::stale(
+                &sch_path,
+                format!("post-write readback still contains deleted item UUID {uuid}"),
+            )
+            .into_result());
+        }
+    }
+
+    let before_junctions = plan
+        .before_items
+        .iter()
+        .filter_map(|(uuid, item)| (item.kind == "junction").then_some(uuid.clone()))
+        .collect::<BTreeSet<_>>();
+    let after_junctions = after_items
+        .iter()
+        .filter_map(|(uuid, item)| (item.kind == "junction").then_some(uuid.clone()))
+        .collect::<BTreeSet<_>>();
+    let pruned_junctions = before_junctions
+        .difference(&after_junctions)
+        .cloned()
+        .collect::<Vec<_>>();
+    let added_junctions = after_junctions
+        .difference(&before_junctions)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    Ok(CallToolResult::json(&json!({
+        "deleted": reference,
+        "deleted_units": plan.unit_uuids.len(),
+        "deleted_unit_uuids": plan.unit_uuids,
+        "removed_no_connects_count": plan.marker_uuids.len(),
+        "removed_no_connect_uuids": plan.marker_uuids,
+        "junctions_added_count": added_junctions.len(),
+        "junctions_added_uuids": added_junctions,
+        "junctions_pruned_count": pruned_junctions.len(),
+        "junctions_pruned_uuids": pruned_junctions
+    })))
+}
+
+#[derive(Debug, Clone)]
+struct IndexedSchematicItem {
+    kind: String,
+    source: String,
+}
+
+struct ComponentDeletePlan {
+    command: SchematicCommand,
+    before_items: BTreeMap<String, IndexedSchematicItem>,
+    unit_uuids: Vec<String>,
+    marker_uuids: Vec<String>,
+}
+
+#[derive(Debug)]
+enum ComponentDeleteTargetError {
+    Ambiguous {
+        target: String,
+        candidates: Vec<String>,
+    },
+    Stale {
+        target: String,
+        reason: String,
+    },
+}
+
+impl ComponentDeleteTargetError {
+    fn stale(path: &std::path::Path, reason: impl Into<String>) -> Self {
+        Self::Stale {
+            target: path.display().to_string(),
+            reason: reason.into(),
+        }
+    }
+
+    fn from_sexp(path: &std::path::Path, error: SexpError) -> Self {
+        Self::stale(path, error.to_string())
+    }
+
+    fn into_result(self) -> CallToolResult {
+        match self {
+            Self::Ambiguous { target, candidates } => {
+                let reason = format!(
+                    "more than one schematic item identifies the target: {}",
+                    candidates.join(", ")
+                );
+                CallToolResult::error_kind(
+                    ToolErrorKind::StaleTarget {
+                        target: target.clone(),
+                        reason: reason.clone(),
+                    },
+                    format!("cannot safely delete from {target}: {reason}"),
+                )
+            }
+            Self::Stale { target, reason } => CallToolResult::error_kind(
+                ToolErrorKind::StaleTarget {
+                    target: target.clone(),
+                    reason: reason.clone(),
+                },
+                format!("cannot safely delete from {target}: {reason}"),
+            ),
+        }
+    }
+}
+
+fn indexed_uuid_items(
+    path: &std::path::Path,
+    content: &str,
+) -> Result<BTreeMap<String, IndexedSchematicItem>, ComponentDeleteTargetError> {
+    let ranges = find_direct_child_blocks(content, "kicad_sch");
+    if ranges.is_empty() {
+        return Err(ComponentDeleteTargetError::stale(
+            path,
+            "the kicad_sch root is missing or malformed",
+        ));
+    }
+    let mut items = BTreeMap::new();
+    for (start, end) in ranges {
+        let node = parse_sexp(&content[start..end])
+            .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?;
+        let Some(uuid) = node.find_str("uuid") else {
+            continue;
+        };
+        let item = IndexedSchematicItem {
+            kind: node.head().unwrap_or("unknown").to_owned(),
+            source: content[start..end].to_owned(),
+        };
+        if let Some(previous) = items.insert(uuid.to_owned(), item) {
+            return Err(ComponentDeleteTargetError::Ambiguous {
+                target: format!("schematic UUID {uuid}"),
+                candidates: vec![previous.kind, node.head().unwrap_or("unknown").to_owned()],
+            });
+        }
+    }
+    Ok(items)
+}
+
+fn dedup_points(points: impl IntoIterator<Item = (f64, f64)>) -> Vec<(f64, f64)> {
+    let mut unique = Vec::new();
+    for point in points {
+        if !unique
+            .iter()
+            .any(|&(x, y)| konnect_sexp::geometry::points_coincident(x, y, point.0, point.1, 0.01))
+        {
+            unique.push(point);
+        }
+    }
+    unique
+}
+
+fn plan_component_deletion(
+    path: &std::path::Path,
+    content: &str,
+    reference: &str,
+) -> Result<ComponentDeletePlan, ComponentDeleteTargetError> {
+    let tree =
+        parse_sexp(content).map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?;
+    let before_items = indexed_uuid_items(path, content)?;
+    let instances = extract_symbol_instances(&tree);
+    let selected = instances
+        .iter()
+        .filter(|instance| instance.reference == reference)
+        .collect::<Vec<_>>();
+    if selected.is_empty() {
+        return Err(ComponentDeleteTargetError::stale(
+            path,
+            format!("component {reference} is not present"),
+        ));
+    }
+
+    let mut by_unit: BTreeMap<u32, Vec<String>> = BTreeMap::new();
+    let mut unit_uuids = Vec::new();
+    for instance in &selected {
+        let uuid = instance.uuid.clone().ok_or_else(|| {
+            ComponentDeleteTargetError::stale(
+                path,
+                format!("component {reference} unit {} has no UUID", instance.unit),
+            )
+        })?;
+        if before_items
+            .get(&uuid)
+            .is_none_or(|item| item.kind != "symbol")
+        {
+            return Err(ComponentDeleteTargetError::stale(
+                path,
+                format!("UUID {uuid} no longer identifies a top-level symbol"),
+            ));
+        }
+        by_unit.entry(instance.unit).or_default().push(uuid.clone());
+        unit_uuids.push(uuid);
+    }
+    if let Some((unit, uuids)) = by_unit.iter().find(|(_, uuids)| uuids.len() > 1) {
+        return Err(ComponentDeleteTargetError::Ambiguous {
+            target: format!("component {reference} unit {unit}"),
+            candidates: uuids.clone(),
+        });
+    }
+    unit_uuids.sort();
+    unit_uuids.dedup();
+    if unit_uuids.len() != selected.len() {
+        return Err(ComponentDeleteTargetError::Ambiguous {
+            target: format!("component {reference}"),
+            candidates: unit_uuids,
+        });
+    }
+
+    // Require every placed symbol's library definition to resolve before
+    // deciding marker ownership or junction validity. Unknown pins are stale
+    // state, not evidence that no pin remains at a coordinate.
+    let grouped = crate::tools::placed_pins_by_reference(&tree);
+    if grouped.len() != instances.len() {
+        return Err(ComponentDeleteTargetError::stale(
+            path,
+            "one or more placed symbols have unresolved library pin geometry",
+        ));
+    }
+    let selected_ids = unit_uuids.iter().cloned().collect::<BTreeSet<_>>();
+    let mut affected = Vec::new();
+    let mut remaining = Vec::new();
+    for (instance, pins) in grouped {
+        let points = pins
+            .into_iter()
+            .map(|(pin, transform)| pin_endpoint(&pin, transform));
+        if instance
+            .uuid
+            .as_ref()
+            .is_some_and(|uuid| selected_ids.contains(uuid))
+        {
+            affected.extend(points);
+        } else {
+            remaining.extend(points);
+        }
+    }
+    let affected = dedup_points(affected);
+    let remaining = dedup_points(remaining);
+
+    let mut marker_uuids = Vec::new();
+    for (start, end) in find_direct_child_blocks(content, "kicad_sch") {
+        let node = parse_sexp(&content[start..end])
+            .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?;
+        if node.head() != Some("no_connect") {
+            continue;
+        }
+        let Some((x, y, _)) = konnect_sexp::schematic::parse_at(&node) else {
+            continue;
+        };
+        let attached = affected
+            .iter()
+            .any(|&(px, py)| konnect_sexp::geometry::points_coincident(x, y, px, py, 0.01));
+        let still_owned = remaining
+            .iter()
+            .any(|&(px, py)| konnect_sexp::geometry::points_coincident(x, y, px, py, 0.01));
+        if attached && !still_owned {
+            let uuid = node.find_str("uuid").ok_or_else(|| {
+                ComponentDeleteTargetError::stale(
+                    path,
+                    format!("attached no-connect at ({x}, {y}) has no UUID"),
+                )
+            })?;
+            marker_uuids.push(uuid.to_owned());
+        }
+    }
+    marker_uuids.sort();
+    marker_uuids.dedup();
+
+    let initial_ids = unit_uuids
+        .iter()
+        .chain(&marker_uuids)
+        .map(|uuid| ItemId::new(uuid.clone()))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?;
+    let initial = SchematicCommand::delete_items(content, initial_ids, "prepare component delete")
+        .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?;
+    let candidate = prepare_command(path, content, &initial)
+        .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?
+        .0;
+    let (reconciled, _, _) = crate::tools::sch_wiring::reconcile_junctions_at(candidate, &affected);
+
+    let after_items = indexed_uuid_items(path, &reconciled)?;
+    let before_ids = before_items.keys().cloned().collect::<BTreeSet<_>>();
+    let after_ids = after_items.keys().cloned().collect::<BTreeSet<_>>();
+    let removed = before_ids
+        .difference(&after_ids)
+        .cloned()
+        .collect::<Vec<_>>();
+    let added = after_ids
+        .difference(&before_ids)
+        .cloned()
+        .collect::<Vec<_>>();
+    let modified = before_ids
+        .intersection(&after_ids)
+        .filter(|uuid| before_items[*uuid].source != after_items[*uuid].source)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    let mut changes = Vec::new();
+    if !removed.is_empty() {
+        let command = SchematicCommand::delete_items(
+            content,
+            removed
+                .iter()
+                .map(|uuid| ItemId::new(uuid.clone()))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?,
+            format!("delete {reference} and dependent markers"),
+        )
+        .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?;
+        changes.extend(command.changes);
+    }
+    for uuid in added {
+        let command = SchematicCommand::insert_item(
+            content,
+            after_items[&uuid].source.clone(),
+            ItemAnchor::EndOfDocument,
+            format!("restore junction after deleting {reference}"),
+        )
+        .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?;
+        changes.extend(command.changes);
+    }
+    for uuid in modified {
+        let command = SchematicCommand::replace_item(
+            content,
+            ItemId::new(uuid.clone())
+                .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?,
+            after_items[&uuid].source.clone(),
+            format!("reconcile {uuid} after deleting {reference}"),
+        )
+        .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?;
+        changes.extend(command.changes);
+    }
+    let command =
+        SchematicCommand::from_changes(content, format!("delete component {reference}"), changes)
+            .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?
+            .requiring_unchanged_document();
+    let prepared = prepare_command(path, content, &command)
+        .map_err(|error| ComponentDeleteTargetError::from_sexp(path, error))?
+        .0;
+    if parse_sexp(&prepared).ok() != parse_sexp(&reconciled).ok() {
+        return Err(ComponentDeleteTargetError::stale(
+            path,
+            "the structural command cannot represent every dependent connectivity edit",
+        ));
+    }
+
+    Ok(ComponentDeletePlan {
+        command,
+        before_items,
+        unit_uuids,
+        marker_uuids,
+    })
+}
+
+fn component_delete_commit_refusal(
+    path: &std::path::Path,
+    error: &SexpError,
+) -> Option<CallToolResult> {
+    let reason = match error {
+        SexpError::Conflict { .. } => "the schematic changed after deletion was planned",
+        SexpError::ItemConflict { reason, .. } => reason,
+        SexpError::KiCadEditorLocked { .. } => {
+            "KiCad owns the schematic; use a live editor mutation or close the document"
+        }
+        _ => return None,
+    };
+    Some(ComponentDeleteTargetError::stale(path, reason).into_result())
 }
 
 /// Properties this tool exposes as first-class parameters. Routing one of them
@@ -4125,6 +4507,220 @@ mod move_connected_tests {
             text.contains("move_schematic_component"),
             "must name the working alternative: {text}"
         );
+    }
+}
+
+#[cfg(test)]
+mod component_delete_connectivity_tests {
+    use super::*;
+    use crate::mcp::{error::extract_error_kind, protocol::ToolContent};
+    use crate::tools::ServerConfig;
+    use std::sync::Arc;
+
+    const CONNECTIVITY: &str = include_str!("../../tests/fixtures/junction_reconcile.kicad_sch");
+
+    fn context() -> ToolContext {
+        ToolContext::new(
+            ServerConfig {
+                kicad_cli: String::new(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+                eager_toolsets: false,
+            },
+            Arc::new(crate::router::ToolRouter::new()),
+        )
+    }
+
+    fn fixture(content: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("delete.kicad_sch");
+        std::fs::write(&path, content).unwrap();
+        (directory, path)
+    }
+
+    fn body(result: &CallToolResult) -> serde_json::Value {
+        assert!(!result.is_error, "{result:?}");
+        let ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text result");
+        };
+        serde_json::from_str(text).unwrap()
+    }
+
+    fn has_junction(content: &str, x: f64, y: f64) -> bool {
+        let tree = parse_sexp(content).unwrap();
+        konnect_sexp::schematic::extract_junctions(&tree)
+            .iter()
+            .any(|&(jx, jy)| konnect_sexp::geometry::points_coincident(x, y, jx, jy, 0.01))
+    }
+
+    #[tokio::test]
+    async fn deleting_a_pin_only_dot_prunes_it_but_preserves_an_unrelated_wire_t() {
+        let (_directory, path) = fixture(CONNECTIVITY);
+        let result = handle_delete_schematic_component(
+            &json!({ "schematic": path, "reference": "R1" }),
+            &context(),
+        )
+        .await
+        .unwrap();
+        let response = body(&result);
+
+        assert_eq!(response["deleted_units"], 1);
+        assert_eq!(response["junctions_pruned_count"], 1);
+        let committed = std::fs::read_to_string(&path).unwrap();
+        assert!(!has_junction(&committed, 120.65, 139.7));
+        assert!(
+            has_junction(&committed, 120.65, 170.18),
+            "the two-wire T remains justified independently of R1"
+        );
+    }
+
+    #[tokio::test]
+    async fn attached_no_connect_is_removed_and_unrelated_marker_survives() {
+        let unrelated = "\t(no_connect\n\t\t(at 250 250)\n\t\t(uuid \"unrelated-marker\")\n\t)\n";
+        let closing = CONNECTIVITY.rfind("\n)").unwrap();
+        let original = format!(
+            "{}{unrelated}{}",
+            &CONNECTIVITY[..closing + 1],
+            &CONNECTIVITY[closing + 1..]
+        );
+        assert!(original.contains("unrelated-marker"));
+        let (_directory, path) = fixture(&original);
+        let result = handle_delete_schematic_component(
+            &json!({ "schematic": path, "reference": "R3" }),
+            &context(),
+        )
+        .await
+        .unwrap();
+        let response = body(&result);
+
+        assert_eq!(response["removed_no_connects_count"], 1);
+        assert_eq!(
+            response["removed_no_connect_uuids"][0],
+            "3f9dbc19-858e-4bf8-b937-b169159de4c8"
+        );
+        let committed = std::fs::read_to_string(&path).unwrap();
+        assert!(!committed.contains("3f9dbc19-858e-4bf8-b937-b169159de4c8"));
+        assert!(committed.contains("unrelated-marker"));
+    }
+
+    #[tokio::test]
+    async fn attached_no_connect_survives_when_a_remaining_pin_shares_the_point() {
+        let original =
+            CONNECTIVITY.replace("\t\t(at 120.65 135.89 0)\n", "\t\t(at 190.5 196.85 0)\n");
+        assert_ne!(original, CONNECTIVITY);
+        let (_directory, path) = fixture(&original);
+        let result = handle_delete_schematic_component(
+            &json!({ "schematic": path, "reference": "R3" }),
+            &context(),
+        )
+        .await
+        .unwrap();
+        let response = body(&result);
+
+        assert_eq!(response["removed_no_connects_count"], 0);
+        let committed = std::fs::read_to_string(&path).unwrap();
+        assert!(committed.contains("3f9dbc19-858e-4bf8-b937-b169159de4c8"));
+    }
+
+    #[tokio::test]
+    async fn missing_reference_is_structured_stale_and_does_not_write() {
+        let (_directory, path) = fixture(CONNECTIVITY);
+        let result = handle_delete_schematic_component(
+            &json!({ "schematic": path, "reference": "R404" }),
+            &context(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(extract_error_kind(&result).as_deref(), Some("stale_target"));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), CONNECTIVITY);
+    }
+
+    #[tokio::test]
+    async fn unresolved_pin_geometry_is_stale_and_does_not_write() {
+        let original = "(kicad_sch\n  (version 20260306)\n  (uuid \"root\")\n  (lib_symbols)\n  (symbol\n    (lib_id \"Missing:Part\")\n    (at 10 10 0)\n    (unit 1)\n    (uuid \"missing-lib\")\n    (property \"Reference\" \"U1\")\n  )\n)\n";
+        let (_directory, path) = fixture(original);
+        let result = handle_delete_schematic_component(
+            &json!({ "schematic": path, "reference": "U1" }),
+            &context(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(extract_error_kind(&result).as_deref(), Some("stale_target"));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), original);
+    }
+
+    #[tokio::test]
+    async fn attached_marker_without_uuid_is_stale_and_does_not_write() {
+        let original =
+            CONNECTIVITY.replace("\t\t(uuid \"3f9dbc19-858e-4bf8-b937-b169159de4c8\")\n", "");
+        assert_ne!(original, CONNECTIVITY);
+        let (_directory, path) = fixture(&original);
+        let result = handle_delete_schematic_component(
+            &json!({ "schematic": path, "reference": "R3" }),
+            &context(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(extract_error_kind(&result).as_deref(), Some("stale_target"));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), original);
+    }
+
+    #[tokio::test]
+    async fn duplicate_reference_and_unit_is_stale_and_does_not_write() {
+        let original = CONNECTIVITY.replacen(
+            "(property \"Reference\" \"R3\"",
+            "(property \"Reference\" \"R1\"",
+            1,
+        );
+        let (_directory, path) = fixture(&original);
+        let result = handle_delete_schematic_component(
+            &json!({ "schematic": path, "reference": "R1" }),
+            &context(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(extract_error_kind(&result).as_deref(), Some("stale_target"));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), original);
+    }
+
+    #[test]
+    fn stale_revision_refuses_the_prepared_delete_without_overwriting() {
+        let (_directory, path) = fixture(CONNECTIVITY);
+        let plan = plan_component_deletion(&path, CONNECTIVITY, "R1").unwrap();
+        let newer = CONNECTIVITY.replace("(paper \"A4\")", "(paper \"A3\")");
+        assert_ne!(newer, CONNECTIVITY);
+        std::fs::write(&path, &newer).unwrap();
+
+        let error = commit_command(&path, &plan.command).unwrap_err();
+        let refusal = component_delete_commit_refusal(&path, &error).unwrap();
+        assert_eq!(
+            extract_error_kind(&refusal).as_deref(),
+            Some("stale_target")
+        );
+        assert_eq!(std::fs::read_to_string(path).unwrap(), newer);
+    }
+
+    #[tokio::test]
+    async fn kicad_lock_is_structured_stale_and_preserves_the_file() {
+        let (_directory, path) = fixture(CONNECTIVITY);
+        let lock = konnect_sexp::writer::kicad_editor_lock_path(&path).unwrap();
+        std::fs::write(&lock, "locked").unwrap();
+        let result = handle_delete_schematic_component(
+            &json!({ "schematic": path, "reference": "R1" }),
+            &context(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(extract_error_kind(&result).as_deref(), Some("stale_target"));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), CONNECTIVITY);
     }
 }
 

--- a/docs/API_MIGRATIONS.md
+++ b/docs/API_MIGRATIONS.md
@@ -3,6 +3,31 @@
 Konnect's tool schemas are public API. This file records intentional argument
 removals and the supported replacement workflow.
 
+## Unreleased: connectivity-safe component deletion (minor release)
+
+`delete_schematic_component`, `batch_delete`, and
+`batch_delete_schematic_components` now resolve a complete logical component
+before writing, remove only no-connect markers owned exclusively by deleted
+pins, and reconcile junctions only at affected pin endpoints. Wires and labels
+remain, matching KiCad's plain-delete behavior. Selecting one placed-unit UUID
+through `batch_delete` deletes every placed unit of that reference.
+
+The existing single-delete fields (`deleted`, `deleted_units`) and batch fields
+(`deleted_count`, `deleted`, `errors`) remain. Single-delete results add
+`deleted_unit_uuids`, plus count-and-UUID evidence for removed no-connects and
+added or pruned junctions. Batch results add `deleted_components` (including
+each reference's observed unit count and UUIDs), `deleted_item_uuids`, and the
+same connectivity evidence fields. These values come from reloading the
+committed schematic rather than echoing requested selectors.
+
+Missing, protected, duplicate, malformed, stale, wrong-document, or
+editor-locked targets refuse with the existing `stale_target` kind before a
+write when Konnect cannot prove a unique safe deletion. A post-write readback
+that still observes a selected reference or UUID also returns `stale_target`;
+inspect and reload the saved schematic before retrying because that refusal can
+follow a committed write. This additive response change is planned for the next
+minor release; no tool or argument was renamed or removed.
+
 ## Unreleased: complete schematic placement instances (minor release)
 
 `add_schematic_component`, `batch_place_components`, and `add_power_symbol`


### PR DESCRIPTION
## Summary

Make single and batch schematic component deletion operate on a structurally identified logical component, remove only pin-owned no-connect markers, reconcile only affected junctions, and report committed absence rather than requested selectors.

Closes #386. This is the delete-side use of #330's junction model; it does not implement #315's wire-carrying move.

Rebuilt directly on current `main` at `a51b856e2835e4fbd2bcbaab8135a93ed8663d8d` after #392 merged. The branch now contains only #393's two outcomes:

- `66bab3b7866c3d7b520926868ace968d2aff8dea` — preserve connectivity on single-component delete;
- `52f4597617191bb54c59a1c5b346dbef482bc8b4` — reuse the planner for batch delete and document the additive response contract.

The effective diff is limited to:

- `crates/konnect-core/src/tools/sch_components.rs`
- `crates/konnect-core/src/tools/sch_batch.rs`
- `docs/API_MIGRATIONS.md`

## Approach

- Resolve every placed unit by reference, unit, and UUID and prove embedded library pin geometry before mutation.
- Record unit-aware pin endpoints and remove a no-connect only when no remaining pin shares its point.
- Reconcile junctions through the shared connectivity index only at affected endpoints.
- Lower symbols, owned markers, and junction edits into one revision-bound `SchematicCommand`.
- Reuse the same planner for both batch aliases, deduplicating overlapping reference and unit-UUID selectors.
- Reload after commit and derive deleted units/items, marker removals, and junction changes from observed state.
- Map duplicate structural evidence to current `main`'s existing `stale_target` contract; this rebuild does not reintroduce the deferred `ambiguous_target` kind.

## Compatibility and safety

Existing deletion response fields remain. Additive UUID/evidence fields change the public response shape and are documented in `docs/API_MIGRATIONS.md` for the next minor release. Selecting one unit UUID now deletes the complete logical multi-unit reference. Wires and labels remain, matching KiCad's plain-delete behavior.

Missing, nested/protected, duplicate, stale, wrong-document, unresolved-geometry, and editor-lock targets fail closed or appear as explicit partial-batch errors; no planned target is silently reported as deleted. A post-write readback refusal can follow a committed write, so callers are instructed to inspect/reload before retrying.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --locked --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked --lib --tests`
- [x] `cargo test --workspace --locked --doc`
- [x] 18 focused single-delete, batch-delete, multi-unit, and real-Eeschema fixture regressions passed
- [x] Real checked-in KiCad fixtures cover junction/no-connect behavior and ECC83 multi-unit deletion through both batch aliases
- [x] Four negative controls failed when shared-pin ownership, pin-geometry completeness, revision binding, and protected-structure guards were deliberately disabled

Environment-dependent ignored tests that require a running KiCad GUI, Java/Freerouting, or other live external state remain intentionally skipped by the unfiltered local gate. All ten hosted checks must pass on exact head `52f4597617191bb54c59a1c5b346dbef482bc8b4`.

## Risk and rollback

Risk is confined to file-based schematic deletion and its additive JSON evidence fields. The revision-bound command and committed readback prevent unreported partial success. Reverting the two commits above restores the prior deletion behavior and response shape.
