### PR TITLE
feat(config): report which configuration file configured the running process

### DIFF
--- a/crates/konnect-core/src/config_resolution.rs
+++ b/crates/konnect-core/src/config_resolution.rs
@@ -1,0 +1,190 @@
+//! Which configuration file configured the running process.
+//!
+//! Konnect selects the **first existing** server configuration file from its
+//! search list and loads only that one; later files are not merged in. Nothing
+//! in the protocol reported which file won, so a user whose settings appeared to
+//! be ignored had no way to tell a shadowed file from a malformed one (#419).
+//!
+//! This type records that decision once, at startup, and
+//! `get_installation_info` reports it. It is deliberately captured rather than
+//! recomputed on demand: re-running the search when the tool is called would
+//! describe the filesystem as it is *now*, which may name a higher-priority file
+//! created after launch — the opposite of the question being asked.
+//!
+//! The record carries paths only. Configuration values, file contents and IPC
+//! credentials are never included.
+
+use std::path::{Path, PathBuf};
+
+/// How the running process obtained its configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigSource {
+    /// An explicit `--config <path>` was given; the search list was not consulted.
+    ExplicitPath,
+    /// A file from the automatic search list was selected.
+    SearchPath,
+    /// No candidate existed, so built-in defaults are in use.
+    Defaults,
+    /// The resolution was not recorded by this entry point. Reported rather than
+    /// guessed, so a caller never reads a fabricated `defaults` for a load whose
+    /// outcome is genuinely unknown.
+    Unavailable,
+}
+
+impl ConfigSource {
+    /// Stable public string, as reported in `get_installation_info`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ConfigSource::ExplicitPath => "explicit_path",
+            ConfigSource::SearchPath => "search_path",
+            ConfigSource::Defaults => "defaults",
+            ConfigSource::Unavailable => "unavailable",
+        }
+    }
+}
+
+/// The startup configuration decision, captured once and reported read-only.
+#[derive(Debug, Clone)]
+pub struct ConfigResolution {
+    source: ConfigSource,
+    selected_path: Option<PathBuf>,
+    skipped_existing_paths: Vec<PathBuf>,
+}
+
+/// The only policy this build implements. Reported so a reader does not have to
+/// infer from a single path whether later files were merged in.
+pub const SEARCH_POLICY: &str = "first_existing_no_merge";
+
+impl ConfigResolution {
+    /// An explicit `--config <path>`. The automatic search list is not consulted,
+    /// so nothing is reported as skipped: those files did not participate.
+    pub fn explicit_path(path: impl AsRef<Path>) -> Self {
+        Self {
+            source: ConfigSource::ExplicitPath,
+            selected_path: Some(absolutize(path.as_ref())),
+            skipped_existing_paths: Vec::new(),
+        }
+    }
+
+    /// A file chosen from the search list, plus any later candidates that exist
+    /// and were therefore shadowed by it.
+    pub fn search_path(selected: impl AsRef<Path>, skipped: &[PathBuf]) -> Self {
+        Self {
+            source: ConfigSource::SearchPath,
+            selected_path: Some(absolutize(selected.as_ref())),
+            skipped_existing_paths: skipped.iter().map(|p| absolutize(p)).collect(),
+        }
+    }
+
+    /// No candidate existed. `selected_path` is `None`.
+    pub fn defaults() -> Self {
+        Self {
+            source: ConfigSource::Defaults,
+            selected_path: None,
+            skipped_existing_paths: Vec::new(),
+        }
+    }
+
+    /// Used by entry points that do not track the decision, so provenance is
+    /// absent rather than wrong.
+    pub fn unavailable() -> Self {
+        Self {
+            source: ConfigSource::Unavailable,
+            selected_path: None,
+            skipped_existing_paths: Vec::new(),
+        }
+    }
+
+    pub fn source(&self) -> ConfigSource {
+        self.source
+    }
+
+    pub fn selected_path(&self) -> Option<&Path> {
+        self.selected_path.as_deref()
+    }
+
+    pub fn skipped_existing_paths(&self) -> &[PathBuf] {
+        &self.skipped_existing_paths
+    }
+}
+
+impl Default for ConfigResolution {
+    fn default() -> Self {
+        Self::unavailable()
+    }
+}
+
+/// Absolute form for diagnosis, because a relative candidate such as
+/// `konnect.toml` is meaningless to a reader who does not know the server's
+/// working directory. `canonicalize` also resolves symlinks, which is what makes
+/// the answer checkable; if it fails the path is returned unchanged rather than
+/// dropped.
+fn absolutize(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .map(|dir| dir.join(path))
+                .unwrap_or_else(|_| path.to_path_buf())
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_report_no_selected_path() {
+        let resolution = ConfigResolution::defaults();
+        assert_eq!(resolution.source().as_str(), "defaults");
+        assert!(resolution.selected_path().is_none());
+        assert!(resolution.skipped_existing_paths().is_empty());
+    }
+
+    #[test]
+    fn unavailable_is_not_reported_as_defaults() {
+        // The distinction #419's reviewer asked for: an entry point that did not
+        // track the load must not look like a clean defaults selection.
+        assert_eq!(
+            ConfigResolution::unavailable().source().as_str(),
+            "unavailable"
+        );
+        assert_ne!(
+            ConfigResolution::unavailable().source(),
+            ConfigResolution::defaults().source()
+        );
+    }
+
+    #[test]
+    fn explicit_path_reports_no_skipped_candidates() {
+        // The automatic list is not consulted for --config, so reporting entries
+        // as "skipped" would claim they took part in a search that never ran.
+        let resolution = ConfigResolution::explicit_path("konnect.toml");
+        assert_eq!(resolution.source().as_str(), "explicit_path");
+        assert!(resolution.skipped_existing_paths().is_empty());
+    }
+
+    #[test]
+    fn selected_and_skipped_paths_are_absolute() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let selected = dir.path().join("konnect.toml");
+        let skipped = dir.path().join("settings.json");
+        std::fs::write(&selected, "").expect("write selected");
+        std::fs::write(&skipped, "").expect("write skipped");
+
+        let resolution = ConfigResolution::search_path(&selected, &[skipped]);
+        assert!(resolution.selected_path().expect("selected").is_absolute());
+        assert!(resolution
+            .skipped_existing_paths()
+            .iter()
+            .all(|path| path.is_absolute()));
+    }
+
+    #[test]
+    fn a_relative_path_is_made_absolute_even_when_it_does_not_exist() {
+        let resolution = ConfigResolution::explicit_path("no_such_konnect.toml");
+        assert!(resolution.selected_path().expect("selected").is_absolute());
+    }
+}

