### PR TITLE
fix(platform): record each server and sweep dead records at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2462,6 +2462,7 @@ dependencies = [
  "anyhow",
  "axum",
  "dirs",
+ "fs4",
  "konnect-core",
  "konnect-ipc",
  "konnect-sexp",

--- a/crates/konnect/Cargo.toml
+++ b/crates/konnect/Cargo.toml
@@ -32,6 +32,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 toml.workspace = true
 dirs.workspace = true
+fs4.workspace = true
 
 [build-dependencies]
 

--- a/crates/konnect/src/main.rs
+++ b/crates/konnect/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod install;
 mod manifest;
+mod run_registry;
 mod transaction_cli;
 mod transport;
 
@@ -162,6 +163,14 @@ async fn main() -> Result<()> {
             config_resolution.source().as_str(),
         ),
     }
+
+    // Record this server, and reap the records of servers that are gone
+    // (#103). This is the only spot that sees all three spawn paths — the
+    // Python ActionPlugin, KiCad 10's `exec` entrypoint, and an external MCP
+    // client — so it is the only spot where the bookkeeping cannot be skipped
+    // by launching a different way. The guard has to outlive every transport
+    // below: it holds the lock that proves this process is still alive.
+    let _run_record = run_registry::sweep_and_register(&config.transport);
 
     let server_config = konnect_core::tools::ServerConfig {
         kicad_cli: config.kicad_cli.clone(),

--- a/crates/konnect/src/run_registry.rs
+++ b/crates/konnect/src/run_registry.rs
@@ -1,0 +1,351 @@
+//! One run record per Konnect server process, and the startup sweep that
+//! reaps the records whose owner is gone (#103).
+//!
+//! `server.pid` only ever named the last server started through the Python
+//! ActionPlugin's toolbar button. KiCad 10 launches the binary itself —
+//! `plugin/plugin.json` declares `"runtime": { "type": "exec" }` with
+//! `"entrypoint": "bin/konnect"` — so for the configuration most users are on
+//! the Python bookkeeping is never in the picture, and nothing records the
+//! server at all. An HTTP server compounds it: `run_http` never reads stdin,
+//! so the parent's death is invisible to it and it outlives the session.
+//!
+//! The record therefore lives here, written by the server about itself:
+//! `<konnect_dir>/run/<pid>.lock`, held under an exclusive advisory lock for
+//! the whole process lifetime. The lock, not the PID number, is the liveness
+//! proof — a PID can be recycled onto an unrelated process, and `kill(pid, 0)`
+//! is not a probe on Windows.
+//!
+//! The sweep deletes *records* and nothing else. It never signals a process.
+//! Konnect is also spawned directly by external MCP clients (Claude Desktop,
+//! Cursor) whose servers have legitimately separate lifecycles, so any scheme
+//! that reaches for a kill reaches for one of those too.
+//!
+//! Nothing here may fail a server start. A read-only or missing cache
+//! directory costs the record, never the session.
+
+use crate::config::TransportMode;
+use fs4::FileExt;
+use serde::Serialize;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tracing::{debug, warn};
+
+/// Body of one `<pid>.lock`. Enough to tell a stranger's server from ours
+/// when reading the directory by hand — the file's existence plus its lock
+/// state is what the sweep actually acts on.
+#[derive(Serialize)]
+struct RunRecord<'a> {
+    pid: u32,
+    version: &'a str,
+    transport: &'a str,
+    started_at_ms: u64,
+    /// Which binary this is, so a record left by a pre-update install is
+    /// recognisable. Absent when the platform will not tell us.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    exe: Option<String>,
+}
+
+/// Holds the process's own record open for as long as it lives, and removes
+/// it on a clean exit.
+///
+/// A killed process drops nothing — that is the orphan case, and the sweep in
+/// the next server's startup is what covers it.
+pub struct RunGuard {
+    /// `None` when registration was skipped; the guard is then inert.
+    path: Option<PathBuf>,
+    lock: Option<File>,
+}
+
+impl RunGuard {
+    fn inert() -> Self {
+        RunGuard {
+            path: None,
+            lock: None,
+        }
+    }
+}
+
+impl Drop for RunGuard {
+    fn drop(&mut self) {
+        let Some(path) = self.path.take() else {
+            return;
+        };
+        // Release and close before unlinking: Windows refuses to delete a file
+        // that is still open without FILE_SHARE_DELETE.
+        if let Some(file) = self.lock.take() {
+            let _ = <File as FileExt>::unlock(&file);
+            drop(file);
+        }
+        if let Err(err) = std::fs::remove_file(&path) {
+            debug!(path = %path.display(), %err, "could not remove run record");
+        }
+    }
+}
+
+/// `<konnect_dir>/run` — same convention as the logs directory, not a second
+/// path scheme.
+fn run_dir() -> PathBuf {
+    konnect_core::observability::konnect_dir().join("run")
+}
+
+/// Reap stale records, then register this process. Sweep first, so our own
+/// record is never a candidate for it.
+pub fn sweep_and_register(transport: &TransportMode) -> RunGuard {
+    let dir = run_dir();
+    sweep(&dir);
+    register(
+        &dir,
+        match transport {
+            TransportMode::Stdio => "stdio",
+            TransportMode::Http => "http",
+            TransportMode::Both => "both",
+        },
+    )
+}
+
+/// Delete every record whose exclusive lock can be taken — a free lock means
+/// the process that held it is gone.
+///
+/// A busy lock means the owner is alive and is left completely alone: it may
+/// be another KiCad window's server, or an MCP client's, and this function has
+/// no way to tell them apart and no business acting on either.
+fn sweep(dir: &Path) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) => {
+            // Missing on a first run, which is not worth a warning.
+            debug!(dir = %dir.display(), %err, "no run directory to sweep");
+            return;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("lock") {
+            continue;
+        }
+
+        let file = match OpenOptions::new().read(true).write(true).open(&path) {
+            Ok(file) => file,
+            Err(err) => {
+                warn!(path = %path.display(), %err, "could not open run record");
+                continue;
+            }
+        };
+
+        // The only liveness test this makes: acquired means nobody holds it.
+        if let Err(err) = <File as FileExt>::try_lock(&file) {
+            debug!(path = %path.display(), %err, "run record has a live owner");
+            continue;
+        }
+
+        let _ = <File as FileExt>::unlock(&file);
+        drop(file);
+        match std::fs::remove_file(&path) {
+            Ok(()) => debug!(path = %path.display(), "reaped stale run record"),
+            Err(err) => warn!(path = %path.display(), %err, "could not reap run record"),
+        }
+    }
+}
+
+/// Write this process's record and hold its lock in the returned guard.
+///
+/// Every failure yields an inert guard rather than an error: an MCP server
+/// that refuses to serve because a cache directory is read-only would be a
+/// worse bug than the one this fixes.
+fn register(dir: &Path, transport: &str) -> RunGuard {
+    if let Err(err) = std::fs::create_dir_all(dir) {
+        warn!(dir = %dir.display(), %err, "no run directory; this server will not be recorded");
+        return RunGuard::inert();
+    }
+
+    let pid = std::process::id();
+    let path = dir.join(format!("{pid}.lock"));
+
+    // Truncating: a same-numbered record can survive a sweep that could not
+    // delete it, and its contents describe a different process.
+    let file = match OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(true)
+        .open(&path)
+    {
+        Ok(file) => file,
+        Err(err) => {
+            warn!(path = %path.display(), %err, "could not create run record");
+            return RunGuard::inert();
+        }
+    };
+
+    // A concurrent sweeper can see this file in the gap between create and
+    // lock and delete it as stale. That costs a record, which is the failure
+    // this module already tolerates everywhere else; it cannot cost a process,
+    // because the sweep never signals one.
+    if let Err(err) = <File as FileExt>::try_lock(&file) {
+        warn!(path = %path.display(), %err, "run record already locked");
+        return RunGuard::inert();
+    }
+
+    let record = RunRecord {
+        pid,
+        version: env!("CARGO_PKG_VERSION"),
+        transport,
+        started_at_ms: konnect_core::observability::unix_ms(),
+        exe: std::env::current_exe()
+            .ok()
+            .map(|p| p.display().to_string()),
+    };
+    match serde_json::to_vec(&record) {
+        Ok(body) => {
+            if let Err(err) = (&file).write_all(&body) {
+                debug!(path = %path.display(), %err, "run record body not written");
+            }
+        }
+        Err(err) => debug!(%err, "run record body not serialized"),
+    }
+
+    debug!(path = %path.display(), "registered run record");
+    RunGuard {
+        path: Some(path),
+        lock: Some(file),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Take and hold a real exclusive lock, the way a running server does.
+    ///
+    /// The tests below never fabricate a PID. A record naming a PID nobody is
+    /// using proves nothing about the sweep, because the sweep does not read
+    /// the PID — it tries the lock. A synthetic record would exercise the
+    /// directory walk and stop there, and would still pass against a sweep
+    /// that deleted everything unconditionally.
+    fn hold(path: &Path) -> File {
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(true)
+            .open(path)
+            .expect("open record");
+        <File as FileExt>::try_lock(&file).expect("lock must be free");
+        file
+    }
+
+    #[test]
+    fn stale_record_is_reaped() {
+        let dir = tempfile::tempdir().unwrap();
+        let stale = dir.path().join("4242.lock");
+        // Locked and then released — exactly the state a killed server leaves,
+        // since the OS drops its locks whether or not it exited cleanly.
+        drop(hold(&stale));
+
+        sweep(dir.path());
+
+        assert!(!stale.exists(), "stale record survived the sweep");
+    }
+
+    #[test]
+    fn record_with_a_live_owner_survives() {
+        let dir = tempfile::tempdir().unwrap();
+        let live = dir.path().join("4243.lock");
+        let held = hold(&live);
+
+        sweep(dir.path());
+
+        assert!(
+            live.exists(),
+            "sweep deleted the record of a process that is still running"
+        );
+        drop(held);
+    }
+
+    /// Both cases at once: a sweep that reaps the dead is not interesting if
+    /// it also reaps the living.
+    #[test]
+    fn a_sweep_separates_the_live_record_from_the_stale_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let stale = dir.path().join("4244.lock");
+        let live = dir.path().join("4245.lock");
+        drop(hold(&stale));
+        let held = hold(&live);
+
+        sweep(dir.path());
+
+        assert!(!stale.exists(), "stale record survived");
+        assert!(live.exists(), "live record was reaped");
+        drop(held);
+    }
+
+    #[test]
+    fn sweep_touches_nothing_but_lock_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("server.log");
+        let pid = dir.path().join("server.pid");
+        let bare = dir.path().join("lock");
+        let subdir = dir.path().join("nested.lock.d");
+        std::fs::write(&log, "text").unwrap();
+        std::fs::write(&pid, "4246").unwrap();
+        std::fs::write(&bare, "no extension").unwrap();
+        std::fs::create_dir(&subdir).unwrap();
+
+        sweep(dir.path());
+
+        assert!(log.exists(), "sweep deleted an unrelated file");
+        assert!(pid.exists(), "sweep deleted the legacy PID file");
+        assert!(bare.exists(), "sweep deleted an extensionless entry");
+        assert!(subdir.exists(), "sweep deleted an unrelated directory");
+    }
+
+    #[test]
+    fn sweeping_a_missing_directory_is_a_no_op() {
+        let dir = tempfile::tempdir().unwrap();
+        sweep(&dir.path().join("never-created"));
+    }
+
+    #[test]
+    fn registration_creates_the_run_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let run = dir.path().join("run");
+
+        let guard = register(&run, "stdio");
+
+        let path = run.join(format!("{}.lock", std::process::id()));
+        assert!(path.exists(), "record not written");
+        let body: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(body["pid"], std::process::id());
+        assert_eq!(body["transport"], "stdio");
+        drop(guard);
+    }
+
+    /// A cache path that cannot become a directory must cost the record and
+    /// nothing else — the server still has to serve.
+    #[test]
+    fn registration_survives_a_run_path_that_cannot_be_a_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let blocked = dir.path().join("run");
+        std::fs::write(&blocked, "a regular file is in the way").unwrap();
+
+        let guard = register(&blocked, "http");
+
+        assert!(blocked.is_file(), "registration clobbered the path");
+        drop(guard);
+    }
+
+    #[test]
+    fn the_guard_removes_its_record_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let guard = register(dir.path(), "both");
+        let path = dir.path().join(format!("{}.lock", std::process::id()));
+        assert!(path.exists(), "record not written");
+
+        drop(guard);
+
+        assert!(!path.exists(), "record outlived its guard");
+    }
+}

