### PR TITLE
fix(schematic): count pins in find_single_pin_nets, not labels

### DIFF
--- a/crates/konnect-core/src/tools/design_review.rs
+++ b/crates/konnect-core/src/tools/design_review.rs
@@ -1338,8 +1338,7 @@ async fn handle_check_bom_health_file(
             None => continue,
         };
 
-        // Skip power symbols and sub-units
-        if reference.starts_with('#') {
+        if crate::tools::is_power_symbol_reference(reference) {
             continue;
         }
         total_components += 1;

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -729,6 +729,18 @@ pub(crate) fn placed_pins(
         .collect()
 }
 
+/// Whether a reference belongs to a symbol that names a net rather than
+/// consuming one — a power symbol, a `PWR_FLAG`. KiCAD prefixes those with `#`
+/// and keeps them out of the netlist as components.
+///
+/// Deliberately not `LabelKind::PowerSymbol`, which `extract_power_symbol_labels`
+/// derives from the `(power)` marker plus a `power_in` pin: `PWR_FLAG`'s pin is
+/// `power_out`, so that test lets it through, and a caller counting what a net
+/// actually reaches wants it out too.
+pub(crate) fn is_power_symbol_reference(reference: &str) -> bool {
+    reference.starts_with('#')
+}
+
 /// [`placed_pins`], grouped under the instance that placed each unit, for
 /// callers that report pins by name rather than position. The whole instance
 /// is returned because a caller reporting a pin usually wants its reference

--- a/crates/konnect-core/src/tools/sch_analysis.rs
+++ b/crates/konnect-core/src/tools/sch_analysis.rs
@@ -5,20 +5,22 @@
 
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
-use crate::tools::sch_connectivity::{net_graph_for, pt_key, ConnectivityIndex};
+use crate::tools::sch_connectivity::{label_roots, net_graph_for, pt_key, ConnectivityIndex};
 use crate::tools::{
-    get_path, opt_f64, placed_pins_by_reference, require_f64, require_str, ToolContext, ToolDef,
+    get_path, is_power_symbol_reference, opt_f64, placed_pins_by_reference, require_f64,
+    require_str, ToolContext, ToolDef,
 };
 use konnect_schematic_editor as cse;
 use konnect_sexp::{
     geometry::{point_on_segment, points_coincident},
     schematic::{
-        extract_all_net_labels, extract_labels, extract_symbol_instances, extract_wires,
-        find_lib_symbol, read_schematic, symbol_bounds_for_instance, LabelKind, SymbolBounds, Wire,
+        extract_all_net_labels, extract_labels, extract_sheet_pins, extract_symbol_instances,
+        extract_wires, find_lib_symbol, read_schematic, symbol_bounds_for_instance, Label,
+        LabelKind, LibPin, SymbolBounds, Wire,
     },
 };
 use serde_json::json;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 pub fn tools() -> Vec<ToolDef> {
     vec![
@@ -152,7 +154,12 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "find_single_pin_nets",
-            "Find nets with only one label/connection — often indicates a missing counterpart.",
+            "Find nets that reach at most one pin — often a missing counterpart, an orphan \
+             label, or a stub left by a deleted component. Component pins and hierarchical \
+             sheet pins count; a power symbol's own pin names the rail rather than consuming \
+             it and does not. Reports the pin and label counts, and every label kind that \
+             named the net. Read per sheet: a net a global, hierarchical or power label can \
+             carry off this one is flagged cross_sheet_unverified.",
             json!({ "type": "object",
                 "properties": { "schematic": { "type": "string" } },
                 "required": ["schematic"] }),
@@ -551,10 +558,9 @@ async fn handle_find_shorted_nets(
     let wires = extract_wires(&tree);
     let labels = extract_all_net_labels(&tree);
     let mut g = net_graph_for(&tree, &wires, &labels);
-    let mut root_nets: HashMap<(i64, i64), Vec<String>> = HashMap::new();
-    for l in &labels {
-        let root = g.find(pt_key(l.x, l.y));
-        root_nets.entry(root).or_default().push(l.net.clone());
+    let mut root_nets: HashMap<(i64, i64), Vec<&str>> = HashMap::new();
+    for (root, label) in label_roots(&mut g, &labels) {
+        root_nets.entry(root).or_default().push(label.net.as_str());
     }
     let shorts: Vec<serde_json::Value> = root_nets
         .into_values()
@@ -573,25 +579,202 @@ async fn handle_find_shorted_nets(
     ))
 }
 
+/// A point that counts as reaching a net.
+enum Connection<'a> {
+    ComponentPin {
+        reference: &'a str,
+        pin: &'a LibPin,
+        x: f64,
+        y: f64,
+    },
+    /// A hierarchical sheet pin: whatever the net meets on the other side.
+    SheetPin { x: f64, y: f64 },
+}
+
+impl Connection<'_> {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            Connection::ComponentPin {
+                reference,
+                pin,
+                x,
+                y,
+            } => json!({
+                "type": "component_pin",
+                "reference": reference,
+                "pin": pin.number,
+                "pin_name": pin.name,
+                "x": x,
+                "y": y
+            }),
+            Connection::SheetPin { x, y } => json!({ "type": "sheet_pin", "x": x, "y": y }),
+        }
+    }
+}
+
+/// Whether a label of this kind can carry its net off the sheet being read.
+///
+/// A local `NetLabel` cannot: it names a net within one sheet, so a count taken
+/// from that sheet is the whole answer. The other three can, and a reader has
+/// to know which it is holding. `GlobalLabel` and a power symbol — which KiCAD
+/// makes a global label out of — join every same-named net in the project;
+/// `HierarchicalLabel` continues through the parent's sheet pin.
+fn reaches_beyond_this_sheet(kind: &LabelKind) -> bool {
+    match kind {
+        LabelKind::NetLabel => false,
+        LabelKind::GlobalLabel | LabelKind::HierarchicalLabel | LabelKind::PowerSymbol => true,
+    }
+}
+
+/// Nets that reach at most one pin.
+///
+/// Zero counts as well as one: a label whose net reaches nothing is the orphan
+/// label or the stub left by a deleted component that the review skill sends
+/// this tool looking for, and `find_orphan_items` reports the dangling wire end
+/// without ever naming the net. `pin_count` tells the two apart.
+///
+/// This counted *label instances* per net name, so every net drawn the ordinary
+/// way — one label on a wire that reaches two or more pins — was reported, and
+/// the defect the tool advertises passed through unreported as soon as its net
+/// carried a second label. The count comes from the shared net graph now, and
+/// the label count stays beside it as its own field: a net with no label at all
+/// is a different smell.
+///
+/// A power symbol's own pin is not a connection here, though it is one to
+/// `find_orphan_items`, which reports an unwired `#PWR01`. The divergence is
+/// deliberate: the rail that reaches exactly one component pin is what this
+/// tool is for, and counting the symbol that named it would hide every one of
+/// them.
+///
+/// The answer is per sheet, so a net named by a global or hierarchical label
+/// may well continue on another one, and the report has to say so rather than
+/// leave the caller to infer it. `cross_sheet_unverified` is that statement:
+/// true when any label naming the net can carry it off this sheet, which is as
+/// far as a single-sheet reader can go. Reporting the net anyway is deliberate
+/// — a rail that reaches one pin here is worth showing — but the flag marks it
+/// as a lead rather than a finding.
+///
+/// # Response compatibility
+///
+/// Every field this tool used to return is still returned and still means the
+/// same thing: `single_pin_net_count`, and per net `net`, `x`, `y`, and `type`.
+/// `type` remains the kind of the *first* label found, so a consumer matching
+/// on it is unaffected. It is also why the other two fields exist: local labels
+/// are extracted first, so a net carrying both a local and a global label
+/// reports `NetLabel` and says nothing about the global one. `label_types`
+/// carries every distinct kind, sorted; `cross_sheet_unverified` is the same
+/// evidence as one boolean.
+///
+/// The additive fields are `label_types`, `cross_sheet_unverified`,
+/// `pin_count`, `label_count`, and `pins`.
+///
+/// What *does* change is which nets appear, because that was the defect: the
+/// membership rule went from "exactly one label instance names it" to "the net
+/// reaches at most one pin". A consumer reading `single_pin_net_count` as a
+/// defect count gets a smaller, truer number and needs no migration; one that
+/// had learned to ignore this tool's noise can stop. No consumer can keep the
+/// old set, since it was wrong in both directions.
 async fn handle_find_single_pin_nets(
     args: &serde_json::Value,
     _ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
     let sch_path = get_path(args, "schematic")?;
     let (_, tree) = read_schematic(&sch_path)?;
+    let wires = extract_wires(&tree);
     let labels = extract_all_net_labels(&tree);
-    let mut counts: HashMap<String, usize> = HashMap::new();
-    for l in &labels {
-        *counts.entry(l.net.clone()).or_insert(0) += 1;
+    let mut graph = net_graph_for(&tree, &wires, &labels);
+
+    // Every connection point, under the graph root that carries it. A sheet
+    // holds hundreds and reports a handful, so nothing is rendered until a net
+    // qualifies.
+    let placed = placed_pins_by_reference(&tree);
+    let mut pins_by_root: HashMap<(i64, i64), Vec<Connection>> = HashMap::new();
+    for (instance, pins) in &placed {
+        if is_power_symbol_reference(&instance.reference) {
+            continue;
+        }
+        for (pin, transform) in pins {
+            let (x, y) = konnect_sexp::schematic::pin_endpoint(pin, *transform);
+            pins_by_root
+                .entry(graph.find(pt_key(x, y)))
+                .or_default()
+                .push(Connection::ComponentPin {
+                    reference: &instance.reference,
+                    pin,
+                    x,
+                    y,
+                });
+        }
     }
-    let singles: Vec<serde_json::Value> = counts
+    for (x, y) in extract_sheet_pins(&tree) {
+        pins_by_root
+            .entry(graph.find(pt_key(x, y)))
+            .or_default()
+            .push(Connection::SheetPin { x, y });
+    }
+
+    // Each net name, the roots its labels sit on, and the first label to name
+    // it. Two labels of one name on segments that never meet are still one net
+    // to KiCAD, so the roots pool.
+    struct NamedNet<'a> {
+        roots: HashSet<(i64, i64)>,
+        label_count: usize,
+        first_label: &'a Label,
+        /// Every kind that named this net, not just the first. Sorted, so the
+        /// field reads the same on two runs over one sheet.
+        kinds: BTreeSet<String>,
+        cross_sheet_unverified: bool,
+    }
+    let mut by_net: HashMap<&str, NamedNet> = HashMap::new();
+    for (root, label) in label_roots(&mut graph, &labels) {
+        let named = by_net
+            .entry(label.net.as_str())
+            .or_insert_with(|| NamedNet {
+                roots: HashSet::new(),
+                label_count: 0,
+                first_label: label,
+                kinds: BTreeSet::new(),
+                cross_sheet_unverified: false,
+            });
+        named.roots.insert(root);
+        named.label_count += 1;
+        named.kinds.insert(format!("{:?}", label.kind));
+        named.cross_sheet_unverified |= reaches_beyond_this_sheet(&label.kind);
+    }
+
+    // HashMap order is not an answer: two runs of one binary over one sheet
+    // would report the same nets in different orders.
+    let mut by_net: Vec<(&str, NamedNet)> = by_net.into_iter().collect();
+    by_net.sort_by_key(|(net, _)| *net);
+
+    let singles: Vec<serde_json::Value> = by_net
         .iter()
-        .filter(|(_, &c)| c == 1)
-        .map(|(net, _)| {
-            let l = labels.iter().find(|l| &l.net == net).unwrap();
-            json!({ "net": net, "x": l.x, "y": l.y, "type": format!("{:?}", l.kind) })
+        .filter_map(|(net, named)| {
+            let mut on_net = named
+                .roots
+                .iter()
+                .filter_map(|root| pins_by_root.get(root))
+                .flatten();
+            let reached = on_net.next();
+            if on_net.next().is_some() {
+                return None;
+            }
+            let pins: Vec<serde_json::Value> =
+                reached.map(Connection::to_json).into_iter().collect();
+            Some(json!({
+                "net": net,
+                "x": named.first_label.x,
+                "y": named.first_label.y,
+                "type": format!("{:?}", named.first_label.kind),
+                "label_types": named.kinds,
+                "cross_sheet_unverified": named.cross_sheet_unverified,
+                "pin_count": pins.len(),
+                "label_count": named.label_count,
+                "pins": pins
+            }))
         })
         .collect();
+
     Ok(CallToolResult::json(
         &json!({ "single_pin_net_count": singles.len(), "nets": singles }),
     ))
@@ -1134,19 +1317,19 @@ mod orphan_item_tests {
 }
 
 #[cfg(test)]
-#[cfg(test)]
-mod power_symbol_net_tests {
+mod tool_call_support {
     use super::*;
     use crate::tools::ServerConfig;
     use std::io::Write;
     use std::sync::Arc;
 
-    /// R1 with pin 1 on a `SIG` label and pin 2 wired down to a `power:GND`
-    /// symbol. The rail is what a label-only net graph loses.
-    const SCH: &str = include_str!("../../tests/fixtures/power_rail.kicad_sch");
-
-    /// Run a tool by name against a temp file holding `sch`.
-    async fn call(sch: &str, tool: &str, mut args: serde_json::Value) -> serde_json::Value {
+    /// Run a tool by name against a temp file holding `sch`, exactly as the MCP
+    /// dispatch layer does after selecting its `ToolDef`.
+    pub(super) async fn call(
+        sch: &str,
+        tool: &str,
+        mut args: serde_json::Value,
+    ) -> serde_json::Value {
         let mut f = tempfile::NamedTempFile::with_suffix(".kicad_sch").unwrap();
         f.write_all(sch.as_bytes()).unwrap();
         f.flush().unwrap();
@@ -1164,6 +1347,16 @@ mod power_symbol_net_tests {
         };
         serde_json::from_str(text).unwrap()
     }
+}
+
+#[cfg(test)]
+mod power_symbol_net_tests {
+    use super::tool_call_support::call;
+    use super::*;
+
+    /// R1 with pin 1 on a `SIG` label and pin 2 wired down to a `power:GND`
+    /// symbol. The rail is what a label-only net graph loses.
+    const SCH: &str = include_str!("../../tests/fixtures/power_rail.kicad_sch");
 
     /// The S-expression path: a pin reached only through a power symbol used to
     /// report no net at all.
@@ -1218,6 +1411,232 @@ mod power_symbol_net_tests {
         );
         let s = call(&shorted, "find_shorted_nets", json!({})).await;
         assert_eq!(s["short_count"], 1, "SIG and GND share one wire: {s}");
+    }
+}
+
+#[cfg(test)]
+mod single_pin_net_tests {
+    use super::tool_call_support::call;
+    use super::*;
+
+    /// A KiCad 10.0.5-authored parent sheet carrying one net of every shape the
+    /// tool has to tell apart. Provenance and the KiCad netlist that fixes the
+    /// expected pin count of each net are in `single_pin_nets.README.md`; the
+    /// counts asserted below are that netlist's, not this crate's.
+    ///
+    /// - `TWO_PIN` — one label, R1.2 and R2.1. The ordinary way to draw a net,
+    ///   and what the label count reported as a single-pin net.
+    /// - `LONE` — two labels on two wire segments that never meet, one pin
+    ///   between them. The defect the tool exists to find, invisible while a
+    ///   second label made the count 2, and it can only be found by pooling the
+    ///   two roots.
+    /// - `SPLIT` — the same shape with a pin on each root. Pooling is what
+    ///   keeps it off the report; KiCad's netlister agrees it is one 2-pin net.
+    /// - `VCC` — a power symbol and one component pin.
+    /// - `FLAGGED` — a `PWR_FLAG` (`#FLG01`) and one component pin.
+    /// - `SHEET_NET` — R8.2 and a hierarchical sheet pin.
+    /// - `MIXED` — a local and a global label naming one net that reaches one
+    ///   pin.
+    /// - `STUB` — a label on a wire that reaches no pin at all.
+    /// - `GND` — the rail nine pins sit on, the control for a net that is
+    ///   named by a power symbol and is not a defect.
+    const SCH: &str = include_str!("../../tests/fixtures/single_pin_nets.kicad_sch");
+
+    /// The child of that sheet: `SHEET_NET` continues here onto R10.2 through
+    /// a hierarchical label, so each sheet on its own sees one pin of a net
+    /// KiCad resolves to two.
+    const CHILD: &str = include_str!("../../tests/fixtures/single_pin_nets_child.kicad_sch");
+
+    async fn nets_of(sch: &str) -> Vec<serde_json::Value> {
+        call(sch, "find_single_pin_nets", json!({})).await["nets"]
+            .as_array()
+            .unwrap()
+            .clone()
+    }
+
+    async fn nets() -> Vec<serde_json::Value> {
+        nets_of(SCH).await
+    }
+
+    fn net<'a>(nets: &'a [serde_json::Value], name: &str) -> Option<&'a serde_json::Value> {
+        nets.iter().find(|net| net["net"] == name)
+    }
+
+    fn expect<'a>(nets: &'a [serde_json::Value], name: &str) -> &'a serde_json::Value {
+        net(nets, name).unwrap_or_else(|| panic!("{name} missing: {nets:?}"))
+    }
+
+    /// The false positive that made the tool unusable: 11 of 11 nets reported
+    /// on a real sheet, every one of them wired to two or more pins.
+    #[tokio::test]
+    async fn a_net_with_one_label_and_two_pins_is_not_reported() {
+        let nets = nets().await;
+
+        assert!(net(&nets, "TWO_PIN").is_none(), "{nets:?}");
+    }
+
+    /// And the miss on the other side: a second label used to make a real
+    /// single-pin net count 2 and disappear.
+    #[tokio::test]
+    async fn a_net_with_two_labels_and_one_pin_is_reported() {
+        let nets = nets().await;
+        let lone = expect(&nets, "LONE");
+
+        assert_eq!(lone["pin_count"], 1);
+        assert_eq!(lone["label_count"], 2, "the label count is kept, not used");
+        assert_eq!(lone["pins"][0]["reference"], "R3");
+        assert_eq!(lone["pins"][0]["pin"], "2");
+    }
+
+    /// `LONE`'s two labels sit on wire segments that never touch. KiCAD joins
+    /// them by name, so the pins under both roots are one net's pins — count
+    /// them per root and the one pin under the far root is a second net that
+    /// reaches nothing.
+    #[tokio::test]
+    async fn labels_of_one_name_on_disconnected_roots_pool() {
+        let nets = nets().await;
+
+        assert_eq!(expect(&nets, "LONE")["pin_count"], 1);
+    }
+
+    /// The same two-root shape with a pin on each root. Pooling is the only
+    /// reason this is not reported, and KiCad's own netlister resolves it to a
+    /// single net of R4.2 and R5.1.
+    #[tokio::test]
+    async fn one_pin_under_each_of_two_pooled_roots_is_two_pins() {
+        let nets = nets().await;
+
+        assert!(net(&nets, "SPLIT").is_none(), "{nets:?}");
+    }
+
+    /// A rail that reaches exactly one component pin is the defect. The power
+    /// symbol's own pin names it and must not make the count 2.
+    #[tokio::test]
+    async fn a_rail_reaching_one_pin_is_reported_without_its_power_symbol() {
+        let nets = nets().await;
+        let vcc = expect(&nets, "VCC");
+
+        assert_eq!(vcc["pin_count"], 1);
+        assert_eq!(vcc["pins"][0]["reference"], "R6", "not #PWR001");
+    }
+
+    /// `PWR_FLAG` is the other symbol whose pin names a net without consuming
+    /// one, and it is not a `LabelKind::PowerSymbol` — its pin is `power_out`,
+    /// so the `(power)` test lets it through. `#FLG01` is what keeps it out.
+    #[tokio::test]
+    async fn a_pwr_flag_pin_does_not_count_as_a_connection() {
+        let nets = nets().await;
+        let flagged = expect(&nets, "FLAGGED");
+
+        assert_eq!(flagged["pin_count"], 1);
+        assert_eq!(flagged["pins"][0]["reference"], "R7", "not #FLG01");
+    }
+
+    /// The rail nine pins sit on. A power symbol names it, so the tool has to
+    /// count past the naming symbol without reporting the net.
+    #[tokio::test]
+    async fn a_rail_reaching_many_pins_is_not_reported() {
+        let nets = nets().await;
+
+        assert!(net(&nets, "GND").is_none(), "{nets:?}");
+    }
+
+    /// A net leaving the sheet is connected to whatever is on the other side.
+    #[tokio::test]
+    async fn a_hierarchical_sheet_pin_counts_as_a_pin() {
+        let nets = nets().await;
+
+        assert!(net(&nets, "SHEET_NET").is_none(), "{nets:?}");
+    }
+
+    /// The stub a deleted component leaves behind reaches nothing at all. The
+    /// label count reported it, `find_orphan_items` names only its wire end,
+    /// and counting pins must not drop it on the floor. KiCad's netlist has no
+    /// `STUB` net to compare against, which is the point.
+    #[tokio::test]
+    async fn a_net_that_reaches_no_pin_is_reported_as_zero() {
+        let nets = nets().await;
+        let stub = expect(&nets, "STUB");
+
+        assert_eq!(stub["pin_count"], 0);
+        assert_eq!(stub["label_count"], 1);
+        assert_eq!(stub["pins"].as_array().unwrap().len(), 0);
+    }
+
+    /// Local labels are extracted first, so `type` alone reports `NetLabel` for
+    /// a net that also carries a global label and hides the one fact a caller
+    /// needs: this count is not the whole net.
+    #[tokio::test]
+    async fn a_net_carrying_a_global_label_reports_every_kind_that_named_it() {
+        let nets = nets().await;
+        let mixed = expect(&nets, "MIXED");
+
+        assert_eq!(mixed["type"], "NetLabel", "the compatibility field");
+        assert_eq!(
+            mixed["label_types"],
+            json!(["GlobalLabel", "NetLabel"]),
+            "sorted, and the global label is not lost"
+        );
+        assert_eq!(mixed["cross_sheet_unverified"], true);
+    }
+
+    /// A net named only by a local label is fully answered by this sheet.
+    #[tokio::test]
+    async fn a_locally_named_net_is_not_flagged_cross_sheet() {
+        let nets = nets().await;
+        let stub = expect(&nets, "STUB");
+
+        assert_eq!(stub["label_types"], json!(["NetLabel"]));
+        assert_eq!(stub["cross_sheet_unverified"], false);
+    }
+
+    /// A power symbol is a global label in KiCAD, so a rail counted on one
+    /// sheet is a lead, not a finding — even when, as here, the project-wide
+    /// netlist agrees that `VCC` reaches exactly one pin.
+    #[tokio::test]
+    async fn a_power_symbol_rail_is_flagged_cross_sheet() {
+        let nets = nets().await;
+        let vcc = expect(&nets, "VCC");
+
+        assert_eq!(vcc["label_types"], json!(["PowerSymbol"]));
+        assert_eq!(vcc["cross_sheet_unverified"], true);
+    }
+
+    /// The hierarchy boundary from the child's side. `SHEET_NET` reaches R10.2
+    /// and its hierarchical label here, and R8.2 and the sheet pin on the
+    /// parent; KiCad resolves the pair to one 2-pin net. Neither sheet can see
+    /// that alone, so the child reports one pin and says it is unverified.
+    #[tokio::test]
+    async fn a_child_sheet_reports_a_hierarchical_net_as_unverified() {
+        let nets = nets_of(CHILD).await;
+        let sheet_net = expect(&nets, "SHEET_NET");
+
+        assert_eq!(sheet_net["pin_count"], 1);
+        assert_eq!(sheet_net["pins"][0]["reference"], "R10");
+        assert_eq!(sheet_net["label_types"], json!(["HierarchicalLabel"]));
+        assert_eq!(sheet_net["cross_sheet_unverified"], true);
+    }
+
+    /// And the control on the same child: a local net of two pins is answered
+    /// there in full.
+    #[tokio::test]
+    async fn a_child_sheet_local_net_of_two_pins_is_not_reported() {
+        let nets = nets_of(CHILD).await;
+
+        assert!(net(&nets, "CHILD_LOCAL").is_none(), "{nets:?}");
+    }
+
+    /// The nets came out of a `HashMap` in whatever order it held them, so two
+    /// runs of the same binary over the same sheet could disagree on the order.
+    #[tokio::test]
+    async fn the_report_is_sorted_and_stable() {
+        let names: Vec<String> = nets()
+            .await
+            .iter()
+            .map(|net| net["net"].as_str().unwrap().to_string())
+            .collect();
+
+        assert_eq!(names, vec!["FLAGGED", "LONE", "MIXED", "STUB", "VCC"]);
     }
 }
 

