### PR TITLE
docs(governance): make validation risk-proportionate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,15 @@ The description should state:
 6. tests run, including intentionally skipped environment-dependent checks;
 7. risk and rollback notes for file formats, IPC, packaging, or release changes.
 
+You do not need personal access to every supported operating system, KiCad
+version, or hardware configuration. For an environment-dependent check you
+cannot run, name the missing environment, provide the deterministic and hosted
+CI evidence you can, and identify any original reporter or community tester who
+may be able to validate it. Maintainers apply the risk-proportionate validation
+rule in [GOVERNANCE.md](GOVERNANCE.md); an unavailable secondary observation is
+not automatically a blocked pull request, but required CI and material safety
+evidence remain mandatory.
+
 Treat MCP tools, schema fields, CLI flags, environment variables, config keys, and
 documented paths as public API. Preserve compatibility or provide an explicit
 migration. Keep generated artifacts, personal settings, downloaded catalogs, build

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -132,11 +132,38 @@ The house rule, and the reason most of this file exists:
 
 - **A response field must be derived from the result, never echoed from the
   request.** Most defects in this project's history are that one mistake.
-- **A check that could not run is `BLOCKED`, never a silent pass.**
+- **A check that could not run is `BLOCKED`, never a silent pass.** That status
+  describes the evidence item; it does not automatically decide whether the
+  whole pull request is blocked.
 - **Fixtures come from real KiCad output.** A hand-authored fixture tends to
   share the assumption the code got wrong, so it agrees with the bug.
 - **Neuter every new guard** and confirm the test catches it. A passing test
   proves nothing until you have watched it fail.
+
+### Risk-proportionate validation
+
+Required hosted CI, deterministic regression tests, and evidence for material
+safety properties remain hard merge gates. Environment-dependent observations
+are shared project work:
+
+- A contributor supplies real-environment evidence from an affected environment
+  they reasonably have access to. They are not expected to personally own every
+  supported operating system, KiCad version, or hardware configuration.
+- Hosted CI owns supported-platform regression coverage. Maintainers recruit the
+  original reporter or community testers when their environment can resolve a
+  remaining uncertainty more directly.
+- An unavailable secondary-environment observation may become explicit
+  validation debt when the change is focused and reversible, required CI is
+  green, deterministic coverage is adequate, and the unobserved path is not a
+  credible data-loss, security, or compatibility hazard. Name the untested
+  environment in the issue completion record or release checklist.
+- Missing evidence blocks the pull request when it is necessary to establish
+  the change's core behavior or a material safety property and no adequate test
+  or proxy exists. State that specific risk instead of requiring every platform
+  by default.
+
+Validation debt is permission to gather field evidence after a safe merge, not
+permission to represent an unavailable check as passed or to bypass required CI.
 
 ## Licensing
 


### PR DESCRIPTION
## Summary

Clarifies that an unavailable evidence item is not automatically a blocked pull request and introduces a risk-proportionate validation rule.

Cross-platform evidence is shared across contributors, hosted CI, maintainers, original reporters, and community testers. Contributors are not expected to personally own every supported environment.

Closes #445

## Behavior

- Required hosted CI, deterministic regression coverage, and material safety evidence remain hard gates.
- Missing secondary-environment observations may be carried as visible validation debt for focused, reversible, adequately tested changes.
- Missing evidence still blocks when it is needed to establish core behavior or a material safety property.
- Contributor guidance explains how to report an environment-dependent check they cannot run.

## Base and scope

- Base: current `upstream/main`
- Dependencies: none
- Documentation-only; no runtime behavior, public API, dependencies, generated files, or tool counts change.

## Validation

- `git diff --check`
- Reviewed rendered Markdown structure and links locally.
- Cargo tests were not run because the change is documentation-only; all required hosted checks must still pass on the exact PR head.

## Risk and rollback

The risk is policy ambiguity rather than runtime regression. The wording explicitly prevents the exception from bypassing required CI or material safety validation. Revert this single commit to roll back.