--- a/crates/konnect/src/run_registry.rs
+++ b/crates/konnect/src/run_registry.rs
@@ -63,7 +63,7 @@ struct RunRecord<'a> {
     /// Which binary this is, so a record left by a pre-update install is
     /// recognisable. Absent when the platform will not tell us.
     #[serde(skip_serializing_if = "Option::is_none")]
-    exe: Option<String>,
+    executable_path: Option<String>,
 }
 
 /// Holds the process's own lock open for as long as it lives, and removes the
@@ -285,7 +285,7 @@ fn register(dir: &Path, transport: &str) -> RunGuard {
         version: env!("CARGO_PKG_VERSION"),
         transport,
         started_at_ms: konnect_core::observability::unix_ms(),
-        exe: std::env::current_exe()
+        executable_path: std::env::current_exe()
             .ok()
             .map(|p| p.display().to_string()),
     };
@@ -531,6 +531,55 @@ mod tests {
 
     /// A cache path that cannot become a directory must cost the record and
     /// nothing else — the server still has to serve.
+    /// The body is a persisted format a stranger reads by hand, so its field
+    /// names are part of the contract rather than an implementation detail.
+    /// `docs/NAMING_CONVENTIONS.md` requires a filesystem path to carry the
+    /// `_path` suffix, and a record already on disk cannot be renamed later
+    /// without a migration — which is why this is pinned by a test and not by
+    /// the reviewer who happens to read the struct next.
+    #[test]
+    fn the_record_names_its_fields_by_the_repository_convention() {
+        let dir = tempfile::tempdir().unwrap();
+        let guard = register(dir.path(), "stdio");
+        let body_path = dir.path().join(format!("{}.json", std::process::id()));
+
+        let body: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&body_path).expect("body must be readable"))
+                .expect("body must parse");
+        let object = body.as_object().expect("the record must be a JSON object");
+
+        for key in object.keys() {
+            assert!(
+                matches!(
+                    key.as_str(),
+                    "pid" | "version" | "transport" | "started_at_ms" | "executable_path"
+                ),
+                "the run record carries an undeclared field `{key}`"
+            );
+        }
+        for required in ["pid", "version", "transport", "started_at_ms"] {
+            assert!(
+                object.contains_key(required),
+                "the run record lost its `{required}` field"
+            );
+        }
+
+        // The binary's path is the one optional field — absent only where the
+        // platform will not name it. Where it is named, it must be named here.
+        if let Ok(current) = std::env::current_exe() {
+            let expected = current.display().to_string();
+            assert_eq!(
+                object
+                    .get("executable_path")
+                    .and_then(|value| value.as_str()),
+                Some(expected.as_str()),
+                "the binary's path is not under `executable_path`"
+            );
+        }
+
+        drop(guard);
+    }
+
     #[test]
     fn registration_survives_a_run_path_that_cannot_be_a_directory() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/konnect/src/run_registry.rs
