### PR TITLE
test(pcb): cover open-board file mutation refusals

### DIFF
--- a/crates/konnect-core/src/tools/pcb_board.rs
+++ b/crates/konnect-core/src/tools/pcb_board.rs
@@ -2154,7 +2154,7 @@ mod layers_block_tests {
 /// given IPC address, and a mock KiCad that answers `GetOpenDocuments` with
 /// one board and delegates every other command to the test.
 #[cfg(test)]
-mod board_mock {
+pub(crate) mod board_mock {
     use crate::router::ToolRouter;
     use crate::tools::{ServerConfig, ToolContext};
     use konnect_ipc::gen::kiapi;
@@ -2244,7 +2244,7 @@ mod board_mock {
 
 #[cfg(test)]
 mod board_session_safety_tests {
-    use super::board_mock::ctx_talking_to;
+    use super::board_mock::{ctx_talking_to, spawn_kicad_holding_board};
     use super::*;
     use konnect_ipc::gen::kiapi;
     use prost::Message;
@@ -2341,6 +2341,77 @@ mod board_session_safety_tests {
             .unwrap();
 
         assert!(matches!(outcome, BoardWrite::File));
+    }
+
+    #[tokio::test]
+    async fn file_only_guard_refuses_the_exact_open_board() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let before = std::fs::read(&board).unwrap();
+        let ctx = ctx_talking_to(spawn_kicad_holding_board(&board, |_| None));
+
+        let result = refuse_if_board_open_in_kicad(&ctx, &board, "test edit")
+            .await
+            .unwrap()
+            .expect("the exact open board must refuse file mutation");
+
+        assert!(result.is_error);
+        let text = super::mounting_hole_tests::result_text(&result);
+        assert!(text.contains("test edit"), "{text}");
+        assert!(text.contains("currently holds this board open"), "{text}");
+        assert_eq!(std::fs::read(&board).unwrap(), before);
+    }
+
+    #[tokio::test]
+    async fn file_only_guard_allows_a_different_open_board() {
+        let dir = tempfile::tempdir().unwrap();
+        let requested = super::mounting_hole_tests::blank_board(dir.path());
+        let other = dir.path().join("other.kicad_pcb");
+        std::fs::write(&other, "").unwrap();
+        let ctx = ctx_talking_to(spawn_kicad_holding_board(&other, |_| None));
+
+        let result = refuse_if_board_open_in_kicad(&ctx, &requested, "test edit")
+            .await
+            .unwrap();
+
+        assert!(
+            result.is_none(),
+            "an unrelated open board must not block the file"
+        );
+    }
+
+    #[tokio::test]
+    async fn file_only_guard_allows_an_unseen_board_when_ipc_is_unreachable() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let ctx = ctx_talking_to(String::new());
+
+        let result = refuse_if_board_open_in_kicad(&ctx, &board, "test edit")
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn file_only_guard_matches_an_equivalent_board_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let equivalent = board
+            .parent()
+            .unwrap()
+            .join(".")
+            .join(board.file_name().unwrap());
+        let ctx = ctx_talking_to(spawn_kicad_holding_board(&board, |_| None));
+
+        let result = refuse_if_board_open_in_kicad(&ctx, &equivalent, "test edit")
+            .await
+            .unwrap();
+
+        assert!(
+            result.is_some(),
+            "equivalent path spelling must identify the open board"
+        );
     }
 
     #[tokio::test]

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -2490,12 +2490,6 @@ async fn handle_flip_component(
     // The helper refuses only when KiCAD holds *this* board, because that is
     // the only case where the edit would be discarded by its next save.
     //
-    // Untested branch, honestly: the only IPC mock in this crate rejects every
-    // request, which exercises the *proceed* side. Confirming the refusal
-    // needs a mock that answers `GetOpenDocuments` naming this board, which
-    // does not exist here — so the refusal is equally untested for
-    // `add_zone` and the copper-pour path, this helper's two other callers.
-    // Tracked as #241 rather than pretended away.
     if let Some(refusal) =
         crate::tools::pcb_board::refuse_if_board_open_in_kicad(ctx, &board, "footprint flip")
             .await?
@@ -5105,6 +5099,65 @@ mod tests {
         assert_eq!(result["source"], "file");
         assert_eq!(result["changed"], true);
         assert_ne!(std::fs::read_to_string(board).unwrap(), before);
+    }
+
+    #[tokio::test]
+    async fn flip_refuses_the_exact_open_board_without_touching_the_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let board = tmp.path().join("flip.kicad_pcb");
+        let before = format!(
+            "(kicad_pcb\n  (version 20260206)\n  (generator \"pcbnew\")\n  (net 0 \"\")\n{}\n)\n",
+            FLIP_FOOTPRINT
+                .lines()
+                .map(|line| format!("  {line}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        std::fs::write(&board, &before).unwrap();
+        let address =
+            crate::tools::pcb_board::board_mock::spawn_kicad_holding_board(&board, |_| None);
+        let ctx = crate::tools::pcb_board::board_mock::ctx_talking_to(address);
+
+        let result = handle_flip_component(
+            &json!({"board": board, "reference": "U1", "layer": "B.Cu"}),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_error);
+        assert!(result_text(&result).contains("footprint flip"));
+        assert_eq!(std::fs::read_to_string(&board).unwrap(), before);
+    }
+
+    #[tokio::test]
+    async fn flip_proceeds_when_kicad_holds_a_different_board() {
+        let tmp = tempfile::tempdir().unwrap();
+        let board = tmp.path().join("flip.kicad_pcb");
+        let other = tmp.path().join("other.kicad_pcb");
+        let before = format!(
+            "(kicad_pcb\n  (version 20260206)\n  (generator \"pcbnew\")\n  (net 0 \"\")\n{}\n)\n",
+            FLIP_FOOTPRINT
+                .lines()
+                .map(|line| format!("  {line}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        std::fs::write(&board, &before).unwrap();
+        std::fs::write(&other, "").unwrap();
+        let address =
+            crate::tools::pcb_board::board_mock::spawn_kicad_holding_board(&other, |_| None);
+        let ctx = crate::tools::pcb_board::board_mock::ctx_talking_to(address);
+
+        let result = handle_flip_component(
+            &json!({"board": board, "reference": "U1", "layer": "B.Cu"}),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.is_error, "{:?}", result.content);
+        assert_ne!(std::fs::read_to_string(&board).unwrap(), before);
     }
 
     #[test]

--- a/crates/konnect-core/src/tools/placement.rs
+++ b/crates/konnect-core/src/tools/placement.rs
@@ -1726,10 +1726,23 @@ mod tests {
         serde_json::from_str(text).unwrap()
     }
 
+    fn result_text(result: &CallToolResult) -> &str {
+        let crate::mcp::protocol::ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text");
+        };
+        text
+    }
+
     fn fixture_copy(dir: &tempfile::TempDir) -> std::path::PathBuf {
         let path = dir.path().join("board.kicad_pcb");
         std::fs::copy(FIXTURE, &path).unwrap();
         path
+    }
+
+    fn ctx_with_open_board(board: &std::path::Path) -> ToolContext {
+        let address =
+            crate::tools::pcb_board::board_mock::spawn_kicad_holding_board(board, |_| None);
+        crate::tools::pcb_board::board_mock::ctx_talking_to(address)
     }
 
     /// The decoupling planner must clear the fixture's only deduction: C1/C2
@@ -1802,6 +1815,41 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn decoupling_apply_refuses_the_exact_open_board() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = fixture_copy(&dir);
+        let before = std::fs::read(&board).unwrap();
+        let result = handle_place_decoupling(
+            &json!({"board": board, "ic_reference": "U1", "dry_run": false}),
+            &ctx_with_open_board(&board),
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_error);
+        assert!(result_text(&result).contains("place_decoupling_caps"));
+        assert_eq!(std::fs::read(&board).unwrap(), before);
+    }
+
+    #[tokio::test]
+    async fn decoupling_apply_proceeds_when_a_different_board_is_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = fixture_copy(&dir);
+        let other = dir.path().join("other.kicad_pcb");
+        std::fs::write(&other, "").unwrap();
+        let before = std::fs::read(&board).unwrap();
+        let result = handle_place_decoupling(
+            &json!({"board": board, "ic_reference": "U1", "dry_run": false}),
+            &ctx_with_open_board(&other),
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.is_error, "{result:?}");
+        assert_ne!(std::fs::read(&board).unwrap(), before);
+    }
+
     /// U2 is Analog_BGA-28 with a 4x7 grid at 0.8 mm pitch. Hand count:
     /// perimeter pads = 2*4 + 2*7 - 4 = 18, inner = 28 - 18 = 10 vias.
     /// Dogbone via offset magnitude = 0.55 * 0.8 = 0.44 mm; track width for
@@ -1857,6 +1905,76 @@ mod tests {
         );
         let b = text_of(&handle_auto_place(&args, &test_ctx()).await.unwrap()).await;
         assert_eq!(a, b, "same input, same plan");
+    }
+
+    #[tokio::test]
+    async fn auto_place_apply_refuses_the_exact_open_board() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = fixture_copy(&dir);
+        let before = std::fs::read(&board).unwrap();
+        let result = handle_auto_place(
+            &json!({"board": board, "dry_run": false}),
+            &ctx_with_open_board(&board),
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_error);
+        assert!(result_text(&result).contains("auto_place_from_schematic"));
+        assert_eq!(std::fs::read(&board).unwrap(), before);
+    }
+
+    #[tokio::test]
+    async fn auto_place_apply_proceeds_when_a_different_board_is_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = fixture_copy(&dir);
+        let other = dir.path().join("other.kicad_pcb");
+        std::fs::write(&other, "").unwrap();
+        let before = std::fs::read(&board).unwrap();
+        let result = handle_auto_place(
+            &json!({"board": board, "dry_run": false}),
+            &ctx_with_open_board(&other),
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.is_error, "{result:?}");
+        assert_ne!(std::fs::read(&board).unwrap(), before);
+    }
+
+    #[tokio::test]
+    async fn force_directed_apply_refuses_the_exact_open_board() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = fixture_copy(&dir);
+        let before = std::fs::read(&board).unwrap();
+        let result = handle_force_directed(
+            &json!({"board": board, "dry_run": false}),
+            &ctx_with_open_board(&board),
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_error);
+        assert!(result_text(&result).contains("refine_placement_force_directed"));
+        assert_eq!(std::fs::read(&board).unwrap(), before);
+    }
+
+    #[tokio::test]
+    async fn force_directed_apply_proceeds_when_a_different_board_is_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = fixture_copy(&dir);
+        let other = dir.path().join("other.kicad_pcb");
+        std::fs::write(&other, "").unwrap();
+        let before = std::fs::read(&board).unwrap();
+        let result = handle_force_directed(
+            &json!({"board": board, "dry_run": false}),
+            &ctx_with_open_board(&other),
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.is_error, "{result:?}");
+        assert_ne!(std::fs::read(&board).unwrap(), before);
     }
 
     /// Lock a footprint the way KiCad does, and neither planner may move it


### PR DESCRIPTION
## Summary

Add deterministic regression coverage for the file-only PCB mutation guard and every current direct caller.

Closes #241.

## What changed

- expose the existing board-answering IPC mock to sibling tool tests under `cfg(test)` only;
- cover the shared guard for exact-board refusal, unrelated-board proceed, unreachable IPC proceed, and equivalent path spelling;
- prove `flip_component`, `place_decoupling_caps`, `auto_place_from_schematic`, and `refine_placement_force_directed` refuse apply-mode file writes when KiCad reports the requested board open;
- prove each handler still proceeds when KiCad reports a different board;
- remove the now-stale comment claiming the refusal branch cannot be tested.

No production behavior, MCP schema, response shape, or tool count changes.

## Negative control

Temporarily changed the guard's identified-board branch from refusal to proceed and ran:

`cargo test -p konnect-core --lib exact_open_board`

All five new exact-board tests failed (shared guard plus all four handlers). The guard was restored and the same command passed all five tests.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --locked --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked --lib --tests`
- [x] `cargo test --workspace --locked --doc`
- [x] focused shared-guard, flip, and placement tests