### PR TITLE
fix(pcb): tell a KiCad without this board open apart from a refusal

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -262,6 +262,7 @@ Tool-call failures are typed via the `ToolErrorKind` enum in `crates/konnect-cor
 | `conflict` | The file changed, a write would replace existing paths, or schematic project ownership cannot be proven uniquely — carries the affected paths; ownership conflicts include the schematic directory and all candidate roots |
 | `ambiguous_target` | More than one observed UUID, reference/unit, field, or instance identity matches the requested target, or component instance records conflict across projects, units, or hierarchy paths — carries `target` and the stable `candidates`; the caller must choose rather than retrying blindly |
 | `stale_target` | Saved symbol instance metadata disagrees with the proven hierarchy, or component readback lacks the expected document, UUID/reference, unit, library, hierarchy, position, rotation, or property value — carries `target` and `reason`; preflight refuses before writing, while a readback failure may follow a committed write |
+| `ambiguous_open_board` | KiCad answered, and its open-document list could not be read as a complete set of comparable board identities — carries `path`; neither the live nor the file path may run |
 | `handler_error` | Catch-all for unmigrated `anyhow::Error` returns |
 
 ### Producing structured errors in a handler

--- a/crates/konnect-core/src/mcp/error.rs
+++ b/crates/konnect-core/src/mcp/error.rs
@@ -64,6 +64,10 @@ pub enum ToolErrorKind {
     /// A board was live earlier in this server process, but IPC is now gone;
     /// its saved file may be stale relative to lost editor state.
     UnsafeFileFallback { path: String },
+    /// KiCad answered, and its open-document list could not be read as a
+    /// complete set of comparable board identities — so whether it holds this
+    /// board is unknown, and neither a live edit nor a file edit is safe.
+    AmbiguousOpenBoard { path: String },
     /// Catch-all for handler `anyhow::Error` that hasn't been migrated yet.
     /// Eventually each variant above subsumes a subset of these.
     HandlerError { reason: String },
@@ -83,6 +87,7 @@ impl ToolErrorKind {
             Self::AmbiguousTarget { .. } => "ambiguous_target",
             Self::StaleTarget { .. } => "stale_target",
             Self::UnsafeFileFallback { .. } => "unsafe_file_fallback",
+            Self::AmbiguousOpenBoard { .. } => "ambiguous_open_board",
             Self::HandlerError { .. } => "handler_error",
         }
     }
@@ -215,6 +220,7 @@ mod tests {
                 reason: "r".into(),
             },
             ToolErrorKind::UnsafeFileFallback { path: "p".into() },
+            ToolErrorKind::AmbiguousOpenBoard { path: "p".into() },
             ToolErrorKind::HandlerError { reason: "r".into() },
         ];
         for kind in kinds {

--- a/crates/konnect-core/src/tools/pcb_board.rs
+++ b/crates/konnect-core/src/tools/pcb_board.rs
@@ -188,12 +188,34 @@ pub(crate) enum BoardWrite<T = ()> {
     /// IPC call returned, for tools that echo it back — the placed footprint,
     /// for instance.
     Ipc(T),
-    /// No live KiCad on this transport and this board was not observed live
+    /// No live KiCad is holding this board and it was not observed live
     /// during the current server session; proceed with the S-expression path.
-    File,
+    /// Carries *why*, because the caller's user has a different next move for
+    /// each — start KiCad, or open this board in the one already running.
+    File(NoLiveBoard),
     /// KiCAD answered and refused. The caller must return this result and must
     /// NOT touch the file.
     Refused(CallToolResult),
+}
+
+/// Why no live KiCad took the write, for the callers that say so.
+#[derive(Debug)]
+pub(crate) enum NoLiveBoard {
+    /// The request never reached KiCad.
+    Unreachable,
+    /// KiCad answered and holds another project, or none. Carries that
+    /// answer, which names the boards it does hold.
+    NotOpen(String),
+}
+
+impl NoLiveBoard {
+    /// The premise sentence an IPC-only tool leads its refusal with.
+    pub(crate) fn premise(&self) -> String {
+        match self {
+            Self::Unreachable => "KiCad IPC is unreachable.".to_string(),
+            Self::NotOpen(answer) => format!("KiCad is reachable but {answer}."),
+        }
+    }
 }
 
 /// Run `f` over IPC against the board named by `board_path`, deciding what the
@@ -210,6 +232,9 @@ pub(crate) enum BoardWrite<T = ()> {
 ///   classification, never a text match. A KiCad that answers — even with an
 ///   error — fails closed. An unreachable transport permits the file path only
 ///   when this server has never observed the requested board live.
+/// * A reachable KiCAD that does not hold this board is a third answer, not a
+///   refusal: it has no unsaved state for a board it never opened, so the file
+///   is authoritative and the edit proceeds there.
 pub(crate) async fn attempt_ipc_write<T, F>(
     ctx: &ToolContext,
     board_path: &std::path::Path,
@@ -229,26 +254,65 @@ where
                  board open, so editing the file directly could be silently overwritten."
             ))))
         }
+        // KiCad answered, and the answer did not say. Not a refusal — it
+        // declined nothing — and emphatically not "not open": the file path
+        // is unlocked by *proving* the board closed, and this is the case
+        // where that proof does not exist.
+        Err(konnect_ipc::IpcFailure::Ambiguous(message)) => {
+            Ok(BoardWrite::Refused(CallToolResult::error_kind(
+                ToolErrorKind::AmbiguousOpenBoard {
+                    path: board_path.display().to_string(),
+                },
+                format!(
+                    "Konnect could not confirm whether KiCAD has this board open, so it did not \
+                     apply the {what}: {message}. The board file was not modified. Close the \
+                     documents KiCAD cannot identify, or open this board in KiCAD and retry."
+                ),
+            )))
+        }
+        // KiCad up on another project, or freshly launched with nothing open.
+        // Gated on the same observation as `Unreachable`: KiCad no longer
+        // holding a board this session already saw it hold is the #240
+        // hazard — a crash-and-restart, or a close mid-operation — and a
+        // reachable transport says nothing about the work that board carried.
+        Err(konnect_ipc::IpcFailure::BoardNotOpen(answer)) => {
+            if ctx.board_session.was_observed_live(board_path) {
+                Ok(BoardWrite::Refused(unsafe_file_fallback(
+                    board_path,
+                    "Konnect previously reached KiCad with this board open, and KiCad no longer \
+                     has it open.",
+                )))
+            } else {
+                Ok(BoardWrite::File(NoLiveBoard::NotOpen(answer)))
+            }
+        }
         Err(konnect_ipc::IpcFailure::Unreachable(_)) => {
             if ctx.board_session.was_observed_live(board_path) {
-                Ok(BoardWrite::Refused(unsafe_file_fallback(board_path)))
+                Ok(BoardWrite::Refused(unsafe_file_fallback(
+                    board_path,
+                    "Konnect previously reached KiCad with this board open, but IPC is now \
+                     unreachable.",
+                )))
             } else {
-                Ok(BoardWrite::File)
+                Ok(BoardWrite::File(NoLiveBoard::Unreachable))
             }
         }
     }
 }
 
-fn unsafe_file_fallback(board_path: &std::path::Path) -> CallToolResult {
+/// The refusal both gates share: `situation` names what changed since this
+/// server saw KiCad holding the board, and the rest is the same advice.
+fn unsafe_file_fallback(board_path: &std::path::Path, situation: &str) -> CallToolResult {
     CallToolResult::error_kind(
         ToolErrorKind::UnsafeFileFallback {
             path: board_path.display().to_string(),
         },
-        "Konnect previously reached KiCad with this board open, but IPC is now unreachable. \
-         The saved board file may be older than unsaved editor state, so Konnect did not \
-         modify it. Reopen or recover the board in KiCad, reconcile it, and save the \
-         authoritative state. If KiCad was deliberately closed cleanly, restart Konnect \
-         only after confirming that the saved file is authoritative.",
+        format!(
+            "{situation} The saved board file may be older than unsaved editor state, so \
+             Konnect did not modify it. Reopen or recover the board in KiCad, reconcile it, \
+             and save the authoritative state. If KiCad was deliberately closed cleanly, \
+             restart Konnect only after confirming that the saved file is authoritative."
+        ),
     )
 }
 
@@ -272,10 +336,37 @@ pub(crate) async fn refuse_if_board_open_in_kicad(
              there) and retry — this tool has no IPC path for a live board yet."
         )))),
         Err(konnect_ipc::IpcFailure::Rejected(_)) => Ok(None),
-        Err(konnect_ipc::IpcFailure::Unreachable(_)) => Ok(ctx
-            .board_session
-            .was_observed_live(board_path)
-            .then(|| unsafe_file_fallback(board_path))),
+        // Unlike `Rejected` — where KiCad answered about *this* board and said
+        // no, leaving the file demonstrably free — an unreadable open-document
+        // list says nothing about this board. Refuse rather than write.
+        Err(konnect_ipc::IpcFailure::Ambiguous(message)) => Ok(Some(CallToolResult::error_kind(
+            ToolErrorKind::AmbiguousOpenBoard {
+                path: board_path.display().to_string(),
+            },
+            format!(
+                "Konnect could not confirm whether KiCAD has this board open, so it did not \
+                     write the {what} to the file: {message}. Close the documents KiCAD cannot \
+                     identify, or make the edit in KiCAD."
+            ),
+        ))),
+        Err(konnect_ipc::IpcFailure::BoardNotOpen(_)) => {
+            Ok(ctx.board_session.was_observed_live(board_path).then(|| {
+                unsafe_file_fallback(
+                    board_path,
+                    "Konnect previously reached KiCad with this board open, and KiCad no longer \
+                     has it open.",
+                )
+            }))
+        }
+        Err(konnect_ipc::IpcFailure::Unreachable(_)) => {
+            Ok(ctx.board_session.was_observed_live(board_path).then(|| {
+                unsafe_file_fallback(
+                    board_path,
+                    "Konnect previously reached KiCad with this board open, but IPC is now \
+                     unreachable.",
+                )
+            }))
+        }
     }
 }
 
@@ -290,10 +381,11 @@ pub(crate) const DEFAULT_ZONE_MIN_WIDTH_MM: f64 = 0.2;
 /// What the caller gets back when no live KiCAD could be reached and the zone
 /// went into the file instead.
 pub(crate) const FILE_FALLBACK_WARNING: &str =
-    "KiCad IPC was unreachable and this board has not been observed live during the current \
-     Konnect server session, so Konnect edited the saved board file directly. If KiCad \
-     crashed or was force-quit before this server started, reconcile any unsaved work \
-     before relying on this change.";
+    "No live KiCad is holding this board — the IPC transport was unreachable, or KiCad has \
+     this board closed — and it has not been observed live during the current Konnect \
+     server session, so Konnect edited the saved board file directly. If KiCad crashed or \
+     was force-quit before this server started, reconcile any unsaved work before relying \
+     on this change. Reload the file in KiCad before editing it there.";
 
 /// The `pad_connection` argument in both the representations it needs: the IPC
 /// enum and the token KiCad's `(connect_pads …)` takes.
@@ -1067,7 +1159,7 @@ async fn handle_set_board_size(
             return Ok(outline_not_replaceable(&kinds))
         }
         BoardWrite::Refused(err) => return Ok(err),
-        BoardWrite::File => {}
+        BoardWrite::File(_) => {}
     }
 
     let content = std::fs::read_to_string(&board_path)?;
@@ -1567,7 +1659,7 @@ async fn handle_add_board_outline(
             })))
         }
         BoardWrite::Refused(err) => return Ok(err),
-        BoardWrite::File => {}
+        BoardWrite::File(_) => {}
     }
 
     let outline = format_outline(&primitives, "Edge.Cuts", w);
@@ -1698,7 +1790,7 @@ async fn handle_delete_graphics(
             "ipc",
         ),
         BoardWrite::Refused(result) => return Ok(result),
-        BoardWrite::File => {
+        BoardWrite::File(_) => {
             let content = std::fs::read_to_string(&board_path)?;
             let matched: Vec<FileGraphic> = read_file_graphics(&content)
                 .into_iter()
@@ -1786,7 +1878,7 @@ async fn handle_add_mounting_hole(
             "source": "ipc"
         }))),
         BoardWrite::Refused(err) => Ok(err),
-        BoardWrite::File => {
+        BoardWrite::File(_) => {
             // No live KiCad now, and this board was not observed live during
             // the current server session: use the guarded file path.
             let fp_sexp = format_npth_footprint(x, y, drill_d, &reference);
@@ -1842,7 +1934,7 @@ async fn handle_add_board_text(
             })))
         }
         BoardWrite::Refused(err) => return Ok(err),
-        BoardWrite::File => {}
+        BoardWrite::File(_) => {}
     }
 
     let gr_text = format_gr_text(&text, x, y, rotation, &layer, size);
@@ -1945,7 +2037,7 @@ pub(crate) async fn add_zone_impl(
             };
             return Ok(CallToolResult::json(&body));
         }
-        BoardWrite::File => {}
+        BoardWrite::File(_) => {}
     }
 
     let content = std::fs::read_to_string(&board_path)?;
@@ -2186,6 +2278,45 @@ pub(crate) mod board_mock {
         board: &std::path::Path,
         respond: impl Fn(&prost_types::Any) -> Option<prost_types::Any> + Send + 'static,
     ) -> String {
+        spawn_kicad_holding_boards(&[board], respond)
+    }
+
+    /// As [`spawn_kicad_holding_board`], for the two answers that are not
+    /// "the board you asked about": some other project, and nothing at all.
+    pub fn spawn_kicad_holding_boards(
+        boards: &[&std::path::Path],
+        respond: impl Fn(&prost_types::Any) -> Option<prost_types::Any> + Send + 'static,
+    ) -> String {
+        spawn_kicad_reporting_documents(
+            boards
+                .iter()
+                .map(|board| board_document(&board.to_string_lossy()))
+                .collect(),
+            respond,
+        )
+    }
+
+    /// One open PCB document in the form KiCad sends: a `board_filename` and,
+    /// when the name is relative, the project directory that places it.
+    pub fn board_document(filename: &str) -> kiapi::common::types::DocumentSpecifier {
+        kiapi::common::types::DocumentSpecifier {
+            r#type: kiapi::common::types::DocumentType::DoctypePcb as i32,
+            project: None,
+            identifier: Some(
+                kiapi::common::types::document_specifier::Identifier::BoardFilename(
+                    filename.to_string(),
+                ),
+            ),
+        }
+    }
+
+    /// As [`spawn_kicad_holding_boards`], but the caller supplies the open
+    /// documents verbatim — including the shapes Konnect cannot place on
+    /// disk, which is the whole subject of the ambiguity gate.
+    pub fn spawn_kicad_reporting_documents(
+        documents: Vec<kiapi::common::types::DocumentSpecifier>,
+        respond: impl Fn(&prost_types::Any) -> Option<prost_types::Any> + Send + 'static,
+    ) -> String {
         use nng::options::Options;
 
         let port = {
@@ -2199,7 +2330,6 @@ pub(crate) mod board_mock {
             .unwrap();
         socket.listen(&url).expect("mock listen");
 
-        let board = board.to_string_lossy().to_string();
         std::thread::spawn(move || {
             while let Ok(message) = socket.recv() {
                 let request = kiapi::common::ApiRequest::decode(message.as_slice()).unwrap();
@@ -2207,15 +2337,7 @@ pub(crate) mod board_mock {
                 let body = if command.type_url.ends_with("GetOpenDocuments") {
                     Some(konnect_ipc::builders::pack_any(
                         &kiapi::common::commands::GetOpenDocumentsResponse {
-                            documents: vec![kiapi::common::types::DocumentSpecifier {
-                                r#type: kiapi::common::types::DocumentType::DoctypePcb as i32,
-                                project: None,
-                                identifier: Some(
-                                    kiapi::common::types::document_specifier::Identifier::BoardFilename(
-                                        board.clone(),
-                                    ),
-                                ),
-                            }],
+                            documents: documents.clone(),
                         },
                         "kiapi.common.commands.GetOpenDocumentsResponse",
                     ))
@@ -2239,6 +2361,257 @@ pub(crate) mod board_mock {
             }
         });
         url
+    }
+}
+
+/// The gate between "KiCad answered" and "the saved file is authoritative".
+///
+/// `BoardNotOpen` is what unlocks a direct file write, so it may only be
+/// reached from an open-document list that was read in full. Every shape that
+/// cannot be placed on disk — no identifier, an empty or bare filename, a
+/// duplicate — has to stop there instead, because a record Konnect skipped is
+/// not evidence that the board is closed (#426).
+#[cfg(test)]
+mod open_document_ambiguity_tests {
+    use super::board_mock::{board_document, ctx_talking_to, spawn_kicad_reporting_documents};
+    use super::*;
+    use konnect_ipc::gen::kiapi;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    fn kind_of(result: &CallToolResult) -> Option<String> {
+        crate::mcp::error::extract_error_kind(result)
+    }
+
+    /// A document KiCad reports that Konnect cannot place on disk: a bare
+    /// filename with no project directory. KiCad's own contract pairs a bare
+    /// `board_filename` with `ProjectSpecifier.path`; without one there is no
+    /// directory, and the record names no file.
+    fn unplaceable_document() -> kiapi::common::types::DocumentSpecifier {
+        board_document("mystery.kicad_pcb")
+    }
+
+    fn document_without_identifier() -> kiapi::common::types::DocumentSpecifier {
+        kiapi::common::types::DocumentSpecifier {
+            r#type: kiapi::common::types::DocumentType::DoctypePcb as i32,
+            project: None,
+            identifier: None,
+        }
+    }
+
+    /// Run a write against a KiCad reporting `documents`, and report both the
+    /// outcome and whether the write closure was ever entered.
+    async fn write_against(
+        board: &std::path::Path,
+        documents: Vec<kiapi::common::types::DocumentSpecifier>,
+    ) -> (BoardWrite<()>, bool) {
+        let ctx = ctx_talking_to(spawn_kicad_reporting_documents(documents, |_| None));
+        let entered = Arc::new(AtomicBool::new(false));
+        let flag = entered.clone();
+        let outcome = attempt_ipc_write(&ctx, board, "test write", move |_| {
+            flag.store(true, Ordering::SeqCst);
+            Ok(())
+        })
+        .await
+        .unwrap();
+        (outcome, entered.load(Ordering::SeqCst))
+    }
+
+    /// The defect: the unresolvable record was skipped, the requested board
+    /// was then "not open", and a file write proceeded on evidence nobody had
+    /// read.
+    #[tokio::test]
+    async fn an_unplaceable_open_document_refuses_and_leaves_the_file_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let before = std::fs::read(&board).unwrap();
+
+        let (outcome, entered) = write_against(&board, vec![unplaceable_document()]).await;
+
+        let BoardWrite::Refused(result) = outcome else {
+            panic!("an unidentifiable open document must not authorize a file write")
+        };
+        assert_eq!(kind_of(&result).as_deref(), Some("ambiguous_open_board"));
+        assert!(!entered, "the IPC write closure must not run");
+        assert_eq!(std::fs::read(&board).unwrap(), before, "board bytes");
+    }
+
+    #[tokio::test]
+    async fn a_document_with_no_identifier_refuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+
+        let (outcome, entered) = write_against(&board, vec![document_without_identifier()]).await;
+
+        let BoardWrite::Refused(result) = outcome else {
+            panic!("a document with no identifier must not authorize a file write")
+        };
+        assert_eq!(kind_of(&result).as_deref(), Some("ambiguous_open_board"));
+        assert!(!entered);
+    }
+
+    #[tokio::test]
+    async fn an_empty_board_filename_refuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+
+        let (outcome, _) = write_against(&board, vec![board_document("")]).await;
+
+        let BoardWrite::Refused(result) = outcome else {
+            panic!("an empty board filename must not authorize a file write")
+        };
+        assert_eq!(kind_of(&result).as_deref(), Some("ambiguous_open_board"));
+    }
+
+    /// One unreadable record poisons the verdict even beside a readable one.
+    /// "Board A is open" says nothing about board B, so a list containing a
+    /// record that might be B cannot prove B closed.
+    #[tokio::test]
+    async fn one_unplaceable_document_beside_a_readable_one_still_refuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let elsewhere = dir.path().join("other.kicad_pcb");
+
+        let (outcome, entered) = write_against(
+            &board,
+            vec![
+                board_document(&elsewhere.to_string_lossy()),
+                unplaceable_document(),
+            ],
+        )
+        .await;
+
+        assert!(matches!(outcome, BoardWrite::Refused(_)));
+        assert!(!entered);
+    }
+
+    /// KiCad opening one board twice is not a list Konnect models, so it is
+    /// not one absence can be read from either.
+    #[tokio::test]
+    async fn a_duplicated_open_document_refuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let elsewhere = dir.path().join("other.kicad_pcb");
+        let twice = board_document(&elsewhere.to_string_lossy());
+
+        let (outcome, entered) = write_against(&board, vec![twice.clone(), twice]).await;
+
+        let BoardWrite::Refused(result) = outcome else {
+            panic!("a duplicated open document must not authorize a file write")
+        };
+        assert_eq!(kind_of(&result).as_deref(), Some("ambiguous_open_board"));
+        assert!(!entered);
+    }
+
+    /// And the requested board itself reported twice: there is no single
+    /// document an edit would reach, so neither path may run.
+    #[tokio::test]
+    async fn the_requested_board_reported_twice_refuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let twice = board_document(&board.to_string_lossy());
+
+        let (outcome, entered) = write_against(&board, vec![twice.clone(), twice]).await;
+
+        let BoardWrite::Refused(result) = outcome else {
+            panic!("the requested board open twice must not be resolved by order")
+        };
+        assert_eq!(kind_of(&result).as_deref(), Some("ambiguous_open_board"));
+        assert!(!entered, "no single document to address");
+    }
+
+    /// A positive identification is the safe direction — the operation goes to
+    /// KiCad, not to the file — so it is not withheld because some *other*
+    /// open document is unreadable.
+    #[tokio::test]
+    async fn a_positive_match_is_not_blocked_by_another_unreadable_document() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+
+        let (outcome, entered) = write_against(
+            &board,
+            vec![
+                unplaceable_document(),
+                board_document(&board.to_string_lossy()),
+            ],
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, BoardWrite::Ipc(())),
+            "KiCad holds this board; the edit belongs there"
+        );
+        assert!(entered);
+    }
+
+    /// The empty list is its own answer and always was: KiCad is running with
+    /// nothing open, which is what a freshly launched editor looks like.
+    #[tokio::test]
+    async fn an_empty_open_document_list_edits_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+
+        let (outcome, entered) = write_against(&board, vec![]).await;
+
+        assert!(matches!(outcome, BoardWrite::File(NoLiveBoard::NotOpen(_))));
+        assert!(!entered, "there was no board to address over IPC");
+    }
+
+    /// The file-only guard reaches the same verdict from the same evidence.
+    #[tokio::test]
+    async fn the_file_only_guard_refuses_an_unplaceable_open_document() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let before = std::fs::read(&board).unwrap();
+        let ctx = ctx_talking_to(spawn_kicad_reporting_documents(
+            vec![unplaceable_document()],
+            |_| None,
+        ));
+
+        let result = refuse_if_board_open_in_kicad(&ctx, &board, "test edit")
+            .await
+            .unwrap()
+            .expect("an unidentifiable open document must refuse the edit");
+
+        assert_eq!(kind_of(&result).as_deref(), Some("ambiguous_open_board"));
+        assert_eq!(std::fs::read(&board).unwrap(), before);
+    }
+
+    /// Ambiguity is not a rejection either. KiCad declined nothing — it was
+    /// never asked — and reporting a refusal it did not make is the same
+    /// misreading in the other direction.
+    #[tokio::test]
+    async fn ambiguity_is_reported_as_itself_not_as_a_kicad_rejection() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+
+        let (outcome, _) = write_against(&board, vec![unplaceable_document()]).await;
+
+        let BoardWrite::Refused(result) = outcome else {
+            panic!("expected a refusal")
+        };
+        let text = super::mounting_hole_tests::result_text(&result);
+        assert!(!text.contains("rejected"), "{text}");
+        assert!(text.contains("could not confirm"), "{text}");
+    }
+
+    /// A board this session watched KiCad hold stays protected: an unreadable
+    /// list cannot release it any more than a proven-closed one can.
+    #[tokio::test]
+    async fn a_previously_live_board_stays_refused_under_ambiguity() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let ctx = ctx_talking_to(spawn_kicad_reporting_documents(
+            vec![unplaceable_document()],
+            |_| None,
+        ));
+        ctx.board_session.observe_live(&board);
+
+        let outcome = attempt_ipc_write(&ctx, &board, "test write", |_| Ok(()))
+            .await
+            .unwrap();
+
+        assert!(matches!(outcome, BoardWrite::Refused(_)));
     }
 }
 
@@ -2340,7 +2713,7 @@ mod board_session_safety_tests {
             .await
             .unwrap();
 
-        assert!(matches!(outcome, BoardWrite::File));
+        assert!(matches!(outcome, BoardWrite::File(_)));
     }
 
     #[tokio::test]
@@ -2428,7 +2801,7 @@ mod board_session_safety_tests {
             .await
             .unwrap();
 
-        assert!(matches!(outcome, BoardWrite::File));
+        assert!(matches!(outcome, BoardWrite::File(_)));
     }
 
     #[tokio::test]
@@ -2491,6 +2864,120 @@ mod board_session_safety_tests {
 
         assert!(matches!(result, Err(konnect_ipc::IpcFailure::Rejected(_))));
         assert!(!ctx.board_session.was_observed_live(&board));
+    }
+
+    /// KiCad up on another project is the ordinary state of a machine where
+    /// one board is being edited by hand and another by Konnect. It used to
+    /// classify as a rejection, so every `attempt_ipc_write` caller refused
+    /// and wrote nothing, quoting a KiCad that had said no such thing.
+    #[tokio::test]
+    async fn a_kicad_holding_another_project_edits_this_board_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let elsewhere = dir.path().join("other.kicad_pcb");
+        let ctx = ctx_talking_to(super::board_mock::spawn_kicad_holding_boards(
+            &[elsewhere.as_path()],
+            |_| None,
+        ));
+
+        let result = handle_add_mounting_hole(
+            &json!({
+                "board": board.to_str().unwrap(),
+                "x": 5.0, "y": 6.0, "drill_diameter": 3.2, "reference": "H1"
+            }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.is_error, "handler errored: {:?}", result.content);
+        let body: serde_json::Value =
+            serde_json::from_str(&super::mounting_hole_tests::result_text(&result)).unwrap();
+        assert_eq!(body["source"], json!("file"));
+        assert!(std::fs::read_to_string(&board).unwrap().contains("H1"));
+        assert!(
+            body["warning"]
+                .as_str()
+                .is_some_and(|warning| warning.contains("closed")),
+            "the warning must cover the path taken, not only an unreachable transport: {}",
+            body["warning"]
+        );
+        assert!(
+            !ctx.board_session.was_observed_live(&board),
+            "KiCad never had this board, so it must not count as observed live"
+        );
+    }
+
+    /// The other half: KiCad running with nothing open, which is what a user
+    /// who has just launched it has.
+    #[tokio::test]
+    async fn a_kicad_with_no_board_open_edits_the_board_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let ctx = ctx_talking_to(super::board_mock::spawn_kicad_holding_boards(&[], |_| None));
+
+        let write = attempt_ipc_write(&ctx, &board, "test edit", |_| Ok(()))
+            .await
+            .unwrap();
+
+        assert!(
+            matches!(write, BoardWrite::File(_)),
+            "an empty document list is not a refusal"
+        );
+    }
+
+    /// The board this session watched KiCad hold, which KiCad no longer has:
+    /// a crash and restart, or a close mid-operation. The transport being
+    /// reachable again says nothing about the work that board carried, so
+    /// this stays the #240 refusal rather than joining the file path.
+    #[tokio::test]
+    async fn a_board_closed_since_konnect_saw_it_live_still_refuses_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let elsewhere = dir.path().join("other.kicad_pcb");
+        let ctx = ctx_talking_to(super::board_mock::spawn_kicad_holding_boards(
+            &[elsewhere.as_path()],
+            |_| None,
+        ));
+        ctx.board_session.observe_live(&board);
+
+        let write = attempt_ipc_write(&ctx, &board, "next write", |_| Ok(()))
+            .await
+            .unwrap();
+
+        let BoardWrite::Refused(result) = write else {
+            panic!("a board KiCad has since closed must not take the file path")
+        };
+        assert_eq!(
+            crate::mcp::error::extract_error_kind(&result).as_deref(),
+            Some("unsafe_file_fallback")
+        );
+        assert!(
+            super::mounting_hole_tests::result_text(&result).contains("no longer has it open"),
+            "the refusal must name what actually changed"
+        );
+    }
+
+    /// The same distinction for the no-IPC-path gate beside it, whose doc
+    /// comment has always claimed it — until now nothing held it to it (#241).
+    #[tokio::test]
+    async fn a_file_only_edit_proceeds_while_kicad_holds_another_project() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let elsewhere = dir.path().join("other.kicad_pcb");
+        let ctx = ctx_talking_to(super::board_mock::spawn_kicad_holding_boards(
+            &[elsewhere.as_path()],
+            |_| None,
+        ));
+
+        let refusal = refuse_if_board_open_in_kicad(&ctx, &board, "test edit")
+            .await
+            .unwrap();
+
+        assert!(
+            refusal.is_none(),
+            "a KiCad holding a different board does not interfere with this file"
+        );
     }
 }
 

--- a/crates/konnect-core/src/tools/pcb_board.rs
+++ b/crates/konnect-core/src/tools/pcb_board.rs
@@ -216,6 +216,37 @@ impl NoLiveBoard {
             Self::NotOpen(answer) => format!("KiCad is reachable but {answer}."),
         }
     }
+
+    /// Stable machine-readable evidence for why a direct file edit was allowed.
+    pub(crate) fn evidence(&self) -> serde_json::Value {
+        match self {
+            Self::Unreachable => json!({
+                "kind": "transport_unreachable",
+                "message": "KiCad IPC is unreachable."
+            }),
+            Self::NotOpen(answer) => json!({
+                "kind": "board_not_open",
+                "message": answer
+            }),
+        }
+    }
+
+    /// User-facing warning derived from the same classification that unlocked
+    /// the file path. Do not collapse these cases: their recovery steps differ.
+    pub(crate) fn warning(&self) -> String {
+        let observed = match self {
+            Self::Unreachable => {
+                "KiCad IPC was unreachable, so Konnect could not contact a live editor.".to_string()
+            }
+            Self::NotOpen(answer) => format!("KiCad was reachable, and {answer}"),
+        };
+        format!(
+            "{observed} This board has not been observed live during the current Konnect server \
+             session, so Konnect edited the saved board file directly. If KiCad crashed or was \
+             force-quit before this server started, reconcile any unsaved work before relying on \
+             this change. Reload the file in KiCad before editing it there."
+        )
+    }
 }
 
 /// Run `f` over IPC against the board named by `board_path`, deciding what the
@@ -378,14 +409,13 @@ pub(crate) async fn refuse_if_board_open_in_kicad(
 pub(crate) const DEFAULT_ZONE_CLEARANCE_MM: f64 = 0.2;
 pub(crate) const DEFAULT_ZONE_MIN_WIDTH_MM: f64 = 0.2;
 
-/// What the caller gets back when no live KiCAD could be reached and the zone
-/// went into the file instead.
-pub(crate) const FILE_FALLBACK_WARNING: &str =
-    "No live KiCad is holding this board — the IPC transport was unreachable, or KiCad has \
-     this board closed — and it has not been observed live during the current Konnect \
-     server session, so Konnect edited the saved board file directly. If KiCad crashed or \
-     was force-quit before this server started, reconcile any unsaved work before relying \
-     on this change. Reload the file in KiCad before editing it there.";
+/// Warning for a board operation that has no live IPC implementation. Its
+/// preflight established only that no live KiCad is holding this board.
+const FILE_ONLY_EDIT_WARNING: &str =
+    "No live KiCad is holding this board, and it has not been observed live during the current \
+     Konnect server session, so Konnect edited the saved board file directly. If KiCad crashed \
+     or was force-quit before this server started, reconcile any unsaved work before relying on \
+     this change. Reload the file in KiCad before editing it there.";
 
 /// The `pad_connection` argument in both the representations it needs: the IPC
 /// enum and the token KiCad's `(connect_pads …)` takes.
@@ -1129,7 +1159,7 @@ async fn handle_set_board_size(
     // to Edge.Cuts and the board failed DRC with a self-intersecting outline
     // while the tool reported success (#314).
     let items = rect_outline_items(ox, oy, x2, y2, w);
-    match attempt_ipc_write(ctx, &board_path, "board size", move |c| {
+    let fallback_reason = match attempt_ipc_write(ctx, &board_path, "board size", move |c| {
         let existing =
             c.get_items(konnect_ipc::gen::kiapi::common::types::KiCadObjectType::KotPcbShape)?;
         let (segment_ids, other_kinds) = partition_edge_cuts_shapes(&existing);
@@ -1159,8 +1189,8 @@ async fn handle_set_board_size(
             return Ok(outline_not_replaceable(&kinds))
         }
         BoardWrite::Refused(err) => return Ok(err),
-        BoardWrite::File(_) => {}
-    }
+        BoardWrite::File(reason) => reason,
+    };
 
     let content = std::fs::read_to_string(&board_path)?;
 
@@ -1210,7 +1240,8 @@ async fn handle_set_board_size(
         "x1": ox, "y1": oy, "x2": x2, "y2": y2,
         "replaced_segments": removed,
         "source": "file",
-        "warning": FILE_FALLBACK_WARNING
+        "fallback_reason": fallback_reason.evidence(),
+        "warning": fallback_reason.warning()
     })))
 }
 
@@ -1644,7 +1675,7 @@ async fn handle_add_board_outline(
     let arc_count = primitives.len() - line_count;
 
     let items = outline_items(&primitives, w);
-    match attempt_ipc_write(ctx, &board_path, "board outline", move |c| {
+    let fallback_reason = match attempt_ipc_write(ctx, &board_path, "board outline", move |c| {
         c.create_items(items).map(|_| ())
     })
     .await?
@@ -1659,8 +1690,8 @@ async fn handle_add_board_outline(
             })))
         }
         BoardWrite::Refused(err) => return Ok(err),
-        BoardWrite::File(_) => {}
-    }
+        BoardWrite::File(reason) => reason,
+    };
 
     let outline = format_outline(&primitives, "Edge.Cuts", w);
 
@@ -1675,7 +1706,8 @@ async fn handle_add_board_outline(
         "corner_radius": corner_radius,
         "line_count": line_count, "arc_count": arc_count,
         "source": "file",
-        "warning": FILE_FALLBACK_WARNING
+        "fallback_reason": fallback_reason.evidence(),
+        "warning": fallback_reason.warning()
     })))
 }
 
@@ -1774,7 +1806,7 @@ async fn handle_delete_graphics(
     })
     .await?;
 
-    let (graphics, source) = match attempt {
+    let (graphics, source, fallback_reason) = match attempt {
         BoardWrite::Ipc(matched) => (
             matched
                 .iter()
@@ -1788,9 +1820,10 @@ async fn handle_delete_graphics(
                 })
                 .collect::<Vec<_>>(),
             "ipc",
+            None,
         ),
         BoardWrite::Refused(result) => return Ok(result),
-        BoardWrite::File(_) => {
+        BoardWrite::File(reason) => {
             let content = std::fs::read_to_string(&board_path)?;
             let matched: Vec<FileGraphic> = read_file_graphics(&content)
                 .into_iter()
@@ -1808,7 +1841,7 @@ async fn handle_delete_graphics(
                     .collect();
                 write_atomic(&board_path, &apply_edits(content, edits))?;
             }
-            (graphics, "file")
+            (graphics, "file", Some(reason))
         }
     };
 
@@ -1818,8 +1851,9 @@ async fn handle_delete_graphics(
         "dry_run": dry_run,
         "graphics": graphics,
         "source": source,
+        "fallback_reason": fallback_reason.as_ref().map(NoLiveBoard::evidence),
         "warning": if source == "file" && !dry_run {
-            Some(FILE_FALLBACK_WARNING)
+            fallback_reason.as_ref().map(NoLiveBoard::warning)
         } else {
             None
         }
@@ -1878,7 +1912,7 @@ async fn handle_add_mounting_hole(
             "source": "ipc"
         }))),
         BoardWrite::Refused(err) => Ok(err),
-        BoardWrite::File(_) => {
+        BoardWrite::File(reason) => {
             // No live KiCad now, and this board was not observed live during
             // the current server session: use the guarded file path.
             let fp_sexp = format_npth_footprint(x, y, drill_d, &reference);
@@ -1891,7 +1925,8 @@ async fn handle_add_mounting_hole(
                 "reference": reference, "x": x, "y": y, "drill_diameter": drill_d,
                 "footprint": lib_id,
                 "source": "file",
-                "warning": FILE_FALLBACK_WARNING
+                "fallback_reason": reason.evidence(),
+                "warning": reason.warning()
             })))
         }
     }
@@ -1920,7 +1955,7 @@ async fn handle_add_board_text(
 
     let text_ipc = text.clone();
     let layer_ipc = layer.clone();
-    match attempt_ipc_write(ctx, &board_path, "board text", move |c| {
+    let fallback_reason = match attempt_ipc_write(ctx, &board_path, "board text", move |c| {
         let bt = builders::board_text(&layer_ipc, &text_ipc, x, y, size, rotation, false);
         let any = builders::pack_any(&bt, "kiapi.board.types.BoardText");
         c.create_items(vec![any]).map(|_| ())
@@ -1934,8 +1969,8 @@ async fn handle_add_board_text(
             })))
         }
         BoardWrite::Refused(err) => return Ok(err),
-        BoardWrite::File(_) => {}
-    }
+        BoardWrite::File(reason) => reason,
+    };
 
     let gr_text = format_gr_text(&text, x, y, rotation, &layer, size);
     let content = std::fs::read_to_string(&board_path)?;
@@ -1946,7 +1981,8 @@ async fn handle_add_board_text(
     Ok(CallToolResult::json(&json!({
         "text": text, "x": x, "y": y, "layer": layer, "size": size,
         "source": "file",
-        "warning": FILE_FALLBACK_WARNING
+        "fallback_reason": fallback_reason.evidence(),
+        "warning": fallback_reason.warning()
     })))
 }
 
@@ -2026,7 +2062,7 @@ pub(crate) async fn add_zone_impl(
     })
     .await?;
 
-    match ipc_attempt {
+    let fallback_reason = match ipc_attempt {
         BoardWrite::Refused(err) => return Ok(err),
         BoardWrite::Ipc(zone_id) => {
             let mut body = describe();
@@ -2037,8 +2073,8 @@ pub(crate) async fn add_zone_impl(
             };
             return Ok(CallToolResult::json(&body));
         }
-        BoardWrite::File(_) => {}
-    }
+        BoardWrite::File(reason) => reason,
+    };
 
     let content = std::fs::read_to_string(&board_path)?;
     let tree = konnect_sexp::parse_sexp(&content)?;
@@ -2061,7 +2097,8 @@ pub(crate) async fn add_zone_impl(
 
     let mut body = describe();
     body["source"] = json!("file");
-    body["warning"] = json!(FILE_FALLBACK_WARNING);
+    body["fallback_reason"] = fallback_reason.evidence();
+    body["warning"] = json!(fallback_reason.warning());
     Ok(CallToolResult::json(&body))
 }
 
@@ -2131,7 +2168,7 @@ async fn handle_import_svg_logo(
         "layer": layer,
         "width_mm": width_mm,
         "source": "file",
-        "warning": FILE_FALLBACK_WARNING
+        "warning": FILE_ONLY_EDIT_WARNING
     })))
 }
 
@@ -2894,11 +2931,15 @@ mod board_session_safety_tests {
         let body: serde_json::Value =
             serde_json::from_str(&super::mounting_hole_tests::result_text(&result)).unwrap();
         assert_eq!(body["source"], json!("file"));
+        assert_eq!(body["fallback_reason"]["kind"], json!("board_not_open"));
+        assert!(body["fallback_reason"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("other.kicad_pcb")));
         assert!(std::fs::read_to_string(&board).unwrap().contains("H1"));
         assert!(
             body["warning"]
                 .as_str()
-                .is_some_and(|warning| warning.contains("closed")),
+                .is_some_and(|warning| warning.contains("is not open in KiCAD")),
             "the warning must cover the path taken, not only an unreachable transport: {}",
             body["warning"]
         );
@@ -3895,7 +3936,15 @@ mod zone_net_format_tests {
         assert!(!result.is_error, "{}", text_of(&result));
         let body = body_of(&result);
         assert_eq!(body["source"], json!("file"));
+        assert_eq!(
+            body["fallback_reason"],
+            json!({
+                "kind": "transport_unreachable",
+                "message": "KiCad IPC is unreachable."
+            })
+        );
         let warning = body["warning"].as_str().expect("a fallback must warn");
+        assert!(warning.contains("IPC was unreachable"), "{warning}");
         assert!(
             warning.contains("current Konnect server session"),
             "{warning}"

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -41,7 +41,14 @@ macro_rules! ipc {
                     msg
                 )))
             }
-            Err(konnect_ipc::IpcFailure::Rejected(msg)) => return Ok(CallToolResult::error(msg)),
+            // "Not open" is its own answer, and so is "could not tell": these
+            // tools have no file path, so both are still errors, but neither
+            // must be dressed up as a KiCad refusal — the message from
+            // `find_open_board` names the boards KiCad does hold, or the ones
+            // it could not identify.
+            Err(konnect_ipc::IpcFailure::BoardNotOpen(msg))
+            | Err(konnect_ipc::IpcFailure::Ambiguous(msg))
+            | Err(konnect_ipc::IpcFailure::Rejected(msg)) => return Ok(CallToolResult::error(msg)),
         }
     }};
 }
@@ -1964,7 +1971,7 @@ pub fn tools() -> Vec<ToolDef> {
             "get_component_pads",
             "Return live board-space pad positions, layers and net assignments for a footprint. \
              Reads the board open in KiCad when it is reachable and falls back to the file only \
-             when KiCad IPC is unreachable — \
+             when no live KiCad holds this board — IPC unreachable, or that board not open — \
              'source' says which, so unsaved placements are visible without a save. \
              A pad's 'net' is its net name, \"\" if the pad carries no net \
              (unconnected), or — reading the file — null if the net node is present \
@@ -2168,7 +2175,7 @@ async fn handle_place_component(
             "source": "ipc"
         }))),
         BoardWrite::Refused(result) => Ok(result),
-        BoardWrite::File => {
+        BoardWrite::File(_) => {
             // No live KiCad on the other end of this transport: fall back to
             // editing the board file directly.
             if board_contains_reference(&board, &reference)? {
@@ -2234,7 +2241,7 @@ async fn handle_move_component(
             &json!({ "moved": reference, "x": x, "y": y, "source": "ipc" }),
         )),
         BoardWrite::Refused(result) => Ok(result),
-        BoardWrite::File => {
+        BoardWrite::File(_) => {
             match update_closed_board_footprint(
                 &board,
                 &reference,
@@ -2338,7 +2345,7 @@ async fn handle_rotate_component(
             "source": "ipc"
         }))),
         BoardWrite::Refused(result) => Ok(result),
-        BoardWrite::File => {
+        BoardWrite::File(_) => {
             match update_closed_board_footprint(
                 &board,
                 &reference,
@@ -2439,7 +2446,7 @@ async fn handle_set_component_placements(
             "undo": "One KiCad undo step reverses the whole placement batch."
         }))),
         BoardWrite::Refused(result) => Ok(result),
-        BoardWrite::File => match update_closed_board_footprints(&board, &placements) {
+        BoardWrite::File(_) => match update_closed_board_footprints(&board, &placements) {
             Ok(applied) => Ok(CallToolResult::json(&json!({
                 "count": applied.len(),
                 "placements": applied,
@@ -2480,12 +2487,13 @@ async fn handle_flip_component(
     // `attempt_ipc_write`.
     //
     // The distinction is not cosmetic. Running `ensure_board_is_active` and
-    // then bailing unconditionally produced an `anyhow` with no
-    // `TransportUnreachable` marker, which `IpcFailure::from_error` classifies
-    // as `Rejected` — so *every* reachable KiCAD refused the flip, including
-    // one holding an unrelated project, where this board file is demonstrably
+    // then bailing unconditionally produced an `anyhow` classified as
+    // `Rejected` — so *every* reachable KiCAD refused the flip, including one
+    // holding an unrelated project, where this board file is demonstrably
     // free. It also reported Konnect's own refusal as "KiCAD rejected the
-    // footprint flip over IPC", which is the class fixed in v0.5.0.
+    // footprint flip over IPC", which is the class fixed in v0.5.0. That
+    // misclassification is now gone at the source: "not open" carries the
+    // `BoardNotOpen` marker and classifies as its own answer.
     //
     // The helper refuses only when KiCAD holds *this* board, because that is
     // the only case where the edit would be discarded by its next save.
@@ -3079,9 +3087,11 @@ async fn handle_repair_corrupted_footprints(
     Ok(match outcome {
         BoardWrite::Ipc(value) => CallToolResult::json(&value),
         BoardWrite::Refused(result) => result,
-        BoardWrite::File => CallToolResult::error(
-            "KiCad IPC is unreachable. repair_corrupted_footprints is live-IPC-only and never edits the board file directly. Open the requested board in KiCad and retry.",
-        ),
+        BoardWrite::File(reason) => CallToolResult::error(format!(
+            "{} repair_corrupted_footprints is live-IPC-only and never edits the board file \
+             directly. Open the requested board in KiCad and retry.",
+            reason.premise()
+        )),
     })
 }
 
@@ -3199,7 +3209,22 @@ async fn handle_get_component_pads(
                 "Footprint '{reference}' not found on the board open in KiCad"
             )))
         }
-        Err(konnect_ipc::IpcFailure::Unreachable(_)) => {}
+        // Unreachable, or reachable and holding some other board: either way
+        // no live KiCad can be answering about this one, so read the file.
+        Err(konnect_ipc::IpcFailure::Unreachable(_))
+        | Err(konnect_ipc::IpcFailure::BoardNotOpen(_)) => {}
+        // Not that, though. The file is the fallback for a board no editor
+        // holds, and an open-document list Konnect could not read does not
+        // establish that — a live KiCad may hold newer state, so answering
+        // from the file would present a stale board as the board.
+        Err(konnect_ipc::IpcFailure::Ambiguous(message)) => {
+            return Ok(CallToolResult::error_kind(
+                crate::mcp::error::ToolErrorKind::AmbiguousOpenBoard {
+                    path: board_path.display().to_string(),
+                },
+                message,
+            ));
+        }
         Err(konnect_ipc::IpcFailure::Rejected(message)) => {
             return Ok(CallToolResult::error(message));
         }

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -7,7 +7,7 @@
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
 use crate::tools::library::{footprint_lib_nickname_for_dir, is_lib_id, resolve_footprint_path};
-use crate::tools::pcb_board::{attempt_ipc_write, BoardWrite, FILE_FALLBACK_WARNING};
+use crate::tools::pcb_board::{attempt_ipc_write, BoardWrite};
 use crate::tools::{
     get_path, require_array, require_f64, require_str, require_u64, with_board_ipc_classified,
     ToolContext, ToolDef,
@@ -2175,7 +2175,7 @@ async fn handle_place_component(
             "source": "ipc"
         }))),
         BoardWrite::Refused(result) => Ok(result),
-        BoardWrite::File(_) => {
+        BoardWrite::File(reason) => {
             // No live KiCad on the other end of this transport: fall back to
             // editing the board file directly.
             if board_contains_reference(&board, &reference)? {
@@ -2207,7 +2207,8 @@ async fn handle_place_component(
                 "footprint": footprint,
                 "x": x, "y": y, "rotation": rotation, "layer": layer,
                 "source": "file",
-                "warning": FILE_FALLBACK_WARNING
+                "fallback_reason": reason.evidence(),
+                "warning": reason.warning()
             })))
         }
     }
@@ -2241,7 +2242,7 @@ async fn handle_move_component(
             &json!({ "moved": reference, "x": x, "y": y, "source": "ipc" }),
         )),
         BoardWrite::Refused(result) => Ok(result),
-        BoardWrite::File(_) => {
+        BoardWrite::File(reason) => {
             match update_closed_board_footprint(
                 &board,
                 &reference,
@@ -2252,7 +2253,8 @@ async fn handle_move_component(
                     "x": x,
                     "y": y,
                     "source": "file",
-                    "warning": FILE_FALLBACK_WARNING
+                    "fallback_reason": reason.evidence(),
+                    "warning": reason.warning()
                 }))),
                 Err(error) => Ok(error.into_result()),
             }
@@ -2345,7 +2347,7 @@ async fn handle_rotate_component(
             "source": "ipc"
         }))),
         BoardWrite::Refused(result) => Ok(result),
-        BoardWrite::File(_) => {
+        BoardWrite::File(reason) => {
             match update_closed_board_footprint(
                 &board,
                 &reference,
@@ -2355,7 +2357,8 @@ async fn handle_rotate_component(
                     "rotated": reference,
                     "rotation": rotation,
                     "source": "file",
-                    "warning": FILE_FALLBACK_WARNING
+                    "fallback_reason": reason.evidence(),
+                    "warning": reason.warning()
                 }))),
                 Err(error) => Ok(error.into_result()),
             }
@@ -2446,12 +2449,13 @@ async fn handle_set_component_placements(
             "undo": "One KiCad undo step reverses the whole placement batch."
         }))),
         BoardWrite::Refused(result) => Ok(result),
-        BoardWrite::File(_) => match update_closed_board_footprints(&board, &placements) {
+        BoardWrite::File(reason) => match update_closed_board_footprints(&board, &placements) {
             Ok(applied) => Ok(CallToolResult::json(&json!({
                 "count": applied.len(),
                 "placements": applied,
                 "source": "file",
-                "warning": FILE_FALLBACK_WARNING
+                "fallback_reason": reason.evidence(),
+                "warning": reason.warning()
             }))),
             Err(error) => Ok(error.into_result()),
         },

--- a/crates/konnect-core/src/tools/pcb_footprint_update.rs
+++ b/crates/konnect-core/src/tools/pcb_footprint_update.rs
@@ -310,10 +310,11 @@ pub(crate) async fn handle_update_footprints_from_library(
 
     Ok(match result {
         BoardWrite::Ipc(response) => response,
-        BoardWrite::File => preflight_conflict(
-            "KiCad IPC is unreachable. update_footprints_from_library is live-IPC-only and \
-             never edits the board file directly. Open the requested board in KiCad and retry.",
-        ),
+        BoardWrite::File(reason) => preflight_conflict(format!(
+            "{} update_footprints_from_library is live-IPC-only and never edits the board \
+             file directly. Open the requested board in KiCad and retry.",
+            reason.premise()
+        )),
         BoardWrite::Refused(result) => {
             let message = result
                 .content

--- a/crates/konnect-core/src/tools/pcb_sync.rs
+++ b/crates/konnect-core/src/tools/pcb_sync.rs
@@ -328,10 +328,11 @@ pub(crate) async fn handle_update_pcb_from_schematic(
 
     Ok(match result {
         BoardWrite::Ipc(result) => result,
-        BoardWrite::File => conflict_result(
-            "KiCad IPC is unreachable. update_pcb_from_schematic is live-IPC-only and never edits the board file directly. Open the requested board in KiCad and retry."
-                .to_string(),
-        ),
+        BoardWrite::File(reason) => conflict_result(format!(
+            "{} update_pcb_from_schematic is live-IPC-only and never edits the board file \
+             directly. Open the requested board in KiCad and retry.",
+            reason.premise()
+        )),
         BoardWrite::Refused(result) => {
             let message = result
                 .content

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -320,6 +320,82 @@ pub fn is_transport_unreachable(error: &anyhow::Error) -> bool {
         .any(|cause| cause.is::<TransportUnreachable>())
 }
 
+/// Marker error carried (via anyhow's error chain) when KiCad answered and
+/// does not hold the requested board: another project is open, or no board is.
+///
+/// It carries its own message rather than taking one from `.context()`, so
+/// the classified failure reads as the one sentence a caller shows the user
+/// — a context line *and* a marker `Display` would say it twice.
+///
+/// Callers must classify with [`IpcFailure::from_error`], never by matching
+/// error text.
+#[derive(Debug)]
+pub struct BoardNotOpen(String);
+
+impl BoardNotOpen {
+    fn err(message: String) -> anyhow::Error {
+        anyhow::Error::new(Self(message))
+    }
+}
+
+impl std::fmt::Display for BoardNotOpen {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for BoardNotOpen {}
+
+/// The "nothing is open" half of [`BoardNotOpen`], shared by the two lookups
+/// that can hit it.
+fn no_board_open() -> anyhow::Error {
+    BoardNotOpen::err("No PCB document is open in KiCAD. Open a board file first.".to_string())
+}
+
+/// Marker error carried when KiCad's open-document list cannot be read as a
+/// complete set of comparable board identities — so whether it holds the
+/// requested board is *unknown*, not answered.
+///
+/// It exists because the alternative is worse than a wrong error message.
+/// [`BoardNotOpen`] tells a caller that KiCad has no unsaved state for this
+/// board and the saved file is authoritative, which is what permits a direct
+/// file write. Reaching that conclusion by discarding the records that could
+/// not be resolved turns "we could not tell" into "it is safe to overwrite".
+///
+/// Like [`BoardNotOpen`], it carries its own message and is classified by
+/// walking the error chain.
+#[derive(Debug)]
+pub struct AmbiguousOpenBoards(String);
+
+impl AmbiguousOpenBoards {
+    fn err(message: String) -> anyhow::Error {
+        anyhow::Error::new(Self(message))
+    }
+}
+
+impl std::fmt::Display for AmbiguousOpenBoards {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for AmbiguousOpenBoards {}
+
+/// Whether `error` says KiCad's open-board list could not be read as a
+/// complete, comparable set. Walks the chain, never the message text.
+fn is_ambiguous_open_boards(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| cause.is::<AmbiguousOpenBoards>())
+}
+
+/// Whether `error` says KiCad is not holding the requested board.
+///
+/// Private: nothing outside the classification needs to ask this yet, and a
+/// caller that does can match [`IpcFailure::BoardNotOpen`]. Like
+/// [`IpcFailure::from_error`], it walks the chain — never the message text.
+fn is_board_not_open(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| cause.is::<BoardNotOpen>())
+}
+
 /// Why an IPC operation failed, for callers deciding whether a file-based
 /// fallback is safe.
 ///
@@ -328,6 +404,20 @@ pub fn is_transport_unreachable(error: &anyhow::Error) -> bool {
 /// KiCad can be holding the board, and editing the board file directly
 /// cannot race an editor.
 ///
+/// `BoardNotOpen` means KiCad answered and does not have the requested board
+/// open — a different project, or none at all. KiCad cannot be holding
+/// unsaved state for a board it never opened, so this is as safe to edit on
+/// disk as `Unreachable`, and it must not be reported as a refusal: KiCad
+/// declined nothing.
+///
+/// `Ambiguous` means KiCad answered and the answer could not be read as a
+/// complete set of comparable board identities, so whether it holds the
+/// requested board is unknown. It is deliberately not `BoardNotOpen`: absence
+/// has to be *proven* before a saved file may be treated as authoritative.
+/// It is not `Rejected` either, because KiCad declined nothing — reporting a
+/// refusal it never made is the misreading this classification exists to end.
+/// Fail closed, and say which it was.
+///
 /// `Rejected` is everything else, including any error after a request was
 /// delivered (a receive timeout may mean KiCad is still processing it).
 /// KiCad is — or may be — alive on the other end, so a file edit could be
@@ -335,6 +425,8 @@ pub fn is_transport_unreachable(error: &anyhow::Error) -> bool {
 #[derive(Debug)]
 pub enum IpcFailure {
     Unreachable(String),
+    BoardNotOpen(String),
+    Ambiguous(String),
     Rejected(String),
 }
 
@@ -346,6 +438,10 @@ impl IpcFailure {
         let message = format!("{error:#}");
         if is_transport_unreachable(&error) {
             IpcFailure::Unreachable(message)
+        } else if is_ambiguous_open_boards(&error) {
+            IpcFailure::Ambiguous(message)
+        } else if is_board_not_open(&error) {
+            IpcFailure::BoardNotOpen(message)
         } else {
             IpcFailure::Rejected(message)
         }
@@ -353,7 +449,10 @@ impl IpcFailure {
 
     pub fn message(&self) -> &str {
         match self {
-            IpcFailure::Unreachable(message) | IpcFailure::Rejected(message) => message,
+            IpcFailure::Unreachable(message)
+            | IpcFailure::BoardNotOpen(message)
+            | IpcFailure::Ambiguous(message)
+            | IpcFailure::Rejected(message) => message,
         }
     }
 }
@@ -564,9 +663,7 @@ impl KiCadIpcClient {
     /// Get the first open PCB's DocumentSpecifier (needed for most commands).
     fn get_board_document(&self) -> Result<kiapi::common::types::DocumentSpecifier> {
         let docs = self.get_open_documents()?;
-        docs.into_iter().next().ok_or_else(|| {
-            anyhow::anyhow!("No PCB document is open in KiCAD. Open a board file first.")
-        })
+        docs.into_iter().next().ok_or_else(no_board_open)
     }
 
     /// Find the open document matching `requested`, so a path-bearing MCP
@@ -581,22 +678,79 @@ impl KiCadIpcClient {
     ) -> Result<kiapi::common::types::DocumentSpecifier> {
         let docs = self.get_open_documents()?;
         if docs.is_empty() {
-            anyhow::bail!("No PCB document is open in KiCAD. Open a board file first.");
+            return Err(no_board_open());
         }
-        let mut open_names = Vec::new();
-        for doc in docs {
-            if let Some(path) = board_document_path(&doc) {
-                if paths_refer_to_same_board(requested, &path) {
-                    return Ok(doc);
-                }
-                open_names.push(path.display().to_string());
-            }
+
+        // Resolve the whole list before deciding anything. A record that could
+        // not be resolved is not evidence that the requested board is absent,
+        // and dropping it where it is produced is what turned "we cannot tell"
+        // into "the saved file is authoritative" (#426).
+        let identities: Vec<_> = docs.iter().map(board_document_identity).collect::<Vec<_>>();
+        let requested_identity = comparable_identity(requested).map_err(|reason| {
+            AmbiguousOpenBoards::err(format!(
+                "the requested board '{}' {reason}, so KiCad's open boards cannot be compared \
+                 against it",
+                requested.display()
+            ))
+        })?;
+
+        // A positive match is the safe direction — it sends the operation to
+        // KiCad rather than to the file — but only when exactly one open
+        // document claims to be this board.
+        let matched: Vec<usize> = identities
+            .iter()
+            .enumerate()
+            .filter(|(_, identity)| identity.as_ref().is_ok_and(|id| *id == requested_identity))
+            .map(|(index, _)| index)
+            .collect();
+        if matched.len() == 1 {
+            return Ok(docs[matched[0]].clone());
         }
-        anyhow::bail!(
+        if matched.len() > 1 {
+            return Err(AmbiguousOpenBoards::err(format!(
+                "KiCAD reports board '{}' open {} times, so Konnect cannot tell which document \
+                 an edit would reach",
+                requested.display(),
+                matched.len()
+            )));
+        }
+
+        // No match. Absence is only proven by a list that was read in full.
+        let unresolved: Vec<&str> = identities
+            .iter()
+            .filter_map(|identity| identity.as_ref().err().map(String::as_str))
+            .collect();
+        if !unresolved.is_empty() {
+            return Err(AmbiguousOpenBoards::err(format!(
+                "KiCAD has {} PCB document(s) open that Konnect cannot identify ({}), so it \
+                 cannot prove that board '{}' is closed",
+                unresolved.len(),
+                unresolved.join("; "),
+                requested.display()
+            )));
+        }
+
+        let open: Vec<&PathBuf> = identities
+            .iter()
+            .filter_map(|id| id.as_ref().ok())
+            .collect();
+        if let Some(duplicated) = first_duplicate(&open) {
+            return Err(AmbiguousOpenBoards::err(format!(
+                "KiCAD reports board '{}' open more than once, so its open-document list is not \
+                 one Konnect can read; it cannot prove that board '{}' is closed",
+                duplicated.display(),
+                requested.display()
+            )));
+        }
+
+        Err(BoardNotOpen::err(format!(
             "requested board '{}' is not open in KiCAD (open boards: {})",
             requested.display(),
-            open_names.join(", ")
-        )
+            open.iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )))
     }
 
     /// Fail closed unless the requested board is open in the IPC session.
@@ -2670,14 +2824,100 @@ fn board_document_path(document: &kiapi::common::types::DocumentSpecifier) -> Op
         .or(Some(path))
 }
 
-fn paths_refer_to_same_board(requested: &Path, active: &Path) -> bool {
-    match (requested.canonicalize(), active.canonicalize()) {
-        (Ok(requested), Ok(active)) => requested == active,
-        _ if active.components().count() == 1 => {
-            requested.components().count() == 1 && requested.file_name() == active.file_name()
+/// One open PCB document as a path that can be compared with a requested
+/// board, or the reason it cannot be.
+///
+/// The reason is returned rather than logged because it is the whole point: an
+/// identity that cannot be compared has to reach the decision, or absence gets
+/// concluded from a list that was never read (#426).
+///
+/// KiCad's own contract is a bare filename plus the project directory —
+/// `board_filename` is documented as "a PCB with a given filename, e.g.
+/// `board.kicad_pcb`", with `ProjectSpecifier.path` supplying the directory —
+/// so a bare name *with* a project path is the ordinary case, and a bare name
+/// *without* one is a record Konnect cannot place on disk.
+fn board_document_identity(
+    document: &kiapi::common::types::DocumentSpecifier,
+) -> std::result::Result<PathBuf, String> {
+    use kiapi::common::types::document_specifier::Identifier;
+
+    let filename = match document.identifier.as_ref() {
+        Some(Identifier::BoardFilename(filename)) => filename,
+        Some(Identifier::LibId(_)) => {
+            return Err("a PCB document identified by a library id".to_string())
         }
-        _ => requested == active,
+        Some(Identifier::SheetPath(_)) => {
+            return Err("a PCB document identified by a sheet path".to_string())
+        }
+        None => return Err("a PCB document that reports no identifier".to_string()),
+    };
+    if filename.trim().is_empty() {
+        return Err("a PCB document with an empty board filename".to_string());
     }
+
+    let path = PathBuf::from(filename);
+    let absolute = if path.is_absolute() {
+        path
+    } else {
+        match document.project.as_ref().map(|project| &project.path) {
+            Some(project_path) if Path::new(project_path).is_absolute() => {
+                Path::new(project_path).join(&path)
+            }
+            _ => {
+                return Err(format!(
+                    "the bare filename '{filename}' with no project directory"
+                ))
+            }
+        }
+    };
+    comparable_identity(&absolute).map_err(|reason| format!("'{filename}' {reason}"))
+}
+
+/// An absolute path reduced to the form two paths can be compared in, or the
+/// reason the filesystem could not say.
+///
+/// A path that does not exist is still comparable — it is normalized
+/// lexically, so a board deleted out from under an open editor still compares
+/// equal to itself. Any *other* failure (a permission denied on a parent
+/// directory, a symlink loop) means the two paths might name one file and
+/// might not, which is exactly the case that must fail closed rather than
+/// resolve to "different".
+fn comparable_identity(path: &Path) -> std::result::Result<PathBuf, String> {
+    match path.canonicalize() {
+        Ok(resolved) => Ok(resolved),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(lexically_normalized(path))
+        }
+        Err(error) => Err(format!("cannot be resolved on this filesystem: {error}")),
+    }
+}
+
+/// `.` and `..` removed without touching the filesystem. Only used for paths
+/// that do not exist, where `canonicalize` cannot do it.
+fn lexically_normalized(path: &Path) -> PathBuf {
+    use std::path::Component;
+
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !out.pop() {
+                    out.push(Component::ParentDir);
+                }
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// The first identity that appears twice, if any. KiCad opening one board
+/// twice is not a list Konnect models, so it is not one absence can be read
+/// from either.
+fn first_duplicate<'a>(paths: &[&'a PathBuf]) -> Option<&'a PathBuf> {
+    let mut seen = std::collections::HashSet::new();
+    paths.iter().copied().find(|path| !seen.insert(*path))
 }
 
 #[cfg(test)]
@@ -2706,44 +2946,167 @@ mod diagnostic_tests {
 mod document_path_tests {
     use super::*;
 
-    #[test]
-    fn relative_board_filename_is_resolved_against_project_path() {
-        let document = kiapi::common::types::DocumentSpecifier {
+    /// An absolute project directory on the platform running the test.
+    ///
+    /// `Path::is_absolute` is what decides whether a project directory can
+    /// place a bare board filename, and a POSIX-rooted path is *not* absolute
+    /// on Windows — it is relative to the current drive. Keeping the rule
+    /// strict is deliberate; the fixture has to speak the local dialect.
+    fn project_dir() -> &'static str {
+        if cfg!(windows) {
+            r"C:\work\controller"
+        } else {
+            "/work/controller"
+        }
+    }
+
+    fn expected_board() -> PathBuf {
+        PathBuf::from(project_dir()).join("controller.kicad_pcb")
+    }
+
+    fn board_document(
+        filename: &str,
+        project_path: Option<&str>,
+    ) -> kiapi::common::types::DocumentSpecifier {
+        kiapi::common::types::DocumentSpecifier {
             r#type: kiapi::common::types::DocumentType::DoctypePcb as i32,
             identifier: Some(
                 kiapi::common::types::document_specifier::Identifier::BoardFilename(
-                    "controller.kicad_pcb".to_string(),
+                    filename.to_string(),
                 ),
             ),
+            project: project_path.map(|path| kiapi::common::types::ProjectSpecifier {
+                name: "controller".to_string(),
+                path: path.to_string(),
+            }),
+        }
+    }
+
+    /// KiCad's documented form: a bare filename plus the project directory.
+    #[test]
+    fn relative_board_filename_is_resolved_against_project_path() {
+        assert_eq!(
+            board_document_path(&board_document("controller.kicad_pcb", Some(project_dir())))
+                .unwrap(),
+            expected_board()
+        );
+        assert_eq!(
+            board_document_identity(&board_document("controller.kicad_pcb", Some(project_dir())))
+                .unwrap(),
+            expected_board()
+        );
+    }
+
+    /// The record that used to be dropped. A bare filename with no project
+    /// directory names no file on disk, and the old lookup skipped it and then
+    /// reported the requested board absent — which is what let a file write
+    /// proceed past evidence nobody had read.
+    #[test]
+    fn a_bare_filename_with_no_project_directory_is_not_an_identity() {
+        let reason = board_document_identity(&board_document("controller.kicad_pcb", None))
+            .expect_err("a bare filename places no file on disk");
+
+        assert!(reason.contains("controller.kicad_pcb"), "{reason}");
+        assert!(reason.contains("no project directory"), "{reason}");
+    }
+
+    #[test]
+    fn a_relative_project_path_is_not_an_identity() {
+        assert!(board_document_identity(&board_document(
+            "controller.kicad_pcb",
+            Some("controller")
+        ))
+        .is_err());
+    }
+
+    #[test]
+    fn an_empty_board_filename_is_not_an_identity() {
+        assert!(board_document_identity(&board_document("", Some(project_dir()))).is_err());
+        assert!(board_document_identity(&board_document("   ", Some(project_dir()))).is_err());
+    }
+
+    #[test]
+    fn a_document_with_no_identifier_is_not_an_identity() {
+        let document = kiapi::common::types::DocumentSpecifier {
+            r#type: kiapi::common::types::DocumentType::DoctypePcb as i32,
+            identifier: None,
             project: Some(kiapi::common::types::ProjectSpecifier {
                 name: "controller".to_string(),
-                path: "/work/controller".to_string(),
+                path: project_dir().to_string(),
             }),
         };
 
+        assert!(board_document_identity(&document)
+            .expect_err("no identifier")
+            .contains("no identifier"));
+    }
+
+    /// A PCB document identified as something other than a board filename is
+    /// a shape Konnect does not model. It is not a board that is absent.
+    #[test]
+    fn a_non_board_identifier_is_not_an_identity() {
+        let document = kiapi::common::types::DocumentSpecifier {
+            r#type: kiapi::common::types::DocumentType::DoctypePcb as i32,
+            identifier: Some(
+                kiapi::common::types::document_specifier::Identifier::SheetPath(
+                    kiapi::common::types::SheetPath {
+                        path: vec![],
+                        path_human_readable: "/".to_string(),
+                    },
+                ),
+            ),
+            project: None,
+        };
+
+        assert!(board_document_identity(&document).is_err());
+    }
+
+    /// A board deleted out from under an open editor still has to compare
+    /// equal to itself — `canonicalize` cannot resolve it, so the identity is
+    /// normalized lexically instead.
+    #[test]
+    fn a_missing_path_is_still_comparable_to_itself() {
         assert_eq!(
-            board_document_path(&document).unwrap(),
-            PathBuf::from("/work/controller/controller.kicad_pcb")
+            comparable_identity(&PathBuf::from(project_dir()).join("./gone.kicad_pcb")).unwrap(),
+            comparable_identity(&PathBuf::from(project_dir()).join("sub/../gone.kicad_pcb"))
+                .unwrap()
+        );
+        assert_ne!(
+            comparable_identity(&PathBuf::from(project_dir()).join("gone.kicad_pcb")).unwrap(),
+            comparable_identity(&PathBuf::from(project_dir()).join("other.kicad_pcb")).unwrap()
+        );
+    }
+
+    /// Two paths through a symlink are one board. `canonicalize` is what makes
+    /// them compare equal, and losing it would turn a board KiCad *has* open
+    /// into one it does not.
+    #[test]
+    fn a_symlinked_path_resolves_to_the_same_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real.kicad_pcb");
+        std::fs::write(&real, "(kicad_pcb)").unwrap();
+        let link = dir.path().join("link.kicad_pcb");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        #[cfg(not(unix))]
+        std::fs::copy(&real, &link).unwrap();
+
+        #[cfg(unix)]
+        assert_eq!(
+            comparable_identity(&real).unwrap(),
+            comparable_identity(&link).unwrap()
         );
     }
 
     #[test]
-    fn bare_kicad_filename_is_not_enough_to_authorize_an_absolute_request() {
-        assert!(!paths_refer_to_same_board(
-            Path::new("/work/controller/controller.kicad_pcb"),
-            Path::new("controller.kicad_pcb")
-        ));
-        assert!(paths_refer_to_same_board(
-            Path::new("controller.kicad_pcb"),
-            Path::new("controller.kicad_pcb")
-        ));
-        assert!(!paths_refer_to_same_board(
-            Path::new("/work/controller/other.kicad_pcb"),
-            Path::new("controller.kicad_pcb")
-        ));
+    fn first_duplicate_finds_a_repeated_identity() {
+        let a = PathBuf::from(project_dir()).join("a.kicad_pcb");
+        let b = PathBuf::from(project_dir()).join("b.kicad_pcb");
+
+        assert_eq!(first_duplicate(&[&a, &b]), None);
+        assert_eq!(first_duplicate(&[&a, &b, &a]), Some(&a));
     }
 }
-
 #[cfg(test)]
 mod footprint_graphics_tests {
     use super::*;

--- a/crates/konnect-ipc/src/lib.rs
+++ b/crates/konnect-ipc/src/lib.rs
@@ -8,7 +8,9 @@ pub mod socket;
 pub mod transform;
 pub mod types;
 
-pub use client::{is_transport_unreachable, IpcFailure, KiCadIpcClient, TransportUnreachable};
+pub use client::{
+    is_transport_unreachable, BoardNotOpen, IpcFailure, KiCadIpcClient, TransportUnreachable,
+};
 pub use endpoint::redact_endpoint;
 pub use socket::{candidate_socket_paths, detect_ipc_address};
 pub use types::*;

--- a/crates/konnect-ipc/tests/footprint_transform_test.rs
+++ b/crates/konnect-ipc/tests/footprint_transform_test.rs
@@ -159,7 +159,10 @@ fn spawn_footprints_mock(
             let resp = kiapi::common::commands::GetOpenDocumentsResponse {
                 documents: vec![kiapi::common::types::DocumentSpecifier {
                     r#type: kiapi::common::types::DocumentType::DoctypePcb as i32,
-                    project: None,
+                    project: Some(kiapi::common::types::ProjectSpecifier {
+                        name: "konnect-mock".to_string(),
+                        path: mock_project_dir().to_string(),
+                    }),
                     identifier: Some(
                         kiapi::common::types::document_specifier::Identifier::BoardFilename(
                             "test.kicad_pcb".to_string(),
@@ -361,7 +364,7 @@ fn footprint_pad_readback_observes_the_updated_live_state_after_a_move() {
 
     client.move_footprint("R1", 50.0, 50.0).unwrap();
     let document = client
-        .find_open_board(std::path::Path::new("test.kicad_pcb"))
+        .find_open_board(&std::path::PathBuf::from(mock_project_dir()).join("test.kicad_pcb"))
         .expect("the mock holds test.kicad_pcb");
     let pads = client
         .get_footprint_pads_in(document, "R1")
@@ -441,4 +444,15 @@ fn placement_batch_moves_and_rotates_multiple_footprints_in_one_update() {
         .collect();
     assert_eq!(placements, vec![(50.0, 50.0, 90.0), (250.0, 150.0, 180.0)]);
     assert_eq!(pad_positions_mm(&sent[0]), vec![(50.0, 51.0), (50.0, 49.0)]);
+}
+
+/// Absolute on the platform running the test — a POSIX-rooted path is not
+/// absolute on Windows, and only an absolute project directory can place the
+/// bare board filename KiCad sends.
+fn mock_project_dir() -> &'static str {
+    if cfg!(windows) {
+        r"C:\konnect-mock-project"
+    } else {
+        "/konnect-mock-project"
+    }
 }

--- a/crates/konnect-ipc/tests/mock_server_test.rs
+++ b/crates/konnect-ipc/tests/mock_server_test.rs
@@ -95,15 +95,7 @@ fn reply_with(inner: prost_types::Any) -> kiapi::common::ApiResponse {
 
 fn open_board_response() -> kiapi::common::ApiResponse {
     let response = kiapi::common::commands::GetOpenDocumentsResponse {
-        documents: vec![kiapi::common::types::DocumentSpecifier {
-            r#type: kiapi::common::types::DocumentType::DoctypePcb as i32,
-            project: None,
-            identifier: Some(
-                kiapi::common::types::document_specifier::Identifier::BoardFilename(
-                    "test.kicad_pcb".to_string(),
-                ),
-            ),
-        }],
+        documents: vec![doc_for("test.kicad_pcb")],
     };
     reply_with(builders::pack_any(
         &response,
@@ -145,7 +137,7 @@ fn save_document_to_string_targets_the_named_open_board() {
 
     let client = KiCadIpcClient::new(&mock.url);
     let document = client
-        .find_open_board(std::path::Path::new("test.kicad_pcb"))
+        .find_open_board(&mock_board("test.kicad_pcb"))
         .expect("the mock holds test.kicad_pcb");
     let snapshot = client
         .save_document_to_string_in(document)
@@ -220,7 +212,7 @@ fn effective_routing_rules_preserve_complete_kicad_values() {
 
     let client = KiCadIpcClient::new(&mock.url);
     let document = client
-        .find_open_board(std::path::Path::new("test.kicad_pcb"))
+        .find_open_board(&mock_board("test.kicad_pcb"))
         .expect("the mock holds test.kicad_pcb");
     let rules = client
         .get_effective_routing_rules_in(document)
@@ -572,7 +564,7 @@ fn place_footprint_sends_graphics_children() {
     let client = KiCadIpcClient::new(&mock.url);
     let placed = client
         .place_footprint(
-            std::path::Path::new("test.kicad_pcb"),
+            &mock_board("test.kicad_pcb"),
             "Resistor_SMD:R_0402",
             "R1",
             "R_0402",
@@ -817,6 +809,55 @@ fn a_live_kicad_that_says_no_classifies_as_rejected() {
     assert!(failure.message().contains("no board open"), "{failure:?}");
 }
 
+/// A KiCad holding some other project has rejected nothing — it was asked
+/// about a board it does not have. Classifying that as `Rejected` made every
+/// board-file write refuse itself while KiCad sat on an unrelated project.
+#[test]
+fn a_kicad_holding_another_board_classifies_as_not_open() {
+    let mock = spawn_mock(|request| {
+        let message = request.message.expect("request must pack a command");
+        if message.type_url.ends_with("GetOpenDocuments") {
+            return Some(open_board_response());
+        }
+        Some(ok_response())
+    });
+    let client = KiCadIpcClient::new(&mock.url);
+    let failure = konnect_ipc::IpcFailure::from_error(
+        client
+            .find_open_board(&mock_board("other.kicad_pcb"))
+            .unwrap_err(),
+    );
+    assert!(
+        matches!(failure, konnect_ipc::IpcFailure::BoardNotOpen(_)),
+        "unexpected classification: {failure:?}"
+    );
+    assert!(failure.message().contains("test.kicad_pcb"), "{failure:?}");
+}
+
+#[test]
+fn a_kicad_with_nothing_open_classifies_as_not_open() {
+    let mock = spawn_mock(|request| {
+        let message = request.message.expect("request must pack a command");
+        if message.type_url.ends_with("GetOpenDocuments") {
+            return Some(reply_with(builders::pack_any(
+                &kiapi::common::commands::GetOpenDocumentsResponse { documents: vec![] },
+                "kiapi.common.commands.GetOpenDocumentsResponse",
+            )));
+        }
+        Some(ok_response())
+    });
+    let client = KiCadIpcClient::new(&mock.url);
+    let failure = konnect_ipc::IpcFailure::from_error(
+        client
+            .find_open_board(&mock_board("test.kicad_pcb"))
+            .unwrap_err(),
+    );
+    assert!(
+        matches!(failure, konnect_ipc::IpcFailure::BoardNotOpen(_)),
+        "unexpected classification: {failure:?}"
+    );
+}
+
 /// The regression the recv timeout exists for: a server that accepts the
 /// request and never replies. The predecessor project hung >600 s here; the
 /// client must give up at its recv timeout instead.
@@ -900,7 +941,7 @@ fn placement_targets_the_named_board_among_several_open() {
 
     let client = KiCadIpcClient::new(&mock.url);
     let _ = client.place_footprint(
-        std::path::Path::new("target.kicad_pcb"),
+        &mock_board("target.kicad_pcb"),
         "Resistor_SMD:R_0402",
         "R1",
         "R_0402",
@@ -924,10 +965,34 @@ fn placement_targets_the_named_board_among_several_open() {
     );
 }
 
+/// The project directory the mock's open documents report.
+///
+/// KiCad identifies an open PCB by a *bare* `board_filename` plus its
+/// `ProjectSpecifier.path` — the form its own proto documents ("a PCB with a
+/// given filename, e.g. `board.kicad_pcb`"). A mock sending `project: None`
+/// was reproducing a document form KiCad does not emit, and it was the one
+/// form Konnect cannot place on disk.
+/// Absolute on the platform running the test: `Path::is_absolute` is what
+/// lets a project directory place a bare board filename, and a POSIX-rooted
+/// path is not absolute on Windows.
+const MOCK_PROJECT_DIR: &str = if cfg!(windows) {
+    r"C:\konnect-mock-project"
+} else {
+    "/konnect-mock-project"
+};
+
+/// The absolute path a caller asks about, for a board the mock reports open.
+fn mock_board(filename: &str) -> std::path::PathBuf {
+    std::path::PathBuf::from(MOCK_PROJECT_DIR).join(filename)
+}
+
 fn doc_for(filename: &str) -> kiapi::common::types::DocumentSpecifier {
     kiapi::common::types::DocumentSpecifier {
         r#type: kiapi::common::types::DocumentType::DoctypePcb as i32,
-        project: None,
+        project: Some(kiapi::common::types::ProjectSpecifier {
+            name: "konnect-mock".to_string(),
+            path: MOCK_PROJECT_DIR.to_string(),
+        }),
         identifier: Some(
             kiapi::common::types::document_specifier::Identifier::BoardFilename(
                 filename.to_string(),
@@ -1205,7 +1270,7 @@ fn a_failed_item_read_is_an_error_not_an_empty_board() {
 
     let client = KiCadIpcClient::new(&mock.url);
     let document = client
-        .find_open_board(std::path::Path::new("test.kicad_pcb"))
+        .find_open_board(&mock_board("test.kicad_pcb"))
         .expect("the mock holds test.kicad_pcb");
 
     let error = client
@@ -1228,7 +1293,7 @@ fn footprint_pads_come_back_in_board_coordinates_with_their_nets() {
     )]);
     let client = KiCadIpcClient::new(&mock.url);
     let document = client
-        .find_open_board(std::path::Path::new("test.kicad_pcb"))
+        .find_open_board(&mock_board("test.kicad_pcb"))
         .expect("the mock holds test.kicad_pcb");
 
     let pads = client
@@ -1257,7 +1322,7 @@ fn an_unreadable_live_pad_is_reported_instead_of_silently_dropped() {
     )]);
     let client = KiCadIpcClient::new(&mock.url);
     let document = client
-        .find_open_board(std::path::Path::new("test.kicad_pcb"))
+        .find_open_board(&mock_board("test.kicad_pcb"))
         .expect("the mock holds test.kicad_pcb");
 
     let error = client
@@ -1278,7 +1343,7 @@ fn a_live_pad_without_a_position_is_reported_instead_of_fabricated_at_zero() {
     let mock = spawn_kicad_holding_items(vec![footprint_with_pads("U1", vec![pad])]);
     let client = KiCadIpcClient::new(&mock.url);
     let document = client
-        .find_open_board(std::path::Path::new("test.kicad_pcb"))
+        .find_open_board(&mock_board("test.kicad_pcb"))
         .expect("the mock holds test.kicad_pcb");
 
     let error = client
@@ -1295,7 +1360,7 @@ fn a_footprint_absent_from_the_live_board_reads_as_none() {
     )]);
     let client = KiCadIpcClient::new(&mock.url);
     let document = client
-        .find_open_board(std::path::Path::new("test.kicad_pcb"))
+        .find_open_board(&mock_board("test.kicad_pcb"))
         .expect("the mock holds test.kicad_pcb");
 
     assert!(client
@@ -1342,7 +1407,7 @@ fn pad_reads_target_the_named_board_among_several_open() {
 
     let client = KiCadIpcClient::new(&mock.url);
     let document = client
-        .find_open_board(std::path::Path::new("target.kicad_pcb"))
+        .find_open_board(&mock_board("target.kicad_pcb"))
         .expect("target.kicad_pcb is open");
     let _ = client.get_footprint_pads_in(document, "R1");
 
@@ -1380,7 +1445,7 @@ fn board_graphics_come_back_with_their_kind_layer_and_identifier() {
 
     let client = KiCadIpcClient::new(&mock.url);
     let document = client
-        .find_open_board(std::path::Path::new("test.kicad_pcb"))
+        .find_open_board(&mock_board("test.kicad_pcb"))
         .expect("the mock holds test.kicad_pcb");
 
     let graphics = client
@@ -1442,7 +1507,7 @@ fn deletes_target_the_named_board_among_several_open() {
 
     let client = KiCadIpcClient::new(&mock.url);
     let document = client
-        .find_open_board(std::path::Path::new("target.kicad_pcb"))
+        .find_open_board(&mock_board("target.kicad_pcb"))
         .expect("target.kicad_pcb is open");
     client
         .delete_items_in(document, vec!["edge-top".to_string()])
@@ -1503,7 +1568,7 @@ fn verified_trace_delete_refuses_a_non_trace_before_delete_items() {
 
     let client = KiCadIpcClient::new(&mock.url);
     let deleted = client
-        .delete_trace_segment_verified(std::path::Path::new("test.kicad_pcb"), "via-or-zone")
+        .delete_trace_segment_verified(&mock_board("test.kicad_pcb"), "via-or-zone")
         .expect("a non-trace is an observed outcome, not an IPC failure");
 
     assert!(deleted.is_none());
@@ -1581,7 +1646,7 @@ fn verified_trace_delete_targets_one_board_and_returns_observed_preimage() {
 
     let client = KiCadIpcClient::new(&mock.url);
     let observed = client
-        .delete_trace_segment_verified(std::path::Path::new("target.kicad_pcb"), "segment-1")
+        .delete_trace_segment_verified(&mock_board("target.kicad_pcb"), "segment-1")
         .expect("verified deletion")
         .expect("the segment existed");
 
@@ -1638,7 +1703,7 @@ fn verified_trace_delete_refuses_success_when_readback_still_contains_the_segmen
 
     let client = KiCadIpcClient::new(&mock.url);
     let error = client
-        .delete_trace_segment_verified(std::path::Path::new("test.kicad_pcb"), "segment-1")
+        .delete_trace_segment_verified(&mock_board("test.kicad_pcb"), "segment-1")
         .unwrap_err()
         .to_string();
 

--- a/crates/konnect/tests/live_kicad_tools.rs
+++ b/crates/konnect/tests/live_kicad_tools.rs
@@ -623,3 +623,63 @@ fn footprint_library_update_apply_then_dry_run_is_noop() {
         "{drc}"
     );
 }
+
+/// What a real KiCad puts in `DocumentSpecifier`, recorded rather than assumed.
+///
+/// The ambiguity gate in `find_open_board` refuses whenever an open PCB
+/// document cannot be placed on disk, and the shapes it refuses were derived
+/// from the vendored proto's own contract — `board_filename` is documented as
+/// "a PCB with a given filename, e.g. `board.kicad_pcb`", with
+/// `ProjectSpecifier.path` supplying the directory. A gate built on that
+/// reading is only as good as the reading, so this prints every field of every
+/// open document and then asserts the property the gate depends on: a live
+/// KiCad's open-document list is one Konnect can resolve in full.
+///
+/// Run it against a KiCad holding the disposable board:
+///
+/// ```text
+/// KICAD_API_SOCKET=… KONNECT_LIVE_KICAD_BOARD=… \
+///   cargo test -p konnect --test live_kicad_tools -- --ignored --nocapture \
+///   real_kicad_open_documents_resolve_to_comparable_paths
+/// ```
+#[test]
+#[ignore = "requires a running KiCad GUI with a board open and its API socket"]
+fn real_kicad_open_documents_resolve_to_comparable_paths() {
+    let board = std::path::PathBuf::from(
+        std::env::var("KONNECT_LIVE_KICAD_BOARD")
+            .expect("KONNECT_LIVE_KICAD_BOARD must name the disposable open board"),
+    );
+    let socket = std::env::var("KICAD_API_SOCKET").expect("KICAD_API_SOCKET is required");
+    let ipc = KiCadIpcClient::new(&socket);
+
+    let documents = ipc.get_open_documents().expect("KiCad answered");
+    assert!(
+        !documents.is_empty(),
+        "open the disposable board in KiCad before running this"
+    );
+    for document in &documents {
+        println!(
+            "open PCB document: type={} identifier={:?} project={:?}",
+            document.r#type, document.identifier, document.project
+        );
+    }
+
+    // The property the gate rests on: against a real KiCad, the requested
+    // board is positively identified rather than refused as ambiguous.
+    ipc.find_open_board(&board)
+        .unwrap_or_else(|error| panic!("KiCad's open-document list was not resolvable: {error:#}"));
+
+    // And a board that is genuinely not open is reported as such, not as an
+    // ambiguity — the distinction that decides whether a file write may run.
+    let absent = board.with_file_name("konnect-not-open-probe.kicad_pcb");
+    let error = ipc
+        .find_open_board(&absent)
+        .expect_err("that board is not open");
+    assert!(
+        matches!(
+            konnect_ipc::IpcFailure::from_error(error),
+            konnect_ipc::IpcFailure::BoardNotOpen(_)
+        ),
+        "a complete open-document list must prove absence, not merely fail to confirm it"
+    );
+}