+++ b/crates/konnect/src/run_registry.rs
@@ -18,6 +18,17 @@
 //!   a probe on Windows.
 //! - `<pid>.json` — the readable body, never locked.
 //!
+//! A record is *published*, not built in place: the file is created and locked
+//! as `<pid>.tmp` and only then renamed to `<pid>.lock`. The sweep judges a
+//! record by whether its lock is free, so a record that existed under its final
+//! name before it was locked would read as stale to a startup happening at the
+//! same moment — and two simultaneous launches are ordinary here. Renaming a
+//! file that is already locked closes that window instead of narrowing it.
+//!
+//! Both sweep passes also filter on a `<digits>` stem. The lock pass acquires
+//! an exclusive lock on each candidate to test it, and "this lock is free" is a
+//! true statement about somebody else's lock file too.
+//!
 //! The split is not tidiness. `LockFileEx` is **mandatory** on Windows, so a
 //! body written inside the locked file cannot be read while its owner is
 //! alive — `fs::read` fails with `ERROR_LOCK_VIOLATION` (os error 33), which
@@ -107,6 +118,28 @@ fn body_for(lock: &Path) -> PathBuf {
     lock.with_extension("json")
 }
 
+/// Where a registration lives between `open` and the lock it is about to take.
+///
+/// `.tmp`, not `.lock`: the sweep only ever considers `<digits>.lock` and
+/// `<digits>.json`, so a record is invisible to it for the whole window in
+/// which it is not yet locked. The name is per-PID and opened truncating, so a
+/// process killed inside that window leaves at most one empty file, which its
+/// own PID slot overwrites on the next start.
+fn staging_path(dir: &Path, pid: u32) -> PathBuf {
+    dir.join(format!("{pid}.tmp"))
+}
+
+/// `<digits>` — a stem this registry could itself have written, i.e. a PID.
+///
+/// Both sweep passes filter on it. Without it the lock pass takes an exclusive
+/// lock on every `*.lock` in the directory and deletes the ones that are free,
+/// which is a correct description of another tool's lock file too.
+fn is_our_stem(path: &Path) -> bool {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .is_some_and(|stem| !stem.is_empty() && stem.bytes().all(|b| b.is_ascii_digit()))
+}
+
 /// Reap stale records, then register this process. Sweep first, so our own
 /// record is never a candidate for it.
 pub fn sweep_and_register(transport: &TransportMode) -> RunGuard {
@@ -138,7 +171,10 @@ fn sweep(dir: &Path) {
         }
     };
 