--- a/crates/konnect-core/src/lib.rs
+++ b/crates/konnect-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod config_resolution;
 pub mod design_hash;
 pub(crate) mod freerouting_mcp;
 pub mod gates;

--- a/crates/konnect-core/src/mcp/handler.rs
+++ b/crates/konnect-core/src/mcp/handler.rs
@@ -32,6 +32,21 @@ pub struct McpHandler {
 
 impl McpHandler {
     pub async fn new(config: crate::tools::ServerConfig) -> anyhow::Result<Self> {
+        Self::new_with_config_resolution(
+            config,
+            crate::config_resolution::ConfigResolution::unavailable(),
+        )
+        .await
+    }
+
+    /// As `new`, but recording which configuration file configured this process
+    /// so `get_installation_info` can report it (#419). The real server entry
+    /// point uses this; `new` keeps its signature for the many callers that do
+    /// not resolve a config file and would otherwise have to invent one.
+    pub async fn new_with_config_resolution(
+        config: crate::tools::ServerConfig,
+        config_resolution: crate::config_resolution::ConfigResolution,
+    ) -> anyhow::Result<Self> {
         let router = Arc::new(ToolRouter::new());
 
         // Load only the starter kit at startup so baseline `tools/list` stays small
@@ -48,11 +63,10 @@ impl McpHandler {
         }
 
         let observer = CallObserver::new(Some(default_calls_log_path()));
-        let ctx = Arc::new(crate::tools::ToolContext::new_with_observer(
-            config,
-            router,
-            observer.clone(),
-        ));
+        let ctx = Arc::new(
+            crate::tools::ToolContext::new_with_observer(config, router, observer.clone())
+                .with_config_resolution(config_resolution),
+        );
 
         Ok(McpHandler {
             ctx,

--- a/crates/konnect-core/src/router/meta_tools.rs
+++ b/crates/konnect-core/src/router/meta_tools.rs
@@ -310,7 +310,7 @@ async fn handle_server_stats(ctx: &std::sync::Arc<ToolContext>) -> CallToolResul
 }
 
 async fn handle_get_installation_info(ctx: &std::sync::Arc<ToolContext>) -> CallToolResult {
-    let info = crate::runtime_info::collect(&ctx.config).await;
+    let info = crate::runtime_info::collect(&ctx.config, &ctx.config_resolution).await;
     CallToolResult::json(&info)
 }
 

--- a/crates/konnect-core/src/runtime_info.rs
+++ b/crates/konnect-core/src/runtime_info.rs
@@ -1,5 +1,6 @@
 //! Read-only runtime and installation provenance for the serving process.
 
+use crate::config_resolution::{ConfigResolution, SEARCH_POLICY};
 use crate::tools::ServerConfig;
 use serde_json::{json, Value};
 use std::cmp::Ordering;
@@ -10,7 +11,7 @@ use tokio::process::Command;
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
 const PCM_IDENTIFIER: &str = "com.github.mixelpixx.konnect";
 
-pub(crate) async fn collect(config: &ServerConfig) -> Value {
+pub(crate) async fn collect(config: &ServerConfig, resolution: &ConfigResolution) -> Value {
     let running_version = env!("CARGO_PKG_VERSION");
     let executable_path = std::env::current_exe().ok();
     let installation = executable_path
@@ -73,7 +74,27 @@ pub(crate) async fn collect(config: &ServerConfig) -> Value {
             "source": "resolved_server_config",
             "endpoint": ipc_endpoint,
         },
+        "configuration": configuration_block(resolution),
         "restart_guidance": restart_guidance(installation.name, newer_than_running),
+    })
+}
+
+/// Report which configuration file configured this process (#419).
+///
+/// Derived from the resolution captured at startup, never from a fresh search:
+/// a file created after launch must not be reported as the one that configured
+/// the running process. Paths only — no configuration values, file contents or
+/// IPC credentials.
+fn configuration_block(resolution: &ConfigResolution) -> Value {
+    json!({
+        "source": resolution.source().as_str(),
+        "selected_path": resolution.selected_path().map(display_path),
+        "search_policy": SEARCH_POLICY,
+        "skipped_existing_paths": resolution
+            .skipped_existing_paths()
+            .iter()
+            .map(|path| display_path(path.as_path()))
+            .collect::<Vec<_>>(),
     })
 }
 

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -124,6 +124,11 @@ pub struct ToolContext {
     /// Boards positively observed open through IPC during this server process.
     /// Sticky state prevents an unsafe file fallback after KiCad disappears.
     pub(crate) board_session: board_session::BoardSessionMemory,
+    /// Which configuration file configured this process, captured at startup
+    /// and reported read-only by `get_installation_info` (#419). Defaults to
+    /// `unavailable` so a caller that does not track the load reports absence
+    /// rather than a fabricated `defaults`.
+    pub config_resolution: crate::config_resolution::ConfigResolution,
 }
 
 impl ToolContext {
@@ -136,6 +141,7 @@ impl ToolContext {
             observer: crate::observability::CallObserver::new(None),
             jlcpcb_cache: QueryCache::default(),
             board_session: board_session::BoardSessionMemory::default(),
+            config_resolution: crate::config_resolution::ConfigResolution::unavailable(),
         }
     }
 
@@ -152,7 +158,19 @@ impl ToolContext {
             observer,
             jlcpcb_cache: QueryCache::default(),
             board_session: board_session::BoardSessionMemory::default(),
+            config_resolution: crate::config_resolution::ConfigResolution::unavailable(),
         }
+    }
+
+    /// Attach the startup configuration decision. Separate from the constructors
+    /// so the 60-plus existing `ServerConfig` call sites keep their signatures;
+    /// only the real server entry point records provenance.
+    pub fn with_config_resolution(
+        mut self,
+        resolution: crate::config_resolution::ConfigResolution,
+    ) -> Self {
+        self.config_resolution = resolution;
+        self
     }
 }
 

--- a/crates/konnect/src/config.rs
+++ b/crates/konnect/src/config.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use konnect_core::config_resolution::ConfigResolution;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tracing::{info, warn};
@@ -144,43 +145,48 @@ fn default_log_level() -> String {
 
 impl Config {
     /// Load from `path` when given, else from the default search path, with
-    /// `ipc_address` resolved either way.
+    /// both the effective `ipc_address` source and configuration-file
+    /// provenance resolved either way.
     ///
     /// Every entry point loads through here. Resolution used to be the
     /// caller's job, and each caller that forgot it was a bug: #39 for
     /// `main.rs`, and `ffi.rs` silently ignoring KICAD_API_SOCKET until the
     /// same fix reached it.
-    pub fn load_resolved(path: Option<&std::path::Path>) -> Result<(Self, IpcAddressSource)> {
+    pub fn load_resolved(
+        path: Option<&std::path::Path>,
+    ) -> Result<(Self, IpcAddressSource, ConfigResolution)> {
         match path {
             Some(path) => {
                 let mut config = Self::load_from(path)?;
                 let ipc_source = config.resolve_ipc_address();
-                Ok((config, ipc_source))
+                Ok((config, ipc_source, ConfigResolution::explicit_path(path)))
             }
             None => Self::load(),
         }
     }
 
-    /// Load config from the default search path, with `ipc_address` resolved.
-    pub fn load() -> Result<(Self, IpcAddressSource)> {
-        let mut config_paths = vec![
-            PathBuf::from("konnect.toml"),
-            PathBuf::from("settings.json"),
-        ];
-        config_paths.extend(exe_relative_settings_paths());
-        config_paths.push(dirs_config_path());
+    /// Load config from the default search path, reporting which file was
+    /// selected and which later existing files it shadowed, so
+    /// `get_installation_info` can say what configured the process instead of
+    /// leaving the user to guess (#419).
+    ///
+    /// Behaviour is unchanged: the first existing candidate wins, a malformed
+    /// selected file is an error rather than permission to fall through to a
+    /// later one, no candidates means defaults, and the environment fallback is
+    /// applied after file or default resolution.
+    fn load() -> Result<(Self, IpcAddressSource, ConfigResolution)> {
+        let (selected, skipped) = select_config_candidate(&default_config_paths());
 
-        let mut config = None;
-        for path in &config_paths {
-            if path.exists() {
-                config = Some(Self::load_from(path)?);
-                break;
+        let (mut config, resolution) = match selected {
+            Some(path) => {
+                let config = Self::load_from(&path)?;
+                (config, ConfigResolution::search_path(&path, &skipped))
             }
-        }
+            None => (Self::default(), ConfigResolution::defaults()),
+        };
 
-        let mut config = config.unwrap_or_default();
         let ipc_source = config.resolve_ipc_address();
-        Ok((config, ipc_source))
+        Ok((config, ipc_source, resolution))
     }
 
     /// Fill in a blank `ipc_address`: env var first, then the platform default
@@ -253,6 +259,43 @@ impl Default for Config {
             eager_toolsets: false,
         }
     }
+}
+
+/// The configuration search list, in precedence order. Only the first existing
+/// entry is loaded; the rest are shadowed, never merged.
+fn default_config_paths() -> Vec<PathBuf> {
+    let mut config_paths = vec![
+        PathBuf::from("konnect.toml"),
+        PathBuf::from("settings.json"),
+    ];
+    config_paths.extend(exe_relative_settings_paths());
+    config_paths.push(dirs_config_path());
+    config_paths
+}
+
+/// Pick the first existing candidate, and report the later ones that exist and
+/// are therefore shadowed by it.
+///
+/// Split out from `Config::load` so precedence is testable against a supplied
+/// list: the real list depends on the process working directory and
+/// `current_exe()`, neither of which a test can change without affecting the
+/// whole process.
+fn select_config_candidate(candidates: &[PathBuf]) -> (Option<PathBuf>, Vec<PathBuf>) {
+    let mut selected: Option<PathBuf> = None;
+    let mut skipped = Vec::new();
+
+    for path in candidates {
+        if !path.exists() {
+            continue;
+        }
+        if selected.is_none() {
+            selected = Some(path.clone());
+        } else {
+            skipped.push(path.clone());
+        }
+    }
+
+    (selected, skipped)
 }
 
 /// settings.json next to the binary, and one dir up (covers <plugin_dir>/bin/konnect).
@@ -514,5 +557,97 @@ mod tests {
         let f = write_temp("conf", "log_level = \"debug\"\n");
         let c = Config::load_from(f.path()).unwrap();
         assert_eq!(c.log_level, "debug");
+    }
+
+    // ─── Config provenance (#419) ─────────────────────────────────────────
+    //
+    // The candidate list is supplied rather than discovered so precedence is
+    // testable: the real list depends on the working directory and
+    // `current_exe()`, and changing either is process-wide.
+
+    fn touch(dir: &std::path::Path, name: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, "").expect("write candidate");
+        path
+    }
+
+    #[test]
+    fn no_candidate_exists_selects_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let candidates = vec![dir.path().join("konnect.toml"), dir.path().join("a.json")];
+
+        let (selected, skipped) = select_config_candidate(&candidates);
+
+        assert!(selected.is_none(), "nothing exists, so nothing is selected");
+        assert!(skipped.is_empty());
+    }
+
+    #[test]
+    fn first_missing_second_existing_selects_the_second() {
+        let dir = tempfile::tempdir().unwrap();
+        let second = touch(dir.path(), "settings.json");
+        let candidates = vec![dir.path().join("konnect.toml"), second.clone()];
+
+        let (selected, skipped) = select_config_candidate(&candidates);
+
+        assert_eq!(selected.as_ref(), Some(&second));
+        assert!(skipped.is_empty(), "nothing exists after the selected file");
+    }
+
+    #[test]
+    fn first_wins_and_a_later_existing_file_is_reported_as_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = touch(dir.path(), "konnect.toml");
+        let missing = dir.path().join("settings.json");
+        let third = touch(dir.path(), "config.toml");
+        let candidates = vec![first.clone(), missing, third.clone()];
+
+        let (selected, skipped) = select_config_candidate(&candidates);
+
+        assert_eq!(selected.as_ref(), Some(&first), "first existing wins");
+        assert_eq!(
+            skipped,
+            vec![third],
+            "the shadowed file is named, not merged"
+        );
+    }
+
+    #[test]
+    fn a_malformed_selected_file_is_an_error_not_a_fall_through() {
+        // The behaviour most worth pinning: a broken file must not silently hand
+        // over to a later valid one, which would load settings the user never
+        // pointed at while their real file sat unreported.
+        let dir = tempfile::tempdir().unwrap();
+        let broken = dir.path().join("konnect.toml");
+        std::fs::write(&broken, "this is not = valid toml [[[").unwrap();
+        let valid = dir.path().join("settings.json");
+        std::fs::write(&valid, "{}").unwrap();
+
+        let (selected, _) = select_config_candidate(&[broken.clone(), valid]);
+        assert_eq!(selected.as_ref(), Some(&broken));
+        assert!(
+            Config::load_from(&broken).is_err(),
+            "the selected file is malformed, so loading it must fail"
+        );
+    }
+
+    #[test]
+    fn defaults_resolution_reports_no_path() {
+        let resolution = ConfigResolution::defaults();
+        assert_eq!(resolution.source().as_str(), "defaults");
+        assert!(resolution.selected_path().is_none());
+    }
+
+    #[test]
+    fn an_explicit_config_does_not_report_the_automatic_list_as_skipped() {
+        // --config bypasses discovery, so reporting search candidates as
+        // "skipped" would claim they took part in a search that never ran.
+        let dir = tempfile::tempdir().unwrap();
+        let explicit = touch(dir.path(), "explicit.toml");
+
+        let resolution = ConfigResolution::explicit_path(&explicit);
+
+        assert_eq!(resolution.source().as_str(), "explicit_path");
+        assert!(resolution.skipped_existing_paths().is_empty());
     }
 }