--- a/docs/API_MIGRATIONS.md
+++ b/docs/API_MIGRATIONS.md
@@ -3,6 +3,22 @@
 Konnect's tool schemas are public API. This file records intentional argument
 removals and the supported replacement workflow.
 
+## Unreleased: guarded PCB file fallback reports its observed reason
+
+Hybrid PCB mutation tools may use their existing direct-file fallback when
+KiCad IPC is unreachable or when a reachable KiCad positively reports that the
+requested board is not open. A successful file-path result now includes
+`fallback_reason.kind` (`transport_unreachable` or `board_not_open`) and
+`fallback_reason.message`; its warning is derived from that same observation.
+Existing `source: "file"` and operation-specific fields remain unchanged.
+
+If KiCad answers but any relevant open PCB document identity is empty, bare,
+malformed, unresolved, duplicated, or otherwise prevents a complete comparison,
+the tool fails closed with structured error kind `ambiguous_open_board` and the
+requested `path`. No IPC mutation or file mutation is attempted. Callers should
+make KiCad's open documents identifiable, then retry; they must not treat this
+error as permission to edit the saved file directly.
+
 ## Unreleased: `score_placement` reports interface filter caps (minor release)
 
 `score_placement`'s decoupling deduction no longer fires on a capacitor placed on

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,8 +46,9 @@ resolution, and parse-mutate-serialize workflows for symbols, wires, labels,
 sheets, and related schematic concepts.
 
 `crates/konnect-ipc` owns the KiCad IPC client, generated protobuf types, NNG
