### PR TITLE
docs: define branch and pull-request workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,28 @@
 ## Summary
 
-<!-- What user-visible problem does this solve? Keep the scope to one reviewable outcome. -->
+<!--
+What user-visible problem does this solve? Keep the scope to one reviewable outcome.
+Use "Part of #N" for a partial PR. Use "Closes #N" only for the terminal PR that
+satisfies every current acceptance criterion.
+-->
 
-Closes #
+Issue: #
 
 ## Approach
 
 <!-- Explain the root cause, design, and important alternatives or trade-offs. -->
+
+## Branch and dependencies
+
+<!--
+Base branch:
+Depends on:
+Series order, if any:
+Unique commits/acceptance criteria owned by this PR:
+
+Follow docs/BRANCH_AND_PULL_REQUEST_WORKFLOW.md. Do not open a cumulative PR
+against main that repeats unmerged prerequisite commits.
+-->
 
 ## Compatibility and safety
 
@@ -23,13 +39,15 @@ Write "No public compatibility impact" when applicable.
 - [ ] `cargo fmt --all -- --check`
 - [ ] `cargo test --workspace --locked --lib --tests` (what CI runs)
 - [ ] `cargo test --workspace --locked --doc`
-- [ ] `cargo clippy --workspace --locked -- -D warnings`
-- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace --locked --all-targets -- -D warnings`
 - [ ] Relevant viewer, plugin, packaging, and real-KiCad checks
 
 ## Review checklist
 
 - [ ] The diff is focused and contains no generated output, personal data, or unrelated cleanup.
+- [ ] The branch includes current `upstream/main`, has no merge conflicts, and CI passed on this exact head.
+- [ ] The branch was based on latest `upstream/main`, not a release tag (unless this is an approved backport).
+- [ ] The PR shows only its unique commits and diff; dependencies and series position are explicit.
 - [ ] New names follow `docs/NAMING_CONVENTIONS.md`; public renames include compatibility handling.
 - [ ] New behavior and failure paths have regression coverage.
 - [ ] File mutations are atomic and preserve unrelated content.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,34 @@ Thanks for your interest! Bug reports, feature requests, and pull requests are w
   you invest time.
 - Keep each pull request focused on one reviewable outcome. Split unrelated platform,
   protocol, feature, and documentation changes into a short PR series.
+- Follow the [branch and pull request workflow](docs/BRANCH_AND_PULL_REQUEST_WORKFLOW.md).
+  Independent changes branch from current `upstream/main`; dependent work exposes one
+  mergeable step at a time instead of opening cumulative PRs against the same old base.
 - Read [docs/NAMING_CONVENTIONS.md](docs/NAMING_CONVENTIONS.md) before adding public
   tools, schema fields, CLI options, environment variables, or user-facing terms.
+
+## Branch and pull request workflow
+
+The PR base and dependency structure are part of the change:
+
+- Branch independent changes separately from current `upstream/main`.
+- Use the latest `upstream/main`, not the latest release tag. Release tags are
+  consumption points, not contribution bases, unless a maintainer explicitly
+  requests a backport.
+- If PR B genuinely depends on PR A, document the complete order, keep only A ready,
+  and retain B in the contributor's fork until A merges. Then rebuild B on current
+  `upstream/main` with only B's unique commits and rerun CI.
+- Do not open several cumulative PRs against `main` from branches that all contain the
+  same unmerged prerequisite commits. Green checks on those old cumulative heads do
+  not establish merge readiness after `main` changes.
+- Use a short-lived `integration/<topic>` branch only with maintainer agreement for a
+  tightly coupled program. Child PRs target that branch; one terminal, fully validated
+  PR merges the combined result into `main` while unrelated work continues normally.
+- Resolve conflicts in the topic branch before final review. When rewriting a published
+  branch, use `--force-with-lease`, never plain `--force`.
+
+The linked workflow includes exact commands, fork limitations, restacking examples,
+merge-readiness criteria, and integration-branch ownership and cleanup rules.
 
 ## Development setup
 
@@ -40,9 +66,11 @@ The description should state:
 
 1. the user-visible problem and scope;
 2. the root cause and chosen design;
-3. compatibility or migration effects;
-4. tests run, including intentionally skipped environment-dependent checks;
-5. risk and rollback notes for file formats, IPC, packaging, or release changes.
+3. the base branch, dependencies, and position in any PR series;
+4. which commits and acceptance criteria this PR uniquely owns;
+5. compatibility or migration effects;
+6. tests run, including intentionally skipped environment-dependent checks;
+7. risk and rollback notes for file formats, IPC, packaging, or release changes.
 
 Treat MCP tools, schema fields, CLI flags, environment variables, config keys, and
 documented paths as public API. Preserve compatibility or provide an explicit
@@ -57,6 +85,10 @@ These are exactly the commands CI runs — if they pass locally, CI should be gr
 - `cargo test --workspace --locked --doc` passes
 - `cargo clippy --workspace --locked --all-targets -- -D warnings` is clean
 - `cargo fmt --all -- --check` is clean
+- The branch includes current `upstream/main`, GitHub reports no conflicts, and the
+  required checks passed on the exact head being reviewed
+- The commit list and diff contain only this PR's unique work; dependencies and stack
+  position are explicit
 - New names follow [the naming conventions](docs/NAMING_CONVENTIONS.md); public name
   changes include compatibility handling and migration notes
 - **Read required arguments through the helpers**, never `unwrap_or`:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -47,6 +47,32 @@ The queue is only legible if claims are visible.
 - Priority labels `P0`/`P1`/`P2` and `area:*` labels are how the queue is read
   at a glance. Keep them current.
 
+## Branches and the PR queue
+
+The detailed contributor workflow is in
+[docs/BRANCH_AND_PULL_REQUEST_WORKFLOW.md](docs/BRANCH_AND_PULL_REQUEST_WORKFLOW.md).
+Maintainers apply these queue rules:
+
+- Independent changes use independent branches from current `main`.
+- Contribution branches start from the latest `main`, not a release tag, except
+  for an explicitly requested release-line backport.
+- A dependent series exposes one mergeable step at a time. Deeper work stays in
+  the contributor's fork or remains draft against an agreed upstream base; it
+  must not appear as several ready, cumulative PRs against an unchanged `main`.
+- After a prerequisite merges, the author reconstructs the next PR from current
+  `main` with only its unique commits. A previous green run on a cumulative head
+  is obsolete.
+- A PR with copied prerequisites, a stale base, or unresolved conflicts is not
+  ready for final review. Maintainers may return it to draft and request a clean
+  reconstruction rather than repeatedly resolving contributor branch history.
+- A short-lived `integration/<topic>` branch requires maintainer agreement on
+  scope, ownership, synchronization, evidence, terminal issue closure, and an
+  expiry. Child PRs receive focused review and CI before one final integration PR
+  is merged to `main`. Unrelated work continues on `main`.
+
+These rules protect review quality without requiring every related change to be
+one large PR. The unit of review remains one focused outcome.
+
 ## Releases
 
 - **Never hand-edit tool counts.** `cargo xtask fix-doc-counts` rewrites them

--- a/docs/BRANCH_AND_PULL_REQUEST_WORKFLOW.md
+++ b/docs/BRANCH_AND_PULL_REQUEST_WORKFLOW.md
@@ -1,0 +1,161 @@
+# Branch and Pull Request Workflow
+
+Konnect accepts independent pull requests, short dependent series, and
+maintainer-approved integration branches. Choose the smallest model that makes
+every review show one coherent change.
+
+The base branch is part of the review contract. A green check on a branch that
+contains obsolete prerequisites does not prove that its unique change works on
+current `main`.
+
+**Contributions start from the latest `upstream/main`, not the latest release
+tag.** Release tags are stable consumption points for users and packagers; they
+do not contain work merged after the release. A PR based on a release can be
+green in isolation while omitting fixes and contracts already present on
+`main`.
+
+## Default: one independent change
+
+Use an independent branch when a change can be reviewed and merged without
+another unmerged pull request.
+
+```text
+git fetch upstream
+git switch -c fix/example upstream/main
+# edit, test, and commit
+git push -u origin fix/example
+```
+
+Open the pull request against `main`. Before final review:
+
+1. fetch `upstream`;
+2. rebase the branch onto current `upstream/main`;
+3. resolve conflicts in the branch rather than asking the merge commit to guess;
+4. push rewritten history with `--force-with-lease`, never plain `--force`;
+5. wait for the required checks to pass on the new head.
+
+Do not use `vX.Y.Z` or another release tag as a development base unless a
+maintainer explicitly requests a backport to that release line.
+
+Do not stack independent changes merely because one contributor is developing
+them at the same time. Separate branches let either change merge, wait, or be
+abandoned without moving the other.
+
+## Dependent changes: expose one mergeable step at a time
+
+A dependent series is appropriate only when change B cannot build, test, or be
+reviewed meaningfully until change A exists.
+
+Record the complete order on the tracking issue and in every PR description:
+
+```text
+#123 -> #124 -> #125
+```
+
+Only the next PR in that sequence should be ready for review against `main`.
+Keep later work on separate local or fork branches. Link those branches from the
+tracking issue if visibility is useful, but do not open cumulative PRs against
+`main` that repeat every prerequisite commit.
+
+After the prerequisite merges, reconstruct the next branch so it contains only
+its unique work on current `upstream/main`. For a simple one-commit step:
+
+```text
+git fetch upstream
+git switch -c fix/next-clean upstream/main
+git cherry-pick <unique-commit>
+# resolve conflicts, test, and inspect the diff
+git push --force-with-lease origin HEAD:fix/next
+```
+
+For several unique commits, use `git rebase --onto` or cherry-pick the precise
+range. In either case, verify both views before requesting review:
+
+```text
+git log --oneline upstream/main..HEAD
+git diff --stat upstream/main...HEAD
+```
+
+The log must contain only the commits this PR owns. The diff must not reintroduce
+already merged prerequisites. Old CI results are superseded by any rewritten
+head or changed base.
+
+### When a stacked PR base is possible
+
+A PR can target an immediate prerequisite branch only when that base branch
+exists in the upstream repository. A branch in a contributor's fork cannot be
+used as the base branch of a PR in the upstream repository.
+
+Collaborators may use an upstream prerequisite branch when maintainers agree,
+but the deeper PR stays draft until its parent is merged. Afterward, retarget it
+to `main`, synchronize it with current `main`, and rerun CI. Do not leave a chain
+of ready PRs whose displayed diffs all contain the same unmerged changes.
+
+## Integration branch: an explicit exception
+
+A short-lived integration branch is useful when a tightly coupled program needs
+several contributors or individually reviewed steps, but cannot keep restacking
+against `main`. It is not the default for a large change.
+
+Before creating `integration/<topic>`, obtain maintainer agreement on:
+
+- the tracking issue and intended user outcome;
+- the ordered child PRs and their owners;
+- the branch owner and expected deletion date;
+- how often current `main` will be incorporated;
+- the integration, compatibility, and rollback evidence required at the end;
+- which terminal PR will close each issue.
+
+Child PRs target `integration/<topic>` and must show only their unique changes.
+They receive the same tests and focused review expected for a PR to `main`.
+Unrelated work continues to target `main`; the integration branch must not hold
+the ordinary queue hostage.
+
+After all child PRs land, update the integration branch from current `main`,
+resolve drift once, and run the complete gate. Open one terminal PR from the
+integration branch to `main`. That final review verifies the combined behavior,
+issue accounting, compatibility, release notes, and rollback plan; it is not a
+substitute for reviewing the child changes.
+
+Delete the integration branch after the terminal merge. If its scope changes or
+it remains open past the agreed lifetime, return to the tracking issue and
+reconfirm the plan.
+
+## What is merge-ready
+
+A PR is merge-ready only when all of the following are true:
+
+- its base and dependencies match the documented plan;
+- its commit list and diff contain only the change it owns;
+- current `main` is incorporated and GitHub reports no conflicts;
+- every required check passed on the exact current head;
+- the issue acceptance criteria, compatibility impact, and validation evidence
+  are current;
+- partial and terminal issue-closing keywords are correct.
+
+A PR is not merge-ready merely because an earlier cumulative head was green.
+
+## Responsibilities when `main` moves
+
+The PR author owns synchronizing the branch and resolving its conflicts. A
+maintainer may help, but branch reconstruction is not a standing maintainer
+service.
+
+When a stale PR contains copied prerequisite commits, the preferred correction
+is to reconstruct it from current `main` with only its unique commits. A
+maintainer may return the PR to draft or request reconstruction instead of
+reviewing a misleading cumulative diff.
+
+Do not repeatedly rebase a deep series after every unrelated merge. Wait until
+the immediate prerequisite lands, then rebuild the next PR once. This keeps the
+queue moving while minimizing conflict work for contributors and reviewers.
+
+## Issue closure in a series
+
+Use `Part of #N` for a partial PR. Use `Closes #N` on exactly one terminal PR
+only when that merge satisfies every current acceptance criterion. For an
+integration branch, child PRs use `Part of`; the terminal PR to `main` carries
+the closing references and the acceptance evidence.
+
+See [GOVERNANCE.md](../GOVERNANCE.md) for claiming, merge authority, required
+checks, and post-merge validation.


