### PR TITLE
fix(exports): verify current-invocation artifacts

### DIFF
--- a/crates/konnect-core/src/tools/cli.rs
+++ b/crates/konnect-core/src/tools/cli.rs
@@ -173,6 +173,31 @@ async fn run_cli(cli: &str, args: &[&str], timeout_dur: Duration) -> Result<Stri
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+/// An export command returning success is necessary but not sufficient: KiCad
+/// can exit successfully without creating the path a caller asked for. Every
+/// path Konnect reports as an artifact passes this check first (#252).
+async fn verify_nonempty_file(path: &Path, artifact: &str) -> Result<u64> {
+    let metadata = tokio::fs::metadata(path).await.with_context(|| {
+        format!(
+            "{artifact} export reported success but did not create {}",
+            path.display()
+        )
+    })?;
+    if !metadata.is_file() {
+        anyhow::bail!(
+            "{artifact} export reported success but {} is not a file",
+            path.display()
+        );
+    }
+    if metadata.len() == 0 {
+        anyhow::bail!(
+            "{artifact} export reported success but created an empty file at {}",
+            path.display()
+        );
+    }
+    Ok(metadata.len())
+}
+
 // ─── ERC ─────────────────────────────────────────────────────────────────────
 
 /// Run ERC on a schematic and return parsed violations.
@@ -439,7 +464,9 @@ pub async fn export_schematic_svg(
     );
     run_cli(cli, &args, LONG_TIMEOUT).await?;
     let stem = schematic.file_stem().unwrap_or_default().to_string_lossy();
-    Ok(output_dir.join(format!("{}.svg", stem)))
+    let output = output_dir.join(format!("{}.svg", stem));
+    verify_nonempty_file(&output, "schematic SVG").await?;
+    Ok(output)
 }
 
 #[derive(Debug, Clone)]
@@ -487,6 +514,7 @@ pub async fn export_schematic_pdf(
         options,
     );
     run_cli(cli, &args, LONG_TIMEOUT).await?;
+    verify_nonempty_file(output, "schematic PDF").await?;
     Ok(())
 }
 
@@ -553,6 +581,7 @@ pub async fn export_bom(
         options,
     );
     run_cli(cli, &args, LONG_TIMEOUT).await?;
+    verify_nonempty_file(output, "BOM").await?;
     Ok(())
 }
 
@@ -611,7 +640,7 @@ pub async fn export_gerber(
     pcb: &Path,
     output_dir: &Path,
     layers: &[&str],
-) -> Result<()> {
+) -> Result<Vec<PathBuf>> {
     let layers_csv = layers.join(",");
     let args = gerber_args(
         output_dir.to_str().unwrap_or(""),
@@ -619,7 +648,40 @@ pub async fn export_gerber(
         &layers_csv,
     );
     run_cli(cli, &args, LONG_TIMEOUT).await?;
-    Ok(())
+
+    let board_stem = pcb.file_stem().unwrap_or_default().to_string_lossy();
+    let mut files = Vec::new();
+    let mut entries = tokio::fs::read_dir(output_dir).await.with_context(|| {
+        format!(
+            "Gerber export reported success but output directory {} is missing",
+            output_dir.display()
+        )
+    })?;
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        let is_gerber = path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.to_ascii_lowercase().starts_with('g'));
+        if name.starts_with(board_stem.as_ref()) && is_gerber {
+            verify_nonempty_file(&path, "Gerber").await?;
+            files.push(path);
+        }
+    }
+    files.sort();
+    let plot_count = files
+        .iter()
+        .filter(|path| path.extension().and_then(|value| value.to_str()) != Some("gbrjob"))
+        .count();
+    if plot_count < layers.len().max(1) {
+        anyhow::bail!(
+            "Gerber export reported success but produced {plot_count} non-empty plot file(s) for {} requested layer(s) in {}",
+            layers.len(),
+            output_dir.display()
+        );
+    }
+    Ok(files)
 }
 
 /// `--output` for a drill export names a *directory*, and some kicad-cli
@@ -681,7 +743,17 @@ pub async fn export_drill(cli: &str, pcb: &Path, output_dir: &Path) -> Result<Ve
     let dir_arg = drill_output_dir_arg(output_dir.to_str().unwrap_or(""));
     let args = drill_args(&dir_arg, pcb.to_str().unwrap_or(""));
     run_cli(cli, &args, LONG_TIMEOUT).await?;
-    Ok(drill_files_in(output_dir).await)
+    let files = drill_files_in(output_dir).await;
+    if files.is_empty() {
+        anyhow::bail!(
+            "drill export reported success but produced no .drl files in {}",
+            output_dir.display()
+        );
+    }
+    for file in &files {
+        verify_nonempty_file(file, "drill").await?;
+    }
+    Ok(files)
 }
 
 fn single_file_pcb_export_args(
@@ -728,6 +800,7 @@ pub async fn export_pdf(
     );
     let args: Vec<&str> = args.iter().map(String::as_str).collect();
     run_cli(cli, &args, LONG_TIMEOUT).await?;
+    verify_nonempty_file(output, "PCB PDF").await?;
     Ok(())
 }
 
