### PR TITLE
docs(schematic): note label scope vs power symbols in instanced sheets

### DIFF
--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -39,7 +39,11 @@ pub fn tools() -> Vec<ToolDef> {
         tool!(
             "batch_connect_to_net",
             "Connect multiple component pins to a named net by adding net labels at each pin \
-             endpoint. Single file read → all labels inserted → single file write.",
+             endpoint. Single file read → all labels inserted → single file write. \
+             Labels are sheet-local: a sheet instanced N times gets N independent nets. \
+             Use add_power_symbol or a global_label for a rail shared by every instance, and \
+             only a local label for one that must stay per-instance — power symbols and \
+             global labels are one net across all sheets and instances.",
             json!({
                 "type": "object",
                 "properties": {

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -329,7 +329,10 @@ pub fn tools() -> Vec<ToolDef> {
         tool!(
             "connect_to_net",
             "Connect a pin to a named net by adding a short wire stub and a net label. \
-             Name the pin with reference + pin_number, or give its coordinates directly.",
+             Name the pin with reference + pin_number, or give its coordinates directly. \
+             The label is sheet-local: a sheet instanced N times gets N independent nets. \
+             A rail shared by every instance needs add_power_symbol or a global_label, \
+             which are one net across all sheets and instances.",
             json!({
                 "type": "object",
                 "properties": {

--- a/crates/konnect/assets/skills/kicad-schematic/SKILL.md
+++ b/crates/konnect/assets/skills/kicad-schematic/SKILL.md
@@ -156,10 +156,17 @@ connect_to_net(schematic, reference, pin_number, net)
 - Placing a label by hand with `add_schematic_net_label` instead? Take its
   rotation from `orientation_degrees` in `get_schematic_pin_locations`, or the
   text reads back across the symbol's pin names.
+- These labels are sheet-local. In a sheet placed more than once, each instance
+  gets its own independent copy of the net — right for per-instance signals,
+  wrong for a rail every instance must share. A shared rail takes
+  `add_power_symbol` or `add_schematic_net_label` with
+  `label_type: global_label`; both are one net across all sheets and instances.
 
 ### add_power_symbol
 
 Use for all power connections, in preference to labelling a pin with the rail name.
+The one exception is a rail that must stay separate per instance of a repeated
+sheet — see below.
 
 ```
 add_power_symbol(schematic, power_net, x, y, rotation?)
@@ -175,6 +182,11 @@ add_power_symbol(schematic, power_net, x, y, rotation?)
 - A power pin landing mid-segment on a wire gets its junction dot
   automatically, in either order: symbol onto an existing wire, or a wire
   routed across an already-placed symbol.
+- Power symbols are global: every `+5V` symbol on every sheet, and in every
+  instance of a sheet, joins one `+5V` net. A rail that must stay separate per
+  instance of a repeated sheet (each node's own 5V, say) takes a local net
+  label via `connect_to_net` instead — `power:+5V` there shorts all the
+  instances' rails together.
 
 ---
 
@@ -303,7 +315,7 @@ production-ready claim.
 3. **Always verify after changes** — run validation tools after placing and wiring
 4. **Use the grid** — all placements on 1.27mm grid
 5. **Search before placing** — use `search_symbols` to confirm lib_id exists
-6. **Power symbols for power** — use `add_power_symbol` for rails, not net labels
+6. **Power symbols for power** — use `add_power_symbol` for rails, not net labels; the exception is a rail that must stay separate per instance of a repeated sheet, which takes a local label because power symbols are global
 7. **Net labels for named signals** — keeps schematics readable
 8. **Save frequently** — call `save_project` after major operations
 9. **Load toolsets first** — check `get_active_toolsets()` and load what you need before starting

--- a/crates/konnect/assets/skills/kicad-schematic/references/wiring-patterns.md
+++ b/crates/konnect/assets/skills/kicad-schematic/references/wiring-patterns.md
@@ -86,6 +86,12 @@
 | Hierarchical label (`hierarchical_label`) | Sheet boundary | Interface pins on hierarchical sheet symbols |
 | Power symbol | Global | Power rails (+3V3, GND, VCC) |
 
+In a sheet placed more than once, a net label is a separate net in each
+instance, while a global label or power symbol is one net across every sheet
+and instance. A rail shared by all instances therefore needs a power symbol or
+global label; a rail private to each instance needs a net label — `power:+5V`
+inside a repeated sheet ties every instance's 5V together.
+
 ## Spacing Guidelines
 
 - Components: minimum 5.08mm (4 grid units) between component bodies


### PR DESCRIPTION
## Summary

Fixes #469

`batch_connect_to_net` and `connect_to_net` emit plain `(label …)` items (via `format_net_label`), which KiCad scopes to the sheet. In a sheet instanced N times that yields N independent nets — right for per-node signals, wrong for a rail every instance must share. Power symbols go the other way: `power:+5V` is one net across every sheet and instance, so using it for a per-node rail shorts all the instances together. Neither the tool descriptions nor the schematic skill said so; the skill's "use `add_power_symbol` for rails, not net labels" rule actively pointed at the wrong choice for the instanced case.

## Approach

Documentation only, no behaviour change:

- `batch_connect_to_net` and `connect_to_net` descriptions: state that the label is sheet-local, that an instanced sheet gets one net per instance, and that a shared rail needs `add_power_symbol` or a `global_label` (`connect_to_net` has the same trap, so it carries the same note rather than pointing at a tool in another toolset).
- `kicad-schematic/SKILL.md`: a bullet under `connect_to_net` on label scope, a bullet under `add_power_symbol` on power symbols being global (with the shorted-rails failure spelled out), and an exception clause on rule 6.
- `references/wiring-patterns.md`: a paragraph under the Net Label Types table tying scope to instanced sheets.

The `net_label`/`global_label`/`hierarchical_label` names in the docs are the `label_type` values `add_schematic_net_label` accepts, so they are left as they are.

## Branch and dependencies

Base: current `upstream/main` (326aa73). No dependencies; independent of the open navigation series (#391, #396–#401), whose hunks in `sch_batch.rs`/`sch_wiring.rs` do not touch these descriptions.

## Compatibility and safety

No public compatibility impact: tool names, schemas, and behaviour are unchanged; only description strings and installed skill text change. No tools added or removed, so the doc-count guard is unaffected.

## Validation

- [x] `cargo fmt --all -- --check` — clean (rustfmt parses both edited files, so the string-literal edits are syntactically sound)
- [ ] `cargo test -p konnect-core -p konnect --locked --lib` — not runnable on my machine: the `nng-sys` build script needs `cmake`, which is not installed here. The Rust diff is two description string literals; leaving the test/clippy/doc gates to CI.
- [ ] Real-KiCad check not run; the behaviour being documented is KiCad's own label/power-port scoping, as observed in the issue's QuadNode run.

## Review checklist

- [x] The diff is focused and contains no generated output, personal data, or unrelated cleanup.
- [x] The branch was based on latest `upstream/main`, not a release tag.
- [x] The PR shows only its unique commits and diff; no dependencies.
- [x] No new names; no public renames.
- [x] No behaviour change, so no new regression coverage.
- [x] No file or IPC mutations.
- [x] No tools added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