### PR DESCRIPTION
## Summary

Define a branch and pull-request workflow that keeps independent changes independent, exposes only one mergeable step from a dependent series, and provides a bounded integration-branch exception for tightly coupled programs.

Closes #417.

## Approach

- Require contribution branches to start from the latest `upstream/main`, not the latest release tag, except for an approved backport.
- Document independent branches, dependent-series reconstruction, fork/base-branch limitations, safe `--force-with-lease` use, merge-readiness criteria, and author responsibilities when `main` moves.
- Permit `integration/<topic>` only with maintainer agreement on scope, owner, lifetime, synchronization, validation, rollback, and terminal issue closure.
- Add the queue policy to `GOVERNANCE.md` and the contributor-facing summary to `CONTRIBUTING.md`.
- Extend the PR template with base/dependency/unique-diff prompts and correct its duplicated/mismatched validation commands.

## Branch and dependencies

Base branch: current `upstream/main`
Depends on: none
Series order: independent
Unique scope: documentation and PR-template policy for issue #417

## Compatibility and safety

No runtime or public API impact. Existing merge-commit, required-CI, claiming, release, and issue-accounting rules remain unchanged. The policy changes which branch shapes are considered ready for review.

## Validation

- [x] `git diff --check`
- [x] `cargo fmt --all -- --check`
- [x] Linked documentation paths verified locally
- [x] PR-template gate commands verified against `CONTRIBUTING.md`
- [x] Duplicate formatting command removed from the PR template
- [ ] Hosted CI

No runtime tests were run locally because this change modifies Markdown and the PR template only.

## Risk and rollback

The main risk is process friction from overly broad use of integration branches. The documentation makes them an explicit, short-lived maintainer-approved exception. Rollback is documentation-only.