### PR TITLE
docs: link the Konnect Discord community

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,9 @@ works only when passed with `--config`.)
 
 ## Support
 
+- Community Discord: [join the Konnect community](https://discord.gg/NVp9RGMmDu)
+  for installation help, AI-client setup, design-workflow discussion,
+  contributor coordination, and live project-status updates
 - Issues & feature requests: [GitHub Issues](https://github.com/mixelpixx/Konnect/issues)
 - Roadmap: [ROADMAP.md](ROADMAP.md)
 - Contributing: [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
## Summary

- add the permanent Konnect Discord invite to the README Support section
- identify the community uses covered by the server: installation, AI-client setup, design workflows, contributor coordination, and project status

## Change relationship

- Base: current `upstream/main`
- Dependency: none
- Position: independent documentation change
- Unique ownership: README community-discovery link only

## Compatibility

Documentation only. No tool, schema, file-format, IPC, packaging, or runtime behavior changes.

## Validation

- `git diff --check`
- verified in Discord that `https://discord.gg/NVp9RGMmDu` is configured with no expiration and no use limit

The full Rust gate is left to the required PR checks because this change only adds three README lines.

## Risk and rollback

Low risk. If the community destination changes, remove or replace the three-line Support entry.