@@ -845,6 +918,7 @@ pub async fn export_position_file(
         side,
     );
     run_cli(cli, &args, LONG_TIMEOUT).await?;
+    verify_nonempty_file(output, "position file").await?;
     Ok(())
 }
 
@@ -1409,6 +1483,54 @@ mod erc_parse_tests {
 }
 
 #[cfg(test)]
+mod artifact_verification_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn missing_and_empty_artifacts_are_not_successes() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing.pdf");
+        let error = verify_nonempty_file(&missing, "test PDF")
+            .await
+            .expect_err("missing file must fail");
+        assert!(error.to_string().contains("did not create"));
+
+        let empty = dir.path().join("empty.pdf");
+        std::fs::write(&empty, []).unwrap();
+        let error = verify_nonempty_file(&empty, "test PDF")
+            .await
+            .expect_err("empty file must fail");
+        assert!(error.to_string().contains("empty file"));
+
+        let real = dir.path().join("real.pdf");
+        std::fs::write(&real, b"%PDF-test").unwrap();
+        assert_eq!(verify_nonempty_file(&real, "test PDF").await.unwrap(), 9);
+    }
+
+    #[test]
+    fn pcb_pdf_uses_one_csv_layer_argument_and_one_file_mode() {
+        let args = pcb_pdf_args(
+            "/out/board.pdf",
+            "/tmp/board.kicad_pcb",
+            "F.Cu,B.Cu,F.SilkS,B.SilkS,Edge.Cuts",
+        );
+        assert_eq!(
+            args.iter()
+                .filter(|argument| **argument == "--layers")
+                .count(),
+            1
+        );
+        let layers = args
+            .iter()
+            .position(|argument| *argument == "--layers")
+            .map(|index| args[index + 1]);
+        assert_eq!(layers, Some("F.Cu,B.Cu,F.SilkS,B.SilkS,Edge.Cuts"));
+        assert!(args.contains(&"--mode-single"));
+        assert_eq!(args.last().copied(), Some("/tmp/board.kicad_pcb"));
+    }
+}
+
+#[cfg(test)]
 mod gerber_export_tests {
     use super::*;
 
@@ -1509,7 +1631,7 @@ mod drill_export_tests {
     async fn drill_files_are_collected_sorted_and_filtered_by_extension() {
         let dir = tempfile::tempdir().unwrap();
         for name in ["board-PTH.drl", "board-NPTH.drl", "board-drl_map.pdf"] {
-            std::fs::write(dir.path().join(name), "").unwrap();
+            std::fs::write(dir.path().join(name), "non-empty").unwrap();
         }
         let files = drill_files_in(dir.path()).await;
         let names: Vec<_> = files

--- a/crates/konnect-core/src/tools/cli.rs
+++ b/crates/konnect-core/src/tools/cli.rs
@@ -198,6 +198,130 @@ async fn verify_nonempty_file(path: &Path, artifact: &str) -> Result<u64> {
     Ok(metadata.len())
 }
 
+fn export_staging_dir(destination: &Path) -> Result<tempfile::TempDir> {
+    let parent = destination
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent)?;
+    tempfile::Builder::new()
+        .prefix(".konnect-export-")
+        .tempdir_in(parent)
+        .context("failed to create an export staging directory")
+}
+
+/// Publish a verified artifact without letting a stale destination stand in
+/// for output from the current command. The staging directory is a sibling of
+/// the destination, so every rename remains on the same filesystem.
+async fn publish_verified_file(staged: &Path, destination: &Path, artifact: &str) -> Result<u64> {
+    let size = verify_nonempty_file(staged, artifact).await?;
+    if let Some(parent) = destination.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+
+    if !destination.exists() {
+        tokio::fs::rename(staged, destination).await?;
+        return Ok(size);
+    }
+
+    let file_name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("artifact");
+    let backup = staged.with_file_name(format!(".konnect-previous-{file_name}"));
+    tokio::fs::rename(destination, &backup)
+        .await
+        .with_context(|| {
+            format!(
+                "cannot preserve the previous artifact at {} before publishing",
+                destination.display()
+            )
+        })?;
+    if let Err(install_error) = tokio::fs::rename(staged, destination).await {
+        if let Err(restore_error) = tokio::fs::rename(&backup, destination).await {
+            anyhow::bail!(
+                "failed to publish {} ({install_error}) and restore its previous contents ({restore_error})",
+                destination.display()
+            );
+        }
+        return Err(install_error).with_context(|| {
+            format!(
+                "failed to publish verified artifact {}",
+                destination.display()
+            )
+        });
+    }
+    tokio::fs::remove_file(backup).await?;
+    Ok(size)
+}
+
+async fn publish_verified_files(
+    staged_files: &[PathBuf],
+    output_dir: &Path,
+    artifact: &str,
+) -> Result<Vec<PathBuf>> {
+    for staged in staged_files {
+        verify_nonempty_file(staged, artifact).await?;
+    }
+
+    let mut published = Vec::with_capacity(staged_files.len());
+    for staged in staged_files {
+        let file_name = staged
+            .file_name()
+            .context("export produced a path without a file name")?;
+        let destination = output_dir.join(file_name);
+        publish_verified_file(staged, &destination, artifact).await?;
+        published.push(destination);
+    }
+    Ok(published)
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+
+    fn write_script(dir: &Path, stem: &str, unix_body: &str, windows_body: &str) -> PathBuf {
+        #[cfg(windows)]
+        let path = dir.join(format!("{stem}.cmd"));
+        #[cfg(not(windows))]
+        let path = dir.join(stem);
+
+        #[cfg(windows)]
+        {
+            let _ = unix_body;
+            std::fs::write(&path, windows_body).unwrap();
+        }
+        #[cfg(not(windows))]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = windows_body;
+            std::fs::write(&path, unix_body).unwrap();
+            let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&path, permissions).unwrap();
+        }
+        path
+    }
+
+    pub(crate) fn noop_cli(dir: &Path) -> PathBuf {
+        write_script(
+            dir,
+            "fake-kicad-cli",
+            "#!/bin/sh\nexit 0\n",
+            "@exit /b 0\r\n",
+        )
+    }
+
+    pub(crate) fn schematic_only_cli(dir: &Path) -> PathBuf {
+        write_script(
+            dir,
+            "fake-kicad-cli",
+            "#!/bin/sh\nif [ \"$1\" = \"sch\" ]; then\n  while [ \"$#\" -gt 0 ]; do\n    if [ \"$1\" = \"--output\" ]; then\n      shift\n      printf '%s' 'PDF-test' > \"$1\"\n      break\n    fi\n    shift\n  done\nfi\nexit 0\n",
+            "@echo off\r\nif not \"%1\"==\"sch\" exit /b 0\r\n:loop\r\nif \"%1\"==\"\" goto done\r\nif not \"%1\"==\"--output\" goto next\r\nshift\r\necho PDF-test>\"%1\"\r\ngoto done\r\n:next\r\nshift\r\ngoto loop\r\n:done\r\nexit /b 0\r\n",
+        )
+    }
+}
+
 // ─── ERC ─────────────────────────────────────────────────────────────────────
 
 /// Run ERC on a schematic and return parsed violations.
