### PR TITLE
fix(pcb): make trace deletion type-safe

### DIFF
--- a/crates/konnect-core/src/tools/pcb_routing.rs
+++ b/crates/konnect-core/src/tools/pcb_routing.rs
@@ -152,7 +152,7 @@ pub fn tools() -> Vec<ToolDef> {
         .with_board_access(crate::tools::BoardAccess::LivePreferredWithFallback),
         tool!(
             "delete_trace",
-            "Delete a trace segment identified by its UUID via KiCAD IPC.",
+            "Delete a trace segment identified by its UUID via KiCAD IPC. Refuses UUIDs that are not observed trace segments on the requested board, then verifies the segment is absent before reporting success. Returns the observed preimage and postcondition.",
             json!({
                 "type": "object",
                 "properties": {
@@ -984,14 +984,179 @@ async fn handle_delete_trace(
     args: &serde_json::Value,
     ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {
+    let board = get_path(args, "board")?;
     let uuid = match require_str(args, "uuid") {
         Ok(v) => v.to_string(),
         Err(e) => return Ok(e),
     };
 
+    let board_ipc = board.clone();
     let uuid_ipc = uuid.clone();
-    ipc!(ctx, args, |c| c.delete_track(&uuid_ipc));
-    Ok(CallToolResult::json(&json!({ "deleted_uuid": uuid })))
+    let deleted = match with_board_ipc_classified(ctx, &board, move |client| {
+        client.delete_trace_segment_verified(&board_ipc, &uuid_ipc)
+    })
+    .await?
+    {
+        Ok(deleted) => deleted,
+        Err(error) => {
+            return Ok(CallToolResult::error(format!(
+                "KiCAD must be running with the board loaded (IPC error: {})",
+                error.message()
+            )))
+        }
+    };
+
+    let Some(trace) = deleted else {
+        return Ok(CallToolResult::error_kind(
+            ToolErrorKind::StaleTarget {
+                target: uuid,
+                reason: "the UUID is not an observed trace segment on the requested board"
+                    .to_string(),
+            },
+            "The requested UUID is not a trace segment on the requested board. No board item was deleted.",
+        ));
+    };
+
+    Ok(CallToolResult::json(&json!({
+        "deleted_uuid": trace.uuid,
+        "deleted_type": "trace_segment",
+        "preimage": {
+            "uuid": trace.uuid,
+            "net": trace.net_name,
+            "layer": trace.layer,
+            "width": trace.width,
+            "from": { "x": trace.start.x, "y": trace.start.y },
+            "to": { "x": trace.end.x, "y": trace.end.y }
+        },
+        "postcondition": "absent_from_trace_readback"
+    })))
+}
+
+#[cfg(test)]
+mod delete_trace_tests {
+    use super::*;
+    use crate::tools::pcb_board::board_mock::{ctx_talking_to, spawn_kicad_holding_board};
+    use konnect_ipc::gen::kiapi;
+    use std::sync::{Arc, Mutex};
+
+    #[tokio::test]
+    async fn non_trace_and_missing_uuids_refuse_before_delete_items() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = dir.path().join("target.kicad_pcb");
+        let original = b"(kicad_pcb (version 20260206))";
+        std::fs::write(&board, original).unwrap();
+        let delete_count = Arc::new(Mutex::new(0usize));
+        let delete_count_in_mock = delete_count.clone();
+        let address = spawn_kicad_holding_board(&board, move |command| {
+            if command.type_url.ends_with("GetItems") {
+                return Some(konnect_ipc::builders::pack_any(
+                    &kiapi::common::commands::GetItemsResponse {
+                        header: None,
+                        status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                        items: vec![],
+                    },
+                    "kiapi.common.commands.GetItemsResponse",
+                ));
+            }
+            if command.type_url.ends_with("DeleteItems") {
+                *delete_count_in_mock.lock().unwrap() += 1;
+                return Some(konnect_ipc::builders::pack_any(
+                    &kiapi::common::commands::DeleteItemsResponse {
+                        header: None,
+                        status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                        deleted_items: vec![],
+                    },
+                    "kiapi.common.commands.DeleteItemsResponse",
+                ));
+            }
+            None
+        });
+
+        let ctx = ctx_talking_to(address);
+        for uuid in ["via-1", "zone-1", "graphic-1", "footprint-1", "missing-1"] {
+            let result = handle_delete_trace(
+                &json!({ "board": board.to_string_lossy(), "uuid": uuid }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+            assert!(result.is_error, "{uuid} unexpectedly succeeded");
+            assert_eq!(
+                crate::mcp::error::extract_error_kind(&result).as_deref(),
+                Some("stale_target"),
+                "wrong error for {uuid}"
+            );
+        }
+        assert_eq!(*delete_count.lock().unwrap(), 0);
+        assert_eq!(std::fs::read(&board).unwrap(), original);
+    }
+
+    #[tokio::test]
+    async fn success_reports_the_observed_trace_and_verified_postcondition() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = dir.path().join("target.kicad_pcb");
+        std::fs::write(&board, "(kicad_pcb (version 20260206))").unwrap();
+        let deleted = Arc::new(Mutex::new(false));
+        let deleted_in_mock = deleted.clone();
+        let mut track =
+            konnect_ipc::builders::build_track("GND", 7, "F.Cu", 0.4, 1.0, 2.0, 3.0, 4.0);
+        track.id = Some(kiapi::common::types::Kiid {
+            value: "segment-1".to_string(),
+        });
+        let packed_track = konnect_ipc::builders::pack_any(&track, "kiapi.board.types.Track");
+        let address = spawn_kicad_holding_board(&board, move |command| {
+            if command.type_url.ends_with("GetItems") {
+                let items = if *deleted_in_mock.lock().unwrap() {
+                    vec![]
+                } else {
+                    vec![packed_track.clone()]
+                };
+                return Some(konnect_ipc::builders::pack_any(
+                    &kiapi::common::commands::GetItemsResponse {
+                        header: None,
+                        status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                        items,
+                    },
+                    "kiapi.common.commands.GetItemsResponse",
+                ));
+            }
+            if command.type_url.ends_with("DeleteItems") {
+                *deleted_in_mock.lock().unwrap() = true;
+                return Some(konnect_ipc::builders::pack_any(
+                    &kiapi::common::commands::DeleteItemsResponse {
+                        header: None,
+                        status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                        deleted_items: vec![],
+                    },
+                    "kiapi.common.commands.DeleteItemsResponse",
+                ));
+            }
+            None
+        });
+
+        let result = handle_delete_trace(
+            &json!({ "board": board.to_string_lossy(), "uuid": "segment-1" }),
+            &ctx_talking_to(address),
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.is_error);
+        let text = match result.content.first() {
+            Some(crate::mcp::protocol::ToolContent::Text { text }) => text,
+            other => panic!("expected text result, got {other:?}"),
+        };
+        let body: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(body["deleted_uuid"], json!("segment-1"));
+        assert_eq!(body["deleted_type"], json!("trace_segment"));
+        assert_eq!(body["preimage"]["net"], json!("GND"));
+        assert_eq!(body["preimage"]["layer"], json!("F.Cu"));
+        assert_eq!(body["preimage"]["width"], json!(0.4));
+        assert_eq!(body["preimage"]["from"], json!({ "x": 1.0, "y": 2.0 }));
+        assert_eq!(body["preimage"]["to"], json!({ "x": 3.0, "y": 4.0 }));
+        assert_eq!(body["postcondition"], json!("absent_from_trace_readback"));
+    }
 }
 
 async fn handle_query_traces(

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -1422,7 +1422,6 @@ impl KiCadIpcClient {
             .filter(|id| !id.is_empty()))
     }
 
-    /// Delete a track by UUID.
     /// One BGA-fanout element: a via and the stub track reaching it.
     pub fn apply_fanout(
         &self,
@@ -1464,6 +1463,48 @@ impl KiCadIpcClient {
         })
     }
 
+    /// Delete one observed trace segment from the requested board.
+    ///
+    /// `DeleteItems` accepts any board-item KIID, so the item must first be
+    /// proven to belong to the requested board's trace set. KiCad 10 commonly
+    /// omits per-item deletion results; a second trace query therefore proves
+    /// the observed segment is gone before this reports success.
+    pub fn delete_trace_segment_verified(
+        &self,
+        requested: &Path,
+        uuid: &str,
+    ) -> Result<Option<IpcTrack>> {
+        let document = self.find_open_board(requested)?;
+        let before = self.get_tracks_in(document.clone(), None, None)?;
+        let Some(track) = before.into_iter().find(|track| track.uuid == uuid) else {
+            return Ok(None);
+        };
+
+        self.delete_items_in(document.clone(), vec![uuid.to_string()])?;
+        let remains = self
+            .get_tracks_in(document, None, None)
+            .with_context(|| {
+                format!(
+                    "KiCad accepted deletion of trace segment '{}' but post-delete read-back failed; the deletion may have committed",
+                    uuid
+                )
+            })?
+            .into_iter()
+            .any(|candidate| candidate.uuid == uuid);
+        if remains {
+            anyhow::bail!(
+                "KiCad accepted deletion of trace segment '{}' but read-back still reports it",
+                uuid
+            );
+        }
+        Ok(Some(track))
+    }
+
+    /// Delete a board item by UUID.
+    ///
+    /// This low-level compatibility helper does not verify an item type or
+    /// postcondition. User-facing trace deletion must use
+    /// [`Self::delete_trace_segment_verified`].
     pub fn delete_track(&self, uuid: &str) -> Result<()> {
         self.delete_items(vec![uuid.to_string()])
     }
@@ -1474,9 +1515,27 @@ impl KiCadIpcClient {
         net_filter: Option<&str>,
         layer_filter: Option<&str>,
     ) -> Result<Vec<IpcTrack>> {
-        let items = self.get_items(kiapi::common::types::KiCadObjectType::KotPcbTrace)?;
+        self.get_tracks_in(self.get_board_document()?, net_filter, layer_filter)
+    }
+
+    /// As [`Self::get_tracks`], targeting one exact open document.
+    pub fn get_tracks_in(
+        &self,
+        document: kiapi::common::types::DocumentSpecifier,
+        net_filter: Option<&str>,
+        layer_filter: Option<&str>,
+    ) -> Result<Vec<IpcTrack>> {
+        let items =
+            self.get_items_in(document, kiapi::common::types::KiCadObjectType::KotPcbTrace)?;
         let mut tracks = Vec::new();
         for item in &items {
+            // KOT_PCB_TRACE is a family selector. KiCad may return vias or
+            // other routing members beside straight Track messages, and
+            // protobuf decoding is permissive enough to accept compatible
+            // bytes under the wrong declared type. Type-check before decode.
+            if !crate::builders::any_is(item, "kiapi.board.types.Track") {
+                continue;
+            }
             if let Ok(track) = kiapi::board::types::Track::decode(item.value.as_slice()) {
                 let net_name = track.net.as_ref().map(|n| n.name.as_str()).unwrap_or("");
                 let layer_name = layer_enum_to_name(track.layer);

--- a/crates/konnect-ipc/tests/live_kicad_test.rs
+++ b/crates/konnect-ipc/tests/live_kicad_test.rs
@@ -274,6 +274,56 @@ fn adding_a_via_actually_creates_it_on_the_board() {
     );
 }
 
+/// #412 live gate: `delete_trace` must identify a real trace on the requested
+/// board before sending the generic KiCad `DeleteItems` command, then prove
+/// that exact trace is absent from live readback. The test creates its own
+/// disposable segment so it does not consume fixture routing.
+#[test]
+#[ignore = "requires a running KiCad GUI with its IPC API enabled and a disposable open board"]
+fn verified_trace_delete_round_trips_through_live_kicad() {
+    let board = std::env::var("KONNECT_LIVE_KICAD_BOARD")
+        .expect("KONNECT_LIVE_KICAD_BOARD must name the disposable open board");
+    let socket = std::env::var("KICAD_API_SOCKET").expect("KICAD_API_SOCKET is required");
+    let client = KiCadIpcClient::new(socket);
+    let net = client
+        .get_nets()
+        .expect("net list query failed")
+        .into_iter()
+        .find(|net| !net.name.is_empty())
+        .expect("the live fixture must contain a named net");
+    let before: std::collections::HashSet<String> = client
+        .get_tracks(None, None)
+        .expect("initial trace query failed")
+        .into_iter()
+        .map(|track| track.uuid)
+        .collect();
+
+    client
+        .add_track(&net.name, "F.Cu", 0.25, 120.0, 125.0, 130.0, 125.0)
+        .expect("temporary trace creation failed");
+    let created = client
+        .get_tracks(None, None)
+        .expect("created trace readback failed")
+        .into_iter()
+        .find(|track| !before.contains(&track.uuid))
+        .expect("KiCad did not return the newly created trace");
+
+    let deleted = client
+        .delete_trace_segment_verified(Path::new(&board), &created.uuid)
+        .expect("verified trace deletion failed")
+        .expect("the created UUID was not observed as a trace");
+    assert_eq!(deleted.uuid, created.uuid);
+    assert!(
+        client
+            .get_tracks(None, None)
+            .expect("final trace readback failed")
+            .iter()
+            .all(|track| track.uuid != created.uuid),
+        "deleted trace remains in live KiCad"
+    );
+    client.save_board().expect("final board save failed");
+}
+
 /// `add_zone` over IPC, end to end: create, read the zone back out of KiCad,
 /// and delete it again.
 ///

--- a/crates/konnect-ipc/tests/mock_server_test.rs
+++ b/crates/konnect-ipc/tests/mock_server_test.rs
@@ -952,6 +952,19 @@ fn record_doc(
     }
 }
 
+fn record_every_doc(
+    slot: &std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    header: &Option<kiapi::common::types::ItemHeader>,
+) {
+    if let Some(kiapi::common::types::document_specifier::Identifier::BoardFilename(name)) = header
+        .as_ref()
+        .and_then(|h| h.document.as_ref())
+        .and_then(|d| d.identifier.as_ref())
+    {
+        slot.lock().unwrap().push(name.clone());
+    }
+}
+
 // --- #244: a pad must never be mistaken for a graphic --------------------
 
 /// A footprint carrying one pad and one silkscreen line, both with KIIDs, as
@@ -1444,4 +1457,190 @@ fn deletes_target_the_named_board_among_several_open() {
         addressed, "target.kicad_pcb",
         "a delete must act on the requested board, not the first open one"
     );
+}
+
+#[test]
+fn verified_trace_delete_refuses_a_non_trace_before_delete_items() {
+    let delete_was_sent = Arc::new(Mutex::new(false));
+    let delete_was_sent_in_mock = delete_was_sent.clone();
+    // The payload is deliberately wire-compatible while the declared type is
+    // a Via. Protobuf decoding is permissive, so the reader must discriminate
+    // on type_url before interpreting bytes as a trace segment.
+    let mut non_trace = builders::build_track("GND", 7, "F.Cu", 0.25, 1.0, 2.0, 3.0, 4.0);
+    non_trace.id = Some(kiapi::common::types::Kiid {
+        value: "via-or-zone".to_string(),
+    });
+    let packed_non_trace = builders::pack_any(&non_trace, "kiapi.board.types.Via");
+
+    let mock = spawn_mock(move |request| {
+        let message = request.message.expect("request must pack a command");
+        if message.type_url.ends_with("GetOpenDocuments") {
+            return Some(open_board_response());
+        }
+        if message.type_url.ends_with("GetItems") {
+            let request =
+                kiapi::common::commands::GetItems::decode(message.value.as_slice()).unwrap();
+            assert_eq!(
+                request.types,
+                vec![kiapi::common::types::KiCadObjectType::KotPcbTrace as i32]
+            );
+            let response = kiapi::common::commands::GetItemsResponse {
+                header: None,
+                status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                items: vec![packed_non_trace.clone()],
+            };
+            return Some(reply_with(builders::pack_any(
+                &response,
+                "kiapi.common.commands.GetItemsResponse",
+            )));
+        }
+        if message.type_url.ends_with("DeleteItems") {
+            *delete_was_sent_in_mock.lock().unwrap() = true;
+            panic!("a UUID absent from the trace set must never be sent for deletion");
+        }
+        panic!("unexpected command {}", message.type_url);
+    });
+
+    let client = KiCadIpcClient::new(&mock.url);
+    let deleted = client
+        .delete_trace_segment_verified(std::path::Path::new("test.kicad_pcb"), "via-or-zone")
+        .expect("a non-trace is an observed outcome, not an IPC failure");
+
+    assert!(deleted.is_none());
+    assert!(!*delete_was_sent.lock().unwrap());
+}
+
+#[test]
+fn verified_trace_delete_targets_one_board_and_returns_observed_preimage() {
+    let deleted = Arc::new(Mutex::new(false));
+    let deleted_in_mock = deleted.clone();
+    let addressed = Arc::new(Mutex::new(Vec::<String>::new()));
+    let addressed_in_mock = addressed.clone();
+
+    let mut track = builders::build_track("GND", 7, "F.Cu", 0.4, 1.0, 2.0, 3.0, 4.0);
+    track.id = Some(kiapi::common::types::Kiid {
+        value: "segment-1".to_string(),
+    });
+    let packed_track = builders::pack_any(&track, "kiapi.board.types.Track");
+
+    let mock = spawn_mock(move |request| {
+        let message = request.message.expect("request must pack a command");
+        if message.type_url.ends_with("GetOpenDocuments") {
+            let response = kiapi::common::commands::GetOpenDocumentsResponse {
+                documents: vec![doc_for("other.kicad_pcb"), doc_for("target.kicad_pcb")],
+            };
+            return Some(reply_with(builders::pack_any(
+                &response,
+                "kiapi.common.commands.GetOpenDocumentsResponse",
+            )));
+        }
+        if message.type_url.ends_with("GetItems") {
+            let request =
+                kiapi::common::commands::GetItems::decode(message.value.as_slice()).unwrap();
+            record_every_doc(&addressed_in_mock, &request.header);
+            let items = if *deleted_in_mock.lock().unwrap() {
+                vec![]
+            } else {
+                vec![packed_track.clone()]
+            };
+            let response = kiapi::common::commands::GetItemsResponse {
+                header: None,
+                status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                items,
+            };
+            return Some(reply_with(builders::pack_any(
+                &response,
+                "kiapi.common.commands.GetItemsResponse",
+            )));
+        }
+        if message.type_url.ends_with("DeleteItems") {
+            let request =
+                kiapi::common::commands::DeleteItems::decode(message.value.as_slice()).unwrap();
+            record_every_doc(&addressed_in_mock, &request.header);
+            assert_eq!(
+                request
+                    .item_ids
+                    .iter()
+                    .map(|id| id.value.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["segment-1"]
+            );
+            *deleted_in_mock.lock().unwrap() = true;
+            let response = kiapi::common::commands::DeleteItemsResponse {
+                header: None,
+                status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                deleted_items: vec![],
+            };
+            return Some(reply_with(builders::pack_any(
+                &response,
+                "kiapi.common.commands.DeleteItemsResponse",
+            )));
+        }
+        panic!("unexpected command {}", message.type_url);
+    });
+
+    let client = KiCadIpcClient::new(&mock.url);
+    let observed = client
+        .delete_trace_segment_verified(std::path::Path::new("target.kicad_pcb"), "segment-1")
+        .expect("verified deletion")
+        .expect("the segment existed");
+
+    assert_eq!(observed.uuid, "segment-1");
+    assert_eq!(observed.net_name, "GND");
+    assert_eq!(observed.layer, "F.Cu");
+    assert_eq!(observed.width, 0.4);
+    assert_eq!((observed.start.x, observed.start.y), (1.0, 2.0));
+    assert_eq!((observed.end.x, observed.end.y), (3.0, 4.0));
+    assert!(*deleted.lock().unwrap());
+    assert_eq!(
+        *addressed.lock().unwrap(),
+        vec!["target.kicad_pcb", "target.kicad_pcb", "target.kicad_pcb"]
+    );
+}
+
+#[test]
+fn verified_trace_delete_refuses_success_when_readback_still_contains_the_segment() {
+    let mut track = builders::build_track("GND", 7, "F.Cu", 0.25, 1.0, 2.0, 3.0, 4.0);
+    track.id = Some(kiapi::common::types::Kiid {
+        value: "segment-1".to_string(),
+    });
+    let packed_track = builders::pack_any(&track, "kiapi.board.types.Track");
+
+    let mock = spawn_mock(move |request| {
+        let message = request.message.expect("request must pack a command");
+        if message.type_url.ends_with("GetOpenDocuments") {
+            return Some(open_board_response());
+        }
+        if message.type_url.ends_with("GetItems") {
+            let response = kiapi::common::commands::GetItemsResponse {
+                header: None,
+                status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                items: vec![packed_track.clone()],
+            };
+            return Some(reply_with(builders::pack_any(
+                &response,
+                "kiapi.common.commands.GetItemsResponse",
+            )));
+        }
+        if message.type_url.ends_with("DeleteItems") {
+            let response = kiapi::common::commands::DeleteItemsResponse {
+                header: None,
+                status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                deleted_items: vec![],
+            };
+            return Some(reply_with(builders::pack_any(
+                &response,
+                "kiapi.common.commands.DeleteItemsResponse",
+            )));
+        }
+        panic!("unexpected command {}", message.type_url);
+    });
+
+    let client = KiCadIpcClient::new(&mock.url);
+    let error = client
+        .delete_trace_segment_verified(std::path::Path::new("test.kicad_pcb"), "segment-1")
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("read-back still reports it"), "{error}");
 }

--- a/docs/API_MIGRATIONS.md
+++ b/docs/API_MIGRATIONS.md
@@ -3,6 +3,19 @@
 Konnect's tool schemas are public API. This file records intentional argument
 removals and the supported replacement workflow.
 
+## Unreleased: type-safe trace deletion (minor release)
+
+`delete_trace` now accepts only a UUID observed in the requested live board's
+trace-segment inventory. Via, zone, graphic, footprint, missing, and stale UUIDs
+return `stale_target` before `DeleteItems` is sent. A successful call reads the
+same board again and refuses success if the segment remains.
+
+The existing `deleted_uuid` field remains, but it is now derived from the
+observed segment rather than echoed from the request. Results add
+`deleted_type: "trace_segment"`, the observed net/layer/width/endpoints under
+`preimage`, and `postcondition: "absent_from_trace_readback"`. No argument or
+tool was renamed or removed.
+
 ## Unreleased: connectivity-safe component deletion (minor release)
 
 `delete_schematic_component`, `batch_delete`, and

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -269,7 +269,7 @@ Seven tools, grouped into *discovery/routing*, *observability*, and *runtime dia
 | `plan_specctra_ses_import` | Strictly validate a Freerouting SES against its revision-bound manifest and the exact live board, returning every planned route item and the preserved locked-track/via inventory without mutation. |
 | `apply_specctra_ses` | Preserve the manifest-bound locked straight tracks and through vias, apply a validated SES through KiCad IPC as one undo transaction, verify post-commit IPC read-back, create a separate candidate board, and report direct KiCad DRC evidence (including whether it is clean). |
 | `add_copper_pour` | Alias of `add_zone`, kept for compatibility: same arguments, same defaults, same IPC-first behaviour. (Its `min_width` default was 0.25 and is now 0.2, matching `add_zone` and KiCad.) |
-| `delete_trace` | Delete a trace segment identified by its UUID via KiCAD IPC. |
+| `delete_trace` | Delete one observed trace segment by UUID via KiCad IPC. Refuses non-trace or stale UUIDs before deletion, targets the requested board, and reports the observed preimage only after readback proves the segment is absent. |
 | `query_traces` | List trace segments on the board, optionally filtered by net and/or layer. |
 | `get_nets_list` | Return all nets defined on the PCB via KiCAD IPC. |
 | `modify_trace` | Modify a trace segment by deleting and re-adding it with new parameters. |


### PR DESCRIPTION
## Summary

Makes `delete_trace` accept only an observed PCB trace segment UUID and verify that the segment is absent after deletion. Non-trace and missing UUIDs now return a structured `stale_target` error before `DeleteItems` is sent.

Issue: #412

Closes #412

## Approach

The previous handler forwarded any UUID directly to KiCad deletion, so the tool name did not constrain the object type and success reflected only the mutation response. The new verified IPC path resolves the requested board, queries that exact document for `KOT_PCB_TRACE`, requires both the trace protobuf type URL and matching UUID, deletes in that same document, and confirms absence through post-delete trace readback.

The success response remains compatible with the existing `deleted_uuid` field and adds the observed trace preimage, `deleted_type`, and the verified postcondition. The low-level IPC helper remains available for existing internal callers.

## Branch and dependencies

Base branch: `upstream/main` at `d73adfa5c1b49f5978823092d3305508ec66ba11`
Depends on: none
Series order: independent
Unique commits/acceptance criteria owned by this PR: all #412 criteria: type-safe lookup, no mutation for non-trace or missing UUIDs, exact-board targeting, post-delete verification, structured refusal, regression tests, and live KiCad evidence.

## Compatibility and safety

No tool or argument rename. This intentionally narrows previously unsafe behavior: UUIDs not observed as trace segments are rejected. Successful responses retain `deleted_uuid` and add fields. The mutation is bound to the exact requested open board. Failure before validation sends no delete request; failure during post-delete readback reports that the deletion may have committed instead of claiming verified success.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --locked --lib --tests`
- [x] `cargo test --workspace --locked --doc`
- [x] `cargo clippy --workspace --locked --all-targets -- -D warnings`
- [x] `cargo test -p konnect-ipc --test live_kicad_test verified_trace_delete_round_trips_through_live_kicad -- --ignored --test-threads=1` against installed KiCad 10
- [x] Focused IPC mock tests cover non-trace refusal before `DeleteItems`, exact-board targeting, observed preimage, and refusal when post-delete readback still contains the trace.
- [x] Core handler tests cover via, zone, graphic, footprint, and missing UUID refusal with zero delete calls and unchanged board bytes.
- [x] Negative control: temporarily bypassing the pre-delete guard made the regression test fail because `DeleteItems` was sent.
- [x] Type-discriminator negative control: Track-decodable bytes declared with a Via type URL caused the new regression to fail before the explicit type URL check was added.

## Review checklist

- [x] The diff is focused and contains no generated output, personal data, or unrelated cleanup.
- [x] The branch includes current `upstream/main`, has no merge conflicts, and local validation passed on this exact head.
- [x] The branch was based on latest `upstream/main`, not a release tag.
- [x] The PR shows only its unique commit and diff; it has no dependencies.
- [x] New names follow `docs/NAMING_CONVENTIONS.md`; no public rename is introduced.
- [x] New behavior and failure paths have regression coverage.
- [x] File mutations are not involved.
- [x] The IPC mutation verifies the requested board and postcondition.
- [x] No tools were added or removed; the changed contract is documented in `tool-directory.md` and `docs/API_MIGRATIONS.md`.