--- a/crates/konnect-core/src/tools/sch_connectivity.rs
+++ b/crates/konnect-core/src/tools/sch_connectivity.rs
@@ -306,6 +306,23 @@ fn seed_net_graph(
     graph
 }
 
+/// Each label paired with the graph root it sits on.
+///
+/// Two tools read the one relation from opposite ends — `find_shorted_nets`
+/// root-first, since more than one name on a root is a short, and
+/// `find_single_pin_nets` name-first, pooling the roots one name reaches. The
+/// walk lives here so a refinement to which label anchors which root cannot
+/// land in only one of them.
+pub(crate) fn label_roots<'a>(
+    graph: &mut NetGraph,
+    labels: &'a [Label],
+) -> Vec<((i64, i64), &'a Label)> {
+    labels
+        .iter()
+        .map(|label| (graph.find(pt_key(label.x, label.y)), label))
+        .collect()
+}
+
 /// The net graph for a whole tree, at [`COINCIDENT_TOLERANCE`].
 ///
 /// `labels` must be `extract_all_net_labels` — power symbols name nets too, and

--- a/crates/konnect-core/tests/fixtures/single_pin_nets.README.md
+++ b/crates/konnect-core/tests/fixtures/single_pin_nets.README.md
@@ -1,0 +1,75 @@
+# Single-pin net fixture
+
+`single_pin_nets.kicad_sch` and its child `single_pin_nets_child.kicad_sch` are
+a parent/child pair carrying one net of every shape `find_single_pin_nets` has
+to tell apart, including the two that cross the hierarchy boundary.
+
+## Provenance
+
+The pair was built through Konnect against KiCad's stock `Device:R` and
+`power:` libraries — `batch_place_components`, `batch_add_wire`,
+`add_schematic_net_label`, `add_power_symbol`, `add_hierarchical_sheet`,
+`import_sheet_pins` — and then parsed and force-resaved by KiCad 10.0.5:
+
+```text
+kicad-cli sch upgrade --force single_pin_nets.kicad_sch
+kicad-cli sch upgrade --force single_pin_nets_child.kicad_sch
+```
+
+What is committed here is that Eeschema serialization: `(generator
+"eeschema")`, `(version 20260306)`, KiCad's own library records, field
+positions and UUIDs. The predecessor of this fixture was hand-authored, with
+placeholder UUIDs and abbreviated symbol definitions, and KiCad refused to open
+it — a parser accepting its own approximation of the format proves nothing.
+
+The `#FLG01` reference is the one deliberate edit made after placement:
+`add_power_symbol` numbers every power symbol in the `#PWR` sequence, and
+eeschema annotates `PWR_FLAG` as `#FLG`. The fixture carries what KiCad writes,
+because `#FLG…` being excluded alongside `#PWR…` is exactly what one of the
+tests asserts.
+
+## KiCad's own answer
+
+The expected pin count of every net is KiCad's, not this crate's. Reload-checked
+with the netlist exporter, which is also the oracle the tests assert against:
+
+```text
+kicad-cli sch export netlist --output single_pin_nets.net single_pin_nets.kicad_sch
+```
+
+| Net | Pins KiCad resolves | Shape under test |
+|---|---|---|
+| `/TWO_PIN` | 2 — R1.2, R2.1 | one label, two pins: the false positive |
+| `/LONE` | 1 — R3.2 | two labels on two disconnected roots, one pin |
+| `/SPLIT` | 2 — R4.2, R5.1 | the same two-root shape with a pin on each |
+| `VCC` | 1 — R6.2 | a rail reaching one pin; `#PWR001` is not a pin |
+| `/FLAGGED` | 1 — R7.2 | `#FLG01` is not a pin either |
+| `/SHEET_NET` | 2 — R8.2, R10.2 | across the sheet boundary |
+| `MIXED` | 1 — R9.2 | one net named by a local *and* a global label |
+| `GND` | 9 | the rail that is not a defect |
+| `/Child/CHILD_LOCAL` | 2 — R11.2, R12.1 | a local net answered by the child alone |
+| `STUB` | — absent | reaches no pin, so KiCad emits no net at all |
+
+`/SPLIT` is the load-bearing row. KiCad resolves two same-named labels on wire
+segments that never touch into one 2-pin net, which is why the tool pools the
+roots a name sits on rather than counting each separately.
+
+`/SHEET_NET` is the limitation the response documents. KiCad sees two pins;
+neither sheet alone can. The parent counts R8.2 and the sheet pin, the child
+counts R10.2 and reports `cross_sheet_unverified`.
+
+`STUB` is the case no netlist can corroborate, which is the point of the tool:
+a label whose net reaches nothing leaves no net for KiCad to export.
+
+## ERC
+
+`kicad-cli sch erc` independently agrees with the fixture's intent — three
+errors and eight warnings, none of them structural:
+
+- `isolated_pin_label` on both `LONE` labels and on both `MIXED` labels — the
+  nets this tool must report;
+- `label_dangling` on `STUB`;
+- no violation for `SPLIT`, `TWO_PIN`, `SHEET_NET` or `GND`;
+- `power_pin_not_driven` on `VCC` and the child `GND`, and
+  `unconnected_wire_endpoint` on the deliberately floating stubs. Those are the
+  cost of a sheet built to hold defects, not defects in the fixture.