@@ -457,16 +581,28 @@ pub async fn export_schematic_svg(
     output_dir: &Path,
     options: &SchematicSvgOptions<'_>,
 ) -> Result<PathBuf> {
+    let staging = export_staging_dir(output_dir)?;
     let args = schematic_svg_args(
-        output_dir.to_str().unwrap(),
+        staging.path().to_str().unwrap(),
         schematic.to_str().unwrap(),
         options,
     );
     run_cli(cli, &args, LONG_TIMEOUT).await?;
     let stem = schematic.file_stem().unwrap_or_default().to_string_lossy();
-    let output = output_dir.join(format!("{}.svg", stem));
-    verify_nonempty_file(&output, "schematic SVG").await?;
-    Ok(output)
+    let staged_root = staging.path().join(format!("{}.svg", stem));
+
+    let mut staged_files = Vec::new();
+    let mut entries = tokio::fs::read_dir(staging.path()).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) == Some("svg") {
+            staged_files.push(path);
+        }
+    }
+    staged_files.sort();
+    verify_nonempty_file(&staged_root, "schematic SVG").await?;
+    publish_verified_files(&staged_files, output_dir, "schematic SVG").await?;
+    Ok(output_dir.join(format!("{}.svg", stem)))
 }
 
 #[derive(Debug, Clone)]
@@ -508,13 +644,19 @@ pub async fn export_schematic_pdf(
     output: &Path,
     options: &SchematicPdfOptions,
 ) -> Result<()> {
+    let staging = export_staging_dir(output)?;
+    let staged = staging.path().join(
+        output
+            .file_name()
+            .context("schematic PDF output has no file name")?,
+    );
     let args = schematic_pdf_args(
-        output.to_str().unwrap(),
+        staged.to_str().unwrap(),
         schematic.to_str().unwrap(),
         options,
     );
     run_cli(cli, &args, LONG_TIMEOUT).await?;
-    verify_nonempty_file(output, "schematic PDF").await?;
+    publish_verified_file(&staged, output, "schematic PDF").await?;
     Ok(())
 }
 
@@ -575,13 +717,17 @@ pub async fn export_bom(
     output: &Path,
     options: &BomOptions<'_>,
 ) -> Result<()> {
+    let staging = export_staging_dir(output)?;
+    let staged = staging
+        .path()
+        .join(output.file_name().context("BOM output has no file name")?);
     let args = bom_args(
-        output.to_str().unwrap_or(""),
+        staged.to_str().unwrap_or(""),
         schematic.to_str().unwrap_or(""),
         options,
     );
     run_cli(cli, &args, LONG_TIMEOUT).await?;
-    verify_nonempty_file(output, "BOM").await?;
+    publish_verified_file(&staged, output, "BOM").await?;
     Ok(())
 }
 
