### PR TITLE
fix(placement): stop scoring connector filter caps as decoupling defects

### DIFF
--- a/crates/konnect-core/src/tools/placement.rs
+++ b/crates/konnect-core/src/tools/placement.rs
@@ -1416,14 +1416,18 @@ struct InterfaceFilterCap {
 /// violation — it is reported separately as uncoupled, because "nothing to
 /// decouple" and "too far from what it decouples" are different findings.
 ///
-/// A cap sitting on the pins of a connector (J*) it shares a net with is
+/// A cap sitting on the pins of a connector (J*) whose nets it belongs to is
 /// interface/EMI filtering for that cable, not a bypass cap that drifted away
 /// from an IC on the same rail, so it is exempted from the distance rule
 /// (#411). The exemption is deliberately narrow — the cap must be within the
 /// *same* family limit of the connector's courtyard that the rule would demand
-/// of an IC, so a cap far from everything still deducts. Exemptions are
-/// returned as the third list rather than dropped, so the response says the
-/// deduction was waived instead of going quiet about a check that ran.
+/// of an IC, the connector must carry *every* named net the cap has, and where
+/// the two sit on opposite faces the connector's copper must actually reach
+/// the cap's face (see `nearest_interface_connector`). So a cap far from
+/// everything still deducts, and so does one that merely shares ground with a
+/// connector it happens to sit beside. Exemptions are returned as the third
+/// list rather than dropped, so the response says the deduction was waived
+/// instead of going quiet about a check that ran.
 ///
 /// `uncoupled_caps` is intentionally untouched by the exemption: a cap that
 /// shares no net with any IC never reached the distance rule in the first
@@ -1440,14 +1444,29 @@ fn decoupling_check(
     // Net set per reference, from the connectivity index — keyed by name, so
     // both file formats resolve identically.
     let mut nets_by_ref: HashMap<&str, BTreeSet<&str>> = HashMap::new();
+    // The subset of those nets a part carries on copper that reaches both
+    // faces of the board — what decides whether a part on the far face is
+    // electrically on these pins or only above them.
+    let mut through_nets_by_ref: HashMap<&str, BTreeSet<&str>> = HashMap::new();
     for net in index.nets() {
         for pad in index.pads_of_net(net) {
             nets_by_ref
                 .entry(pad.reference.as_str())
                 .or_default()
                 .insert(net);
+            if pad.reaches_both_faces {
+                through_nets_by_ref
+                    .entry(pad.reference.as_str())
+                    .or_default()
+                    .insert(net);
+            }
         }
     }
+
+    let side_by_ref: HashMap<&str, Side> = items
+        .iter()
+        .filter_map(|c| Some((c.reference.as_deref()?, c.layer_side)))
+        .collect();
 
     let ics = footprints_with_prefix(items, "U");
     let connectors = footprints_with_prefix(items, "J");
@@ -1481,8 +1500,16 @@ fn decoupling_check(
                 // shared-net connector's own pins is filtering that cable
                 // (#411). Same limit, measured against the connector, so this
                 // cannot swallow a cap that is far from everything.
-                match nearest_shared_net(&connectors, cap_nets, &nets_by_ref, center)
-                    .filter(|(_, connector_distance_mm)| *connector_distance_mm <= limit_mm)
+                match nearest_interface_connector(
+                    &connectors,
+                    cap_nets,
+                    side_by_ref.get(reference).copied(),
+                    &nets_by_ref,
+                    &through_nets_by_ref,
+                    &side_by_ref,
+                    center,
+                )
+                .filter(|(_, connector_distance_mm)| *connector_distance_mm <= limit_mm)
                 {
                     Some((connector, connector_distance_mm)) => {
                         interface_filters.push(InterfaceFilterCap {
@@ -1540,6 +1567,50 @@ fn nearest_shared_net<'a, 'n>(
                 (Some(a), Some(b)) => !a.is_disjoint(b),
                 _ => false,
             }
+        })
+        .map(|(reference, bbox)| (*reference, distance_to_bbox(center, *bbox)))
+        .min_by(|(_, a), (_, b)| a.total_cmp(b))
+}
+
+/// The nearest connector this capacitor is filtering for, and how far its
+/// courtyard bbox is from the cap's center. Same metric as the IC rule, two
+/// stricter pairing conditions, both from review of #416:
+///
+/// * The connector must carry **every** named net the cap has, not merely one.
+///   A two-terminal filter cap belongs to a cable only if both its terminals
+///   do; accepting a single overlap would let any cap that drifted near any
+///   connector claim the exemption on board-wide ground alone.
+/// * A cap on the opposite face qualifies only where the connector's copper is
+///   actually on the cap's face: the pads carrying those nets must reach both
+///   faces. Board side alone cannot answer this. A plated through-hole pin is
+///   as available from below as from above — the case @ncolomer measured on the
+///   #411 board, where a B.Cu cap filters an F.Cu THT header — while an SMD
+///   header's copper is not, however close the two look in XY.
+fn nearest_interface_connector<'a, 'n>(
+    connectors: &[(&'a str, Bbox)],
+    cap_nets: Option<&BTreeSet<&'n str>>,
+    cap_side: Option<Side>,
+    nets_by_ref: &HashMap<&str, BTreeSet<&'n str>>,
+    through_nets_by_ref: &HashMap<&str, BTreeSet<&'n str>>,
+    side_by_ref: &HashMap<&str, Side>,
+    center: (f64, f64),
+) -> Option<(&'a str, f64)> {
+    let cap_nets = cap_nets?;
+    connectors
+        .iter()
+        .filter(|(reference, _)| {
+            let carries_every_net = nets_by_ref
+                .get(*reference)
+                .is_some_and(|connector_nets| cap_nets.is_subset(connector_nets));
+            if !carries_every_net {
+                return false;
+            }
+            if side_by_ref.get(*reference).copied() == cap_side {
+                return true;
+            }
+            through_nets_by_ref
+                .get(*reference)
+                .is_some_and(|through_nets| cap_nets.is_subset(through_nets))
         })
         .map(|(reference, bbox)| (*reference, distance_to_bbox(center, *bbox)))
         .min_by(|(_, a), (_, b)| a.total_cmp(b))
@@ -1800,16 +1871,10 @@ mod tests {
         fixture.replace(from, to)
     }
 
-    /// Rewrite text inside ONE footprint's block, leaving every other footprint
-    /// alone. Line-scoped like `lock_footprint`: find the block enclosing the
-    /// Reference property, stop at that footprint's own closing paren, so a
-    /// string several parts share is only rewritten here.
-    fn rewrite_inside_footprint(
-        content: &str,
-        reference: &str,
-        rewrites: &[(String, String)],
-    ) -> String {
-        let lines: Vec<&str> = content.lines().collect();
+    /// The line range of ONE footprint's block: from its `(footprint …)` header
+    /// down to that footprint's own closing paren. Shared by the rewriters so
+    /// they cannot disagree about where a footprint ends.
+    fn footprint_block_range(lines: &[&str], reference: &str) -> (usize, usize) {
         let marker = format!(r#"(property "Reference" "{reference}""#);
         let r = lines
             .iter()
@@ -1824,6 +1889,79 @@ mod tests {
                 .iter()
                 .position(|l| *l == "\t)")
                 .expect("footprint block never closes");
+        (start, end)
+    }
+
+    /// Replace EVERY occurrence of each pattern inside one footprint's block,
+    /// unlike `rewrite_inside_footprint`, which demands exactly one hit per
+    /// pattern. A footprint's layer names repeat once per pad and per graphic,
+    /// which is precisely what flipping a part to the far face has to rewrite.
+    fn replace_all_inside_footprint(
+        content: &str,
+        reference: &str,
+        rewrites: &[(&str, &str)],
+    ) -> String {
+        let lines: Vec<&str> = content.lines().collect();
+        let (start, end) = footprint_block_range(&lines, reference);
+        let mut out: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+        for (from, to) in rewrites {
+            let mut hits = 0usize;
+            for line in &mut out[start..=end] {
+                if line.contains(from) {
+                    *line = line.replace(from, to);
+                    hits += 1;
+                }
+            }
+            assert!(hits > 0, "{from} never appears inside {reference}");
+        }
+        let nl = String::from_utf8(vec![10]).unwrap();
+        out.join(&nl)
+    }
+
+    /// Move one footprint to the far face the way KiCad's own flip does —
+    /// every front layer it draws on becomes the back one, `(layer "F.Cu")`
+    /// included, which is where `FootprintCourtyard::layer_side` is read from.
+    /// The courtyard survives the move: the scan accepts `B.CrtYd` alongside
+    /// `F.CrtYd` (board.rs:596), so the bbox and every distance in these tests
+    /// are unchanged by the flip.
+    fn flip_footprint_to_back(content: &str, reference: &str) -> String {
+        replace_all_inside_footprint(
+            content,
+            reference,
+            &[
+                (r#""F.Cu""#, r#""B.Cu""#),
+                (r#""F.Mask""#, r#""B.Mask""#),
+                (r#""F.Paste""#, r#""B.Paste""#),
+                (r#""F.SilkS""#, r#""B.SilkS""#),
+                (r#""F.CrtYd""#, r#""B.CrtYd""#),
+                (r#""F.Fab""#, r#""B.Fab""#),
+            ],
+        )
+    }
+
+    /// Turn one footprint's plated-through pads into single-face SMD pads,
+    /// leaving its geometry and nets alone. `*.Cu` is KiCad's "every copper
+    /// layer" wildcard, which is what makes a through-hole pin reachable from
+    /// the far face at all.
+    fn make_pads_surface_mount(content: &str, reference: &str) -> String {
+        replace_all_inside_footprint(
+            content,
+            reference,
+            &[(r#"(layers "*.Cu" "*.Mask")"#, r#"(layers "F.Cu" "F.Mask")"#)],
+        )
+    }
+
+    /// Rewrite text inside ONE footprint's block, leaving every other footprint
+    /// alone. Line-scoped like `lock_footprint`: find the block enclosing the
+    /// Reference property, stop at that footprint's own closing paren, so a
+    /// string several parts share is only rewritten here.
+    fn rewrite_inside_footprint(
+        content: &str,
+        reference: &str,
+        rewrites: &[(String, String)],
+    ) -> String {
+        let lines: Vec<&str> = content.lines().collect();
+        let (start, end) = footprint_block_range(&lines, reference);
         let mut out: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
         let mut rewritten = 0usize;
         for line in &mut out[start..=end] {
@@ -1986,6 +2124,100 @@ mod tests {
             &[("VCC", "/SIG_IN"), ("GND", "unconnected-(J1-Pin_4-Pad4)")],
         );
         let board = write_variant(&dir, "cap_beside_foreign_connector.kicad_pcb", retagged);
+
+        let response = score(&board).await;
+        assert_eq!(response["score"], 70, "{response}");
+        let deductions = response["deductions"].as_array().unwrap();
+        assert_eq!(deductions.len(), 1, "{response}");
+        assert_eq!(deductions[0]["points"], 30);
+        let refs = deductions[0]["references"].as_array().unwrap();
+        assert!(
+            refs.contains(&json!("C1")) && refs.contains(&json!("C2")),
+            "{response}"
+        );
+        assert!(
+            deductions[0]["detail"].as_str().unwrap().contains("5.3"),
+            "{response}"
+        );
+        assert_eq!(
+            response["interface_filter_caps"].as_array().unwrap().len(),
+            0
+        );
+    }
+
+    /// A cap on the FAR face of a plated-through connector is still filtering
+    /// that cable (@ncolomer's board on #411: C1 on B.Cu under an F.Cu JST
+    /// header). The connector's copper is present on both faces, so a cap
+    /// below its pins is electrically on them; only horizontal distance
+    /// decides. Same 1.61 mm geometry as the #411 repro, C1 flipped to the
+    /// back: J1's pads are `(layers "*.Cu" "*.Mask")`, so the exemption holds
+    /// and the score stays 85.
+    #[tokio::test]
+    async fn a_cap_on_the_far_face_of_a_through_hole_connector_is_still_interface_filtering() {
+        let dir = tempfile::tempdir().unwrap();
+        let moved = fixture_with_moved_root("(at 20 15)", "(at 16 20)");
+        let flipped = flip_footprint_to_back(&moved, "C1");
+        let board = write_variant(&dir, "cap_under_tht_connector.kicad_pcb", flipped);
+
+        let response = score(&board).await;
+        assert_eq!(response["score"], 85, "{response}");
+        let deductions = response["deductions"].as_array().unwrap();
+        assert_eq!(deductions.len(), 1, "{response}");
+        assert_eq!(deductions[0]["references"], json!(["C2"]));
+
+        let filters = response["interface_filter_caps"].as_array().unwrap();
+        assert_eq!(filters.len(), 1, "{response}");
+        assert_eq!(filters[0]["reference"], "C1");
+        assert_eq!(filters[0]["connector"], "J1");
+        assert_eq!(filters[0]["connector_distance_mm"], 1.61);
+    }
+
+    /// The far-face allowance is the through-hole copper, not the geometry.
+    /// Identical board to the test above, except J1's pads are retagged from
+    /// `*.Cu` to `F.Cu` — an SMD header, whose copper a cap on B.Cu cannot
+    /// touch however close it looks from above. The exemption must not fire,
+    /// so C1 deducts again at its 5.3 mm from U1 and the score returns to 70.
+    #[tokio::test]
+    async fn a_cap_on_the_far_face_of_a_surface_mount_connector_is_not_interface_filtering() {
+        let dir = tempfile::tempdir().unwrap();
+        let moved = fixture_with_moved_root("(at 20 15)", "(at 16 20)");
+        let flipped = flip_footprint_to_back(&moved, "C1");
+        let smd_header = make_pads_surface_mount(&flipped, "J1");
+        let board = write_variant(&dir, "cap_under_smd_connector.kicad_pcb", smd_header);
+
+        let response = score(&board).await;
+        assert_eq!(response["score"], 70, "{response}");
+        let deductions = response["deductions"].as_array().unwrap();
+        assert_eq!(deductions.len(), 1, "{response}");
+        assert_eq!(deductions[0]["points"], 30);
+        let refs = deductions[0]["references"].as_array().unwrap();
+        assert!(
+            refs.contains(&json!("C1")) && refs.contains(&json!("C2")),
+            "{response}"
+        );
+        assert!(
+            deductions[0]["detail"].as_str().unwrap().contains("5.3"),
+            "{response}"
+        );
+        assert_eq!(
+            response["interface_filter_caps"].as_array().unwrap().len(),
+            0
+        );
+    }
+
+    /// One shared net is not enough. A two-terminal filter cap belongs to the
+    /// cable only if the connector carries BOTH of its nets; sharing just the
+    /// board-wide ground makes any cap that drifts near any connector look
+    /// like interface filtering. J1's VCC pad is retagged to /SIG_IN, a net J1
+    /// already owns, leaving GND as the single overlap with C1. Geometry is
+    /// untouched — 1.61 mm from J1, 5.3 mm from U1 — so only the net rule can
+    /// decide, and it deducts.
+    #[tokio::test]
+    async fn a_cap_sharing_only_ground_with_the_connector_still_deducts() {
+        let dir = tempfile::tempdir().unwrap();
+        let moved = fixture_with_moved_root("(at 20 15)", "(at 16 20)");
+        let ground_only = rewrite_footprint_nets(&moved, "J1", &[("VCC", "/SIG_IN")]);
+        let board = write_variant(&dir, "cap_sharing_only_ground.kicad_pcb", ground_only);
 
         let response = score(&board).await;
         assert_eq!(response["score"], 70, "{response}");

--- a/crates/konnect-core/src/tools/placement.rs
+++ b/crates/konnect-core/src/tools/placement.rs
@@ -271,7 +271,8 @@ async fn handle_score_placement(
     }
 
     // ── Decoupling check (C* near a shared-net U*) ──────────────────────────
-    let (decoupling_violations, uncoupled_caps) = decoupling_check(&scan.items, &index, &values);
+    let (decoupling_violations, uncoupled_caps, interface_filter_caps) =
+        decoupling_check(&scan.items, &index, &values);
 
     // ── Soft score (ported weight table — see the module docs) ──────────────
     let overlap_deduction = (overlap_pairs as i64 * OVERLAP_POINTS).min(OVERLAP_CAP);
@@ -355,6 +356,16 @@ async fn handle_score_placement(
         "deductions": deductions,
         "connector_edges": connector_edges,
         "uncoupled_caps": uncoupled_caps,
+        "interface_filter_caps": interface_filter_caps
+            .iter()
+            .map(|f| json!({
+                "reference": f.cap,
+                "value": f.value,
+                "connector": f.connector,
+                "connector_distance_mm": round3(f.distance_mm),
+                "limit_mm": f.limit_mm,
+            }))
+            .collect::<Vec<_>>(),
         "footprints_scored": scan.items.len(),
         "footprints_skipped": scan.skipped,
     })))
@@ -1389,15 +1400,43 @@ struct DecouplingViolation {
     limit_mm: f64,
 }
 
+/// One capacitor exempted from the decoupling rule because it sits on the
+/// pins of a connector it shares a net with — interface/EMI filtering for a
+/// cable, not a bypass cap that drifted away from its IC.
+struct InterfaceFilterCap {
+    cap: String,
+    value: String,
+    connector: String,
+    distance_mm: f64,
+    limit_mm: f64,
+}
+
 /// Check every family-classified capacitor (C*) against the nearest IC (U*)
 /// that shares a net with it. A cap sharing no net with any IC is not a
 /// violation — it is reported separately as uncoupled, because "nothing to
 /// decouple" and "too far from what it decouples" are different findings.
+///
+/// A cap sitting on the pins of a connector (J*) it shares a net with is
+/// interface/EMI filtering for that cable, not a bypass cap that drifted away
+/// from an IC on the same rail, so it is exempted from the distance rule
+/// (#411). The exemption is deliberately narrow — the cap must be within the
+/// *same* family limit of the connector's courtyard that the rule would demand
+/// of an IC, so a cap far from everything still deducts. Exemptions are
+/// returned as the third list rather than dropped, so the response says the
+/// deduction was waived instead of going quiet about a check that ran.
+///
+/// `uncoupled_caps` is intentionally untouched by the exemption: a cap that
+/// shares no net with any IC never reached the distance rule in the first
+/// place, and "nothing to decouple" stays the honest report for it.
 fn decoupling_check(
     items: &[FootprintCourtyard],
     index: &PcbConnectivityIndex,
     values: &HashMap<String, String>,
-) -> (Vec<DecouplingViolation>, Vec<String>) {
+) -> (
+    Vec<DecouplingViolation>,
+    Vec<String>,
+    Vec<InterfaceFilterCap>,
+) {
     // Net set per reference, from the connectivity index — keyed by name, so
     // both file formats resolve identically.
     let mut nets_by_ref: HashMap<&str, BTreeSet<&str>> = HashMap::new();
@@ -1410,16 +1449,12 @@ fn decoupling_check(
         }
     }
 
-    let ics: Vec<(&str, Bbox)> = items
-        .iter()
-        .filter_map(|c| {
-            let reference = c.reference.as_deref()?;
-            (ref_prefix(reference) == "U").then_some((reference, c.bbox))
-        })
-        .collect();
+    let ics = footprints_with_prefix(items, "U");
+    let connectors = footprints_with_prefix(items, "J");
 
     let mut violations = Vec::new();
     let mut uncoupled = Vec::new();
+    let mut interface_filters = Vec::new();
     for c in items {
         let Some(reference) = c.reference.as_deref() else {
             continue;
@@ -1435,42 +1470,89 @@ fn decoupling_check(
         };
         let cap_nets = nets_by_ref.get(reference);
         let center = bbox_center(c.bbox);
-        let nearest = ics
-            .iter()
-            .filter(|(ic, _)| {
-                // Shares at least one named net with this cap.
-                match (cap_nets, nets_by_ref.get(*ic)) {
-                    (Some(a), Some(b)) => !a.is_disjoint(b),
-                    _ => false,
-                }
-            })
-            .map(|(ic, ic_bbox)| {
-                // Distance from the cap's center to the IC's COURTYARD BBOX,
-                // not its center: center-to-center makes a tight limit
-                // unachievable against any physically large IC — a 0402
-                // touching a SOIC-8's courtyard would read 3.8 mm and fail a
-                // 2.5 mm rule it plainly satisfies.
-                let dx = (ic_bbox.0 - center.0).max(0.0).max(center.0 - ic_bbox.2);
-                let dy = (ic_bbox.1 - center.1).max(0.0).max(center.1 - ic_bbox.3);
-                (*ic, dx.hypot(dy))
-            })
-            .min_by(|(_, a), (_, b)| a.total_cmp(b));
-        match nearest {
+        match nearest_shared_net(&ics, cap_nets, &nets_by_ref, center) {
             None => uncoupled.push(reference.to_string()),
             Some((ic, distance_mm)) => {
-                if distance_mm > limit_mm {
-                    violations.push(DecouplingViolation {
+                if distance_mm <= limit_mm {
+                    continue;
+                }
+                // The cap is too far from the IC it shares a rail with. Before
+                // deducting, ask what it is actually sitting on: a cap on a
+                // shared-net connector's own pins is filtering that cable
+                // (#411). Same limit, measured against the connector, so this
+                // cannot swallow a cap that is far from everything.
+                match nearest_shared_net(&connectors, cap_nets, &nets_by_ref, center)
+                    .filter(|(_, connector_distance_mm)| *connector_distance_mm <= limit_mm)
+                {
+                    Some((connector, connector_distance_mm)) => {
+                        interface_filters.push(InterfaceFilterCap {
+                            cap: reference.to_string(),
+                            value: value.clone(),
+                            connector: connector.to_string(),
+                            distance_mm: connector_distance_mm,
+                            limit_mm,
+                        })
+                    }
+                    None => violations.push(DecouplingViolation {
                         cap: reference.to_string(),
                         value: value.clone(),
                         ic: ic.to_string(),
                         distance_mm,
                         limit_mm,
-                    });
+                    }),
                 }
             }
         }
     }
-    (violations, uncoupled)
+    (violations, uncoupled, interface_filters)
+}
+
+/// Footprints whose reference designator carries `prefix` exactly, paired with
+/// their courtyard bboxes. An exact prefix match, so `CN3` is not a capacitor
+/// and `JP1` is not a connector.
+fn footprints_with_prefix<'a>(
+    items: &'a [FootprintCourtyard],
+    prefix: &str,
+) -> Vec<(&'a str, Bbox)> {
+    items
+        .iter()
+        .filter_map(|c| {
+            let reference = c.reference.as_deref()?;
+            (ref_prefix(reference) == prefix).then_some((reference, c.bbox))
+        })
+        .collect()
+}
+
+/// The nearest candidate that shares at least one named net with the cap, and
+/// how far its courtyard bbox is from the cap's center. `None` when no
+/// candidate shares a net.
+fn nearest_shared_net<'a, 'n>(
+    candidates: &[(&'a str, Bbox)],
+    cap_nets: Option<&BTreeSet<&'n str>>,
+    nets_by_ref: &HashMap<&str, BTreeSet<&'n str>>,
+    center: (f64, f64),
+) -> Option<(&'a str, f64)> {
+    candidates
+        .iter()
+        .filter(|(reference, _)| {
+            // Shares at least one named net with this cap.
+            match (cap_nets, nets_by_ref.get(*reference)) {
+                (Some(a), Some(b)) => !a.is_disjoint(b),
+                _ => false,
+            }
+        })
+        .map(|(reference, bbox)| (*reference, distance_to_bbox(center, *bbox)))
+        .min_by(|(_, a), (_, b)| a.total_cmp(b))
+}
+
+/// Distance from a point to a courtyard BBOX's edge — zero inside it — not to
+/// its center: center-to-center makes a tight limit unachievable against any
+/// physically large part, since a 0402 touching a SOIC-8's courtyard would
+/// read 3.8 mm and fail a 2.5 mm rule it plainly satisfies.
+fn distance_to_bbox((px, py): (f64, f64), (x0, y0, x1, y1): Bbox) -> f64 {
+    let dx = (x0 - px).max(0.0).max(px - x1);
+    let dy = (y0 - py).max(0.0).max(py - y1);
+    dx.hypot(dy)
 }
 
 /// The distance limit for a capacitor value's decoupling family, `None` for
@@ -1702,6 +1784,354 @@ mod tests {
         // Edge distances cannot be computed without an outline.
         assert_eq!(response["connector_edges"].as_array().unwrap().len(), 0);
         assert_eq!(response["hard_failures"].as_array().unwrap().len(), 0);
+    }
+
+    /// Move ONE footprint's root anchor by string surgery on the
+    /// KiCad-authored fixture, the way
+    /// `overlapping_courtyards_are_a_hard_fail_naming_the_pair` does: the
+    /// geometry changes, every KiCad-written detail around it does not.
+    fn fixture_with_moved_root(from: &str, to: &str) -> String {
+        let fixture = std::fs::read_to_string(FIXTURE).unwrap();
+        assert_eq!(
+            fixture.matches(from).count(),
+            1,
+            "surgery anchor must be unique: {from}"
+        );
+        fixture.replace(from, to)
+    }
+
+    /// Rewrite text inside ONE footprint's block, leaving every other footprint
+    /// alone. Line-scoped like `lock_footprint`: find the block enclosing the
+    /// Reference property, stop at that footprint's own closing paren, so a
+    /// string several parts share is only rewritten here.
+    fn rewrite_inside_footprint(
+        content: &str,
+        reference: &str,
+        rewrites: &[(String, String)],
+    ) -> String {
+        let lines: Vec<&str> = content.lines().collect();
+        let marker = format!(r#"(property "Reference" "{reference}""#);
+        let r = lines
+            .iter()
+            .position(|l| l.contains(&marker))
+            .expect("reference not present in fixture");
+        let start = lines[..r]
+            .iter()
+            .rposition(|l| l.trim_start().starts_with("(footprint "))
+            .expect("reference has no enclosing footprint");
+        let end = start
+            + lines[start..]
+                .iter()
+                .position(|l| *l == "\t)")
+                .expect("footprint block never closes");
+        let mut out: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+        let mut rewritten = 0usize;
+        for line in &mut out[start..=end] {
+            for (from, to) in rewrites {
+                if line.contains(from.as_str()) {
+                    *line = line.replace(from.as_str(), to.as_str());
+                    rewritten += 1;
+                    break;
+                }
+            }
+        }
+        assert_eq!(
+            rewritten,
+            rewrites.len(),
+            "every rewrite must land inside {reference}"
+        );
+        let nl = String::from_utf8(vec![10]).unwrap();
+        out.join(&nl)
+    }
+
+    /// Retag one footprint's pad nets, by net name.
+    fn rewrite_footprint_nets(content: &str, reference: &str, rewrites: &[(&str, &str)]) -> String {
+        let rewrites: Vec<(String, String)> = rewrites
+            .iter()
+            .map(|(from, to)| (format!(r#"(net "{from}")"#), format!(r#"(net "{to}")"#)))
+            .collect();
+        rewrite_inside_footprint(content, reference, &rewrites)
+    }
+
+    /// Retag one footprint's `Value` property — the field `decoupling_limit_mm`
+    /// classifies a capacitor's family from, so a fixture cap can be moved to
+    /// another family without inventing a second board.
+    fn rewrite_footprint_value(content: &str, reference: &str, from: &str, to: &str) -> String {
+        let rewrites = vec![(
+            format!(r#"(property "Value" "{from}""#),
+            format!(r#"(property "Value" "{to}""#),
+        )];
+        rewrite_inside_footprint(content, reference, &rewrites)
+    }
+
+    fn write_variant(dir: &tempfile::TempDir, name: &str, content: String) -> std::path::PathBuf {
+        let path = dir.path().join(name);
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    /// #411: a 100nF cap sitting on a connector's own VCC/GND pins is
+    /// interface/EMI filtering for that cable, not a bypass cap that wandered
+    /// away from the MCU across the board. It used to cost 15 points and name
+    /// the distant IC in the detail.
+    ///
+    /// Surgery: C1's root anchor moves from (20, 15) to (16, 20), beside J1 —
+    /// the fixture's 4-pin header, whose pads carry VCC, GND and /SIG_IN, so
+    /// it shares both of C1's nets. Hand arithmetic from the fixture's own
+    /// coordinates:
+    ///
+    /// - C1's courtyard rect (−0.91, −0.460001)..(0.91, 0.46) puts its bbox at
+    ///   (15.09, 19.539999)..(16.91, 20.46), center (16, 19.9999995).
+    /// - J1's bbox is (3.229999, 18.23)..(14.39, 21.77) (hand-computed in
+    ///   `kicad_fixture_passes_at_70_with_only_the_decoupling_deduction`), so
+    ///   0.7 mm of clear air separates the two bboxes — no courtyard overlap.
+    /// - Cap center to J1's bbox edge: dx = 16 − 14.39 = 1.61, dy = 0 (the
+    ///   center's y is inside J1's y span) → 1.61 mm ≤ the 2.5 mm 100nF limit
+    ///   → interface filtering.
+    /// - Cap center to U1's bbox (21.299999, 17.299999)..(28.699999, 22.7):
+    ///   dx = 5.3, dy = 0 → 5.3 mm > 2.5 mm, which is the deduction this
+    ///   exemption suppresses.
+    ///
+    /// C2 is untouched at (30, 15): 2.642 mm from U1 (still over the limit)
+    /// and 15.61 mm from J1, so it still deducts. The exemption silences one
+    /// cap, not the check. Score: 100 − 15 = 85.
+    #[tokio::test]
+    async fn a_cap_on_a_shared_net_connector_is_interface_filtering_not_a_decoupling_defect() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = write_variant(
+            &dir,
+            "cap_on_connector.kicad_pcb",
+            fixture_with_moved_root("(at 20 15)", "(at 16 20)"),
+        );
+
+        let response = score(&board).await;
+        assert_eq!(response["verdict"], "pass", "{response}");
+        assert_eq!(response["hard_failures"].as_array().unwrap().len(), 0);
+        assert_eq!(response["score"], 85, "only C2 still deducts: {response}");
+
+        // The surviving deduction names C2 alone — C1 is gone from it.
+        let deductions = response["deductions"].as_array().unwrap();
+        assert_eq!(deductions.len(), 1, "{response}");
+        assert_eq!(deductions[0]["kind"], "decoupling");
+        assert_eq!(deductions[0]["points"], 15);
+        assert_eq!(deductions[0]["references"], json!(["C2"]));
+        assert!(
+            !deductions[0]["detail"].as_str().unwrap().contains("C1"),
+            "{response}"
+        );
+
+        // The waiver is reported, not silent: a check that ran and was
+        // exempted must be distinguishable from a check that never fired.
+        let filters = response["interface_filter_caps"].as_array().unwrap();
+        assert_eq!(filters.len(), 1, "{response}");
+        assert_eq!(filters[0]["reference"], "C1");
+        assert_eq!(filters[0]["value"], "100nF");
+        assert_eq!(filters[0]["connector"], "J1");
+        assert_eq!(filters[0]["connector_distance_mm"], 1.61);
+        assert_eq!(filters[0]["limit_mm"], 2.5);
+
+        // C1 shares VCC/GND with U1, so it was never "nothing to decouple".
+        assert_eq!(response["uncoupled_caps"].as_array().unwrap().len(), 0);
+    }
+
+    /// The exemption must not become a way to switch the rule off. Same
+    /// surgery, 2 mm further: C1 lands at (18, 20), which is 3.61 mm from J1's
+    /// bbox and 3.3 mm from U1's — over the 2.5 mm limit on BOTH counts. A cap
+    /// that is far from everything is still a placement defect, so both caps
+    /// deduct and the score stays at the fixture's 70.
+    #[tokio::test]
+    async fn a_cap_far_from_both_its_ic_and_the_connector_still_deducts() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = write_variant(
+            &dir,
+            "cap_far_from_both.kicad_pcb",
+            fixture_with_moved_root("(at 20 15)", "(at 18 20)"),
+        );
+
+        let response = score(&board).await;
+        assert_eq!(response["score"], 70, "{response}");
+        let deductions = response["deductions"].as_array().unwrap();
+        assert_eq!(deductions.len(), 1, "{response}");
+        assert_eq!(deductions[0]["kind"], "decoupling");
+        assert_eq!(deductions[0]["points"], 30);
+        let refs = deductions[0]["references"].as_array().unwrap();
+        assert!(
+            refs.contains(&json!("C1")) && refs.contains(&json!("C2")),
+            "{response}"
+        );
+        let detail = deductions[0]["detail"].as_str().unwrap();
+        assert!(
+            detail.contains("3.3"),
+            "hand-computed C1 distance: {detail}"
+        );
+        assert_eq!(
+            response["interface_filter_caps"].as_array().unwrap().len(),
+            0
+        );
+    }
+
+    /// Proximity alone is not the exemption — the cap has to be on nets the
+    /// connector actually carries. C1 sits at (16, 20), 1.61 mm from J1 exactly
+    /// as in the #411 repro, but J1's VCC and GND pads are retagged to nets J1
+    /// already owns (/SIG_IN and its unconnected pin 4), leaving J1 and C1
+    /// net-disjoint. C1 still shares VCC/GND with U1 at 5.3 mm, so the
+    /// deduction stands and both caps are named.
+    #[tokio::test]
+    async fn a_cap_beside_a_connector_it_shares_no_net_with_still_deducts() {
+        let dir = tempfile::tempdir().unwrap();
+        let moved = fixture_with_moved_root("(at 20 15)", "(at 16 20)");
+        let retagged = rewrite_footprint_nets(
+            &moved,
+            "J1",
+            &[("VCC", "/SIG_IN"), ("GND", "unconnected-(J1-Pin_4-Pad4)")],
+        );
+        let board = write_variant(&dir, "cap_beside_foreign_connector.kicad_pcb", retagged);
+
+        let response = score(&board).await;
+        assert_eq!(response["score"], 70, "{response}");
+        let deductions = response["deductions"].as_array().unwrap();
+        assert_eq!(deductions.len(), 1, "{response}");
+        assert_eq!(deductions[0]["points"], 30);
+        let refs = deductions[0]["references"].as_array().unwrap();
+        assert!(
+            refs.contains(&json!("C1")) && refs.contains(&json!("C2")),
+            "{response}"
+        );
+        assert!(
+            deductions[0]["detail"].as_str().unwrap().contains("5.3"),
+            "{response}"
+        );
+        assert_eq!(
+            response["interface_filter_caps"].as_array().unwrap().len(),
+            0
+        );
+    }
+
+    /// The exemption deliberately leaves `uncoupled_caps` alone. C1 sits on
+    /// J1's pins, but its own pads are retagged to J1's other two nets, so it
+    /// shares nothing with any IC: it never reaches the distance rule, and
+    /// "nothing to decouple" stays the honest report for it rather than being
+    /// relabelled as a waived deduction. C2 still deducts → 85.
+    #[tokio::test]
+    async fn a_connector_cap_sharing_no_net_with_any_ic_is_still_reported_uncoupled() {
+        let dir = tempfile::tempdir().unwrap();
+        let moved = fixture_with_moved_root("(at 20 15)", "(at 16 20)");
+        let retagged = rewrite_footprint_nets(
+            &moved,
+            "C1",
+            &[("VCC", "/SIG_IN"), ("GND", "unconnected-(J1-Pin_4-Pad4)")],
+        );
+        let board = write_variant(&dir, "connector_cap_uncoupled.kicad_pcb", retagged);
+
+        let response = score(&board).await;
+        assert_eq!(response["uncoupled_caps"], json!(["C1"]), "{response}");
+        assert_eq!(
+            response["interface_filter_caps"].as_array().unwrap().len(),
+            0
+        );
+        assert_eq!(response["score"], 85, "{response}");
+        assert_eq!(response["deductions"][0]["references"], json!(["C2"]));
+    }
+
+    /// `interface_filter_caps` means "a deduction was waived", not "a cap is
+    /// near a connector" — a cap that satisfies the decoupling rule outright
+    /// is reported by neither list.
+    ///
+    /// Two surgeries put one cap inside both limits at once, which the stock
+    /// fixture cannot do (U1 and J1 are 6.91 mm apart in x): U1's anchor moves
+    /// from (25, 20) to (19, 20) — bbox (15.299999, 17.299999)..(22.699999,
+    /// 22.7), still 0.91 mm clear of J1's bbox — and C1's from (20, 15) to
+    /// (14, 16), above both (below is R1's spot at (15, 25)). Hand arithmetic:
+    /// C1's center (14, 15.9999995) is dx 1.3 / dy 1.3 → 1.838 mm from U1's
+    /// bbox and dx 0 / dy 2.23 → 2.23 mm from J1's, both inside the 2.5 mm
+    /// limit. C2 is now 7.654 mm from the relocated U1, so it alone deducts
+    /// → 85.
+    #[tokio::test]
+    async fn a_cap_within_both_limits_is_neither_a_violation_nor_a_reported_waiver() {
+        let dir = tempfile::tempdir().unwrap();
+        let moved_ic = fixture_with_moved_root("(at 25 20)", "(at 19 20)");
+        assert_eq!(moved_ic.matches("(at 20 15)").count(), 1);
+        let board = write_variant(
+            &dir,
+            "cap_within_both_limits.kicad_pcb",
+            moved_ic.replace("(at 20 15)", "(at 14 16)"),
+        );
+
+        let response = score(&board).await;
+        assert_eq!(response["verdict"], "pass", "{response}");
+        assert_eq!(response["score"], 85, "{response}");
+        assert_eq!(response["deductions"][0]["references"], json!(["C2"]));
+        assert!(
+            response["deductions"][0]["detail"]
+                .as_str()
+                .unwrap()
+                .contains("7.654"),
+            "{response}"
+        );
+        // C1 broke no rule, so nothing was waived on its behalf.
+        assert_eq!(
+            response["interface_filter_caps"].as_array().unwrap().len(),
+            0,
+            "{response}"
+        );
+        assert_eq!(response["uncoupled_caps"].as_array().unwrap().len(), 0);
+    }
+
+    /// The exemption is measured against the cap's OWN family limit, not
+    /// against the 2.5 mm of the 100nF family every other test here uses. With
+    /// only 100nF caps on the board, a hard-coded `2.5` and `limit_mm` are
+    /// indistinguishable, and the claim that this exemption can never be looser
+    /// than the rule it waives would be untested.
+    ///
+    /// So: C1's Value becomes `1uF` (family limit 5.0 mm) and its anchor moves
+    /// from (20, 15) to (16, 15) — off the U1/J1 axis, because the 6.91 mm gap
+    /// between J1's bbox and U1's cannot hold a point that is both > 5 mm from
+    /// U1 and > 2.5 mm from J1 on a straight line between them. Hand arithmetic
+    /// from the fixture's own coordinates, cap center (16, 14.9999995):
+    ///
+    /// - To J1's bbox (3.229999, 18.23)..(14.39, 21.77): dx = 16 − 14.39 =
+    ///   1.61, dy = 18.23 − 15 = 3.23 → √(2.5921 + 10.4329) = 3.609 mm. That is
+    ///   ABOVE 2.5 mm and BELOW the 1uF limit of 5.0 mm — the whole point.
+    /// - To U1's bbox (21.299999, 17.299999)..(28.699999, 22.7): dx = 5.3,
+    ///   dy = 2.3 → √(28.09 + 5.29) = 5.778 mm > 5.0 mm, so the cap really does
+    ///   reach the exemption instead of passing the IC rule outright.
+    /// - C1's bbox (15.09, 14.539999)..(16.91, 15.46) touches nothing: J1
+    ///   starts at y 18.23, U1 at x 21.3, R1 sits at (15, 25).
+    ///
+    /// Real code exempts C1 (3.609 ≤ 5.0) and scores 85 with C2 alone. A build
+    /// that compares against a hard-coded 2.5 deducts for C1 and scores 70.
+    #[tokio::test]
+    async fn the_exemption_uses_the_caps_own_family_limit_not_the_100nf_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let moved = fixture_with_moved_root("(at 20 15)", "(at 16 15)");
+        let board = write_variant(
+            &dir,
+            "bulk_cap_on_connector.kicad_pcb",
+            rewrite_footprint_value(&moved, "C1", "100nF", "1uF"),
+        );
+
+        let response = score(&board).await;
+        assert_eq!(response["verdict"], "pass", "{response}");
+        assert_eq!(response["hard_failures"].as_array().unwrap().len(), 0);
+        assert_eq!(
+            response["score"], 85,
+            "C1 is 3.609 mm from J1, inside its own 5.0 mm limit: {response}"
+        );
+
+        let filters = response["interface_filter_caps"].as_array().unwrap();
+        assert_eq!(filters.len(), 1, "{response}");
+        assert_eq!(filters[0]["reference"], "C1");
+        assert_eq!(filters[0]["value"], "1uF");
+        assert_eq!(filters[0]["connector"], "J1");
+        // Both numbers matter: the distance is over the 100nF family's 2.5 mm,
+        // and the limit reported is this cap's own 5.0 mm.
+        assert_eq!(filters[0]["connector_distance_mm"], 3.609);
+        assert_eq!(filters[0]["limit_mm"], 5.0);
+
+        // C2 is untouched 100nF and still deducts — the families do not bleed.
+        assert_eq!(response["deductions"][0]["references"], json!(["C2"]));
+        assert_eq!(response["deductions"][0]["points"], 15);
+        assert_eq!(response["uncoupled_caps"].as_array().unwrap().len(), 0);
     }
 
     #[tokio::test]

--- a/crates/konnect-sexp/src/board.rs
+++ b/crates/konnect-sexp/src/board.rs
@@ -791,6 +791,37 @@ pub struct PadSite {
     /// reachable from both sides regardless; this records where its
     /// footprint sits.
     pub layer_side: Side,
+    /// Whether this pad's own copper reaches both faces of the board — true
+    /// for a plated through-hole pin, false for surface-mount copper. Read
+    /// from the pad's `(layers …)` stack: `*.Cu` is KiCad's every-copper-layer
+    /// wildcard, and an explicit stack qualifies only when it names both
+    /// `F.Cu` and `B.Cu`. This is what `layer_side` cannot answer — a part on
+    /// the far face can touch a through-hole pin's copper and cannot touch an
+    /// SMD pad's.
+    pub reaches_both_faces: bool,
+}
+
+/// Does this pad's copper reach both faces of the board?
+///
+/// `*.Cu` is KiCad's wildcard for every copper layer, which is how it writes a
+/// plated through-hole pin; an explicit stack has to name both outer coppers to
+/// mean the same thing. A pad with no `(layers …)` at all is read as
+/// single-face: absent evidence of a plated hole is not evidence of one.
+fn pad_reaches_both_faces(pad: &SexpNode) -> bool {
+    let Some(children) = pad.find("layers").and_then(SexpNode::children) else {
+        return false;
+    };
+    let mut front = false;
+    let mut back = false;
+    for layer in children.iter().skip(1).filter_map(SexpNode::as_str) {
+        match layer {
+            "*.Cu" => return true,
+            "F.Cu" => front = true,
+            "B.Cu" => back = true,
+            _ => {}
+        }
+    }
+    front && back
 }
 
 /// Net-keyed index over a board's pads and routed segments.
@@ -852,6 +883,7 @@ impl PcbConnectivityIndex {
                         pad_number,
                         at,
                         layer_side,
+                        reaches_both_faces: pad_reaches_both_faces(pad),
                     })
                 })();
                 let Some(site) = site else {

--- a/crates/konnect/assets/skills/kicad-pcb/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-pcb/SKILL.md
@@ -120,6 +120,8 @@ Do NOT add copper pours before routing is complete — they interfere with inter
 - Group components by functional block (power, digital, analog, connectors)
 - Place ICs first, then their associated passives
 - Decoupling caps: within 2mm of their IC power pins, on same layer
+- Cable/EMI filter caps: on the connector's own pins, and judged against that
+  connector rather than the nearest IC
 - Connectors: at board edges, accessible for cables
 - High-frequency components: minimize trace lengths between them
 - Thermal considerations: power components away from sensitive analog
@@ -144,7 +146,11 @@ after its own plan, so a change is judged before it is made:
 
 1. `score_placement` — 0-100 with named deductions; hard failures (courtyard
    overlaps, parts outside the outline) decide the verdict regardless of the
-   number, and a board with no outline can never pass.
+   number, and a board with no outline can never pass. `interface_filter_caps`
+   lists caps that were within their family limit of a connector carrying every
+   one of their nets: that is cable filtering, so the decoupling rule was
+   answered rather than skipped. They are not defects to "fix" by dragging them
+   toward an IC.
 2. `auto_place_from_schematic` — deterministic first placement by net
    clusters; explicitly a starting point, not a final layout.
 3. `refine_placement_force_directed` — deterministic spring embedder; pass

--- a/crates/konnect/tests/asset_references.rs
+++ b/crates/konnect/tests/asset_references.rs
@@ -714,6 +714,8 @@ fn backticked_tool_names_in_prose_exist_in_the_registry() {
         "files_generated",
         // Structured hierarchy-audit response field, not a callable tool.
         "sheet_instance_path",
+        // Structured placement-score response field, not a callable tool.
+        "interface_filter_caps",
     ];
 
     let mut phantom = Vec::new();

--- a/docs/API_MIGRATIONS.md
+++ b/docs/API_MIGRATIONS.md
@@ -3,6 +3,25 @@
 Konnect's tool schemas are public API. This file records intentional argument
 removals and the supported replacement workflow.
 
+## Unreleased: `score_placement` reports interface filter caps (minor release)
+
+`score_placement`'s decoupling deduction no longer fires on a capacitor placed on
+a connector's own pins for cable/EMI filtering (#411). A cap beyond its value
+family's limit from the nearest shared-net IC is exempted only when a `J*`
+connector carries **every** net that cap carries and its courtyard edge is within
+that same limit of the cap's center. The cap must be on the connector's face,
+unless the connector's pads carrying those nets reach both copper faces — a
+plated through-hole pin, not an SMD one.
+
+Results add `interface_filter_caps`: one entry per exempted cap, with
+`reference`, `value`, `connector`, `connector_distance_mm`, and `limit_mm`. It is
+evidence rather than a score — an exempted cap deducts nothing, and a waiver that
+vanished silently would be indistinguishable from a check that never ran. The
+array is empty on boards without such caps.
+
+No tool, argument, or existing response field was renamed or removed. This
+additive response field is planned for the next minor release.
+
 ## Unreleased: type-safe trace deletion (minor release)
 
 `delete_trace` now accepts only a UUID observed in the requested live board's

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -284,7 +284,7 @@ Seven tools, grouped into *discovery/routing*, *observability*, and *runtime dia
 
 | Tool | Description |
 |------|-------------|
-| `score_placement` | Score the placement 0-100 with named deductions (courtyard overlaps, off-board parts, connector edge distance, decoupling distance). Hard failures decide the verdict regardless of the numeric score; a missing outline blocks a pass rather than passing silently. |
+| `score_placement` | Score the placement 0-100 with named deductions (courtyard overlaps, off-board parts, connector edge distance, decoupling distance). Hard failures decide the verdict regardless of the numeric score; a missing outline blocks a pass rather than passing silently. A cap sitting on a connector's own pins for cable filtering is judged against that connector instead of the nearest IC, and every such waiver is listed in `interface_filter_caps` — evidence that the check ran and was answered, not a separate score. |
 | `place_decoupling_caps` | Plan (dry-run default) or apply a row of decoupling caps beside an IC, paired by shared nets, never reference guessing; the response carries the board score before and after the plan. |
 | `plan_bga_fanout` | Plan a BGA fanout with the pitch detected from the pad grid: dogbone or inline vias for inner pads, stub traces, conservative via sizes. Apply executes the whole plan as one KiCad undo commit over live IPC. |
 | `auto_place_from_schematic` | Deterministic first placement: net-clustered groups laid out as grids inside the outline, courtyards non-overlapping; explicitly a starting point, with before/after scores in the response. |


### PR DESCRIPTION
Closes #411

**1. Problem and scope.**

`score_placement`'s decoupling heuristic measures every family-classified capacitor to the nearest **IC** (`U*`) it shares a net with, and deducts 15 points if that distance exceeds the value family's limit. It has no notion of a capacitor deliberately placed **on a connector's own pins** for cable/EMI filtering. On the board in #411 — an MCU `U1` and a 4-pin cable header `J2` — a 100 nF cap sitting on J2's VCC/GND pins is reported as a placement defect naming an IC it was never meant to bypass:

```
{"kind":"decoupling","points":15,"references":["C1"],
 "detail":"C1 (100nF, limit 2.5 mm) is 3.8 mm from nearest shared-net IC U1"}
```

Scope is `score_placement`'s decoupling check only. Weights, verdict logic, hard failures, the connector-edge check, and `place_decoupling_caps` are untouched.

**2. Root cause and chosen design.**

The check asked one question — "how far is this cap from its IC?" — and treated the answer as the whole story. Before deducting, it now asks what the cap is actually sitting on. A capacitor is interface/EMI filtering for a cable, and is exempted, when **all three** hold:

1. it is within its **own family limit** of the **courtyard bbox** of a connector (`J*`) — the same limit and the same courtyard-edge metric the IC rule uses, so the exemption can never be looser than the rule it waives;
2. that connector carries **every** named net the cap carries — a two-terminal filter cap belongs to a cable only if both its terminals do. One shared net is not enough: board-wide `GND` alone would let any cap that drifted near any connector claim the waiver;
3. the cap is on the connector's **face**, unless the connector's pads carrying those nets reach **both** copper faces — a plated through-hole pin, not an SMD one.

Condition 3 exists because a blanket same-side rule would reintroduce the exact false positive this issue is about: @ncolomer's board has a `B.Cu` cap filtering an `F.Cu` through-hole header, and that cap is electrically on those pins. Reading a pad's copper stack needs one additive field on `PadSite` in `konnect-sexp` (`layer_side` records where a *footprint* sits and cannot say whether its copper reaches the far face), so this PR is two commits: the sexp field, then the placement change.

The waiver is **reported rather than silent**: exempted caps appear in a new `interface_filter_caps` array (`reference`, `value`, `connector`, `connector_distance_mm`, `limit_mm`), because a deduction that vanishes without a trace is indistinguishable from a broken checker — the same reason this tool already reports `outline_missing` and passing `connector_edges` explicitly.

Alternatives rejected: exempting whenever a connector is merely *nearer* than the closest IC (unbounded — a cap abandoned in a corner 20 mm from everything qualifies for being 19 mm from a connector); a separate, larger connector threshold (a second magic number with nothing behind its value); footprint/value heuristics (this module identifies by net pairing, never by reference guessing).

Implementation reuses existing helpers rather than duplicating them: the IC and connector lookups share `nearest_shared_net`, the point-to-courtyard-bbox formula moved verbatim into `distance_to_bbox`, and `footprints_with_prefix` wraps the existing `ref_prefix` idiom.

**3. Documentation.**

The new response field is documented as public API, per review:

- `tool-directory.md` — `score_placement`'s row names `interface_filter_caps` and says it is evidence, not a separate score.
- `crates/konnect/assets/skills/kicad-pcb/SKILL.md` — an agent reading a score now knows a filter cap is judged against its connector rather than the nearest IC, and that entries in the array are answered checks, not defects to "fix" by dragging a cap toward an IC.
- `docs/API_MIGRATIONS.md` — additive field, minor-release impact, and the exact predicate (every named net; courtyard-edge distance inside the cap's own family limit; same face unless the connector's pads carrying those nets reach both faces).

`interface_filter_caps` is also registered in the `NOT_TOOLS` list of `crates/konnect/tests/asset_references.rs`: the shipped-docs guard reads a backticked identifier in prose as a tool name, and this one is a response field.

**4. Compatibility and migration.**

Additive. No existing response field changes shape or meaning. Scores only ever move **up**, and only for caps that satisfy all three conditions — a board with no such cap scores exactly as before (the repository's own fixture still scores 70 with the same two caps named).

`uncoupled_caps` is intentionally unchanged: a cap sharing no net with any IC never reaches the distance rule, so "nothing to decouple" remains the honest report for it rather than being relabelled a waived deduction. That decision is pinned by its own test.

Known limits, stated rather than hidden: only the `J*` prefix counts as a connector (consistent with the existing connector-edge check, so a board naming connectors `CN1` is unaffected); `place_decoupling_caps` will still plan a move for an exempted cap if a user explicitly asks it to; and a two-terminal cap whose nets are, say, `VCC`+`GND` is exempted by a connector carrying both, which for a power header is the intended reading.

**5. Tests run.**

Nine tests in `tools::placement::tests` cover this change. All are derived from the existing KiCad-authored `placement_fixture.kicad_pcb` by the string surgery this module already uses, with every distance hand-computed from the fixture's own coordinates in the doc comments:

- `a_cap_on_a_shared_net_connector_is_interface_filtering_not_a_decoupling_defect` — the #411 repro: C1 moved onto J1's pins (1.61 mm from J1's courtyard, 5.3 mm from U1). Was 70 with C1 named; now 85 with only C2 named and C1 reported as an interface filter.
- `a_cap_far_from_both_its_ic_and_the_connector_still_deducts` — 3.61 mm from J1, 3.3 mm from U1: still a defect, score stays 70. The exemption is not an off-switch.
- `a_cap_beside_a_connector_it_shares_no_net_with_still_deducts` — same 1.61 mm geometry, J1's pads retagged so the two are net-disjoint: still deducts. Proximity alone is not the exemption.
- `a_connector_cap_sharing_no_net_with_any_ic_is_still_reported_uncoupled` — pins the `uncoupled_caps` decision.
- `a_cap_within_both_limits_is_neither_a_violation_nor_a_reported_waiver` — pins that `interface_filter_caps` means "a deduction was waived", not "a cap is near a connector".
- `the_exemption_uses_the_caps_own_family_limit_not_the_100nf_one` — C1 retagged to `1uF` (5.0 mm family) at 3.609 mm from J1 and 5.778 mm from U1, so the exemption fires at a distance the 100 nF family would reject.
- `a_cap_on_the_far_face_of_a_through_hole_connector_is_still_interface_filtering` — @ncolomer's topology, and the guard against a blanket same-side rule.
- `a_cap_on_the_far_face_of_a_surface_mount_connector_is_not_interface_filtering` — the same board with J1's pads retagged `*.Cu` → `F.Cu` deducts again (85 → 70), so the through-hole carve-out is not a hole.
- `a_cap_sharing_only_ground_with_the_connector_still_deducts` — 85 → 70, pinning the every-net rule.

Each was shown **failing first** on the commit before it. Eleven mutations of the first round were caught one at a time (threshold widened ×3; comparison flipped; distance gate deleted; connector limit hard-coded to `2.5`; connector limit zeroed; prefix ignored; `J`→`U`; shared-net requirement dropped on the connector path; shared-net requirement dropped globally; exemption ordered before the IC-distance check; full revert), and a six-way grid on the tightening round kills every way of loosening either new condition.

Measured on the exact head of this branch, macOS, today: `cargo test --workspace --locked --lib --tests` → **29 suites, 1492 passed, 0 failed, 20 pre-existing ignored**. The docs guard `-p konnect --test asset_references` is 12 passed (it fails without the `NOT_TOOLS` entry above, which is how that entry was found rather than guessed).

Not covered, stated plainly rather than left for you to find: the 10uF family (only 100 nF and 1uF are exercised); `decoupling_limit_mm`'s own string parsing (`µ`/`u`, trailing `F`, `1000n`); and boards with more than one connector, so "nearest shared-net connector" is only ever a one-element minimum.

**6. Risk and rollback.**

Low. No file format, IPC, packaging or release surface is touched. The only behavioural risk is a false exemption — a genuinely misplaced cap that happens to sit within its family limit of a connector carrying all of its nets, on a face its copper reaches. That is the definition of being on its pins. Rollback is reverting these commits: no state, no persisted data, no migration.

@ncolomer's measurement on the real board is in #411: C1's centre is **1.1 mm** from J2's courtyard edge (the issue's 3.7 mm was to pad 1's centre), both of C1's nets are on J2, and J2 is a through-hole JST whose pads report `*.Cu`. All three conditions hold, so the exemption fires on the board that reported this.

Authored by Mycroft, the synthetic co-founder at Anton Dzyatkovsky's lab (autonomous mode; named responsible person: Anton Dziatkovskii). The test runs above were re-executed on this head before submission.
