### PR TITLE
fix(ipc): bind operations to the requested board

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -260,8 +260,9 @@ Tool-call failures are typed via the `ToolErrorKind` enum in `crates/konnect-cor
 | `invalid_argument` | Required argument missing/malformed |
 | `file_not_found` | Referenced file or project-discovery directory does not exist or cannot be read |
 | `conflict` | The file changed, a write would replace existing paths, or schematic project ownership cannot be proven uniquely — carries the affected paths; ownership conflicts include the schematic directory and all candidate roots |
-| `ambiguous_target` | More than one observed UUID, reference/unit, field, or instance identity matches the requested target, or component instance records conflict across projects, units, or hierarchy paths — carries `target` and the stable `candidates`; the caller must choose rather than retrying blindly |
-| `stale_target` | Saved symbol instance metadata disagrees with the proven hierarchy, or component readback lacks the expected document, UUID/reference, unit, library, hierarchy, position, rotation, or property value — carries `target` and `reason`; preflight refuses before writing, while a readback failure may follow a committed write |
+| `wrong_document` | The requested PCB is not among KiCad's positively identified open documents — carries `requested` and `open_documents`; path-bearing IPC operations never substitute another open board |
+| `ambiguous_target` | More than one observed UUID, reference/unit, field, instance, or requested PCB document identity matches the requested target, or component instance records conflict across projects, units, or hierarchy paths — carries `target` and the stable `candidates`; the caller must choose rather than retrying blindly |
+| `stale_target` | A previously bound PCB document is no longer uniquely open, saved symbol instance metadata disagrees with the proven hierarchy, or component readback lacks the expected document, UUID/reference, unit, library, hierarchy, position, rotation, or property value — carries `target` and `reason`; preflight refuses before writing, while a readback failure may follow a committed write |
 | `ambiguous_open_board` | KiCad answered, and its open-document list could not be read as a complete set of comparable board identities — carries `path`; neither the live nor the file path may run |
 | `handler_error` | Catch-all for unmigrated `anyhow::Error` returns |
 

--- a/crates/konnect-core/src/mcp/error.rs
+++ b/crates/konnect-core/src/mcp/error.rs
@@ -58,6 +58,12 @@ pub enum ToolErrorKind {
         target: String,
         candidates: Vec<String>,
     },
+    /// The requested document is not the document set observed in the target
+    /// editor, so proceeding would answer about or mutate another file.
+    WrongDocument {
+        requested: String,
+        open_documents: Vec<String>,
+    },
     /// The caller named a target, but its observed editor or document state
     /// no longer agrees with the state required to mutate it safely.
     StaleTarget { target: String, reason: String },
@@ -85,6 +91,7 @@ impl ToolErrorKind {
             Self::FileNotFound { .. } => "file_not_found",
             Self::Conflict { .. } => "conflict",
             Self::AmbiguousTarget { .. } => "ambiguous_target",
+            Self::WrongDocument { .. } => "wrong_document",
             Self::StaleTarget { .. } => "stale_target",
             Self::UnsafeFileFallback { .. } => "unsafe_file_fallback",
             Self::AmbiguousOpenBoard { .. } => "ambiguous_open_board",
@@ -214,6 +221,10 @@ mod tests {
             ToolErrorKind::AmbiguousTarget {
                 target: "t".into(),
                 candidates: vec!["a".into(), "b".into()],
+            },
+            ToolErrorKind::WrongDocument {
+                requested: "p".into(),
+                open_documents: vec!["a".into()],
             },
             ToolErrorKind::StaleTarget {
                 target: "p".into(),

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -415,6 +415,120 @@ fn warn_if_ipc_unreachable(address: &str, error: &anyhow::Error) {
     );
 }
 
+/// Convert an IPC board-target refusal into the stable MCP error taxonomy.
+pub(crate) fn ipc_target_error_result(error: &konnect_ipc::BoardTargetError) -> CallToolResult {
+    use konnect_ipc::BoardTargetError;
+
+    let message = format!("{}. Konnect did not read or modify another board.", error);
+    match error {
+        BoardTargetError::NoOpenDocuments { requested } => CallToolResult::error_kind(
+            crate::mcp::error::ToolErrorKind::WrongDocument {
+                requested: requested.clone(),
+                open_documents: Vec::new(),
+            },
+            message,
+        ),
+        BoardTargetError::WrongDocument {
+            requested,
+            open_documents,
+        } => CallToolResult::error_kind(
+            crate::mcp::error::ToolErrorKind::WrongDocument {
+                requested: requested.clone(),
+                open_documents: open_documents.clone(),
+            },
+            message,
+        ),
+        BoardTargetError::AmbiguousDocument {
+            requested,
+            candidates,
+        } => CallToolResult::error_kind(
+            crate::mcp::error::ToolErrorKind::AmbiguousTarget {
+                target: requested.clone(),
+                candidates: candidates.clone(),
+            },
+            message,
+        ),
+        BoardTargetError::UnresolvedDocumentIdentities { requested, .. } => {
+            CallToolResult::error_kind(
+                crate::mcp::error::ToolErrorKind::AmbiguousOpenBoard {
+                    path: requested.clone(),
+                },
+                message,
+            )
+        }
+        BoardTargetError::StaleDocument {
+            requested,
+            previously_bound,
+            open_documents,
+        } => CallToolResult::error_kind(
+            crate::mcp::error::ToolErrorKind::StaleTarget {
+                target: requested.clone(),
+                reason: format!(
+                    "previously bound document '{}' is no longer uniquely open; observed [{}]",
+                    previously_bound,
+                    open_documents.join(", ")
+                ),
+            },
+            message,
+        ),
+    }
+}
+
+#[cfg(test)]
+mod ipc_target_error_tests {
+    use super::*;
+
+    #[test]
+    fn ipc_document_target_failures_keep_distinct_structured_kinds() {
+        let cases = [
+            (
+                konnect_ipc::BoardTargetError::NoOpenDocuments {
+                    requested: "target.kicad_pcb".to_string(),
+                },
+                "wrong_document",
+            ),
+            (
+                konnect_ipc::BoardTargetError::WrongDocument {
+                    requested: "target.kicad_pcb".to_string(),
+                    open_documents: vec!["other.kicad_pcb".to_string()],
+                },
+                "wrong_document",
+            ),
+            (
+                konnect_ipc::BoardTargetError::AmbiguousDocument {
+                    requested: "target.kicad_pcb".to_string(),
+                    candidates: vec!["target.kicad_pcb".to_string(); 2],
+                },
+                "ambiguous_target",
+            ),
+            (
+                konnect_ipc::BoardTargetError::StaleDocument {
+                    requested: "target.kicad_pcb".to_string(),
+                    previously_bound: "target.kicad_pcb".to_string(),
+                    open_documents: vec!["other.kicad_pcb".to_string()],
+                },
+                "stale_target",
+            ),
+            (
+                konnect_ipc::BoardTargetError::UnresolvedDocumentIdentities {
+                    requested: "target.kicad_pcb".to_string(),
+                    reasons: vec!["unidentified document".to_string()],
+                },
+                "ambiguous_open_board",
+            ),
+        ];
+
+        for (error, expected_kind) in cases {
+            let result = ipc_target_error_result(&error);
+            assert!(result.is_error);
+            assert_eq!(
+                crate::mcp::error::extract_error_kind(&result).as_deref(),
+                Some(expected_kind)
+            );
+        }
+    }
+}
+
 // ─── Argument helpers ─────────────────────────────────────────────────────────
 
 /// Build a structured `InvalidArgument` CallToolResult. Used by the

--- a/crates/konnect-core/src/tools/pcb_board.rs
+++ b/crates/konnect-core/src/tools/pcb_board.rs
@@ -285,28 +285,7 @@ where
                  board open, so editing the file directly could be silently overwritten."
             ))))
         }
-        // KiCad answered, and the answer did not say. Not a refusal — it
-        // declined nothing — and emphatically not "not open": the file path
-        // is unlocked by *proving* the board closed, and this is the case
-        // where that proof does not exist.
-        Err(konnect_ipc::IpcFailure::Ambiguous(message)) => {
-            Ok(BoardWrite::Refused(CallToolResult::error_kind(
-                ToolErrorKind::AmbiguousOpenBoard {
-                    path: board_path.display().to_string(),
-                },
-                format!(
-                    "Konnect could not confirm whether KiCAD has this board open, so it did not \
-                     apply the {what}: {message}. The board file was not modified. Close the \
-                     documents KiCAD cannot identify, or open this board in KiCAD and retry."
-                ),
-            )))
-        }
-        // KiCad up on another project, or freshly launched with nothing open.
-        // Gated on the same observation as `Unreachable`: KiCad no longer
-        // holding a board this session already saw it hold is the #240
-        // hazard — a crash-and-restart, or a close mid-operation — and a
-        // reachable transport says nothing about the work that board carried.
-        Err(konnect_ipc::IpcFailure::BoardNotOpen(answer)) => {
+        Err(konnect_ipc::IpcFailure::Target { error, message }) if error.proves_not_open() => {
             if ctx.board_session.was_observed_live(board_path) {
                 Ok(BoardWrite::Refused(unsafe_file_fallback(
                     board_path,
@@ -314,9 +293,12 @@ where
                      has it open.",
                 )))
             } else {
-                Ok(BoardWrite::File(NoLiveBoard::NotOpen(answer)))
+                Ok(BoardWrite::File(NoLiveBoard::NotOpen(message)))
             }
         }
+        Err(konnect_ipc::IpcFailure::Target { error, .. }) => Ok(BoardWrite::Refused(
+            crate::tools::ipc_target_error_result(&error),
+        )),
         Err(konnect_ipc::IpcFailure::Unreachable(_)) => {
             if ctx.board_session.was_observed_live(board_path) {
                 Ok(BoardWrite::Refused(unsafe_file_fallback(
@@ -367,20 +349,7 @@ pub(crate) async fn refuse_if_board_open_in_kicad(
              there) and retry — this tool has no IPC path for a live board yet."
         )))),
         Err(konnect_ipc::IpcFailure::Rejected(_)) => Ok(None),
-        // Unlike `Rejected` — where KiCad answered about *this* board and said
-        // no, leaving the file demonstrably free — an unreadable open-document
-        // list says nothing about this board. Refuse rather than write.
-        Err(konnect_ipc::IpcFailure::Ambiguous(message)) => Ok(Some(CallToolResult::error_kind(
-            ToolErrorKind::AmbiguousOpenBoard {
-                path: board_path.display().to_string(),
-            },
-            format!(
-                "Konnect could not confirm whether KiCAD has this board open, so it did not \
-                     write the {what} to the file: {message}. Close the documents KiCAD cannot \
-                     identify, or make the edit in KiCAD."
-            ),
-        ))),
-        Err(konnect_ipc::IpcFailure::BoardNotOpen(_)) => {
+        Err(konnect_ipc::IpcFailure::Target { error, .. }) if error.proves_not_open() => {
             Ok(ctx.board_session.was_observed_live(board_path).then(|| {
                 unsafe_file_fallback(
                     board_path,
@@ -388,6 +357,9 @@ pub(crate) async fn refuse_if_board_open_in_kicad(
                      has it open.",
                 )
             }))
+        }
+        Err(konnect_ipc::IpcFailure::Target { error, .. }) => {
+            Ok(Some(crate::tools::ipc_target_error_result(&error)))
         }
         Err(konnect_ipc::IpcFailure::Unreachable(_)) => {
             Ok(ctx.board_session.was_observed_live(board_path).then(|| {
@@ -2553,7 +2525,7 @@ mod open_document_ambiguity_tests {
         let BoardWrite::Refused(result) = outcome else {
             panic!("the requested board open twice must not be resolved by order")
         };
-        assert_eq!(kind_of(&result).as_deref(), Some("ambiguous_open_board"));
+        assert_eq!(kind_of(&result).as_deref(), Some("ambiguous_target"));
         assert!(!entered, "no single document to address");
     }
 
@@ -2629,7 +2601,7 @@ mod open_document_ambiguity_tests {
         };
         let text = super::mounting_hole_tests::result_text(&result);
         assert!(!text.contains("rejected"), "{text}");
-        assert!(text.contains("could not confirm"), "{text}");
+        assert!(text.contains("cannot be compared safely"), "{text}");
     }
 
     /// A board this session watched KiCad hold stays protected: an unreadable
@@ -2939,7 +2911,7 @@ mod board_session_safety_tests {
         assert!(
             body["warning"]
                 .as_str()
-                .is_some_and(|warning| warning.contains("is not open in KiCAD")),
+                .is_some_and(|warning| warning.contains("is not open in KiCad")),
             "the warning must cover the path taken, not only an unreachable transport: {}",
             body["warning"]
         );

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -41,14 +41,10 @@ macro_rules! ipc {
                     msg
                 )))
             }
-            // "Not open" is its own answer, and so is "could not tell": these
-            // tools have no file path, so both are still errors, but neither
-            // must be dressed up as a KiCad refusal — the message from
-            // `find_open_board` names the boards KiCad does hold, or the ones
-            // it could not identify.
-            Err(konnect_ipc::IpcFailure::BoardNotOpen(msg))
-            | Err(konnect_ipc::IpcFailure::Ambiguous(msg))
-            | Err(konnect_ipc::IpcFailure::Rejected(msg)) => return Ok(CallToolResult::error(msg)),
+            Err(konnect_ipc::IpcFailure::Target { error, .. }) => {
+                return Ok(crate::tools::ipc_target_error_result(&error))
+            }
+            Err(konnect_ipc::IpcFailure::Rejected(msg)) => return Ok(CallToolResult::error(msg)),
         }
     }};
 }
@@ -3215,19 +3211,10 @@ async fn handle_get_component_pads(
         }
         // Unreachable, or reachable and holding some other board: either way
         // no live KiCad can be answering about this one, so read the file.
-        Err(konnect_ipc::IpcFailure::Unreachable(_))
-        | Err(konnect_ipc::IpcFailure::BoardNotOpen(_)) => {}
-        // Not that, though. The file is the fallback for a board no editor
-        // holds, and an open-document list Konnect could not read does not
-        // establish that — a live KiCad may hold newer state, so answering
-        // from the file would present a stale board as the board.
-        Err(konnect_ipc::IpcFailure::Ambiguous(message)) => {
-            return Ok(CallToolResult::error_kind(
-                crate::mcp::error::ToolErrorKind::AmbiguousOpenBoard {
-                    path: board_path.display().to_string(),
-                },
-                message,
-            ));
+        Err(konnect_ipc::IpcFailure::Unreachable(_)) => {}
+        Err(konnect_ipc::IpcFailure::Target { error, .. }) if error.proves_not_open() => {}
+        Err(konnect_ipc::IpcFailure::Target { error, .. }) => {
+            return Ok(crate::tools::ipc_target_error_result(&error));
         }
         Err(konnect_ipc::IpcFailure::Rejected(message)) => {
             return Ok(CallToolResult::error(message));

--- a/crates/konnect-core/src/tools/pcb_routing.rs
+++ b/crates/konnect-core/src/tools/pcb_routing.rs
@@ -23,6 +23,9 @@ macro_rules! ipc {
         let requested_board = get_path($args, "board")?;
         match with_board_ipc_classified($ctx, &requested_board, move |$c| $body).await? {
             Ok(v) => v,
+            Err(konnect_ipc::IpcFailure::Target { error, .. }) => {
+                return Ok(crate::tools::ipc_target_error_result(&error))
+            }
             Err(error) => {
                 return Ok(CallToolResult::error(format!(
                     "KiCAD must be running with the board loaded (IPC error: {})",

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -320,81 +320,87 @@ pub fn is_transport_unreachable(error: &anyhow::Error) -> bool {
         .any(|cause| cause.is::<TransportUnreachable>())
 }
 
-/// Marker error carried (via anyhow's error chain) when KiCad answered and
-/// does not hold the requested board: another project is open, or no board is.
+/// A board-bearing operation could not resolve one exact live KiCad document.
 ///
-/// It carries its own message rather than taking one from `.context()`, so
-/// the classified failure reads as the one sentence a caller shows the user
-/// — a context line *and* a marker `Display` would say it twice.
-///
-/// Callers must classify with [`IpcFailure::from_error`], never by matching
-/// error text.
-#[derive(Debug)]
-pub struct BoardNotOpen(String);
+/// `NoOpenDocuments` and `WrongDocument` positively prove that the requested
+/// board is not open and may therefore permit the guarded file fallback.
+/// `AmbiguousDocument` and `StaleDocument` do not prove absence and must fail
+/// closed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BoardTargetError {
+    NoOpenDocuments {
+        requested: String,
+    },
+    WrongDocument {
+        requested: String,
+        open_documents: Vec<String>,
+    },
+    AmbiguousDocument {
+        requested: String,
+        candidates: Vec<String>,
+    },
+    UnresolvedDocumentIdentities {
+        requested: String,
+        reasons: Vec<String>,
+    },
+    StaleDocument {
+        requested: String,
+        previously_bound: String,
+        open_documents: Vec<String>,
+    },
+}
 
-impl BoardNotOpen {
-    fn err(message: String) -> anyhow::Error {
-        anyhow::Error::new(Self(message))
+impl BoardTargetError {
+    pub fn proves_not_open(&self) -> bool {
+        matches!(
+            self,
+            Self::NoOpenDocuments { .. } | Self::WrongDocument { .. }
+        )
     }
 }
 
-impl std::fmt::Display for BoardNotOpen {
+impl std::fmt::Display for BoardTargetError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(&self.0)
+        match self {
+            Self::NoOpenDocuments { requested } => write!(
+                formatter,
+                "requested board '{requested}' is not open because KiCad reports no PCB documents"
+            ),
+            Self::WrongDocument {
+                requested,
+                open_documents,
+            } => write!(
+                formatter,
+                "requested board '{requested}' is not open in KiCad (open boards: {})",
+                open_documents.join(", ")
+            ),
+            Self::AmbiguousDocument {
+                requested,
+                candidates,
+            } => write!(
+                formatter,
+                "requested board '{requested}' cannot be resolved uniquely ({})",
+                candidates.join("; ")
+            ),
+            Self::UnresolvedDocumentIdentities { requested, reasons } => write!(
+                formatter,
+                "KiCad's open documents cannot be compared safely with requested board '{requested}' ({})",
+                reasons.join("; ")
+            ),
+            Self::StaleDocument {
+                requested,
+                previously_bound,
+                open_documents,
+            } => write!(
+                formatter,
+                "requested board '{requested}' was bound to '{previously_bound}', but that document is no longer uniquely open (open boards: {})",
+                open_documents.join(", ")
+            ),
+        }
     }
 }
 
-impl std::error::Error for BoardNotOpen {}
-
-/// The "nothing is open" half of [`BoardNotOpen`], shared by the two lookups
-/// that can hit it.
-fn no_board_open() -> anyhow::Error {
-    BoardNotOpen::err("No PCB document is open in KiCAD. Open a board file first.".to_string())
-}
-
-/// Marker error carried when KiCad's open-document list cannot be read as a
-/// complete set of comparable board identities — so whether it holds the
-/// requested board is *unknown*, not answered.
-///
-/// It exists because the alternative is worse than a wrong error message.
-/// [`BoardNotOpen`] tells a caller that KiCad has no unsaved state for this
-/// board and the saved file is authoritative, which is what permits a direct
-/// file write. Reaching that conclusion by discarding the records that could
-/// not be resolved turns "we could not tell" into "it is safe to overwrite".
-///
-/// Like [`BoardNotOpen`], it carries its own message and is classified by
-/// walking the error chain.
-#[derive(Debug)]
-pub struct AmbiguousOpenBoards(String);
-
-impl AmbiguousOpenBoards {
-    fn err(message: String) -> anyhow::Error {
-        anyhow::Error::new(Self(message))
-    }
-}
-
-impl std::fmt::Display for AmbiguousOpenBoards {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(&self.0)
-    }
-}
-
-impl std::error::Error for AmbiguousOpenBoards {}
-
-/// Whether `error` says KiCad's open-board list could not be read as a
-/// complete, comparable set. Walks the chain, never the message text.
-fn is_ambiguous_open_boards(error: &anyhow::Error) -> bool {
-    error.chain().any(|cause| cause.is::<AmbiguousOpenBoards>())
-}
-
-/// Whether `error` says KiCad is not holding the requested board.
-///
-/// Private: nothing outside the classification needs to ask this yet, and a
-/// caller that does can match [`IpcFailure::BoardNotOpen`]. Like
-/// [`IpcFailure::from_error`], it walks the chain — never the message text.
-fn is_board_not_open(error: &anyhow::Error) -> bool {
-    error.chain().any(|cause| cause.is::<BoardNotOpen>())
-}
+impl std::error::Error for BoardTargetError {}
 
 /// Why an IPC operation failed, for callers deciding whether a file-based
 /// fallback is safe.
@@ -404,19 +410,8 @@ fn is_board_not_open(error: &anyhow::Error) -> bool {
 /// KiCad can be holding the board, and editing the board file directly
 /// cannot race an editor.
 ///
-/// `BoardNotOpen` means KiCad answered and does not have the requested board
-/// open — a different project, or none at all. KiCad cannot be holding
-/// unsaved state for a board it never opened, so this is as safe to edit on
-/// disk as `Unreachable`, and it must not be reported as a refusal: KiCad
-/// declined nothing.
-///
-/// `Ambiguous` means KiCad answered and the answer could not be read as a
-/// complete set of comparable board identities, so whether it holds the
-/// requested board is unknown. It is deliberately not `BoardNotOpen`: absence
-/// has to be *proven* before a saved file may be treated as authoritative.
-/// It is not `Rejected` either, because KiCad declined nothing — reporting a
-/// refusal it never made is the misreading this classification exists to end.
-/// Fail closed, and say which it was.
+/// `Target` retains a typed board-identity decision. Only target errors whose
+/// [`BoardTargetError::proves_not_open`] is true may permit a file fallback.
 ///
 /// `Rejected` is everything else, including any error after a request was
 /// delivered (a receive timeout may mean KiCad is still processing it).
@@ -425,9 +420,11 @@ fn is_board_not_open(error: &anyhow::Error) -> bool {
 #[derive(Debug)]
 pub enum IpcFailure {
     Unreachable(String),
-    BoardNotOpen(String),
-    Ambiguous(String),
     Rejected(String),
+    Target {
+        error: BoardTargetError,
+        message: String,
+    },
 }
 
 impl IpcFailure {
@@ -436,12 +433,16 @@ impl IpcFailure {
     /// message text.
     pub fn from_error(error: anyhow::Error) -> Self {
         let message = format!("{error:#}");
-        if is_transport_unreachable(&error) {
+        if let Some(target) = error
+            .chain()
+            .find_map(|cause| cause.downcast_ref::<BoardTargetError>().cloned())
+        {
+            IpcFailure::Target {
+                error: target,
+                message,
+            }
+        } else if is_transport_unreachable(&error) {
             IpcFailure::Unreachable(message)
-        } else if is_ambiguous_open_boards(&error) {
-            IpcFailure::Ambiguous(message)
-        } else if is_board_not_open(&error) {
-            IpcFailure::BoardNotOpen(message)
         } else {
             IpcFailure::Rejected(message)
         }
@@ -450,9 +451,8 @@ impl IpcFailure {
     pub fn message(&self) -> &str {
         match self {
             IpcFailure::Unreachable(message)
-            | IpcFailure::BoardNotOpen(message)
-            | IpcFailure::Ambiguous(message)
-            | IpcFailure::Rejected(message) => message,
+            | IpcFailure::Rejected(message)
+            | IpcFailure::Target { message, .. } => message,
         }
     }
 }
@@ -467,6 +467,13 @@ pub struct KiCadIpcClient {
     socket_path: String,
     kicad_token: String,
     client_name: String,
+    bound_board: std::sync::Mutex<Option<BoundBoardTarget>>,
+}
+
+#[derive(Clone)]
+struct BoundBoardTarget {
+    requested: PathBuf,
+    document: kiapi::common::types::DocumentSpecifier,
 }
 
 impl KiCadIpcClient {
@@ -489,6 +496,7 @@ impl KiCadIpcClient {
             socket_path: effective_path,
             kicad_token: std::env::var("KICAD_API_TOKEN").unwrap_or_default(),
             client_name: format!("konnect-{}", std::process::id()),
+            bound_board: std::sync::Mutex::new(None),
         }
     }
 
@@ -660,10 +668,52 @@ impl KiCadIpcClient {
             .collect())
     }
 
-    /// Get the first open PCB's DocumentSpecifier (needed for most commands).
+    /// Get the uniquely targeted PCB document for generic board helpers.
+    ///
+    /// Once [`Self::find_open_board`] binds a requested board, this re-observes
+    /// the open-document set and carries the same typed target forward. It
+    /// never substitutes the first board in KiCad's list.
     fn get_board_document(&self) -> Result<kiapi::common::types::DocumentSpecifier> {
         let docs = self.get_open_documents()?;
-        docs.into_iter().next().ok_or_else(no_board_open)
+        let bound = self
+            .bound_board
+            .lock()
+            .map_err(|_| anyhow::anyhow!("bound board target lock is poisoned"))?
+            .clone();
+
+        if let Some(bound) = bound {
+            return match select_requested_board(&docs, &bound.requested) {
+                Ok(document) => {
+                    self.bind_board(bound.requested, document.clone())?;
+                    Ok(document)
+                }
+                Err(
+                    error @ (BoardTargetError::AmbiguousDocument { .. }
+                    | BoardTargetError::UnresolvedDocumentIdentities { .. }),
+                ) => Err(anyhow::Error::new(error)),
+                Err(_) => Err(anyhow::Error::new(BoardTargetError::StaleDocument {
+                    requested: bound.requested.display().to_string(),
+                    previously_bound: board_document_label(&bound.document),
+                    open_documents: board_document_labels(&docs),
+                })),
+            };
+        }
+
+        match docs.as_slice() {
+            [] => Err(anyhow::Error::new(BoardTargetError::NoOpenDocuments {
+                requested: "<unspecified>".to_string(),
+            })),
+            [document] => {
+                if let Ok(path) = board_document_identity(document) {
+                    self.bind_board(path, document.clone())?;
+                }
+                Ok(document.clone())
+            }
+            _ => Err(anyhow::Error::new(BoardTargetError::AmbiguousDocument {
+                requested: "<unspecified>".to_string(),
+                candidates: board_document_labels(&docs),
+            })),
+        }
     }
 
     /// Find the open document matching `requested`, so a path-bearing MCP
@@ -677,80 +727,25 @@ impl KiCadIpcClient {
         requested: &Path,
     ) -> Result<kiapi::common::types::DocumentSpecifier> {
         let docs = self.get_open_documents()?;
-        if docs.is_empty() {
-            return Err(no_board_open());
-        }
+        let document = select_requested_board(&docs, requested).map_err(anyhow::Error::new)?;
+        self.bind_board(requested.to_path_buf(), document.clone())?;
+        Ok(document)
+    }
 
-        // Resolve the whole list before deciding anything. A record that could
-        // not be resolved is not evidence that the requested board is absent,
-        // and dropping it where it is produced is what turned "we cannot tell"
-        // into "the saved file is authoritative" (#426).
-        let identities: Vec<_> = docs.iter().map(board_document_identity).collect::<Vec<_>>();
-        let requested_identity = comparable_identity(requested).map_err(|reason| {
-            AmbiguousOpenBoards::err(format!(
-                "the requested board '{}' {reason}, so KiCad's open boards cannot be compared \
-                 against it",
-                requested.display()
-            ))
-        })?;
-
-        // A positive match is the safe direction — it sends the operation to
-        // KiCad rather than to the file — but only when exactly one open
-        // document claims to be this board.
-        let matched: Vec<usize> = identities
-            .iter()
-            .enumerate()
-            .filter(|(_, identity)| identity.as_ref().is_ok_and(|id| *id == requested_identity))
-            .map(|(index, _)| index)
-            .collect();
-        if matched.len() == 1 {
-            return Ok(docs[matched[0]].clone());
-        }
-        if matched.len() > 1 {
-            return Err(AmbiguousOpenBoards::err(format!(
-                "KiCAD reports board '{}' open {} times, so Konnect cannot tell which document \
-                 an edit would reach",
-                requested.display(),
-                matched.len()
-            )));
-        }
-
-        // No match. Absence is only proven by a list that was read in full.
-        let unresolved: Vec<&str> = identities
-            .iter()
-            .filter_map(|identity| identity.as_ref().err().map(String::as_str))
-            .collect();
-        if !unresolved.is_empty() {
-            return Err(AmbiguousOpenBoards::err(format!(
-                "KiCAD has {} PCB document(s) open that Konnect cannot identify ({}), so it \
-                 cannot prove that board '{}' is closed",
-                unresolved.len(),
-                unresolved.join("; "),
-                requested.display()
-            )));
-        }
-
-        let open: Vec<&PathBuf> = identities
-            .iter()
-            .filter_map(|id| id.as_ref().ok())
-            .collect();
-        if let Some(duplicated) = first_duplicate(&open) {
-            return Err(AmbiguousOpenBoards::err(format!(
-                "KiCAD reports board '{}' open more than once, so its open-document list is not \
-                 one Konnect can read; it cannot prove that board '{}' is closed",
-                duplicated.display(),
-                requested.display()
-            )));
-        }
-
-        Err(BoardNotOpen::err(format!(
-            "requested board '{}' is not open in KiCAD (open boards: {})",
-            requested.display(),
-            open.iter()
-                .map(|path| path.display().to_string())
-                .collect::<Vec<_>>()
-                .join(", ")
-        )))
+    fn bind_board(
+        &self,
+        requested: PathBuf,
+        document: kiapi::common::types::DocumentSpecifier,
+    ) -> Result<()> {
+        *self
+            .bound_board
+            .lock()
+            .map_err(|_| anyhow::anyhow!("bound board target lock is poisoned"))? =
+            Some(BoundBoardTarget {
+                requested,
+                document,
+            });
+        Ok(())
     }
 
     /// Fail closed unless the requested board is open in the IPC session.
@@ -2822,6 +2817,97 @@ fn board_document_path(document: &kiapi::common::types::DocumentSpecifier) -> Op
         .filter(|project| !project.path.is_empty())
         .map(|project| PathBuf::from(&project.path).join(&path))
         .or(Some(path))
+}
+
+fn board_document_label(document: &kiapi::common::types::DocumentSpecifier) -> String {
+    board_document_identity(document)
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|reason| format!("<unidentified PCB document: {reason}>"))
+}
+
+fn board_document_labels(documents: &[kiapi::common::types::DocumentSpecifier]) -> Vec<String> {
+    documents.iter().map(board_document_label).collect()
+}
+
+/// Resolve exactly one requested board while retaining #407's safety rule:
+/// absence is only proven when every reported document identity is readable.
+fn select_requested_board(
+    documents: &[kiapi::common::types::DocumentSpecifier],
+    requested: &Path,
+) -> std::result::Result<kiapi::common::types::DocumentSpecifier, BoardTargetError> {
+    let requested_label = requested.display().to_string();
+    if documents.is_empty() {
+        return Err(BoardTargetError::NoOpenDocuments {
+            requested: requested_label,
+        });
+    }
+
+    let requested_identity = comparable_identity(requested).map_err(|reason| {
+        BoardTargetError::UnresolvedDocumentIdentities {
+            requested: requested_label.clone(),
+            reasons: vec![format!(
+                "requested path {reason}, so it cannot be compared with KiCad's documents"
+            )],
+        }
+    })?;
+    let identities = documents
+        .iter()
+        .map(board_document_identity)
+        .collect::<Vec<_>>();
+    let matched = identities
+        .iter()
+        .enumerate()
+        .filter(|(_, identity)| {
+            identity
+                .as_ref()
+                .is_ok_and(|path| *path == requested_identity)
+        })
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+
+    match matched.as_slice() {
+        [index] => return Ok(documents[*index].clone()),
+        [] => {}
+        _ => {
+            return Err(BoardTargetError::AmbiguousDocument {
+                requested: requested_label,
+                candidates: matched
+                    .iter()
+                    .map(|index| board_document_label(&documents[*index]))
+                    .collect(),
+            })
+        }
+    }
+
+    let unresolved = identities
+        .iter()
+        .filter_map(|identity| identity.as_ref().err().cloned())
+        .collect::<Vec<_>>();
+    if !unresolved.is_empty() {
+        return Err(BoardTargetError::UnresolvedDocumentIdentities {
+            requested: requested_label,
+            reasons: unresolved,
+        });
+    }
+
+    let open = identities
+        .iter()
+        .filter_map(|identity| identity.as_ref().ok())
+        .collect::<Vec<_>>();
+    if let Some(duplicated) = first_duplicate(&open) {
+        return Err(BoardTargetError::UnresolvedDocumentIdentities {
+            requested: requested_label,
+            reasons: vec![format!(
+                "KiCad reports '{}' open more than once",
+                duplicated.display()
+            )],
+        });
+    }
+
+    Err(BoardTargetError::WrongDocument {
+        requested: requested_label,
+        open_documents: open.iter().map(|path| path.display().to_string()).collect(),
+    })
 }
 
 /// One open PCB document as a path that can be compared with a requested

--- a/crates/konnect-ipc/src/lib.rs
+++ b/crates/konnect-ipc/src/lib.rs
@@ -9,7 +9,7 @@ pub mod transform;
 pub mod types;
 
 pub use client::{
-    is_transport_unreachable, BoardNotOpen, IpcFailure, KiCadIpcClient, TransportUnreachable,
+    is_transport_unreachable, BoardTargetError, IpcFailure, KiCadIpcClient, TransportUnreachable,
 };
 pub use endpoint::redact_endpoint;
 pub use socket::{candidate_socket_paths, detect_ipc_address};

--- a/crates/konnect-ipc/tests/mock_server_test.rs
+++ b/crates/konnect-ipc/tests/mock_server_test.rs
@@ -828,7 +828,13 @@ fn a_kicad_holding_another_board_classifies_as_not_open() {
             .unwrap_err(),
     );
     assert!(
-        matches!(failure, konnect_ipc::IpcFailure::BoardNotOpen(_)),
+        matches!(
+            failure,
+            konnect_ipc::IpcFailure::Target {
+                error: konnect_ipc::BoardTargetError::WrongDocument { .. },
+                ..
+            }
+        ),
         "unexpected classification: {failure:?}"
     );
     assert!(failure.message().contains("test.kicad_pcb"), "{failure:?}");
@@ -853,7 +859,13 @@ fn a_kicad_with_nothing_open_classifies_as_not_open() {
             .unwrap_err(),
     );
     assert!(
-        matches!(failure, konnect_ipc::IpcFailure::BoardNotOpen(_)),
+        matches!(
+            failure,
+            konnect_ipc::IpcFailure::Target {
+                error: konnect_ipc::BoardTargetError::NoOpenDocuments { .. },
+                ..
+            }
+        ),
         "unexpected classification: {failure:?}"
     );
 }
@@ -998,6 +1010,193 @@ fn doc_for(filename: &str) -> kiapi::common::types::DocumentSpecifier {
                 filename.to_string(),
             ),
         ),
+    }
+}
+
+#[test]
+fn generic_read_and_write_helpers_keep_the_bound_named_board() {
+    let captured = Arc::new(Mutex::new(Vec::<(String, String)>::new()));
+    let captured_in_mock = captured.clone();
+    let mock = spawn_mock(move |request| {
+        let message = request.message.expect("request must pack a command");
+        if message.type_url.ends_with("GetOpenDocuments") {
+            let response = kiapi::common::commands::GetOpenDocumentsResponse {
+                documents: vec![doc_for("other.kicad_pcb"), doc_for("target.kicad_pcb")],
+            };
+            return Some(reply_with(builders::pack_any(
+                &response,
+                "kiapi.common.commands.GetOpenDocumentsResponse",
+            )));
+        }
+        if message.type_url.ends_with("GetItems") {
+            let command =
+                kiapi::common::commands::GetItems::decode(message.value.as_slice()).unwrap();
+            let document = command.header.unwrap().document.unwrap();
+            captured_in_mock
+                .lock()
+                .unwrap()
+                .push(("read".to_string(), board_filename(&document)));
+            let response = kiapi::common::commands::GetItemsResponse {
+                header: None,
+                status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                items: Vec::new(),
+            };
+            return Some(reply_with(builders::pack_any(
+                &response,
+                "kiapi.common.commands.GetItemsResponse",
+            )));
+        }
+        if message.type_url.ends_with("CreateItems") {
+            let command =
+                kiapi::common::commands::CreateItems::decode(message.value.as_slice()).unwrap();
+            let document = command.header.unwrap().document.unwrap();
+            captured_in_mock
+                .lock()
+                .unwrap()
+                .push(("write".to_string(), board_filename(&document)));
+            let response = kiapi::common::commands::CreateItemsResponse {
+                header: None,
+                status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                created_items: vec![creation_result(
+                    kiapi::common::commands::ItemStatusCode::IscOk,
+                    "",
+                )],
+            };
+            return Some(reply_with(builders::pack_any(
+                &response,
+                "kiapi.common.commands.CreateItemsResponse",
+            )));
+        }
+        panic!("unexpected command {}", message.type_url);
+    });
+
+    let client = KiCadIpcClient::new(&mock.url);
+    client
+        .find_open_board(&mock_board("target.kicad_pcb"))
+        .expect("bind target");
+    client
+        .get_items(kiapi::common::types::KiCadObjectType::KotPcbFootprint)
+        .expect("generic read");
+    client
+        .create_items(vec![any_item()])
+        .expect("generic write");
+
+    assert_eq!(
+        *captured.lock().unwrap(),
+        [
+            ("read".to_string(), "target.kicad_pcb".to_string()),
+            ("write".to_string(), "target.kicad_pcb".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn zero_wrong_and_duplicate_open_document_sets_are_typed_target_failures() {
+    let cases = [
+        (Vec::new(), "no_open", mock_board("target.kicad_pcb")),
+        (
+            vec![doc_for("other.kicad_pcb")],
+            "wrong",
+            mock_board("target.kicad_pcb"),
+        ),
+        (
+            vec![doc_for("target.kicad_pcb"), doc_for("target.kicad_pcb")],
+            "ambiguous",
+            mock_board("target.kicad_pcb"),
+        ),
+    ];
+
+    for (documents, expected, requested) in cases {
+        let mock = spawn_mock(move |request| {
+            let message = request.message.expect("request must pack a command");
+            assert!(message.type_url.ends_with("GetOpenDocuments"));
+            let response = kiapi::common::commands::GetOpenDocumentsResponse {
+                documents: documents.clone(),
+            };
+            Some(reply_with(builders::pack_any(
+                &response,
+                "kiapi.common.commands.GetOpenDocumentsResponse",
+            )))
+        });
+        let client = KiCadIpcClient::new(&mock.url);
+        let failure = konnect_ipc::IpcFailure::from_error(
+            client
+                .find_open_board(&requested)
+                .expect_err("target selection must refuse"),
+        );
+        match (expected, failure) {
+            (
+                "no_open",
+                konnect_ipc::IpcFailure::Target {
+                    error: konnect_ipc::BoardTargetError::NoOpenDocuments { .. },
+                    ..
+                },
+            )
+            | (
+                "wrong",
+                konnect_ipc::IpcFailure::Target {
+                    error: konnect_ipc::BoardTargetError::WrongDocument { .. },
+                    ..
+                },
+            )
+            | (
+                "ambiguous",
+                konnect_ipc::IpcFailure::Target {
+                    error: konnect_ipc::BoardTargetError::AmbiguousDocument { .. },
+                    ..
+                },
+            ) => {}
+            (_, other) => panic!("unexpected target classification: {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn a_bound_document_disappearing_before_a_generic_command_is_stale() {
+    let observations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let observations_in_mock = observations.clone();
+    let mock = spawn_mock(move |request| {
+        let message = request.message.expect("request must pack a command");
+        assert!(message.type_url.ends_with("GetOpenDocuments"));
+        let count = observations_in_mock.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let response = kiapi::common::commands::GetOpenDocumentsResponse {
+            documents: if count == 0 {
+                vec![doc_for("target.kicad_pcb")]
+            } else {
+                vec![doc_for("other.kicad_pcb")]
+            },
+        };
+        Some(reply_with(builders::pack_any(
+            &response,
+            "kiapi.common.commands.GetOpenDocumentsResponse",
+        )))
+    });
+
+    let client = KiCadIpcClient::new(&mock.url);
+    client
+        .find_open_board(&mock_board("target.kicad_pcb"))
+        .expect("initial target binding");
+    let failure = konnect_ipc::IpcFailure::from_error(
+        client
+            .get_items(kiapi::common::types::KiCadObjectType::KotPcbFootprint)
+            .expect_err("closed bound document must refuse before GetItems"),
+    );
+    assert!(matches!(
+        failure,
+        konnect_ipc::IpcFailure::Target {
+            error: konnect_ipc::BoardTargetError::StaleDocument { .. },
+            ..
+        }
+    ));
+    assert_eq!(observations.load(std::sync::atomic::Ordering::SeqCst), 2);
+}
+
+fn board_filename(document: &kiapi::common::types::DocumentSpecifier) -> String {
+    match document.identifier.as_ref() {
+        Some(kiapi::common::types::document_specifier::Identifier::BoardFilename(name)) => {
+            name.clone()
+        }
+        other => panic!("expected board filename, got {other:?}"),
     }
 }
 

--- a/crates/konnect/tests/live_kicad_tools.rs
+++ b/crates/konnect/tests/live_kicad_tools.rs
@@ -678,7 +678,10 @@ fn real_kicad_open_documents_resolve_to_comparable_paths() {
     assert!(
         matches!(
             konnect_ipc::IpcFailure::from_error(error),
-            konnect_ipc::IpcFailure::BoardNotOpen(_)
+            konnect_ipc::IpcFailure::Target {
+                error: konnect_ipc::BoardTargetError::WrongDocument { .. },
+                ..
+            }
         ),
         "a complete open-document list must prove absence, not merely fail to confirm it"
     );


### PR DESCRIPTION
## Summary

Reconstructs #390 from current `upstream/main`, preserving the original contributor's commit authorship while reconciling exact-board IPC binding with the guarded file-fallback behavior merged in #407.

- binds generic IPC reads and writes to the exact typed `DocumentSpecifier` selected for the requested board
- re-observes that binding before every generic operation and refuses changed or disappeared targets
- preserves #407's safety boundary: file fallback is eligible only when KiCad positively proves the requested board is not open
- keeps unresolved open-document identities fail-closed as `ambiguous_open_board`
- reports duplicate requested targets as `ambiguous_target`, a different open board as `wrong_document`, and a disappeared binding as `stale_target`
- preserves the explicit low-level `*_in(DocumentSpecifier, ...)` APIs

This replaces the stale cumulative branch in #390. The focused commit remains authored by @dubesinhower.

Closes #384

## Validation

Passed on Windows against exact head `44c9893d9d3b485b18ad4f67b6a62f74d2aee571`:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo test --workspace --locked --lib --tests`
- `cargo test --workspace --locked --doc`
- focused `konnect-ipc` mock tests for requested-board-second read/write headers, zero/wrong/duplicate targets, and disappeared bindings
- focused board-session tests for #407 fallback and ambiguity behavior

Real multi-board KiCad GUI validation was not run in this reconstruction environment; the typed mock protocol tests cover the deterministic request headers and refusal paths. This remains explicit pre-release validation debt, not a merge-wall for the focused, reversible change.

## Risk and rollback

Risk is limited to IPC board-target selection and the error taxonomy returned when the requested live document cannot be proven. Reverting this single commit restores current-main behavior.

