### PR TITLE
docs(pcb): clarify predefined-size example

### DIFF
--- a/crates/konnect/assets/skills/kicad-pcb/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-pcb/SKILL.md
@@ -243,6 +243,12 @@ Netclass width is the default. The Track/Via dropdowns are a separate palette
 in the sibling `.kicad_pro`. Fill them with `set_predefined_sizes` so `W` /
 `Shift+W` can step through extra widths without changing netclasses:
 
+The values below show call syntax only; they are not engineering recommendations.
+Replace every value with one from the accepted project sizing record, derived
+from the current fabrication contract, stackup, and electrical requirements. If
+that evidence is unavailable, report the sizing task as `INCOMPLETE` instead of
+reusing these illustrative values.
+
 ```
 set_predefined_sizes(board, track_widths=[0.2, 0.5, 0.8],
     via_dimensions=[{diameter:0.6, drill:0.3}, {diameter:0.8, drill:0.4}])

--- a/crates/konnect/tests/asset_references.rs
+++ b/crates/konnect/tests/asset_references.rs
@@ -272,6 +272,7 @@ fn skills_define_the_same_evidence_boundary_as_their_agents() {
 fn manufacturing_guidance_is_contract_bound_and_fail_closed() {
     let manufacture = include_str!("../assets/skills/kicad-manufacture/SKILL.md");
     let jlcpcb = include_str!("../assets/skills/kicad-manufacture/references/jlcpcb-rules.md");
+    let pcb = include_str!("../assets/skills/kicad-pcb/SKILL.md");
     let design_rules = include_str!("../assets/skills/kicad-pcb/references/design-rules.md");
     let trace_width = include_str!("../assets/skills/kicad-pcb/references/trace-width-table.md");
 
@@ -327,6 +328,19 @@ fn manufacturing_guidance_is_contract_bound_and_fail_closed() {
         assert!(
             !jlcpcb.contains(stale_value),
             "JLCPCB reference still caches volatile value `{stale_value}`"
+        );
+    }
+
+    for marker in [
+        "show call syntax only",
+        "not engineering recommendations",
+        "accepted project sizing record",
+        "current fabrication contract",
+        "report the sizing task as `INCOMPLETE`",
+    ] {
+        assert!(
+            pcb.contains(marker),
+            "PCB skill predefined-size example is missing authority marker: {marker}"
         );
     }
 


### PR DESCRIPTION
## User-visible problem and scope

The `set_predefined_sizes` example used literal trace and via dimensions without explicitly saying they were illustrative. An agent could reuse them as universal recommendations instead of substituting values accepted for the current board.

This change is limited to the bundled PCB skill and its existing asset contract test.

## Root cause and design

The surrounding guidance distinguished the KiCad routing palette from DRC limits, but it did not bind the example values to project-specific sizing evidence. The skill now labels the values as syntax-only, requires replacements from the accepted project sizing record and current fabrication contract, and reports missing evidence as `INCOMPLETE`.

The existing manufacturing guidance guard now checks those authority and fail-closed statements in `kicad-pcb/SKILL.md`.

## Compatibility and migration

No MCP schema, Rust runtime behavior, public API, or file format changes.

## Tests

- `cargo test -p konnect --locked --test asset_references manufacturing_guidance_is_contract_bound_and_fail_closed -- --exact`
- Temporarily replaced `accepted project sizing record`; confirmed the focused test failed on that missing marker, then restored the text
- `cargo test --workspace --locked --lib --tests`
- `cargo test --workspace --locked --doc`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

## Risks and rollback

Risk is limited to agent-facing wording and a string-based contract guard. Reverting this commit restores the previous guidance and test behavior; no persisted project data or runtime behavior is affected.

Closes #377