--- a/crates/konnect/src/ffi.rs
+++ b/crates/konnect/src/ffi.rs
@@ -36,16 +36,20 @@ pub unsafe extern "C" fn kicad_plugin_init(config_path: *const c_char) -> c_int 
 
     rt.spawn(async move {
         use crate::config::{Config, TransportMode};
+        use konnect_core::config_resolution::ConfigResolution;
         use konnect_core::mcp::handler::McpHandler;
 
         // KiCad loads this cdylib with KICAD_API_SOCKET set, so this path needs
         // the same ipc_address resolution the standalone server does.
-        let (config, ipc_source) =
+        // A failed load still falls back to defaults here, unchanged: that is a
+        // separate defect. Report its provenance as unavailable rather than
+        // fabricating a clean defaults selection.
+        let (config, ipc_source, config_resolution) =
             Config::load_resolved(config_path_str.as_deref().map(std::path::Path::new))
                 .unwrap_or_else(|_| {
                     let mut config = Config::default();
                     let ipc_source = config.resolve_ipc_address();
-                    (config, ipc_source)
+                    (config, ipc_source, ConfigResolution::unavailable())
                 });
         // `main.rs` installs a subscriber before reporting the resolution.
         // This entry point installed none, so the report — including the
@@ -68,7 +72,7 @@ pub unsafe extern "C" fn kicad_plugin_init(config_path: *const c_char) -> c_int 
             auto_load_toolsets: config.auto_load_toolsets,
             eager_toolsets: config.eager_toolsets,
         };
-        match McpHandler::new(server_config).await {
+        match McpHandler::new_with_config_resolution(server_config, config_resolution).await {
             Ok(handler) => match config.transport {
                 TransportMode::Stdio => {
                     let _ = crate::transport::stdio::run_stdio(handler).await;

--- a/crates/konnect/src/main.rs
+++ b/crates/konnect/src/main.rs
@@ -6,6 +6,7 @@ mod transport;
 
 use anyhow::Result;
 use config::{Config, TransportMode};
+use konnect_core::config_resolution::ConfigSource;
 use konnect_core::mcp::handler::McpHandler;
 use std::io::IsTerminal;
 use tracing::info;
@@ -120,7 +121,7 @@ async fn main() -> Result<()> {
         .and_then(|pos| args.get(pos + 1))
         .map(std::path::PathBuf::from);
 
-    let (config, ipc_source) = Config::load_resolved(config_path.as_deref())?;
+    let (config, ipc_source, config_resolution) = Config::load_resolved(config_path.as_deref())?;
 
     // ─── Initialize tracing (stderr only — stdout is MCP protocol) ──
     let filter =
@@ -134,6 +135,34 @@ async fn main() -> Result<()> {
     info!("Konnect v{} starting", env!("CARGO_PKG_VERSION"));
     ipc_source.log(&config.ipc_address);
 
+    // Name the configuration that actually started this process. A user whose
+    // settings appear to be ignored otherwise has nothing to go on before the
+    // first tool call, and `get_installation_info` may not be reachable at all
+    // if the transport is the thing misconfigured (#419). One record, not one
+    // per shadowed file: first-match is the intended policy, so a warning per
+    // skipped file would be noise.
+    match (
+        config_resolution.source(),
+        config_resolution.selected_path(),
+    ) {
+        // An explicit --config bypasses discovery, so a count of "later
+        // candidates" would claim a search ran that never did.
+        (ConfigSource::ExplicitPath, Some(path)) => info!(
+            "configuration: explicit_path from {} (search list not consulted)",
+            path.display(),
+        ),
+        (_, Some(path)) => info!(
+            "configuration: {} from {} ({} later candidate(s) exist and were not merged)",
+            config_resolution.source().as_str(),
+            path.display(),
+            config_resolution.skipped_existing_paths().len(),
+        ),
+        (_, None) => info!(
+            "configuration: {} (no configuration file was loaded)",
+            config_resolution.source().as_str(),
+        ),
+    }
+
     let server_config = konnect_core::tools::ServerConfig {
         kicad_cli: config.kicad_cli.clone(),
         kicad_binary: config.kicad_binary.clone(),
@@ -143,7 +172,7 @@ async fn main() -> Result<()> {
         auto_load_toolsets: config.auto_load_toolsets,
         eager_toolsets: config.eager_toolsets,
     };
-    let handler = McpHandler::new(server_config).await?;
+    let handler = McpHandler::new_with_config_resolution(server_config, config_resolution).await?;
 
     match config.transport {
         TransportMode::Stdio => {

--- a/crates/konnect/tests/protocol_stdio.rs
+++ b/crates/konnect/tests/protocol_stdio.rs
@@ -21,12 +21,43 @@ impl McpProcess {
     }
 
     /// Spawn with the process working directory set to `dir`, so
-    /// `Config::load()`'s first search path (`konnect.toml` in cwd) picks up
+    /// the config search's first path (`konnect.toml` in cwd) picks up
     /// a test config file placed there.
     fn spawn_in_dir(dir: Option<&std::path::Path>) -> Self {
+        Self::spawn_configured(dir, false)
+    }
+
+    /// Spawn with the working directory set to `dir` and, when `isolate_home`,
+    /// the platform config directory redirected there too.
+    ///
+    /// `dirs_config_path()` is the last search candidate and is built from
+    /// `HOME` (`APPDATA` on Windows), so on a developer machine that already has
+    /// `~/Library/Application Support/konnect/config.toml` a "no config exists"
+    /// test silently resolves to that real file instead. Redirecting HOME makes
+    /// the candidate list depend only on the temp dir.
+    fn spawn_configured(dir: Option<&std::path::Path>, isolate_home: bool) -> Self {
+        Self::spawn_with_env(dir, isolate_home, &[])
+    }
+
+    /// As `spawn_configured`, with extra environment variables for the child.
+    /// Set on the child rather than this process because `std::env::set_var` is
+    /// process-wide and the unit tests run in parallel — doing it in-process
+    /// raced the #39 env-fallback test.
+    fn spawn_with_env(
+        dir: Option<&std::path::Path>,
+        isolate_home: bool,
+        env: &[(&str, &str)],
+    ) -> Self {
         let mut command = Command::new(env!("CARGO_BIN_EXE_konnect"));
+        for (key, value) in env {
+            command.env(key, value);
+        }
         if let Some(dir) = dir {
             command.current_dir(dir);
+            if isolate_home {
+                command.env("HOME", dir);
+                command.env("APPDATA", dir);
+            }
         }
         let mut child = command
             .stdin(Stdio::piped())
@@ -452,5 +483,198 @@ fn auto_load_toolsets_config_loads_and_executes_on_miss() {
     assert!(
         saw_notification,
         "expected notifications/tools/list_changed after auto-load; saw: {lines:#?}"
+    );
+}
+
+// ─── Config provenance over the protocol (#419) ───────────────────────────────
+//
+// These spawn the real binary, so they prove what a client actually receives —
+// not what the resolver returns in isolation. Paths are compared after
+// `canonicalize` because macOS resolves a temp dir under /var to /private/var,
+// and the server reports the resolved form.
+
+fn canonical(path: &std::path::Path) -> String {
+    path.canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn configuration_block(p: &mut McpProcess) -> Value {
+    let result = p.call_tool("get_installation_info", json!({}));
+    assert_ne!(result["isError"], json!(true), "{result:#?}");
+    McpProcess::tool_body(&result)["configuration"].clone()
+}
+
+#[test]
+fn installation_info_names_the_config_file_that_configured_startup() {
+    let tmp = tempfile::tempdir().unwrap();
+    let selected = tmp.path().join("konnect.toml");
+    std::fs::write(&selected, "log_level = \"debug\"\n").unwrap();
+
+    let mut p = McpProcess::spawn_configured(Some(tmp.path()), true);
+    let configuration = configuration_block(&mut p);
+
+    assert_eq!(configuration["source"], "search_path");
+    assert_eq!(configuration["selected_path"], canonical(&selected));
+    assert_eq!(configuration["search_policy"], "first_existing_no_merge");
+    assert_eq!(configuration["skipped_existing_paths"], json!([]));
+}
+
+#[test]
+fn installation_info_reports_a_shadowed_later_candidate() {
+    // konnect.toml precedes settings.json, so the second exists but is not read.
+    // Naming it is the whole point: "my settings.json is ignored" was
+    // indistinguishable from "my settings.json is malformed" (#419).
+    let tmp = tempfile::tempdir().unwrap();
+    let selected = tmp.path().join("konnect.toml");
+    let shadowed = tmp.path().join("settings.json");
+    std::fs::write(&selected, "log_level = \"debug\"\n").unwrap();
+    std::fs::write(&shadowed, "{\"log_level\": \"trace\"}").unwrap();
+
+    let mut p = McpProcess::spawn_configured(Some(tmp.path()), true);
+    let configuration = configuration_block(&mut p);
+
+    assert_eq!(configuration["source"], "search_path");
+    assert_eq!(configuration["selected_path"], canonical(&selected));
+    assert_eq!(
+        configuration["skipped_existing_paths"],
+        json!([canonical(&shadowed)]),
+        "the shadowed file must be named, not merged and not hidden"
+    );
+}
+
+#[test]
+fn installation_info_reports_startup_state_not_a_fresh_search() {
+    // Start with only settings.json, then create the higher-priority
+    // konnect.toml while the server runs. The answer must not change: the
+    // question is what configured this process, not what would configure a new
+    // one.
+    let tmp = tempfile::tempdir().unwrap();
+    let selected = tmp.path().join("settings.json");
+    std::fs::write(&selected, "{\"log_level\": \"debug\"}").unwrap();
+
+    let mut p = McpProcess::spawn_configured(Some(tmp.path()), true);
+    assert_eq!(
+        configuration_block(&mut p)["selected_path"],
+        canonical(&selected)
+    );
+
+    std::fs::write(tmp.path().join("konnect.toml"), "log_level = \"trace\"\n").unwrap();
+
+    let after = configuration_block(&mut p);
+    assert_eq!(
+        after["selected_path"],
+        canonical(&selected),
+        "a file created after launch must not be reported as having configured this process"
+    );
+    assert_eq!(after["skipped_existing_paths"], json!([]));
+}
+
+#[test]
+fn installation_info_reports_defaults_when_no_config_file_exists() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut p = McpProcess::spawn_configured(Some(tmp.path()), true);
+
+    let configuration = configuration_block(&mut p);
+
+    assert_eq!(configuration["source"], "defaults");
+    assert_eq!(configuration["selected_path"], Value::Null);
+    assert_eq!(configuration["skipped_existing_paths"], json!([]));
+}
+
+#[test]
+fn env_fallback_applies_without_disturbing_reported_provenance() {
+    // Acceptance row: a selected file with a blank ipc_address plus
+    // KICAD_API_SOCKET in the environment. The env fallback must still be
+    // applied after file resolution (#39), and provenance must still name the
+    // file that was selected -- the env var configures a value, not a source.
+    let tmp = tempfile::tempdir().unwrap();
+    let selected = tmp.path().join("konnect.toml");
+    std::fs::write(&selected, "ipc_address = \"\"\n").unwrap();
+
+    let mut p = McpProcess::spawn_with_env(
+        Some(tmp.path()),
+        true,
+        &[("KICAD_API_SOCKET", "ipc://konnect-419-env.sock")],
+    );
+
+    let result = p.call_tool("get_installation_info", json!({}));
+    assert_ne!(result["isError"], json!(true), "{result:#?}");
+    let body = McpProcess::tool_body(&result);
+
+    assert_eq!(body["configuration"]["source"], "search_path");
+    assert_eq!(body["configuration"]["selected_path"], canonical(&selected));
+    assert_eq!(
+        body["ipc"]["configured"],
+        json!(true),
+        "the blank ipc_address should have been filled from the environment"
+    );
+}
+
+/// Run the server to completion with the given args, returning (exit ok, stderr).
+/// Used for the cases where startup must FAIL: the MCP harness above expects a
+/// handshake, and there deliberately is not one.
+fn run_expecting_startup_failure(dir: &std::path::Path, args: &[&str]) -> (bool, String) {
+    let output = Command::new(env!("CARGO_BIN_EXE_konnect"))
+        .args(args)
+        .current_dir(dir)
+        .env("HOME", dir)
+        .env("APPDATA", dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to run konnect binary");
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn a_malformed_selected_file_stops_startup_instead_of_falling_through() {
+    // konnect.toml is selected and is broken; settings.json is valid and later.
+    // Falling through would silently run on a configuration the user never
+    // pointed at, while their real file went unreported — the failure #419 is
+    // about, in its worst form.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("konnect.toml"), "not = valid toml [[[").unwrap();
+    std::fs::write(
+        tmp.path().join("settings.json"),
+        "{\"log_level\":\"trace\"}",
+    )
+    .unwrap();
+
+    let (ok, stderr) = run_expecting_startup_failure(tmp.path(), &[]);
+
+    assert!(!ok, "a malformed selected file must not start the server");
+    assert!(
+        !stderr.contains("configuration: search_path"),
+        "startup must not report a selection it never completed: {stderr}"
+    );
+}
+
+#[test]
+fn a_malformed_explicit_config_stops_startup_instead_of_falling_back() {
+    // --config bypasses discovery, so a valid settings.json sitting next to it
+    // must not rescue a broken explicit file either.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("bad.toml"), "not = valid toml [[[").unwrap();
+    std::fs::write(
+        tmp.path().join("settings.json"),
+        "{\"log_level\":\"trace\"}",
+    )
+    .unwrap();
+
+    let (ok, stderr) = run_expecting_startup_failure(tmp.path(), &["--config", "bad.toml"]);
+
+    assert!(
+        !ok,
+        "a malformed explicit --config must not start the server"
+    );
+    assert!(
+        !stderr.contains("configuration:"),
+        "startup must not report any configuration selection: {stderr}"
     );
 }

--- a/docs/KICAD_INTEGRATION.md
+++ b/docs/KICAD_INTEGRATION.md
@@ -88,7 +88,13 @@ through Python.
 
 ## Configuration
 
-`crates/konnect/src/config.rs` searches, in order:
+Konnect selects the first existing server configuration file in the order below
+and loads only that file. It does not merge settings from later locations. Call
+`get_installation_info` to see which file configured the running process and
+which later files were shadowed.
+
+So a value present only in a lower-priority file has no effect while a
+higher-priority file exists.
 
 1. `konnect.toml` in the working directory;
 2. `settings.json` in the working directory;
@@ -96,7 +102,30 @@ through Python.
 4. `settings.json` one directory above the executable;
 5. the platform configuration directory.
 
-`--config <path>` loads an explicit file. Relevant fields include `kicad_cli`,
+Two consequences worth stating outright, because both have been reported as
+missing functionality:
+
+- In the standard plugin layout a `settings.json` exists beside the binary, so
+  the platform configuration directory is never reached and any `config.toml`
+  there is inert.
+- A stray `konnect.toml` or `settings.json` in a working directory takes over the
+  entire configuration for that run.
+
+Call **`get_installation_info`** to see which file configured the running
+process: its `configuration` block reports `source`
+(`explicit_path` | `search_path` | `defaults`), the absolute `selected_path`, the
+`search_policy`, and `skipped_existing_paths` — the later files that exist and
+were shadowed. The values are captured at startup, so a file created afterwards
+is not reported. The server also logs one INFO line naming the selection at
+startup, for when no tool call is possible yet.
+
+Note that `load_user_config` is a different plane: it reads a user
+design-preferences file (`config.json`), not the server startup configuration
+described here, so its path does not answer "which file configured the server".
+
+`--config <path>` loads an explicit file and bypasses the search entirely; the
+list above is not consulted, and `get_installation_info` reports
+`source: "explicit_path"` with no skipped candidates. Relevant fields include `kicad_cli`,
 `kicad_binary`, `ipc_address`, `transport`, `http_address`, `jlcpcb_db_path`,
 `log_level`, `auto_load_toolsets`, and `eager_toolsets`. The legacy
 `ipc_socket_path` alias is accepted by the serde definition in `config.rs`.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -184,7 +184,13 @@ result is not what you expect.
 
 Common install paths are auto-detected (including the Windows registry). If
 your install is somewhere unusual, set the path in the plugin settings dialog
-in a `settings.json` beside the binary, or in a `konnect.toml` in the working directory (`kicad_cli`). Discovery order is `konnect.toml` and `settings.json` in the CWD, then `settings.json` next to the binary and one level up, then the platform config dir. A file under any other name is only read when passed with `--config`.
+in a `settings.json` beside the binary, or in a `konnect.toml` in the working directory (`kicad_cli`). Discovery order is `konnect.toml` and `settings.json` in the CWD, then `settings.json` next to the binary and one level up, then the platform config dir. **Only the first existing file is loaded — later ones are not merged in**, so a `kicad_cli` set in a lower-priority file is ignored while a higher-priority file exists. A file under any other name is only read when passed with `--config`.
+
+If a setting appears to be ignored, call `get_installation_info` and read its
+`configuration` block: `selected_path` is the file that configured the running
+process and `skipped_existing_paths` lists the ones it shadowed. That
+distinguishes "my file was never read" from "my file was read and the value is
+wrong", which otherwise look identical.
 
 ## Native Specctra export used the Rust fallback
 


### PR DESCRIPTION
## Summary

Konnect loads the **first existing** configuration file from its search list and ignores the rest, but nothing reported which one won. A user whose settings appear to have no effect cannot distinguish a shadowed file from a malformed one, and in the standard plugin layout a `settings.json` beside the binary makes the platform config directory permanently unreachable with no indication at all.

`get_installation_info` now reports the configuration that actually started the process, and the docs state the first-match-no-merge policy outright.

Issue: #419

Closes #419

## Approach

An immutable `ConfigResolution` is captured once during startup and reported read-only as an additive `configuration` block:

```json
"configuration": {
  "source": "explicit_path | search_path | defaults | unavailable",
  "selected_path": "/absolute/path/to/settings.json",
  "search_policy": "first_existing_no_merge",
  "skipped_existing_paths": ["/absolute/path/to/later/config.toml"]
}
```

Captured at startup rather than recomputed on call: re-running the search when the tool is invoked would describe the filesystem as it is *then*, and could name a higher-priority file created after launch — the opposite of the question being asked. A protocol test pins that.

Candidate selection is extracted into `select_config_candidate(&[PathBuf])` so precedence is testable against a supplied list; the real list depends on the working directory and `current_exe()`, neither of which a test can change without affecting the whole process.

Startup also emits one INFO record naming the selection, for when no tool call is possible yet — not one warning per shadowed file, since first-match is the intended policy.

**Three choices that differ from the outline in the issue, all easy to change:**

1. **`ConfigResolution` lives in `konnect-core`, not beside `Config` in the `konnect` crate.** `get_installation_info` is serialized in core and the dependency runs `konnect → konnect-core` only, so a record defined next to `Config` is invisible to the serializer. The alternative — passing a pre-built JSON value out of the binary crate — would put this response's shape somewhere no other field of `get_installation_info` lives.
2. **The constructor is `McpHandler::new_with_config_resolution`**, where the issue suggested `new_with_runtime_provenance`. Named after the type so one noun spans the JSON key, the type, the field and the constructor. Happy to rename if the other reads better.
3. **`search_policy` is a module constant, not a field on the record.** It describes the build, not the individual resolution. The public JSON is identical either way.

**The `ffi.rs` caveat is deliberately not fixed here.** `kicad_plugin_init` uses `unwrap_or_default()` on both config loads, so a malformed explicit `--config` silently starts on defaults. That is a separate defect and is left for its own issue to keep this PR to one reviewable outcome. What this PR does guarantee is that provenance never *lies* about it: that path reports the real resolution when the load succeeds and `unavailable` when it fails, never a fabricated clean `defaults`. (While implementing, I also noticed `ffi.rs` never calls `apply_env_fallbacks`, so its `--config` branch skips it while `main.rs` does it for the same case — relevant on that path specifically, since it is the KiCad plugin route and #39 exists because KiCad launches with `--config` and `KICAD_API_SOCKET` together. Behaviour unchanged here; I will file both symptoms together.)

`Config::load()` is removed rather than kept as a wrapper: `mod config` is private in both `main.rs` and `lib.rs`, so it was unreachable outside the crate, and both call sites now take the resolution.

## Branch and dependencies

- Base branch: `main` (branched from `a51b856`)
- Depends on: nothing
- Series order: standalone, not part of a series
- Unique commits/acceptance criteria owned: one commit; the whole of #419's provenance and documentation outcome

## Compatibility and safety

**This is an additive public response change, not a no-op for compatibility.** `get_installation_info` gains a `configuration` object; no existing field is renamed, removed or changed. Per GOVERNANCE.md's version rule a changed response shape is a **minor**, and the release notes should mention the new block.

Behaviour is otherwise unchanged, and this is asserted rather than assumed — the first existing candidate still wins, a malformed selected file is still a startup error rather than permission to fall through, no candidates still means defaults, `--config` still bypasses discovery, and the environment fallback (#39) still applies after file or default resolution.

No file or IPC mutations. The block carries **paths only** — never configuration values, file contents or IPC credentials — verified by a test that puts a token in `ipc_address` and asserts it does not appear.

No dependencies added; `Cargo.lock`, `Cargo.toml`, `registry.rs` and `tool-directory.md` are untouched, and no tools were added or removed, so `fix-doc-counts` does not apply.

## Validation

```
cargo fmt --all -- --check                                     → 0
cargo test --workspace --locked --lib --tests                  → 0  (29 suites)
cargo test --workspace --locked --doc                          → 0
cargo clippy --workspace --locked --all-targets -- -D warnings  → 0
```

Acceptance matrix from the issue, all covered: no files exist → `defaults`/null/empty; first missing, second exists → the second; first and third exist → first selected, third reported skipped; malformed selected file → startup error, no fall-through; valid explicit `--config` → `explicit_path` with the automatic list not consulted; malformed explicit `--config` → startup error, no fall-back; blank IPC plus environment socket → same source and path, env fallback still applied.

Protocol-level tests spawn the real binary and prove the returned absolute path is the file that controlled startup, that a shadowed later candidate is named, and that creating a higher-priority file *after* launch does not change the answer.

**Per the evidence rule, every new guard was neutered and watched to fail.** Discarding the resolution in the handler fails all provenance tests (and they report `unavailable`, not a fabricated `defaults`). Making the malformed-file loads `unwrap_or_default()` fails both startup-failure tests. All pass again on restore.

**Existing fields verified unchanged**, as requested: I built a binary from `a51b856`, ran both through the same scenario and diffed the whole `get_installation_info` response. Keys added: exactly `configuration` and its four children. Keys removed: none. The only differing shared values were `build.commit` and `runtime.executable_path`, which differ because they are two different binaries.

Also exercised by hand against the real binary, including the case that motivates the issue: with `<plugin>/bin/konnect` and `<plugin>/settings.json`, the response names that `settings.json` as selected and reports the platform `config.toml` as shadowed.

**Not run, and why:** the Windows `APPDATA` branch of `dirs_config_path` (developed and tested on macOS; it is exercised only on Windows CI). `source: "unavailable"` is not reachable through the binary — it belongs to the cdylib entry point, so it is covered by unit tests and by the neutering run rather than end-to-end. No real-KiCad, viewer or packaging checks were relevant to this change.