-request/reply transport, typed board operations, and the distinction between an
-unreachable transport and a request KiCad received and rejected.
+request/reply transport, typed board operations, and the distinction among an
+unreachable transport, a requested board positively absent from KiCad's complete
+open-document set, an ambiguous document set, and a request KiCad rejected.
 
 ### Non-workspace and non-Rust boundaries
 
@@ -122,8 +123,11 @@ Board writes use three distinct patterns:
 1. Live IPC handlers call `KiCadIpcClient::ensure_board_is_active` in
    `konnect-ipc/src/client.rs` before changing the editor document.
 2. Hybrid handlers use `attempt_ipc_write` in
-   `konnect-core/src/tools/pcb_board.rs`. Only an unreachable IPC transport may
-   fall back to a file edit; a reached-and-rejected request fails closed.
+   `konnect-core/src/tools/pcb_board.rs`. File fallback is allowed only when the
+   transport is unreachable or the requested board is positively absent from a
+   complete, trustworthy set of open PCB document identities. Ambiguous document
+   identities and reached-and-rejected requests fail closed. A board observed
+   live earlier in the server process also remains protected if it disappears.
 3. File-only board handlers call `refuse_if_board_open_in_kicad` in
    `tools/pcb_board.rs` so KiCad cannot later overwrite an invisible file edit.
 