-    for path in entries.iter().filter(|p| has_extension(p, "lock")) {
+    for path in entries
+        .iter()
+        .filter(|p| has_extension(p, "lock") && is_our_stem(p))
+    {
         let file = match OpenOptions::new().read(true).write(true).open(path) {
             Ok(file) => file,
             Err(err) => {
@@ -180,12 +216,7 @@ fn has_extension(path: &Path, want: &str) -> bool {
 
 /// A `<digits>.json` with no `<digits>.lock` beside it any more.
 fn is_orphaned_body(path: &Path) -> bool {
-    has_extension(path, "json")
-        && path
-            .file_stem()
-            .and_then(|stem| stem.to_str())
-            .is_some_and(|stem| !stem.is_empty() && stem.bytes().all(|b| b.is_ascii_digit()))
-        && !path.with_extension("lock").exists()
+    has_extension(path, "json") && is_our_stem(path) && !path.with_extension("lock").exists()
 }
 
 fn remove_quietly(path: &Path) {
@@ -209,27 +240,43 @@ fn register(dir: &Path, transport: &str) -> RunGuard {
 
     let pid = std::process::id();
     let lock_path = dir.join(format!("{pid}.lock"));
+    let staged = staging_path(dir, pid);
 
+    // Create and lock under `<pid>.tmp`, then publish under `<pid>.lock` by
+    // rename. A sweep running concurrently in another startup only ever sees
+    // the final name, and by the time that name exists the lock behind it is
+    // already held — so the "free lock means the owner is gone" test it makes
+    // can no longer be true of a record that is still being written.
+    //
+    // The rename does not disturb the lock: on Unix a `flock` belongs to the
+    // open file description, not to the path, and on Windows `File` is opened
+    // with FILE_SHARE_DELETE, so the entry can be moved under the open handle.
     let file = match OpenOptions::new()
         .create(true)
         .read(true)
         .write(true)
         .truncate(true)
-        .open(&lock_path)
+        .open(&staged)
     {
         Ok(file) => file,
         Err(err) => {
-            warn!(path = %lock_path.display(), %err, "could not create run lock");
+            warn!(path = %staged.display(), %err, "could not create run lock");
             return RunGuard::inert();
         }
     };
 
-    // A concurrent sweeper can see this file in the gap between create and
-    // lock and delete it as stale. That costs a record, which is the failure
-    // this module already tolerates everywhere else; it cannot cost a process,
-    // because the sweep never signals one.
     if let Err(err) = <File as FileExt>::try_lock(&file) {
-        warn!(path = %lock_path.display(), %err, "run lock already held");
+        // Another live process already owns this PID's staging file, which
+        // means this one is not what it claims to be. Leave it alone.
+        warn!(path = %staged.display(), %err, "run lock already held");
+        return RunGuard::inert();
+    }
+
+    if let Err(err) = std::fs::rename(&staged, &lock_path) {
+        warn!(path = %staged.display(), %err, "could not publish run record");
+        let _ = <File as FileExt>::unlock(&file);
+        drop(file);
+        remove_quietly(&staged);
         return RunGuard::inert();
     }
 
@@ -352,8 +399,14 @@ mod tests {
         let pid = dir.path().join("server.pid");
         let bare = dir.path().join("lock");
         let notes = dir.path().join("notes.json");
+        // A `.lock` this registry could never have written. The contract is
+        // `<pid>.lock`, and the sweep takes a lock on every candidate before
+        // deleting it — so an unrelated lock file that happens to be free is
+        // exactly the thing a name filter has to keep it away from.
+        let foreign_lock = dir.path().join("notes.lock");
         let subdir = dir.path().join("nested.lock.d");
         std::fs::write(&log, "text").unwrap();
+        std::fs::write(&foreign_lock, "not ours").unwrap();
         std::fs::write(&pid, "4246").unwrap();
         std::fs::write(&bare, "no extension").unwrap();
         std::fs::write(&notes, "{}").unwrap();
@@ -368,7 +421,58 @@ mod tests {
             notes.exists(),
             "sweep deleted a .json whose name it could never have written"
         );
+        assert!(
+            foreign_lock.exists(),
+            "sweep deleted a .lock whose name it could never have written"
+        );
         assert!(subdir.exists(), "sweep deleted an unrelated directory");
+    }
+
+    /// The create-before-lock race, as a property rather than a schedule.
+    ///
+    /// A registration is unavoidably visible on disk for an instant before it
+    /// holds its lock. If that instant is spent under a name the sweep
+    /// considers, a concurrent startup reaps a record that is about to become
+    /// live — and Konnect is back to an untracked running server, which is the
+    /// state this module exists to remove. Two simultaneous launches are the
+    /// ordinary case in #103, not a corner.
+    ///
+    /// Testing it by racing threads would prove nothing on a green run: the
+    /// window is microseconds and a passing schedule is not evidence. The
+    /// invariant is checkable without a schedule — put the directory in the
+    /// mid-registration state and sweep it.
+    #[test]
+    fn a_registration_in_progress_survives_a_concurrent_sweep() {
+        let dir = tempfile::tempdir().unwrap();
+        let staged = staging_path(dir.path(), 4248);
+        // Created, not yet locked: exactly what another process can observe
+        // between our `open` and our `try_lock`.
+        std::fs::write(&staged, b"").unwrap();
+
+        sweep(dir.path());
+
+        assert!(
+            staged.exists(),
+            "a concurrent sweep reaped a registration that had not locked yet"
+        );
+    }
+
+    /// The published record is the locked one, so the rename is the moment the
+    /// record becomes visible to a sweep — never before.
+    #[test]
+    fn registration_leaves_no_staging_file_behind() {
+        let dir = tempfile::tempdir().unwrap();
+        let guard = register(dir.path(), "stdio");
+
+        let staged = staging_path(dir.path(), std::process::id());
+        assert!(!staged.exists(), "staging file outlived the registration");
+        assert!(
+            dir.path()
+                .join(format!("{}.lock", std::process::id()))
+                .exists(),
+            "record was not published under its final name"
+        );
+        drop(guard);
     }
 
     /// A body left behind without its lock describes nothing, and would

--- a/crates/konnect/src/run_registry.rs
+++ b/crates/konnect/src/run_registry.rs
@@ -9,11 +9,21 @@
 //! server at all. An HTTP server compounds it: `run_http` never reads stdin,
 //! so the parent's death is invisible to it and it outlives the session.
 //!
-//! The record therefore lives here, written by the server about itself:
-//! `<konnect_dir>/run/<pid>.lock`, held under an exclusive advisory lock for
-//! the whole process lifetime. The lock, not the PID number, is the liveness
-//! proof — a PID can be recycled onto an unrelated process, and `kill(pid, 0)`
-//! is not a probe on Windows.
+//! The record therefore lives here, written by the server about itself, as a
+//! pair under `<konnect_dir>/run/`:
+//!
+//! - `<pid>.lock` — empty, held under an exclusive advisory lock for the whole
+//!   process lifetime. The lock, not the PID number, is the liveness proof: a
+//!   PID can be recycled onto an unrelated process, and `kill(pid, 0)` is not
+//!   a probe on Windows.
+//! - `<pid>.json` — the readable body, never locked.
+//!
+//! The split is not tidiness. `LockFileEx` is **mandatory** on Windows, so a
+//! body written inside the locked file cannot be read while its owner is
+//! alive — `fs::read` fails with `ERROR_LOCK_VIOLATION` (os error 33), which
+//! is precisely the moment the record is worth reading. `flock` is advisory
+//! and hides this on Unix. Keeping the locked token empty means the body is
+//! readable on every platform, by a person or by whatever reads these next.
 //!
 //! The sweep deletes *records* and nothing else. It never signals a process.
 //! Konnect is also spawned directly by external MCP clients (Claude Desktop,
@@ -27,13 +37,12 @@ use crate::config::TransportMode;
 use fs4::FileExt;
 use serde::Serialize;
 use std::fs::{File, OpenOptions};
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use tracing::{debug, warn};
 
-/// Body of one `<pid>.lock`. Enough to tell a stranger's server from ours
-/// when reading the directory by hand — the file's existence plus its lock
-/// state is what the sweep actually acts on.
+/// Body of one `<pid>.json`. Enough to tell a stranger's server from ours
+/// when reading the directory by hand — the lock file's state is what the
+/// sweep actually acts on.
 #[derive(Serialize)]
 struct RunRecord<'a> {
     pid: u32,
@@ -46,21 +55,23 @@ struct RunRecord<'a> {
     exe: Option<String>,
 }
 
-/// Holds the process's own record open for as long as it lives, and removes
-/// it on a clean exit.
+/// Holds the process's own lock open for as long as it lives, and removes the
+/// pair on a clean exit.
 ///
 /// A killed process drops nothing — that is the orphan case, and the sweep in
 /// the next server's startup is what covers it.
 pub struct RunGuard {
     /// `None` when registration was skipped; the guard is then inert.
-    path: Option<PathBuf>,
+    lock_path: Option<PathBuf>,
+    body_path: Option<PathBuf>,
     lock: Option<File>,
 }
 
 impl RunGuard {
     fn inert() -> Self {
         RunGuard {
-            path: None,
+            lock_path: None,
+            body_path: None,
             lock: None,
         }
     }
@@ -68,17 +79,19 @@ impl RunGuard {
 
 impl Drop for RunGuard {
     fn drop(&mut self) {
-        let Some(path) = self.path.take() else {
-            return;
-        };
         // Release and close before unlinking: Windows refuses to delete a file
         // that is still open without FILE_SHARE_DELETE.
         if let Some(file) = self.lock.take() {
             let _ = <File as FileExt>::unlock(&file);
             drop(file);
         }
-        if let Err(err) = std::fs::remove_file(&path) {
-            debug!(path = %path.display(), %err, "could not remove run record");
+        for path in [self.body_path.take(), self.lock_path.take()]
+            .into_iter()
+            .flatten()
+        {
+            if let Err(err) = std::fs::remove_file(&path) {
+                debug!(path = %path.display(), %err, "could not remove run record");
+            }
         }
     }
 }
@@ -87,6 +100,11 @@ impl Drop for RunGuard {
 /// path scheme.
 fn run_dir() -> PathBuf {
     konnect_core::observability::konnect_dir().join("run")
+}
+
+/// The body that belongs to a `<pid>.lock`.
+fn body_for(lock: &Path) -> PathBuf {
+    lock.with_extension("json")
 }
 
 /// Reap stale records, then register this process. Sweep first, so our own
@@ -111,8 +129,8 @@ pub fn sweep_and_register(transport: &TransportMode) -> RunGuard {
 /// be another KiCad window's server, or an MCP client's, and this function has
 /// no way to tell them apart and no business acting on either.
 fn sweep(dir: &Path) {
-    let entries = match std::fs::read_dir(dir) {
-        Ok(entries) => entries,
+    let entries: Vec<PathBuf> = match std::fs::read_dir(dir) {
+        Ok(entries) => entries.flatten().map(|e| e.path()).collect(),
         Err(err) => {
             // Missing on a first run, which is not worth a warning.
             debug!(dir = %dir.display(), %err, "no run directory to sweep");
@@ -120,16 +138,11 @@ fn sweep(dir: &Path) {
         }
     };
 
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|ext| ext.to_str()) != Some("lock") {
-            continue;
-        }
-
-        let file = match OpenOptions::new().read(true).write(true).open(&path) {
+    for path in entries.iter().filter(|p| has_extension(p, "lock")) {
+        let file = match OpenOptions::new().read(true).write(true).open(path) {
             Ok(file) => file,
             Err(err) => {
-                warn!(path = %path.display(), %err, "could not open run record");
+                warn!(path = %path.display(), %err, "could not open run lock");
                 continue;
             }
         };
@@ -142,9 +155,43 @@ fn sweep(dir: &Path) {
 
         let _ = <File as FileExt>::unlock(&file);
         drop(file);
-        match std::fs::remove_file(&path) {
+        // Only the lock is removed here. Its body is then a body with no
+        // lock, which the pass below already deletes — a second call to do it
+        // from here is unreachable code that looks like a safeguard.
+        match std::fs::remove_file(path) {
             Ok(()) => debug!(path = %path.display(), "reaped stale run record"),
-            Err(err) => warn!(path = %path.display(), %err, "could not reap run record"),
+            Err(err) => warn!(path = %path.display(), %err, "could not reap run lock"),
+        }
+    }
+
+    // A body whose lock is gone describes nothing. This runs after the pass
+    // above, so a live server's body still has its lock and is not a match.
+    // Restricted to `<digits>.json` so the sweep can only ever delete a name
+    // it could itself have written.
+    for path in entries.iter().filter(|p| is_orphaned_body(p)) {
+        debug!(path = %path.display(), "reaped body with no lock");
+        remove_quietly(path);
+    }
+}
+
+fn has_extension(path: &Path, want: &str) -> bool {
+    path.extension().and_then(|ext| ext.to_str()) == Some(want)
+}
+
+/// A `<digits>.json` with no `<digits>.lock` beside it any more.
+fn is_orphaned_body(path: &Path) -> bool {
+    has_extension(path, "json")
+        && path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .is_some_and(|stem| !stem.is_empty() && stem.bytes().all(|b| b.is_ascii_digit()))
+        && !path.with_extension("lock").exists()
+}
+
+fn remove_quietly(path: &Path) {
+    if let Err(err) = std::fs::remove_file(path) {
+        if err.kind() != std::io::ErrorKind::NotFound {
+            debug!(path = %path.display(), %err, "could not remove run record body");
         }
     }
 }
@@ -161,20 +208,18 @@ fn register(dir: &Path, transport: &str) -> RunGuard {
     }
 
     let pid = std::process::id();
-    let path = dir.join(format!("{pid}.lock"));
+    let lock_path = dir.join(format!("{pid}.lock"));
 
-    // Truncating: a same-numbered record can survive a sweep that could not
-    // delete it, and its contents describe a different process.
     let file = match OpenOptions::new()
         .create(true)
         .read(true)
         .write(true)
         .truncate(true)
-        .open(&path)
+        .open(&lock_path)
     {
         Ok(file) => file,
         Err(err) => {
-            warn!(path = %path.display(), %err, "could not create run record");
+            warn!(path = %lock_path.display(), %err, "could not create run lock");
             return RunGuard::inert();
         }
     };
@@ -184,7 +229,7 @@ fn register(dir: &Path, transport: &str) -> RunGuard {
     // this module already tolerates everywhere else; it cannot cost a process,
     // because the sweep never signals one.
     if let Err(err) = <File as FileExt>::try_lock(&file) {
-        warn!(path = %path.display(), %err, "run record already locked");
+        warn!(path = %lock_path.display(), %err, "run lock already held");
         return RunGuard::inert();
     }
 
@@ -197,18 +242,22 @@ fn register(dir: &Path, transport: &str) -> RunGuard {
             .ok()
             .map(|p| p.display().to_string()),
     };
+    let body_path = body_for(&lock_path);
     match serde_json::to_vec(&record) {
+        // Truncating write: a same-numbered body can survive a sweep that
+        // could not delete it, and it describes a different process.
         Ok(body) => {
-            if let Err(err) = (&file).write_all(&body) {
-                debug!(path = %path.display(), %err, "run record body not written");
+            if let Err(err) = std::fs::write(&body_path, &body) {
+                debug!(path = %body_path.display(), %err, "run record body not written");
             }
         }
         Err(err) => debug!(%err, "run record body not serialized"),
     }
 
-    debug!(path = %path.display(), "registered run record");
+    debug!(path = %lock_path.display(), "registered run record");
     RunGuard {
-        path: Some(path),
+        lock_path: Some(lock_path),
+        body_path: Some(body_path),
         lock: Some(file),
     }
 }
@@ -231,35 +280,48 @@ mod tests {
             .write(true)
             .truncate(true)
             .open(path)
-            .expect("open record");
+            .expect("open lock");
         <File as FileExt>::try_lock(&file).expect("lock must be free");
         file
+    }
+
+    /// A `<pid>.lock` plus its `<pid>.json`, as `register` leaves them.
+    fn pair(dir: &Path, pid: u32) -> (PathBuf, PathBuf) {
+        let lock = dir.join(format!("{pid}.lock"));
+        let body = dir.join(format!("{pid}.json"));
+        std::fs::write(&body, b"{}").unwrap();
+        (lock, body)
     }
 
     #[test]
     fn stale_record_is_reaped() {
         let dir = tempfile::tempdir().unwrap();
-        let stale = dir.path().join("4242.lock");
+        let (lock, body) = pair(dir.path(), 4242);
         // Locked and then released — exactly the state a killed server leaves,
         // since the OS drops its locks whether or not it exited cleanly.
-        drop(hold(&stale));
+        drop(hold(&lock));
 
         sweep(dir.path());
 
-        assert!(!stale.exists(), "stale record survived the sweep");
+        assert!(!lock.exists(), "stale lock survived the sweep");
+        assert!(!body.exists(), "stale body survived the sweep");
     }
 
     #[test]
     fn record_with_a_live_owner_survives() {
         let dir = tempfile::tempdir().unwrap();
-        let live = dir.path().join("4243.lock");
-        let held = hold(&live);
+        let (lock, body) = pair(dir.path(), 4243);
+        let held = hold(&lock);
 
         sweep(dir.path());
 
         assert!(
-            live.exists(),
-            "sweep deleted the record of a process that is still running"
+            lock.exists(),
+            "sweep deleted the lock of a process that is still running"
+        );
+        assert!(
+            body.exists(),
+            "sweep deleted the body of a process that is still running"
         );
         drop(held);
     }
@@ -269,28 +331,32 @@ mod tests {
     #[test]
     fn a_sweep_separates_the_live_record_from_the_stale_one() {
         let dir = tempfile::tempdir().unwrap();
-        let stale = dir.path().join("4244.lock");
-        let live = dir.path().join("4245.lock");
+        let (stale, stale_body) = pair(dir.path(), 4244);
+        let (live, live_body) = pair(dir.path(), 4245);
         drop(hold(&stale));
         let held = hold(&live);
 
         sweep(dir.path());
 
         assert!(!stale.exists(), "stale record survived");
+        assert!(!stale_body.exists(), "stale body survived");
         assert!(live.exists(), "live record was reaped");
+        assert!(live_body.exists(), "live body was reaped");
         drop(held);
     }
 
     #[test]
-    fn sweep_touches_nothing_but_lock_files() {
+    fn sweep_touches_nothing_it_did_not_write() {
         let dir = tempfile::tempdir().unwrap();
         let log = dir.path().join("server.log");
         let pid = dir.path().join("server.pid");
         let bare = dir.path().join("lock");
+        let notes = dir.path().join("notes.json");
         let subdir = dir.path().join("nested.lock.d");
         std::fs::write(&log, "text").unwrap();
         std::fs::write(&pid, "4246").unwrap();
         std::fs::write(&bare, "no extension").unwrap();
+        std::fs::write(&notes, "{}").unwrap();
         std::fs::create_dir(&subdir).unwrap();
 
         sweep(dir.path());
@@ -298,7 +364,24 @@ mod tests {
         assert!(log.exists(), "sweep deleted an unrelated file");
         assert!(pid.exists(), "sweep deleted the legacy PID file");
         assert!(bare.exists(), "sweep deleted an extensionless entry");
+        assert!(
+            notes.exists(),
+            "sweep deleted a .json whose name it could never have written"
+        );
         assert!(subdir.exists(), "sweep deleted an unrelated directory");
+    }
+
+    /// A body left behind without its lock describes nothing, and would
+    /// otherwise sit in the directory claiming a server that is gone.
+    #[test]
+    fn a_body_with_no_lock_is_reaped() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = dir.path().join("4247.json");
+        std::fs::write(&body, b"{}").unwrap();
+
+        sweep(dir.path());
+
+        assert!(!body.exists(), "orphaned body survived the sweep");
     }
 
     #[test]
@@ -314,10 +397,29 @@ mod tests {
 
         let guard = register(&run, "stdio");
 
-        let path = run.join(format!("{}.lock", std::process::id()));
-        assert!(path.exists(), "record not written");
+        let lock = run.join(format!("{}.lock", std::process::id()));
+        let body = run.join(format!("{}.json", std::process::id()));
+        assert!(lock.exists(), "lock not written");
+        assert!(body.exists(), "record not written");
+        drop(guard);
+    }
+
+    /// The Windows regression, and the reason the lock and the body are two
+    /// files. `LockFileEx` is mandatory, so a body written inside the locked
+    /// file is unreadable exactly while its owner is alive: CI failed here
+    /// with `Os { code: 33, "another process has locked a portion of the
+    /// file" }` when this module kept both in one file. `flock` is advisory,
+    /// so on Unix this test passes either way and only Windows CI proves it.
+    #[test]
+    fn the_body_is_readable_while_its_owner_holds_the_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let guard = register(dir.path(), "stdio");
+        let body_path = dir.path().join(format!("{}.json", std::process::id()));
+
         let body: serde_json::Value =
-            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+            serde_json::from_slice(&std::fs::read(&body_path).expect("body must be readable"))
+                .expect("body must parse");
+
         assert_eq!(body["pid"], std::process::id());
         assert_eq!(body["transport"], "stdio");
         drop(guard);
@@ -341,11 +443,13 @@ mod tests {
     fn the_guard_removes_its_record_on_drop() {
         let dir = tempfile::tempdir().unwrap();
         let guard = register(dir.path(), "both");
-        let path = dir.path().join(format!("{}.lock", std::process::id()));
-        assert!(path.exists(), "record not written");
+        let lock = dir.path().join(format!("{}.lock", std::process::id()));
+        let body = dir.path().join(format!("{}.json", std::process::id()));
+        assert!(lock.exists() && body.exists(), "record not written");
 
         drop(guard);
 
-        assert!(!path.exists(), "record outlived its guard");
+        assert!(!lock.exists(), "lock outlived its guard");
+        assert!(!body.exists(), "body outlived its guard");
     }
 }


### PR DESCRIPTION
I am an AI agent (Claude), running unattended as the synthetic co-founder at Anton Dzyatkovsky's lab. Named responsible person: Anton Dziatkovskii, github user `tonydzi`. Every number below comes from a run on the exact head named; please re-run rather than trust me.

**Part of #103.** This is the recording half that PR #199 did not reach. It must not close #103: the user-visible orphan-process leak stays open behind it, because nothing here ever signals a process.

The design is yours, from the 2026-08-15 comment on that issue:

> a `<cache>/run/<pid>.lock` directory that the server itself writes on start and removes on clean exit, with a sweep at startup that reaps entries whose PID is gone. That works regardless of which entrypoint launched it, and it does not depend on the parent process cooperating.

`crates/konnect/src/run_registry.rs` does that. Each server writes a pair under `<konnect_dir>/run/`: an empty `<pid>.lock` it holds an exclusive advisory lock on (`fs4`, already a workspace dependency, no new third-party crate) for its whole lifetime, and a `<pid>.json` holding the readable body. Both go on a clean exit. Startup sweeps first: for each `<pid>.lock` it tries the lock; acquired means the owner is gone and the record is deleted, busy means the owner is alive and the record is untouched. The lock rather than the PID number is the liveness proof, so a recycled PID cannot mislead it and no `kill(pid, 0)` probe is needed on Windows. It runs from `main.rs`, the one place that sees all three spawn paths: the Python ActionPlugin, KiCad 10's `exec` entrypoint, and an external MCP client.

The lock and the body are two files for a reason your Windows runner is what found: `LockFileEx` is a **mandatory** lock, so a body written inside the locked file cannot be read while its owner is alive. The read fails with `ERROR_LOCK_VIOLATION`, which is exactly the moment the record is worth reading. `flock` is advisory and hides this completely on Unix. Details in the thread below.

Registration also publishes rather than builds in place: the record is created and locked as `<pid>.tmp`, then renamed to `<pid>.lock`. The sweep never considers `.tmp`, so the window in which a record exists unlocked is spent outside the swept namespace instead of being narrowed inside it.

**What this deliberately does not do.** No process is ever signalled, by the sweep or anything else. Konnect is also spawned directly by external MCP clients whose servers are legitimately separate lifecycles, and a reaper that kills would reach those. Nothing here can fail a server start either: every filesystem error is logged and swallowed, since a read-only cache directory must not stop an MCP server from serving.

**Two honest limits.** The sweep runs at startup, so an orphan is only recorded as stale the next time a server starts; between the orphan's death and the next launch its record still claims a live process. And this does not by itself reap the orphan *processes* in #103. The five you and the reporter counted would still be running. What changes is that they become identifiable (pid, version, transport, executable path, start time, one record per process, whatever launched them) and the records stop lying about which servers exist, which is what any later reaper, or a `konnect status` view, needs first. #420 reports the same leak from the other end: per-session `claude-code`-spawned servers that sit unused, seven live at once.

### Base, and what this depends on

* Base: `main`. Rebased onto `8635895` (current `main` at the time of this push, which is past the `22dbeeae` named in review), so this head contains current main rather than merely being mergeable with it.
* Depends on nothing unmerged. No companion PR, no ordering constraint against another branch.
* New dependency: none. `fs4` is already in the workspace.
* Files: one new module `crates/konnect/src/run_registry.rs`, plus its wiring in `crates/konnect/src/main.rs` (9 lines) and the `fs4` entry in `crates/konnect/Cargo.toml`. No existing behaviour is modified.

### Compatibility

* **On-disk artifacts are new in this PR and unreleased.** `<konnect_dir>/run/` did not exist before, so no shipped build writes or reads these names. There is nothing to migrate and no format version to bump.
* **Field names.** The record body carries `pid`, `version`, `transport`, `started_at_ms`, and `executable_path`. The last was `exe` in the earlier heads of this PR and was renamed to satisfy `docs/NAMING_CONVENTIONS.md`, which requires the `_path` suffix on a filesystem path. Since nothing has ever read it, the rename costs nobody anything today, and it is the last cheap moment to make it.
* **Nothing reads the record yet.** No CLI surface, no tool, no plugin parses these files in this PR. A future `konnect status` is the first intended reader.
* **Directory manners.** Both sweep passes are restricted to a `<digits>` stem, so the sweep can only ever delete a name it could itself have written. An unrelated `notes.lock` or `notes.json` in that directory is not its business, and a test says so.

### Risk and rollback

* Blast radius is one directory under `<konnect_dir>/run/` and roughly one `open`, one `try_lock`, one `rename`, and one small write on startup. No network, no user project files, no KiCad state.
* Worst realistic failure is a lost or stale record: a record that survives its owner is reaped by the next startup, and a record that never got written costs bookkeeping only. Neither can fail a server start, because every filesystem error here is logged and swallowed rather than propagated.
* The one path that touches an existing process's data is deletion inside `<konnect_dir>/run/`, and it is gated twice: the name must have a `<digits>` stem, and the lock must be free.
* **Rollback is a plain revert** of this PR's commits with no cleanup step. The module is additive and the only caller is one call in `main.rs`. Records left behind by a build that had the feature become inert files in a directory nothing reads; deleting `<konnect_dir>/run/` by hand is safe at any time, including while a server is running, on Unix.

### Tests

Twelve unit tests in the module, plus the field-name contract test. Each was shown **red** against a targeted mutation of the code it covers before being accepted:

| Mutation | Test killed | Failing assertion |
|---|---|---|
| sweep deletes unconditionally (liveness probe removed) | `record_with_a_live_owner_survives` | `sweep deleted the lock of a process that is still running` |
| " | `a_sweep_separates_the_live_record_from_the_stale_one` | `live record was reaped` |
| sweep never calls `remove_file` | `stale_record_is_reaped` | `stale record survived the sweep` |
| the `<digits>` stem restriction dropped | `sweep_touches_nothing_it_did_not_write` | `sweep deleted a .json whose name it could never have written` |
| the orphan-body pass removed | `a_body_with_no_lock_is_reaped` | `orphaned body survived the sweep` |
| `Drop` removes only the lock | `the_guard_removes_its_record_on_drop` | `body outlived its guard` |
| `register` locks after publishing instead of before | `a_registration_in_progress_survives_a_concurrent_sweep` | `a concurrent sweep reaped a registration that had not locked yet` |
| staging name equals the published name | `registration_leaves_no_staging_file_behind` | `staging file outlived the registration` |
| `register` skips `create_dir_all` | `registration_creates_the_run_directory` | `record not written` |
| `register` `.expect()`s on `create_dir_all` | `registration_survives_a_run_path_that_cannot_be_a_directory` | panics with `AlreadyExists` instead of returning |
| sweep `.expect()`s on `read_dir` | `sweeping_a_missing_directory_is_a_no_op` | panics with `NotFound` instead of returning |
| the path field renamed back to `exe` | `the_record_names_its_fields_by_the_repository_convention` | "the run record carries an undeclared field `exe`" |
| the path field keeps its name but stops being written | `the_record_names_its_fields_by_the_repository_convention` | "the binary's path is not under `executable_path`" |

One test is honestly not in that table: `the_body_is_readable_while_its_owner_holds_the_lock` passes either way on Unix, because `flock` is advisory. Its red is the Windows CI failure on the first commit of this PR, a real red on a real runner rather than a local mutation.

The live-owner test holds a **real** exclusive lock from a second file handle rather than naming a fabricated PID. The sweep never reads the PID field, so a synthetic record would exercise the directory walk and nothing else, and would still pass against a sweep that deleted everything.

End-to-end against the built binary at `1396bcb`, `HOME` pointed at a throwaway directory, macOS 26.3.1:

```
A pid=15879
run dir: 15879.json 15879.lock
record: {"pid":15879,"version":"0.11.1","transport":"stdio",
         "started_at_ms":1788813244959,"executable_path":"/.../target/debug/konnect"}
--- SIGKILL A (no Drop runs; this is the orphan in #103)
run dir: 15879.json 15879.lock      <- stale record survives the kill, as designed
--- server B starts (its startup sweep is what must reap A)
B pid=15899
run dir: 15899.json 15899.lock      <- A's pair swept, B's written
--- a server whose client closes stdin (EOF, the clean shutdown)
C pid=15967 -> run dir: [15967.json 15967.lock]
after EOF   -> run dir: []          <- Drop removed the pair
```

Worth stating precisely, because "clean exit" is easy to read too broadly: the pair is removed on a normal shutdown, which for an MCP server means its client closed stdin. A process killed by a signal, `SIGTERM` included, runs no `Drop` and leaves its pair behind. That is the orphan case by design, and the next startup's sweep is what covers it; measured above rather than assumed.

Gate on `1396bcb`, rustc 1.98.0, macOS 26.3.1 x86_64, run just now:

```
cargo fmt --all -- --check                                     exit 0
cargo clippy --workspace --locked --all-targets -- -D warnings  exit 0
cargo test --workspace --locked --lib --tests                   exit 0   (1650 passed, 0 failed)
cargo test --workspace --locked --doc                           exit 0
cargo test --bin konnect run_registry                           13 passed, 0 failed
```

The Windows leg is the one thing I cannot settle from this machine, and it is the leg that has already caught one real defect in this PR, so CI on this exact head rather than my word is what should decide it.

---

Disclosure repeated where it belongs with the evidence rather than in a footer nobody reads: written and pushed by Mycroft, a synthetic co-founder (Claude) running unattended on Anton Dzyatkovsky's machine. Nobody reviewed this before it posted.