@@ -641,9 +787,10 @@ pub async fn export_gerber(
     output_dir: &Path,
     layers: &[&str],
 ) -> Result<Vec<PathBuf>> {
+    let staging = export_staging_dir(output_dir)?;
     let layers_csv = layers.join(",");
     let args = gerber_args(
-        output_dir.to_str().unwrap_or(""),
+        staging.path().to_str().unwrap_or(""),
         pcb.to_str().unwrap_or(""),
         &layers_csv,
     );
@@ -651,10 +798,10 @@ pub async fn export_gerber(
 
     let board_stem = pcb.file_stem().unwrap_or_default().to_string_lossy();
     let mut files = Vec::new();
-    let mut entries = tokio::fs::read_dir(output_dir).await.with_context(|| {
+    let mut entries = tokio::fs::read_dir(staging.path()).await.with_context(|| {
         format!(
             "Gerber export reported success but output directory {} is missing",
-            output_dir.display()
+            staging.path().display()
         )
     })?;
     while let Some(entry) = entries.next_entry().await? {
@@ -678,10 +825,10 @@ pub async fn export_gerber(
         anyhow::bail!(
             "Gerber export reported success but produced {plot_count} non-empty plot file(s) for {} requested layer(s) in {}",
             layers.len(),
-            output_dir.display()
+            staging.path().display()
         );
     }
-    Ok(files)
+    publish_verified_files(&files, output_dir, "Gerber").await
 }
 
 /// `--output` for a drill export names a *directory*, and some kicad-cli
@@ -739,21 +886,21 @@ async fn drill_files_in(dir: &Path) -> Vec<PathBuf> {
 ///
 /// Returns the `.drl` files produced, sorted.
 pub async fn export_drill(cli: &str, pcb: &Path, output_dir: &Path) -> Result<Vec<PathBuf>> {
-    tokio::fs::create_dir_all(output_dir).await?;
-    let dir_arg = drill_output_dir_arg(output_dir.to_str().unwrap_or(""));
+    let staging = export_staging_dir(output_dir)?;
+    let dir_arg = drill_output_dir_arg(staging.path().to_str().unwrap_or(""));
     let args = drill_args(&dir_arg, pcb.to_str().unwrap_or(""));
     run_cli(cli, &args, LONG_TIMEOUT).await?;
-    let files = drill_files_in(output_dir).await;
+    let files = drill_files_in(staging.path()).await;
     if files.is_empty() {
         anyhow::bail!(
             "drill export reported success but produced no .drl files in {}",
-            output_dir.display()
+            staging.path().display()
         );
     }
     for file in &files {
         verify_nonempty_file(file, "drill").await?;
     }
-    Ok(files)
+    publish_verified_files(&files, output_dir, "drill").await
 }
 
 fn single_file_pcb_export_args(
@@ -791,16 +938,22 @@ pub async fn export_pdf(
     layers: &[&str],
     black_and_white: bool,
 ) -> Result<()> {
+    let staging = export_staging_dir(output)?;
+    let staged = staging.path().join(
+        output
+            .file_name()
+            .context("PCB PDF output has no file name")?,
+    );
     let args = single_file_pcb_export_args(
         "pdf",
-        output.to_str().unwrap(),
+        staged.to_str().unwrap(),
         layers,
         black_and_white,
         pcb.to_str().unwrap(),
     );
     let args: Vec<&str> = args.iter().map(String::as_str).collect();
     run_cli(cli, &args, LONG_TIMEOUT).await?;
-    verify_nonempty_file(output, "PCB PDF").await?;
+    publish_verified_file(&staged, output, "PCB PDF").await?;
     Ok(())
 }
 
@@ -910,15 +1063,21 @@ pub async fn export_position_file(
     units: &str,
     side: &str,
 ) -> Result<()> {
+    let staging = export_staging_dir(output)?;
+    let staged = staging.path().join(
+        output
+            .file_name()
+            .context("position output has no file name")?,
+    );
     let args = position_args(
-        output.to_str().unwrap_or(""),
+        staged.to_str().unwrap_or(""),
         pcb.to_str().unwrap_or(""),
         format,
         units,
         side,
     );
     run_cli(cli, &args, LONG_TIMEOUT).await?;
-    verify_nonempty_file(output, "position file").await?;
+    publish_verified_file(&staged, output, "position file").await?;
     Ok(())
 }
 
@@ -1507,26 +1666,30 @@ mod artifact_verification_tests {
         assert_eq!(verify_nonempty_file(&real, "test PDF").await.unwrap(), 9);
     }
 
-    #[test]
-    fn pcb_pdf_uses_one_csv_layer_argument_and_one_file_mode() {
-        let args = pcb_pdf_args(
-            "/out/board.pdf",
-            "/tmp/board.kicad_pcb",
-            "F.Cu,B.Cu,F.SilkS,B.SilkS,Edge.Cuts",
-        );
+    #[tokio::test]
+    async fn stale_destination_cannot_satisfy_a_new_export() {
+        let dir = tempfile::tempdir().unwrap();
+        let cli = test_support::noop_cli(dir.path());
+        let schematic = dir.path().join("clock.kicad_sch");
+        let destination = dir.path().join("clock.pdf");
+        std::fs::write(&schematic, "placeholder").unwrap();
+        std::fs::write(&destination, "stale-but-nonempty").unwrap();
+
+        let error = export_schematic_pdf(
+            cli.to_str().unwrap(),
+            &schematic,
+            &destination,
+            &SchematicPdfOptions::default(),
+        )
+        .await
+        .expect_err("the current invocation produced no artifact");
+
+        assert!(error.to_string().contains("did not create"), "{error:#}");
         assert_eq!(
-            args.iter()
-                .filter(|argument| **argument == "--layers")
-                .count(),
-            1
+            std::fs::read_to_string(destination).unwrap(),
+            "stale-but-nonempty",
+            "a failed export must preserve the previous artifact"
         );
-        let layers = args
-            .iter()
-            .position(|argument| *argument == "--layers")
-            .map(|index| args[index + 1]);
-        assert_eq!(layers, Some("F.Cu,B.Cu,F.SilkS,B.SilkS,Edge.Cuts"));
-        assert!(args.contains(&"--mode-single"));
-        assert_eq!(args.last().copied(), Some("/tmp/board.kicad_pcb"));
     }
 }
 

--- a/crates/konnect-core/src/tools/manufacturing.rs
+++ b/crates/konnect-core/src/tools/manufacturing.rs
@@ -326,7 +326,7 @@ async fn handle_export_manufacturing_package(
 
     let next_steps = if complete {
         format!(
-                "Upload the contents of {} to {}'s order page. Gerbers go in the PCB order, BOM + positions go in the assembly order.",
+                "Upload only the verified paths listed in `files` from {} to {}'s order page. Gerbers go in the PCB order, BOM + positions go in the assembly order.",
                 output_dir.display(),
                 fab_house.to_uppercase()
             )
@@ -650,11 +650,8 @@ mod package_export_option_tests {
         );
     }
 
-    #[cfg(unix)]
     #[tokio::test]
     async fn package_is_an_error_when_cli_success_produces_no_artifacts() {
-        use std::os::unix::fs::PermissionsExt;
-
         let dir = tempfile::tempdir().unwrap();
         let board = dir.path().join("live_ipc.kicad_pcb");
         // Real KiCad 9 output, as required for tests that parse board layers.
@@ -663,11 +660,7 @@ mod package_export_option_tests {
             include_str!("../../../konnect-ipc/tests/fixtures/live_ipc.kicad_pcb"),
         )
         .unwrap();
-        let cli = dir.path().join("fake-kicad-cli");
-        std::fs::write(&cli, "#!/bin/sh\nexit 0\n").unwrap();
-        let mut permissions = std::fs::metadata(&cli).unwrap().permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&cli, permissions).unwrap();
+        let cli = crate::tools::cli::test_support::noop_cli(dir.path());
         let ctx = ToolContext::new(
             crate::tools::ServerConfig {
                 kicad_cli: cli.display().to_string(),

--- a/crates/konnect-core/src/tools/manufacturing.rs
+++ b/crates/konnect-core/src/tools/manufacturing.rs
@@ -8,7 +8,7 @@ use crate::tool;
 use crate::tools::{get_path, ToolContext, ToolDef};
 use serde_json::json;
 use std::path::PathBuf;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 use super::{cli, pcb_export};
 
@@ -169,6 +169,7 @@ async fn handle_export_manufacturing_package(
 
     let cli_path = &ctx.config.kicad_cli;
     let mut files_generated = Vec::new();
+    let mut verified_paths = Vec::new();
     let mut warnings = Vec::new();
 
     // 1. Export Gerbers
@@ -176,12 +177,14 @@ async fn handle_export_manufacturing_package(
     tokio::fs::create_dir_all(&gerber_dir).await?;
     let gerber_layer_refs = gerber_layers.iter().map(String::as_str).collect::<Vec<_>>();
     match cli::export_gerber(cli_path, &board, &gerber_dir, &gerber_layer_refs).await {
-        Ok(()) => {
-            info!("[BETA] Gerber export succeeded");
+        Ok(gerber_files) => {
+            info!(files = gerber_files.len(), "[BETA] Gerber export succeeded");
+            verified_paths.extend(gerber_files.iter().cloned());
             files_generated.push(json!({
                 "type": "gerber",
                 "path": gerber_dir.to_str().unwrap_or(""),
-                "layers": gerber_layers.clone()
+                "layers": gerber_layers.clone(),
+                "files": gerber_files.iter().map(|path| path.to_str().unwrap_or("")).collect::<Vec<_>>()
             }));
         }
         Err(e) => {
@@ -198,22 +201,18 @@ async fn handle_export_manufacturing_package(
     //    the real Excellon output never appeared in the file list at all.
     match cli::export_drill(cli_path, &board, &gerber_dir).await {
         Ok(drill_files) => {
-            if drill_files.is_empty() {
-                warn!("[BETA] Drill export produced no .drl files");
-                warnings.push("Drill export produced no .drl files.".to_string());
-            } else {
-                info!(files = drill_files.len(), "[BETA] Drill export succeeded");
-                for file in &drill_files {
-                    files_generated.push(json!({
-                        "type": "drill",
-                        "path": file.to_str().unwrap_or("")
-                    }));
-                }
+            info!(files = drill_files.len(), "[BETA] Drill export succeeded");
+            verified_paths.extend(drill_files.iter().cloned());
+            for file in &drill_files {
+                files_generated.push(json!({
+                    "type": "drill",
+                    "path": file.to_str().unwrap_or("")
+                }));
             }
         }
         Err(e) => {
-            warn!(error = %e, "[BETA] Drill export failed (may be included in gerbers)");
-            // Not critical — some gerber exports include drill
+            error!(error = %e, "[BETA] Drill export failed");
+            warnings.push(format!("Drill export failed: {e}"));
         }
     }
 
@@ -237,6 +236,7 @@ async fn handle_export_manufacturing_package(
         {
             Ok(()) => {
                 info!("[BETA] Position file export succeeded");
+                verified_paths.push(pos_path.clone());
                 files_generated.push(json!({
                     "type": "pick_and_place",
                     "path": pos_path.to_str().unwrap_or(""),
@@ -266,6 +266,7 @@ async fn handle_export_manufacturing_package(
             match cli::export_bom(cli_path, sch, &bom_path, &bom_options).await {
                 Ok(()) => {
                     info!("[BETA] BOM export succeeded");
+                    verified_paths.push(bom_path.clone());
                     files_generated.push(json!({
                         "type": "bom",
                         "path": bom_path.to_str().unwrap_or(""),
@@ -283,23 +284,30 @@ async fn handle_export_manufacturing_package(
         }
     }
 
-    // List all files in output dir
-    let mut all_files = Vec::new();
-    if let Ok(mut rd) = tokio::fs::read_dir(&output_dir).await {
-        while let Ok(Some(entry)) = rd.next_entry().await {
-            all_files.push(entry.file_name().to_string_lossy().to_string());
-        }
-    }
-    // Also list gerber subdir
-    if let Ok(mut rd) = tokio::fs::read_dir(&gerber_dir).await {
-        while let Ok(Some(entry)) = rd.next_entry().await {
-            all_files.push(format!("gerbers/{}", entry.file_name().to_string_lossy()));
-        }
-    }
+    // Derive the public file list only from artifacts the CLI boundary already
+    // verified as regular and non-empty. A stale or empty directory entry can
+    // no longer make an incomplete package look successful (#252).
+    let mut all_files = verified_paths
+        .iter()
+        .map(|path| {
+            path.strip_prefix(&output_dir)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .replace('\\', "/")
+        })
+        .collect::<Vec<_>>();
     all_files.sort();
+    all_files.dedup();
+
+    let complete = warnings.is_empty();
 
     let summary = format!(
-        "Generated for {}. {} files total. {}",
+        "{} for {}. {} verified non-empty files. {}",
+        if complete {
+            "Complete package"
+        } else {
+            "INCOMPLETE package"
+        },
         fab_house.to_uppercase(),
         all_files.len(),
         if warnings.is_empty() {
@@ -310,30 +318,40 @@ async fn handle_export_manufacturing_package(
     );
 
     info!(
+        complete = complete,
         files = all_files.len(),
         warnings = warnings.len(),
-        "[BETA] Manufacturing package complete"
+        "[BETA] Manufacturing package finished"
     );
 
-    Ok(CallToolResult::text(
-        serde_json::to_string(&json!({
-            "fab_house": fab_house,
-            "output_dir": output_dir.to_str().unwrap_or(""),
-            "files": all_files,
-            "files_generated": files_generated,
-            "gerber_layers": gerber_layers,
-            "position_units": if include_assembly { Some(position_units) } else { None },
-            "position_side": if include_assembly { Some(position_side) } else { None },
-            "warnings": warnings,
-            "summary": summary,
-            "next_steps": format!(
+    let next_steps = if complete {
+        format!(
                 "Upload the contents of {} to {}'s order page. Gerbers go in the PCB order, BOM + positions go in the assembly order.",
                 output_dir.display(),
                 fab_house.to_uppercase()
             )
-        }))
-        .unwrap(),
-    ))
+    } else {
+        "Do not upload this package. Resolve every warning and export again.".to_string()
+    };
+    let body = serde_json::to_string(&json!({
+        "complete": complete,
+        "fab_house": fab_house,
+        "output_dir": output_dir.to_str().unwrap_or(""),
+        "files": all_files,
+        "files_generated": files_generated,
+        "gerber_layers": gerber_layers,
+        "position_units": if include_assembly { Some(position_units) } else { None },
+        "position_side": if include_assembly { Some(position_side) } else { None },
+        "warnings": warnings,
+        "summary": summary,
+        "next_steps": next_steps
+    }))
+    .unwrap();
+    Ok(if complete {
+        CallToolResult::text(body)
+    } else {
+        CallToolResult::error(body)
+    })
 }
 
 fn invalid_manufacturing_argument(field: &str, reason: impl Into<String>) -> CallToolResult {
@@ -608,6 +626,15 @@ async fn handle_estimate_cost(
 mod package_export_option_tests {
     use super::*;
 
+    fn result_json(result: &CallToolResult) -> serde_json::Value {
+        match result.content.first() {
+            Some(crate::mcp::protocol::ToolContent::Text { text }) => {
+                serde_json::from_str(text).unwrap()
+            }
+            other => panic!("expected text result, got {other:?}"),
+        }
+    }
+
     #[test]
     fn package_schema_exposes_applied_gerber_and_position_options() {
         let package = tools()
@@ -621,6 +648,58 @@ mod package_export_option_tests {
             properties["position_side"]["enum"],
             json!(["front", "back", "both"])
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn package_is_an_error_when_cli_success_produces_no_artifacts() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let board = dir.path().join("live_ipc.kicad_pcb");
+        // Real KiCad 9 output, as required for tests that parse board layers.
+        std::fs::write(
+            &board,
+            include_str!("../../../konnect-ipc/tests/fixtures/live_ipc.kicad_pcb"),
+        )
+        .unwrap();
+        let cli = dir.path().join("fake-kicad-cli");
+        std::fs::write(&cli, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut permissions = std::fs::metadata(&cli).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&cli, permissions).unwrap();
+        let ctx = ToolContext::new(
+            crate::tools::ServerConfig {
+                kicad_cli: cli.display().to_string(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+                eager_toolsets: false,
+            },
+            std::sync::Arc::new(crate::router::ToolRouter::new()),
+        );
+
+        let result = handle_export_manufacturing_package(
+            &json!({
+                "board": board.display().to_string(),
+                "output_dir": dir.path().join("package").display().to_string(),
+                "include_assembly": false
+            }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert!(result.is_error, "incomplete package must fail closed");
+        let body = result_json(&result);
+        assert_eq!(body["complete"], false);
+        assert_eq!(body["files"], json!([]));
+        assert!(body["warnings"].as_array().unwrap().len() >= 2, "{body}");
+        assert!(body["next_steps"]
+            .as_str()
+            .unwrap()
+            .starts_with("Do not upload"));
     }
 }
 

--- a/crates/konnect-core/src/tools/pcb_export.rs
+++ b/crates/konnect-core/src/tools/pcb_export.rs
@@ -464,7 +464,7 @@ async fn handle_export_gerber(
     tokio::fs::create_dir_all(&output_dir).await?;
 
     let cli = &ctx.config.kicad_cli;
-    cli::export_gerber(cli, &board, &output_dir, &layer_refs).await?;
+    let mut verified_files = cli::export_gerber(cli, &board, &output_dir, &layer_refs).await?;
 
     if drill {
         // kicad-cli also has a dedicated drill export. Its --output is a
@@ -473,16 +473,16 @@ async fn handle_export_gerber(
         // `output_dir.join("drill.drl")` made KiCad create a *directory*
         // called drill.drl and bury the drill files inside it, where the
         // listing below never saw them.
-        let _ = cli::export_drill(cli, &board, &output_dir).await; // best-effort
+        verified_files.extend(cli::export_drill(cli, &board, &output_dir).await?);
     }
 
-    // List produced files
-    let mut files = Vec::new();
-    if let Ok(mut rd) = tokio::fs::read_dir(&output_dir).await {
-        while let Ok(Some(entry)) = rd.next_entry().await {
-            files.push(entry.file_name().to_string_lossy().to_string());
-        }
-    }
+    // Report only files that this export path verified as regular and
+    // non-empty; never echo a directory listing containing stale artifacts.
+    let mut files = verified_files
+        .iter()
+        .filter_map(|path| path.file_name())
+        .map(|name| name.to_string_lossy().to_string())
+        .collect::<Vec<_>>();
     files.sort();
 
     Ok(CallToolResult::text(

--- a/crates/konnect-core/src/tools/project.rs
+++ b/crates/konnect-core/src/tools/project.rs
@@ -488,14 +488,14 @@ async fn handle_snapshot_project(
         let pcb_pdf_name = format!("{}_pcb_{}_{}.pdf", stem, label, ts);
         let pcb_pdf_path = output_dir.join(&pcb_pdf_name);
         let layers = &["F.Cu", "B.Cu", "F.Silkscreen", "B.Silkscreen", "Edge.Cuts"];
-        let _ = crate::tools::cli::export_pdf(
+        crate::tools::cli::export_pdf(
             &ctx.config.kicad_cli,
             &pcb,
             &pcb_pdf_path,
             layers,
             false,
         )
-        .await;
+        .await?;
         result["pcb_snapshot"] = json!(pcb_pdf_path.display().to_string());
     }
 
@@ -887,6 +887,57 @@ mod tests {
             extract_error_kind(&result).as_deref(),
             Some("file_not_found")
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn snapshot_propagates_a_missing_pcb_artifact() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let cli = dir.path().join("fake-kicad-cli");
+        // Produce the first (schematic) PDF, then report success without
+        // producing the PCB PDF. This is the exact phantom-path failure #252
+        // described, independent of whether a real KiCad is installed.
+        std::fs::write(
+            &cli,
+            "#!/bin/sh\nif [ \"$1\" = \"sch\" ]; then\n  while [ \"$#\" -gt 0 ]; do\n    if [ \"$1\" = \"--output\" ]; then\n      shift\n      printf '%s' '%PDF-test' > \"$1\"\n      break\n    fi\n    shift\n  done\nfi\nexit 0\n",
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&cli).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&cli, permissions).unwrap();
+
+        let schematic = dir.path().join("voice.kicad_sch");
+        let board = dir.path().join("voice.kicad_pcb");
+        std::fs::write(&schematic, "placeholder").unwrap();
+        std::fs::write(&board, "placeholder").unwrap();
+        let ctx = ToolContext::new(
+            ServerConfig {
+                kicad_cli: cli.display().to_string(),
+                kicad_binary: String::new(),
+                ipc_address: String::new(),
+                project_dir: None,
+                jlcpcb_db_path: None,
+                auto_load_toolsets: false,
+                eager_toolsets: false,
+            },
+            Arc::new(ToolRouter::new()),
+        );
+
+        let error = handle_snapshot_project(
+            &json!({
+                "schematic": schematic.display().to_string(),
+                "pcb": board.display().to_string(),
+                "output_dir": dir.path().join("snapshots").display().to_string(),
+                "label": "regression"
+            }),
+            &ctx,
+        )
+        .await
+        .expect_err("missing PCB PDF must fail the snapshot call");
+        assert!(error.to_string().contains("did not create"), "{error:#}");
+        assert!(error.to_string().contains("pcb"), "{error:#}");
     }
 
     fn response_json(result: &CallToolResult) -> serde_json::Value {

--- a/crates/konnect-core/src/tools/project.rs
+++ b/crates/konnect-core/src/tools/project.rs
@@ -488,14 +488,8 @@ async fn handle_snapshot_project(
         let pcb_pdf_name = format!("{}_pcb_{}_{}.pdf", stem, label, ts);
         let pcb_pdf_path = output_dir.join(&pcb_pdf_name);
         let layers = &["F.Cu", "B.Cu", "F.Silkscreen", "B.Silkscreen", "Edge.Cuts"];
-        crate::tools::cli::export_pdf(
-            &ctx.config.kicad_cli,
-            &pcb,
-            &pcb_pdf_path,
-            layers,
-            false,
-        )
-        .await?;
+        crate::tools::cli::export_pdf(&ctx.config.kicad_cli, &pcb, &pcb_pdf_path, layers, false)
+            .await?;
         result["pcb_snapshot"] = json!(pcb_pdf_path.display().to_string());
     }
 
@@ -889,24 +883,13 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[tokio::test]
     async fn snapshot_propagates_a_missing_pcb_artifact() {
-        use std::os::unix::fs::PermissionsExt;
-
         let dir = tempfile::tempdir().unwrap();
-        let cli = dir.path().join("fake-kicad-cli");
         // Produce the first (schematic) PDF, then report success without
         // producing the PCB PDF. This is the exact phantom-path failure #252
         // described, independent of whether a real KiCad is installed.
-        std::fs::write(
-            &cli,
-            "#!/bin/sh\nif [ \"$1\" = \"sch\" ]; then\n  while [ \"$#\" -gt 0 ]; do\n    if [ \"$1\" = \"--output\" ]; then\n      shift\n      printf '%s' '%PDF-test' > \"$1\"\n      break\n    fi\n    shift\n  done\nfi\nexit 0\n",
-        )
-        .unwrap();
-        let mut permissions = std::fs::metadata(&cli).unwrap().permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&cli, permissions).unwrap();
+        let cli = crate::tools::cli::test_support::schematic_only_cli(dir.path());
 
         let schematic = dir.path().join("voice.kicad_sch");
         let board = dir.path().join("voice.kicad_pcb");


### PR DESCRIPTION
Closes #252.

This is the clean replacement for #270, rebuilt on current `main`. It preserves @nordic-style's original artifact-verification commit and authorship, then closes the stale-output gap identified during review.

What changed:
- propagate PCB snapshot export failures instead of discarding them
- verify every artifact reported by snapshot and manufacturing paths as a regular, non-empty file
- export PDFs, BOMs, position files, schematic SVGs, Gerbers, and drills into fresh sibling staging areas before publication
- preserve an existing destination when the current invocation exits zero but produces no output
- derive manufacturing manifests and upload guidance only from verified files
- make the fake-CLI regressions run on Windows and Unix

Evidence:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo test --workspace --locked --lib --tests`
- `cargo test --workspace --locked --doc`
- `cargo test -p konnect --test e2e_kicad -- --ignored --nocapture` (real KiCad 10: project created, wired, ERC, 10 Gerber files, DRC)
- negative control: temporarily bypassing the staging boundary makes `stale_destination_cannot_satisfy_a_new_export` fail; restoring it makes the test pass

Supersedes #270 without losing its implementation history or contributor credit.