--- a/crates/konnect-core/tests/fixtures/single_pin_nets.kicad_sch
+++ b/crates/konnect-core/tests/fixtures/single_pin_nets.kicad_sch
@@ -1,0 +1,1864 @@
+(kicad_sch
+	(version 20260306)
+	(generator "eeschema")
+	(generator_version "10.0")
+	(uuid "8f963024-f701-4c8a-84ca-3e41a181c121")
+	(paper "A4")
+	(lib_symbols
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:GND"
+			(power global)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "GND"
+				(at 0 -3.81 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "GND_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GND_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:PWR_FLAG"
+			(power global)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#FLG"
+				(at 0 1.905 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "PWR_FLAG"
+				(at 0 3.81 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Special symbol for telling ERC where power comes from"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "flag power"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "PWR_FLAG_0_0"
+				(pin power_out line
+					(at 0 0 90)
+					(length 0)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(symbol "PWR_FLAG_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 1.27) (xy -1.016 1.905) (xy 0 2.54) (xy 1.016 1.905) (xy 0 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:VCC"
+			(power global)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -3.81 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "VCC"
+				(at 0 3.556 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"VCC\""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "VCC_0_1"
+				(polyline
+					(pts
+						(xy -0.762 1.27) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy 0.762 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "VCC_1_1"
+				(pin power_in line
+					(at 0 0 90)
+					(length 0)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(junction
+		(at 50.8 100.33)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "65505003-676f-4de6-96bf-a43be84489b6")
+	)
+	(junction
+		(at 50.8 80.01)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ac3391c6-759f-4295-8d1c-3c8c1087383b")
+	)
+	(junction
+		(at 50.8 139.7)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c0d5bb0e-4f60-43ab-80b5-02a5ae96886d")
+	)
+	(junction
+		(at 50.8 119.38)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d462e101-17c0-4073-abae-b6820ca5e28c")
+	)
+	(junction
+		(at 50.8 59.69)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e852349b-2899-4739-a415-e8c420fe80a2")
+	)
+	(no_connect
+		(at 114.3 80.01)
+		(uuid "09ae2dde-e503-4679-ba51-9753814cce01")
+	)
+	(no_connect
+		(at 114.3 39.37)
+		(uuid "1c2bf565-7178-4e88-b620-93b922853e75")
+	)
+	(wire
+		(pts
+			(xy 63.5 160.02) (xy 76.2 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "013f1c04-ae52-42aa-90b9-936a63e2ddd3")
+	)
+	(wire
+		(pts
+			(xy 55.88 59.69) (xy 50.8 59.69)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1af04e71-5081-41ed-a547-858660e26dae")
+	)
+	(wire
+		(pts
+			(xy 140.97 139.7) (xy 140.97 132.08)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "406171a1-0d25-4a4c-986d-e52cd52611d2")
+	)
+	(wire
+		(pts
+			(xy 140.97 132.08) (xy 149.86 132.08)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4319b08c-7df6-4438-8117-2b940f4bce34")
+	)
+	(wire
+		(pts
+			(xy 63.5 59.69) (xy 76.2 59.69)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "674d788b-ee8e-40ba-94ee-fa16f9aaddb7")
+	)
+	(wire
+		(pts
+			(xy 50.8 39.37) (xy 50.8 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "69fd2862-ef05-444e-8408-43b8c67238f4")
+	)
+	(wire
+		(pts
+			(xy 55.88 139.7) (xy 50.8 139.7)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6c26a746-dddc-4794-b6cb-81f594f0d539")
+	)
+	(wire
+		(pts
+			(xy 50.8 160.02) (xy 50.8 167.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "73781584-846c-43fd-a34f-0be8abb21936")
+	)
+	(wire
+		(pts
+			(xy 55.88 119.38) (xy 50.8 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "785f761a-c1d2-45a9-ab6d-2518fc99e8db")
+	)
+	(wire
+		(pts
+			(xy 55.88 80.01) (xy 50.8 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7ad57db0-02c9-4473-8e5f-8b302e796e68")
+	)
+	(wire
+		(pts
+			(xy 63.5 139.7) (xy 140.97 139.7)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "805948d0-8190-42cc-b2b7-4f454f138fa2")
+	)
+	(wire
+		(pts
+			(xy 95.25 59.69) (xy 107.95 59.69)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8d7b339b-9b0c-4323-b478-76010b34a068")
+	)
+	(wire
+		(pts
+			(xy 63.5 39.37) (xy 106.68 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "92a4a3a6-c3d9-4c77-b4d9-9be8e418c4df")
+	)
+	(wire
+		(pts
+			(xy 93.98 80.01) (xy 106.68 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "93cc8877-e916-445b-815a-bfb702a3af3a")
+	)
+	(wire
+		(pts
+			(xy 63.5 100.33) (xy 73.66 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a10e0f09-efd2-4aca-8f4c-977bd677338a")
+	)
+	(wire
+		(pts
+			(xy 55.88 100.33) (xy 50.8 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a2302769-295e-4a61-8eaa-152e34a83334")
+	)
+	(wire
+		(pts
+			(xy 63.5 119.38) (xy 76.2 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ba56ad04-c82b-4122-8104-d71f3ac38b87")
+	)
+	(wire
+		(pts
+			(xy 63.5 180.34) (xy 76.2 180.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e20b570e-9f71-4204-a907-fdeb365956b8")
+	)
+	(wire
+		(pts
+			(xy 55.88 160.02) (xy 50.8 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ea201218-42f0-4c3e-8d7e-fc70ef86e787")
+	)
+	(wire
+		(pts
+			(xy 55.88 39.37) (xy 50.8 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f728c295-5077-443d-aedb-5c5721b675cd")
+	)
+	(wire
+		(pts
+			(xy 63.5 80.01) (xy 76.2 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f83a03bd-2d3c-4769-bd1b-49316641a6fe")
+	)
+	(label "LONE"
+		(at 95.25 59.69 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "0c28b9cb-e3fd-49b9-9b32-a0ef4a63f32e")
+	)
+	(label "FLAGGED"
+		(at 76.2 119.38 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "2f1fa4b5-4e10-418b-b183-f9f13a7ad111")
+	)
+	(label "SPLIT"
+		(at 76.2 80.01 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "413d5a81-60f3-417f-8611-61535183b829")
+	)
+	(label "STUB"
+		(at 69.85 180.34 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "485c0c1a-2a15-4c84-85da-d32ed20d613a")
+	)
+	(label "TWO_PIN"
+		(at 85.09 39.37 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "6f563532-1960-4bee-8635-18eb1ecb12f6")
+	)
+	(label "SHEET_NET"
+		(at 76.2 139.7 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "b65c5fad-e621-4b95-bd54-4c586ed3f01a")
+	)
+	(label "LONE"
+		(at 76.2 59.69 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "cda78b2d-f2d7-4a2e-8caf-0c5e17f4fd82")
+	)
+	(label "SPLIT"
+		(at 93.98 80.01 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "d0aef65a-dfdf-4f6f-9897-0b358a3144b3")
+	)
+	(label "MIXED"
+		(at 69.85 160.02 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "f09b57cc-2f69-4f4e-80a7-9de3cb56bb02")
+	)
+	(global_label "MIXED"
+		(shape bidirectional)
+		(at 76.2 160.02 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "5ff0e940-4486-44f3-ba88-2c0fd8071a42")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 76.2 160.02 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 59.69 80.01 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "155cd523-228f-4324-863f-1b021e069431")
+		(property "Reference" "R4"
+			(at 59.69 77.978 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 59.69 80.01 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 59.69 80.01 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 59.69 80.01 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 59.69 80.01 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "e047fc0d-a23a-4f57-96c5-b37ebedcb1d6")
+		)
+		(pin "2"
+			(uuid "2dbc9dfe-d1b3-42ff-9d6f-0568dc9695d1")
+		)
+		(instances
+			(project "single_pin_nets"
+				(path "/8f963024-f701-4c8a-84ca-3e41a181c121"
+					(reference "R4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 59.69 119.38 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "1ccd1c16-7bcb-4e18-9ba2-9e047584b115")
+		(property "Reference" "R7"
+			(at 59.69 117.348 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 59.69 119.38 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 59.69 119.38 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 59.69 119.38 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 59.69 119.38 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "0c6990ef-22e5-4c3c-b941-99eb20d91959")
+		)
+		(pin "1"
+			(uuid "3c4b13cb-568f-47c2-bbfd-f1c91d412c61")
+		)
+		(instances
+			(project "single_pin_nets"
+				(path "/8f963024-f701-4c8a-84ca-3e41a181c121"
+					(reference "R7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 59.69 160.02 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "46650cfd-f90d-499e-b243-2c7c62d792d9")
+		(property "Reference" "R9"
+			(at 59.69 157.988 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 59.69 160.02 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 59.69 160.02 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 59.69 160.02 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 59.69 160.02 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "e1cc9877-d5af-47b0-b8ad-a705092ceef8")
+		)
+		(pin "2"
+			(uuid "10b2ae38-3fc6-49d5-82a8-98ad3712db05")
+		)
+		(instances
+			(project "single_pin_nets"
+				(path "/8f963024-f701-4c8a-84ca-3e41a181c121"
+					(reference "R9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 59.69 100.33 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "4b275ea7-5e71-46f6-92b9-bc8a5c1ee883")
+		(property "Reference" "R6"
+			(at 59.69 98.298 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 59.69 100.33 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 59.69 100.33 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 59.69 100.33 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 59.69 100.33 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "40cc77b7-4ed2-4806-9b9f-5fd9fe92d872")
+		)
+		(pin "1"
+			(uuid "ddc74e31-e133-43b2-831f-d9fb2a3a04dc")
+		)
+		(instances
+			(project "single_pin_nets"
+				(path "/8f963024-f701-4c8a-84ca-3e41a181c121"
+					(reference "R6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 76.2 119.38 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "4d9d0229-af12-4e22-91cc-7c4c64276d50")
+		(property "Reference" "#FLG01"
+			(at 76.2 117.475 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "PWR_FLAG"
+			(at 76.2 115.57 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 76.2 119.38 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 76.2 119.38 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 76.2 119.38 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "ec70682f-045f-41e6-a20a-ebb2c1cbf880")
+		)
+		(instances
+			(project "single_pin_nets"
+				(path "/8f963024-f701-4c8a-84ca-3e41a181c121"
+					(reference "#FLG01")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 59.69 39.37 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "8100b782-a05d-4127-9f53-90da29b603f5")
+		(property "Reference" "R1"
+			(at 59.69 37.338 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 59.69 39.37 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 59.69 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 59.69 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 59.69 39.37 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "61542421-93a3-4677-8f14-de056c78809f")
+		)
+		(pin "2"
+			(uuid "8060acb6-4e7f-424e-99d8-f470da5d666b")
+		)
+		(instances
+			(project "single_pin_nets"
+				(path "/8f963024-f701-4c8a-84ca-3e41a181c121"
+					(reference "R1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 110.49 39.37 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "86915005-3190-44c3-99c7-6214d88e879e")
+		(property "Reference" "R2"
+			(at 110.49 37.338 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 110.49 39.37 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 110.49 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 110.49 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 110.49 39.37 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "e52c38ef-d5de-4ca2-b27d-5d090a24c9f9")
+		)
+		(pin "1"
+			(uuid "d0293b4a-be04-4696-a048-b07e9c7fd184")
+		)
+		(instances
+			(project "single_pin_nets"
+				(path "/8f963024-f701-4c8a-84ca-3e41a181c121"
+					(reference "R2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:VCC")
+		(at 73.66 100.33 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "99e18175-eb5d-4904-bd92-73a59d0c494c")
+		(property "Reference" "#PWR001"
+			(at 73.66 104.14 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "VCC"
+			(at 73.66 96.774 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 73.66 100.33 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 73.66 100.33 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 100.33 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "6abb53ba-2f08-4f2f-a4cf-f792dfc45070")
+		)
+		(instances
+			(project "single_pin_nets"
+				(path "/8f963024-f701-4c8a-84ca-3e41a181c121"
+					(reference "#PWR001")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 110.49 80.01 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "9cd751a5-551d-4e4f-b0d0-f1149213b808")
+		(property "Reference" "R5"
+			(at 110.49 77.978 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 110.49 80.01 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 110.49 80.01 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 110.49 80.01 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 110.49 80.01 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "4b7240d2-cabb-4326-a8a5-fb29fcf96394")
+		)
+		(pin "2"
+			(uuid "c6ed674a-121a-4737-9aeb-2e92fcca128c")
+		)
+		(instances
+			(project "single_pin_nets"
+				(path "/8f963024-f701-4c8a-84ca-3e41a181c121"
+					(reference "R5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 59.69 139.7 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "a578f650-8359-4d1c-9da1-66d394eab901")
+		(property "Reference" "R8"
+			(at 59.69 137.668 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 59.69 139.7 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 59.69 139.7 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 59.69 139.7 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 59.69 139.7 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "a85dd717-bd71-4e83-be9f-d86d0d4d94e2")
+		)
+		(pin "2"
+			(uuid "c1fb2160-9433-4cb5-a717-f7d714c0f889")
+		)
+		(instances
+			(project "single_pin_nets"
+				(path "/8f963024-f701-4c8a-84ca-3e41a181c121"
+					(reference "R8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 50.8 167.64 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "d6100939-dee2-4924-b9eb-80523f363191")
+		(property "Reference" "#PWR002"
+			(at 50.8 173.99 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 50.8 171.45 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 50.8 167.64 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 50.8 167.64 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 50.8 167.64 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "a6569d27-45e2-4cc2-937c-efaaf6229a28")
+		)
+		(instances
+			(project "single_pin_nets"
+				(path "/8f963024-f701-4c8a-84ca-3e41a181c121"
+					(reference "#PWR002")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 59.69 59.69 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "e9b8c41c-e7bd-405d-9c99-392751a4b054")
+		(property "Reference" "R3"
+			(at 59.69 57.658 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 59.69 59.69 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 59.69 59.69 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 59.69 59.69 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 59.69 59.69 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "7a3c1d5d-5d7c-4e10-b084-7346087ac4ba")
+		)
+		(pin "2"
+			(uuid "58fe2845-9e5c-4773-a586-77e508f58783")
+		)
+		(instances
+			(project "single_pin_nets"
+				(path "/8f963024-f701-4c8a-84ca-3e41a181c121"
+					(reference "R3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(sheet
+		(at 149.86 129.54)
+		(size 76.2 50.8)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(stroke
+			(width 0.1524)
+			(type solid)
+		)
+		(fill
+			(color 0 0 0 0)
+		)
+		(uuid "f7757b17-8bab-483c-b920-389a4c502640")
+		(property "Sheetname" "Child"
+			(at 149.86 128.905 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "single_pin_nets_child.kicad_sch"
+			(at 149.86 180.975 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "SHEET_NET" input
+			(at 149.86 132.08 180)
+			(uuid "d45fe90c-b739-4237-8f86-877f35fffd5f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(instances
+			(project "single_pin_nets"
+				(path "/8f963024-f701-4c8a-84ca-3e41a181c121"
+					(page "2")
+				)
+			)
+		)
+	)
+)

--- a/crates/konnect-core/tests/fixtures/single_pin_nets_child.kicad_sch
+++ b/crates/konnect-core/tests/fixtures/single_pin_nets_child.kicad_sch
@@ -1,0 +1,659 @@
+(kicad_sch
+	(version 20260306)
+	(generator "eeschema")
+	(generator_version "10.0")
+	(uuid "e1253673-85ae-4c03-a31b-1875f3acaa82")
+	(paper "A4")
+	(lib_symbols
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:GND"
+			(power global)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "GND"
+				(at 0 -3.81 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "GND_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GND_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(no_connect
+		(at 114.3 59.69)
+		(uuid "b937ee4b-8c7a-40a1-a50d-6ff402c1a80b")
+	)
+	(wire
+		(pts
+			(xy 63.5 59.69) (xy 106.68 59.69)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0089c5c7-6ebe-492a-937c-b2dcb034da5f")
+	)
+	(wire
+		(pts
+			(xy 55.88 59.69) (xy 50.8 59.69)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "66296c1e-84be-4c0d-9853-ecd32319dadf")
+	)
+	(wire
+		(pts
+			(xy 50.8 39.37) (xy 50.8 59.69)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7e6d3657-544d-4359-8c5a-4e9f3737b572")
+	)
+	(wire
+		(pts
+			(xy 50.8 59.69) (xy 50.8 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7e995411-4390-4d4c-88b0-8a7c9c820f18")
+	)
+	(wire
+		(pts
+			(xy 55.88 39.37) (xy 50.8 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "857b1315-f0dd-4697-866a-1c3f432a8668")
+	)
+	(wire
+		(pts
+			(xy 63.5 39.37) (xy 76.2 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ba799366-8657-49f6-a8b5-32ef98e118e8")
+	)
+	(label "CHILD_LOCAL"
+		(at 85.09 59.69 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "81427a13-8c2e-4fc2-9eb9-db88c28cbbb1")
+	)
+	(hierarchical_label "SHEET_NET"
+		(shape input)
+		(at 76.2 39.37 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "27f62676-1284-4dbb-a2f6-b74c4a504c15")
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 110.49 59.69 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "6396f539-6950-4670-b494-88393a56a421")
+		(property "Reference" "R12"
+			(at 110.49 57.658 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1k"
+			(at 110.49 59.69 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 110.49 59.69 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 110.49 59.69 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 110.49 59.69 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "51c08ae4-8549-480c-aab4-247bbffe58bd")
+		)
+		(pin "2"
+			(uuid "47c08e0b-a31d-4705-90ba-ab29910916b3")
+		)
+		(instances
+			(project ""
+				(path "/e1253673-85ae-4c03-a31b-1875f3acaa82"
+					(reference "R12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 50.8 67.31 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "ab28bafd-42b6-4fd6-aa8b-ae7c54443abc")
+		(property "Reference" "#PWR001"
+			(at 50.8 73.66 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 50.8 71.12 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 50.8 67.31 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 50.8 67.31 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 50.8 67.31 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "bf22cc5e-dbbb-4dd6-beed-2393148d41fc")
+		)
+		(instances
+			(project ""
+				(path "/e1253673-85ae-4c03-a31b-1875f3acaa82"
+					(reference "#PWR001")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 59.69 39.37 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "ba4399fc-4690-4d00-9802-d92f320b3d65")
+		(property "Reference" "R10"
+			(at 59.69 37.338 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1k"
+			(at 59.69 39.37 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 59.69 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 59.69 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 59.69 39.37 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "1cb224bf-b994-4a6d-afd7-3227e16b71cf")
+		)
+		(pin "1"
+			(uuid "b548c956-7413-4589-8de5-aba96d3729c7")
+		)
+		(instances
+			(project ""
+				(path "/e1253673-85ae-4c03-a31b-1875f3acaa82"
+					(reference "R10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 59.69 59.69 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "c42dd9ad-f8ef-4af8-9594-e75839f84553")
+		(property "Reference" "R11"
+			(at 59.69 57.658 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1k"
+			(at 59.69 59.69 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 59.69 59.69 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 59.69 59.69 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 59.69 59.69 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "3f1a1660-cfa5-47d8-bcc2-5ad1d25e8544")
+		)
+		(pin "2"
+			(uuid "34463c5d-a6aa-43b4-8aa9-820284932052")
+		)
+		(instances
+			(project ""
+				(path "/e1253673-85ae-4c03-a31b-1875f3acaa82"
+					(reference "R11")
+					(unit 1)
+				)
+			)
+		)
+	)
+)

--- a/docs/API_MIGRATIONS.md
+++ b/docs/API_MIGRATIONS.md
@@ -3,6 +3,44 @@
 Konnect's tool schemas are public API. This file records intentional argument
 removals and the supported replacement workflow.
 
+## Unreleased: `find_single_pin_nets` counts pins, not labels (minor release)
+
+`find_single_pin_nets` counted label instances per net name, so an ordinary net
+— one label on a wire reaching two or more pins — was reported, and a genuine
+single-pin net disappeared as soon as it carried a second label. Membership now
+comes from the shared net graph: a net is reported when it reaches **at most one
+pin**, zero included, since a label whose net reaches nothing is the orphan label
+and the deleted-component stub the tool is sent looking for. Hierarchical sheet
+pins count as pins; a power symbol's own pin does not, or the rail reaching
+exactly one component pin would be hidden.
+
+Every existing field remains with its existing meaning: `single_pin_net_count`,
+and per net `net`, `x`, `y`, and `type`. `type` is still the kind of the *first*
+label found, so a consumer matching on it is unaffected.
+
+Results add five fields:
+
+- `pin_count` — pins the net reaches, `0` or `1` for a reported net.
+- `label_count` — label instances naming it, the value the old membership rule
+  used. A net with no label at all is a different smell, so the count is kept.
+- `pins` — the reached pin, as a one-or-zero-element array of the same
+  `component_pin` / `sheet_pin` objects the other connectivity tools return.
+- `label_types` — every distinct label kind naming the net, sorted. Local labels
+  are extracted first, so a net carrying both a local and a global label reports
+  `type: "NetLabel"` and says nothing about the global one; this field does.
+- `cross_sheet_unverified` — true when any label naming the net can carry it off
+  this sheet (global, hierarchical, or a power symbol). The answer is per sheet,
+  and a flagged net is a lead rather than a finding. Such nets are still
+  reported: a rail reaching one pin on this sheet is worth showing.
+
+**`single_pin_net_count` changes meaning**: it now counts nets reaching at most
+one actual pin, not nets named by exactly one label instance. A consumer reading
+it as a defect count gets a smaller, truer number and needs no migration; one
+that had learned to ignore this tool's noise can stop. No consumer can keep the
+old set, since it was wrong in both directions.
+
+No tool, argument, or existing response field was renamed or removed.
+
 ## Unreleased: guarded PCB file fallback reports its observed reason
 
 Hybrid PCB mutation tools may use their existing direct-file fallback when

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -160,7 +160,7 @@ Seven tools, grouped into *discovery/routing*, *observability*, and *runtime dia
 | `trace_from_point` | Trace connectivity from any (X,Y) point — returns what is at that point and the net it belongs to. |
 | `find_orphan_items` | Find dangling wire ends, floating labels, and unconnected pin endpoints. Pins, sheet pins, junctions, and no-connect flags all count as connections. |
 | `find_shorted_nets` | Detect accidentally merged nets — pairs of distinct net names sharing a wire path. |
-| `find_single_pin_nets` | Find nets with only one label/connection — often indicates a missing counterpart. |
+| `find_single_pin_nets` | Find nets that reach at most one pin — often a missing counterpart, an orphan label, or a stub left by a deleted component. Component pins and hierarchical sheet pins count; a power symbol's own pin names the rail rather than consuming it and does not. Reports the pin and label counts, and every label kind that named the net. Read per sheet: a net a global, hierarchical or power label can carry off this one is flagged cross_sheet_unverified. |
 | `get_connected_items` | Get all wires, labels, and components connected to a given component by tracing each of its pins. |
 | `check_schematic_overlaps` | Find collisions using transformed symbol drawings and pins (excluding free text), with a reported origin fallback when geometry is unavailable. |
 


### PR DESCRIPTION
`find_single_pin_nets` counted *label instances* per net name and reported every net
carrying exactly one. Pins, wires and junctions were never consulted, so a net drawn the
ordinary way — one label on a wire that reaches two or more pins — came back as a
single-pin net. Redrawing a real board's schematic through the tools, all 11 nets it
reported were false positives: `VBUS` (five pins), `ACT`, `ACT_A`, `CC1`, `CC2`,
`PWR_LED_A`, and the five `*_INT` nets between U1 and its series resistors.

It missed the case it exists for just as readily — a net that really does reach one pin
is invisible as soon as it carries a second label.

Closes #430, which captures the semantics and the acceptance checklist. #249 was the
same pin blindness one tool over (`find_orphan_items`) and closed without reaching this
one.

### The count comes from the shared net graph

Connection points are grouped by their union-find root — the `ConnectivityIndex` and
`net_graph_for` machinery #323 gave the other connectivity tools — and a net is reported
when it reaches at most one. Each entry carries `pin_count`, `label_count` and the
`pins` that were counted, so the label count is still there to read and is no longer the
answer.

Two labels of one name on wire segments that never touch are still one net to KiCad, so
their roots pool before the count is taken. `SPLIT` in the fixture is the case that makes
pooling load-bearing: a pin under each of two disconnected roots, which KiCad resolves to
one 2-pin net and this tool must therefore not report.

### Two connection points are treated unalike

- **A hierarchical sheet pin counts.** A net leaving the sheet through one reaches
  whatever is on the other side; not counting it would report every such net, which is
  the same false-positive shape being fixed here.
- **A power symbol's own pin does not.** It names the rail rather than consuming it, and
  counting it would hide the rail that reaches exactly one component pin — the defect
  worth reporting. The rule is `is_power_symbol_reference`, KiCad's `#` prefix, now with
  one home for a heuristic `design_review` carried inline too. Deliberately *not*
  `LabelKind::PowerSymbol`: that is derived from the `(power)` marker plus a `power_in`
  pin, so `PWR_FLAG`'s `power_out` pin passes it — `#FLG…` is what actually excludes it.

So `find_orphan_items` and this tool disagree about a power symbol's pin on purpose — an
unwired `#PWR01` is an orphan there and not a consumer here. The handler doc says so,
since the whole point of `sch_connectivity` is that these tools cannot drift silently.

### Zero counts as well as one

A label whose net reaches nothing is the orphan label and the deleted-component stub the
review skill sends this tool looking for, and the label count did report both.
`find_orphan_items` names the dangling wire end but never the net, so reporting only `1`
would have quietly retired a documented behaviour. `pin_count` carries the real number.

### Shared rather than local

The label-to-root walk is now `sch_connectivity::label_roots`. `find_shorted_nets` reads
that same relation from the other end — root-first, since more than one name on a root
is a short — and the two drifting apart is exactly what that module exists to prevent.

The report is also sorted by net name. It came out of a `HashMap` in whatever order it
held them, so two runs of one binary over one sheet could disagree.

### Cross-sheet scope is stated, not inferred

The answer is per sheet, so a net named by a global or hierarchical label may well
continue on another one. `type` alone cannot say so: local labels are extracted first, so
a net carrying a global label too reports `NetLabel` and hides the one fact a caller
needs. Two additive fields carry the evidence instead:

- **`label_types`** — every distinct kind that named the net, sorted. `MIXED` reports
  `["GlobalLabel", "NetLabel"]` where `type` alone says `NetLabel`.
- **`cross_sheet_unverified`** — true when any label naming the net can carry it off this
  sheet. Power symbols included, since KiCad makes a global label out of one: `VCC` is
  flagged even though the project-wide netlist happens to agree it reaches one pin,
  because a single sheet cannot know that.

A flagged net is still reported — a rail reaching one pin here is worth showing — but the
flag marks it a lead rather than a finding. Ranking a `NetLabel` net above a hierarchical
one is the follow-up.

### Response compatibility

Every existing field keeps its name and meaning: `single_pin_net_count`, and per net
`net`, `x`, `y`, and `type`. The additive fields are `pin_count`, `label_count`, `pins`,
`label_types`, and `cross_sheet_unverified`.

The one real change is which nets appear, because that was the defect: membership went
from "exactly one label instance names it" to "the net reaches at most one pin", and
`single_pin_net_count` counts the latter. A consumer reading it as a defect count gets a
smaller, truer number and needs no migration; one that had learned to ignore this tool's
noise can stop. No consumer can keep the old set, since it was wrong in both directions.
No tool, argument, or existing field was renamed or removed.

Recorded in `docs/API_MIGRATIONS.md` and at the handler.

### Fixtures

A KiCad 10.0.5 parent/child pair, built through Konnect against the stock `Device:R` and
`power:` libraries, then parsed and force-resaved by eeschema — the same recipe, and the
same reason, as `structural_scans_kicad10`:

```
kicad-cli sch upgrade --force single_pin_nets.kicad_sch
kicad-cli sch upgrade --force single_pin_nets_child.kicad_sch
```

What is committed is that Eeschema serialization: `(generator "eeschema")`,
`(version 20260306)`, KiCad's own library records and field positions. Provenance and the
whole case table are in `single_pin_nets.README.md`.

**Every expected pin count is KiCad's, not this crate's** — taken from the netlist
exporter, which is also the oracle the tests assert against:

| Net | KiCad resolves | Shape |
|---|---|---|
| `/TWO_PIN` | 2 — R1.2, R2.1 | the false positive |
| `/LONE` | 1 — R3.2 | two labels, two disconnected roots, one pin |
| `/SPLIT` | 2 — R4.2, R5.1 | the same shape with a pin on each root |
| `VCC` | 1 — R6.2 | `#PWR001` is not a pin |
| `/FLAGGED` | 1 — R7.2 | `#FLG01` is not a pin either |
| `/SHEET_NET` | 2 — R8.2, R10.2 | across the sheet boundary |
| `MIXED` | 1 — R9.2 | local *and* global label on one net |
| `GND` | 9 | the rail that is not a defect |
| `/Child/CHILD_LOCAL` | 2 | a local net the child answers in full |
| `STUB` | absent | reaches no pin, so there is no net to export |

`kicad-cli sch erc` independently agrees: `isolated_pin_label` on both `LONE` labels and
both `MIXED` labels, `label_dangling` on `STUB`, and no violation for `SPLIT`, `TWO_PIN`,
`SHEET_NET` or `GND`.

The dispatch boilerplate in this file is down one copy: `power_symbol_net_tests`' helper
is hoisted to a module both test modules use.

### Negative controls

Six guards neutralized one at a time against the 15 `single_pin_net_tests`, on this exact
head:

| Neutralized | Tests failing |
|---|---|
| count label instances again | 8 |
| power-symbol / `#FLG` exclusion | 4 |
| only the lowest root counts | 2 |
| cross-sheet flag always false | 3 |
| sheet pins do not count | 2 |
| `label_types` keeps only the first kind | 1 |

Restored tree: 15/15 pass.

### Validation

Run on this exact head, Fedora 44, rustc/cargo 1.96.0 (the pinned toolchain), KiCad
10.0.5:

| Command | Result |
|---|---|
| `cargo test --workspace --locked --lib --tests` | 1687 passed, 0 failed, 24 ignored |
| `cargo test --workspace --locked --doc` | 8 passed, 0 failed, 2 ignored |
| `cargo clippy --workspace --locked -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |
| `cd crates/schematic-viewer && cargo test` | 20 passed, 0 failed |
| `kicad-cli sch export netlist --format kicadsexpr` on the fixture | table above |
| `kicad-cli sch erc --format json --severity-all` on the fixture | as described above |

**Not run:** the 24 `#[ignore]`d tests, which need a live KiCad IPC session,
Freerouting, or a discovered `kicad-cli` — none exercise `find_single_pin_nets`. The
`e2e-kicad` workflow is weekly/dispatch and not a per-PR gate.

### Risk and rollback

Read-only: `find_single_pin_nets` opens a `.kicad_sch`, parses it, and returns JSON. No
write path, no IPC, no `.kicad_sch` is modified, so a wrong answer cannot corrupt a
project. The blast radius is one tool's report and the `design_review` audit that reads
it — `is_power_symbol_reference` replaces an inline `#` check there with the identical
rule.

Rollback is `git revert` of the single commit. It restores the previous membership rule
and drops the five additive fields; nothing persisted needs undoing, and no caller state
migrates in either direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