### PR DESCRIPTION
Closes #426.

## Problem

KiCad being reachable while the requested board is positively not open is not an IPC rejection. That observation may permit the existing guarded direct-file fallback, but only after every reported open PCB document has been resolved into a complete, trustworthy set of comparable identities.

The old behavior classified both “another board is open” and “nothing is open” as `Rejected`. An earlier version of this PR then skipped identities it could not resolve, which could turn ambiguous live-editor evidence into permission to mutate the saved file.

## Current implementation

- Adds typed `BoardNotOpen` only when the requested canonical board is absent from a complete, comparable set of open PCB document identities.
- Adds typed `AmbiguousOpenBoards` and public structured error kind `ambiguous_open_board` for empty, bare, malformed, unresolved, duplicate, or otherwise uncomparable relevant identities.
- Treats an empty open-document list explicitly as `BoardNotOpen`.
- Lets a positive requested-board match select the live IPC path even if another document is unreadable; ambiguity never unlocks file mode.
- Preserves process-lifetime stale-board refusal when a board observed live later disappears or IPC becomes unreachable.
- Returns `fallback_reason.kind` (`board_not_open` or `transport_unreachable`) and `fallback_reason.message` from successful hybrid file mutations; the warning is derived from the same observed classification.
- Documents the runtime boundary in `docs/ARCHITECTURE.md` and the additive response/error contract in `docs/API_MIGRATIONS.md`.

## Acceptance accounting

- [x] Requested board absent from a complete trustworthy list permits only the existing guarded fallback.
- [x] Empty open list is handled explicitly.
- [x] Requested board present, duplicated, changed, or disappeared refuses or routes safely as appropriate.
- [x] Bare, unresolved, malformed, missing, and duplicate document identities fail closed and never invoke a file-write closure.
- [x] A board observed live earlier remains protected.
- [x] Negative controls prove that skipping unresolved records and collapsing the new fallback evidence are caught by tests.
- [x] Windows live KiCad evidence covers the emitted bare filename plus absolute project-directory form on exact predecessor head `ced0754e475f4d38b17f88827421882496b734a1` with KiCad 10.0.5; the reconstruction does not change identity parsing.
- [x] Reconstructed on current `upstream/main` base `c22cef1ca1cb6dc6c89c7cb1b1838f0d6f329d71`.

## Validation

Current reconstructed head: `e1257025441ac82bde0ea63e5051869181e8d1ea`.

Local required gate:

- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace --locked --all-targets -- -D warnings` — pass
- `cargo test --workspace --locked --lib --tests` — pass
- `cargo test --workspace --locked --doc` — pass

Focused `konnect-ipc`, PCB-board, and PCB-component tests also pass. For the added response evidence, a negative control temporarily reported a positive `BoardNotOpen` observation as `transport_unreachable`; `a_kicad_holding_another_project_edits_this_board_file` failed on the exact field mismatch and passed again after restoration.

Hosted CI on the reconstructed head is the merge gate.

## Validation debt

Linux and macOS live-GUI `GetOpenDocuments` captures remain unavailable. Hosted unit tests cover their path dialects, but that is not represented as live evidence. This is recorded validation debt under the risk-proportionate contribution policy: the implementation fails closed for any form it cannot compare, Windows supplies a real KiCad observation, and no absent-platform inference is used to unlock a write.

The original contributor commit and authorship are preserved; the reconstruction resolves drift from the current IPC endpoint-discovery/redaction work and adds one focused maintainer completion commit for response evidence and documentation.
