### PR TITLE
feat(mcp): add a safe Unix stdio reload tool

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -77,7 +77,7 @@ Konnect/
 │   │       ├── router/
 │   │       │   ├── mod.rs           # ToolRouter: load/unload toolsets
 │   │       │   ├── registry.rs      # Static toolset metadata + tools_for() dispatcher
-│   │       │   └── meta_tools.rs    # 7 always-visible meta-tools
+│   │       │   └── meta_tools.rs    # 7 baseline meta-tools + Unix stdio reload
 │   │       └── tools/
 │   │           ├── mod.rs            # ToolDef, ToolContext, tool! macro, helpers, kicad_config_dir()
 │   │           ├── cli.rs            # kicad-cli v10 subprocess wrapper (verified against actual binary)
@@ -396,6 +396,7 @@ convention for other `kicad-cli`-calling code.
 ## Current Stats
 
 - **21 toolsets, 226 tools** + 7 meta-tools (4 routing + 2 observability + 1 runtime diagnostic — see `tool-directory.md`)
+- Unix stdio adds one conditional maintenance meta-tool, `reload_server`; it is not registered for HTTP, mixed transport, or Windows.
 - Baseline `tools/list`: 21 tools / ~2K tokens (starter kit + meta-tools)
 - Full-catalog `tools/list` (all loaded): 233 tools (226 registered + 7 meta) / ~25K tokens
 - **0 IPC stubs** (all protobuf methods implemented)

--- a/DEV.md
+++ b/DEV.md
@@ -396,7 +396,9 @@ convention for other `kicad-cli`-calling code.
 ## Current Stats
 
 - **21 toolsets, 226 tools** + 7 meta-tools (4 routing + 2 observability + 1 runtime diagnostic — see `tool-directory.md`)
-- Unix stdio adds one conditional maintenance meta-tool, `reload_server`; it is not registered for HTTP, mixed transport, or Windows.
+- The standalone Unix executable adds one conditional stdio maintenance meta-tool,
+  `reload_server`; it is not registered for an embedded server, HTTP, mixed
+  transport, or Windows.
 - Baseline `tools/list`: 21 tools / ~2K tokens (starter kit + meta-tools)
 - Full-catalog `tools/list` (all loaded): 233 tools (226 registered + 7 meta) / ~25K tokens
 - **0 IPC stubs** (all protobuf methods implemented)

--- a/crates/konnect-core/src/mcp/handler.rs
+++ b/crates/konnect-core/src/mcp/handler.rs
@@ -102,9 +102,10 @@ impl McpHandler {
         &self.observer
     }
 
-    /// Enable the Unix-only in-place reload tool for a server whose sole
-    /// transport is stdio. HTTP and mixed transports intentionally never call
-    /// this, so they neither advertise nor dispatch the operation.
+    /// Enable the Unix-only in-place reload tool for the standalone executable
+    /// when its sole transport is stdio. Embedded, HTTP, and mixed transports
+    /// intentionally never call this, so they neither advertise nor dispatch
+    /// the operation.
     pub fn enable_stdio_reload(&self) {
         #[cfg(unix)]
         self.reload.enable();

--- a/crates/konnect-core/src/mcp/handler.rs
+++ b/crates/konnect-core/src/mcp/handler.rs
@@ -20,6 +20,7 @@ use tracing::{debug, info, warn};
 #[derive(Clone)]
 pub struct McpHandler {
     ctx: Arc<crate::tools::ToolContext>,
+    reload: meta_tools::ReloadControl,
     sse_senders: Arc<RwLock<Vec<mpsc::Sender<Event>>>>,
     /// Raw-JSON-line notification sinks for non-SSE transports (stdio). A
     /// server-initiated notification (e.g. tools/list_changed) must reach the
@@ -88,6 +89,7 @@ impl McpHandler {
 
         Ok(McpHandler {
             ctx,
+            reload: meta_tools::ReloadControl::default(),
             sse_senders: Arc::new(RwLock::new(Vec::new())),
             notif_sinks: Arc::new(RwLock::new(Vec::new())),
             observer,
@@ -98,6 +100,18 @@ impl McpHandler {
     /// and `server_stats` that live on `ToolContext`.
     pub fn observer(&self) -> &CallObserver {
         &self.observer
+    }
+
+    /// Enable the Unix-only in-place reload tool for a server whose sole
+    /// transport is stdio. HTTP and mixed transports intentionally never call
+    /// this, so they neither advertise nor dispatch the operation.
+    pub fn enable_stdio_reload(&self) {
+        #[cfg(unix)]
+        self.reload.enable();
+    }
+
+    pub fn take_reload_request(&self) -> Option<meta_tools::ReloadPlan> {
+        self.reload.take()
     }
 
     pub async fn register_sse_sender(&self, tx: mpsc::Sender<Event>) {
@@ -191,7 +205,7 @@ impl McpHandler {
             // ── Tool listing ───────────────────────────────────────────────
             "tools/list" => {
                 // Meta-tools (always visible) + all domain tools (pre-loaded at startup)
-                let mut tools = meta_tools::meta_tool_descriptions();
+                let mut tools = meta_tools::meta_tool_descriptions_for(self.reload.is_enabled());
                 for def in self.ctx.router.active_tools().await {
                     tools.push(def.to_mcp_description());
                 }
@@ -282,7 +296,9 @@ impl McpHandler {
         args: &Value,
     ) -> (CallToolResult, CallStatus, Option<String>) {
         // Meta-tools always win.
-        if let Some(result) = meta_tools::handle_meta_tool(name, args, &self.ctx).await {
+        if let Some(result) =
+            meta_tools::handle_meta_tool_with_reload(name, args, &self.ctx, &self.reload).await
+        {
             if name == "load_toolset" || name == "unload_toolset" {
                 self.notify_tools_list_changed().await;
             }

--- a/crates/konnect-core/src/router/meta_tools.rs
+++ b/crates/konnect-core/src/router/meta_tools.rs
@@ -23,14 +23,133 @@ use crate::mcp::protocol::{CallToolResult, McpToolDescription};
 use crate::tools::ToolContext;
 use serde_json::{json, Value};
 use std::ffi::OsString;
+#[cfg(unix)]
+use std::fs::File;
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::os::fd::AsRawFd;
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ReloadPlan {
-    pub executable: PathBuf,
+    /// User-facing path of the installed binary. The open handle below is the
+    /// executable identity used for both validation and the eventual exec.
+    pub binary_path: PathBuf,
+    #[cfg(unix)]
+    executable: File,
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+    identity: ExecutableIdentity,
     pub arguments: Vec<OsString>,
+}
+
+impl ReloadPlan {
+    /// Resolve the platform's safest handoff for the candidate that passed the
+    /// version probe.
+    #[cfg(unix)]
+    pub fn validated_exec_path(&self) -> Result<PathBuf, String> {
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            // Linux can execute the open file itself, so a concurrent rename
+            // of the installation path cannot change the selected image.
+            Ok(executable_handle_path(&self.executable))
+        }
+
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        {
+            // macOS and the remaining Unix targets expose no portable fexecve.
+            // Recheck the open file and its pathname at the final handoff so a
+            // normal atomic build/install replacement is refused.
+            self.identity.verify(&self.executable, &self.binary_path)?;
+            Ok(self.binary_path.clone())
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn executable_handle_path(executable: &File) -> PathBuf {
+    PathBuf::from("/proc/self/fd").join(executable.as_raw_fd().to_string())
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ExecutableIdentity {
+    device: u64,
+    inode: u64,
+    length: u64,
+    modified_seconds: i64,
+    modified_nanoseconds: i64,
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+impl ExecutableIdentity {
+    fn from_metadata(metadata: &std::fs::Metadata) -> Self {
+        Self {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            length: metadata.len(),
+            modified_seconds: metadata.mtime(),
+            modified_nanoseconds: metadata.mtime_nsec(),
+        }
+    }
+
+    fn capture(executable: &File, path: &std::path::Path) -> Result<Self, String> {
+        let open = Self::from_metadata(
+            &executable
+                .metadata()
+                .map_err(|error| format!("cannot inspect open candidate: {error}"))?,
+        );
+        let named = Self::from_metadata(
+            &std::fs::metadata(path)
+                .map_err(|error| format!("cannot inspect candidate path: {error}"))?,
+        );
+        if open != named {
+            return Err("candidate path changed during validation".to_string());
+        }
+        Ok(open)
+    }
+
+    fn verify(&self, executable: &File, path: &std::path::Path) -> Result<(), String> {
+        let current = Self::capture(executable, path)?;
+        if current != *self {
+            return Err("candidate executable changed after its version probe".to_string());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(any(unix, test))]
+#[derive(Debug, PartialEq, Eq)]
+enum ReloadVersionRefusal {
+    Downgrade,
+    SameVersionNeedsOptIn,
+    Uncomparable,
+}
+
+#[cfg(any(unix, test))]
+fn validate_reload_version(
+    candidate: &str,
+    running: &str,
+    allow_same_version: bool,
+) -> Result<(), ReloadVersionRefusal> {
+    match crate::runtime_info::compare_konnect_versions(candidate, running) {
+        Some(std::cmp::Ordering::Less) => Err(ReloadVersionRefusal::Downgrade),
+        Some(std::cmp::Ordering::Equal) if !allow_same_version => {
+            Err(ReloadVersionRefusal::SameVersionNeedsOptIn)
+        }
+        None => Err(ReloadVersionRefusal::Uncomparable),
+        _ => Ok(()),
+    }
+}
+
+#[cfg(any(unix, test))]
+fn reload_arguments<I>(arguments: I) -> Vec<OsString>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    arguments.into_iter().skip(1).collect()
 }
 
 /// One-shot handoff between the core handler and the stdio transport. The
@@ -67,7 +186,7 @@ impl ReloadControl {
 }
 
 /// Return the always-visible meta-tool descriptions. `reload_server` is added
-/// only for a Unix server running stdio exclusively.
+/// only by the standalone Unix server when it runs stdio exclusively.
 pub fn meta_tool_descriptions() -> Vec<McpToolDescription> {
     meta_tool_descriptions_for(false)
 }
@@ -194,7 +313,7 @@ pub fn meta_tool_descriptions_for(reload_enabled: bool) -> Vec<McpToolDescriptio
         if reload_enabled {
             descriptions.push(McpToolDescription {
             name: "reload_server".to_string(),
-            description: "Replace this Unix stdio server with the verified Konnect binary now on disk while preserving the client-owned pipes and original command-line arguments. The transport stops accepting requests, flushes this response, and then performs the one-way exec. Loaded toolsets reset to startup state. Same-version development builds require allow_same_version=true."
+            description: "Replace this standalone Unix stdio server with the verified Konnect binary now on disk while preserving the client-owned pipes and original command-line arguments. The transport stops accepting requests and flushes this response, process bookkeeping is released, and then the validated executable identity is rechecked at the one-way exec handoff. Linux executes the open file directly. Loaded toolsets reset to startup state. Same-version development builds require allow_same_version=true."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
@@ -278,7 +397,26 @@ async fn handle_reload_server(args: &Value, reload: &ReloadControl) -> CallToolR
         }
     };
 
-    let disk_version = match crate::runtime_info::probe_konnect_version(&executable).await {
+    let candidate = match File::open(&executable) {
+        Ok(file) => file,
+        Err(error) => {
+            return CallToolResult::error_kind(
+                ToolErrorKind::HandlerError {
+                    reason: format!("cannot open candidate executable: {error}"),
+                },
+                format!(
+                    "reload_server could not open the Konnect binary at {}: {error}",
+                    executable.display()
+                ),
+            )
+        }
+    };
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    let candidate_probe_path = executable_handle_path(&candidate);
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    let candidate_probe_path = executable.clone();
+    let disk_version = match crate::runtime_info::probe_konnect_version(&candidate_probe_path).await
+    {
         Ok(version) => version,
         Err(status) => {
             return CallToolResult::error_kind(
@@ -292,22 +430,32 @@ async fn handle_reload_server(args: &Value, reload: &ReloadControl) -> CallToolR
             )
         }
     };
-    let running_version = env!("CARGO_PKG_VERSION");
-    match crate::runtime_info::compare_konnect_versions(&disk_version, running_version) {
-        Some(std::cmp::Ordering::Less) => {
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    let identity = match ExecutableIdentity::capture(&candidate, &executable) {
+        Ok(identity) => identity,
+        Err(reason) => {
             return CallToolResult::error_kind(
-                ToolErrorKind::InvalidArgument {
-                    field: "binary".to_string(),
+                ToolErrorKind::HandlerError {
+                    reason: reason.clone(),
+                },
+                format!("reload_server refused the candidate: {reason}"),
+            )
+        }
+    };
+    let running_version = env!("CARGO_PKG_VERSION");
+    let allow_same_version = args.get("allow_same_version").and_then(Value::as_bool) == Some(true);
+    match validate_reload_version(&disk_version, running_version, allow_same_version) {
+        Err(ReloadVersionRefusal::Downgrade) => {
+            return CallToolResult::error_kind(
+                ToolErrorKind::HandlerError {
                     reason: format!(
-                        "on-disk version {disk_version} is older than running version {running_version}"
+                        "candidate version {disk_version} is older than running version {running_version}"
                     ),
                 },
                 "reload_server refuses to downgrade the serving process.",
             )
         }
-        Some(std::cmp::Ordering::Equal)
-            if args.get("allow_same_version").and_then(Value::as_bool) != Some(true) =>
-        {
+        Err(ReloadVersionRefusal::SameVersionNeedsOptIn) => {
             return CallToolResult::error_kind(
                 ToolErrorKind::InvalidArgument {
                     field: "allow_same_version".to_string(),
@@ -318,7 +466,7 @@ async fn handle_reload_server(args: &Value, reload: &ReloadControl) -> CallToolR
                 "Set allow_same_version=true only when intentionally loading a development rebuild.",
             )
         }
-        None => {
+        Err(ReloadVersionRefusal::Uncomparable) => {
             return CallToolResult::error_kind(
                 ToolErrorKind::HandlerError {
                     reason: format!(
@@ -328,12 +476,15 @@ async fn handle_reload_server(args: &Value, reload: &ReloadControl) -> CallToolR
                 "reload_server could not prove that the candidate is not a downgrade.",
             )
         }
-        _ => {}
+        Ok(()) => {}
     }
 
     let plan = ReloadPlan {
-        executable: executable.clone(),
-        arguments: std::env::args_os().skip(1).collect(),
+        binary_path: executable.clone(),
+        executable: candidate,
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        identity,
+        arguments: reload_arguments(std::env::args_os()),
     };
     if let Err(reason) = reload.request(plan) {
         return CallToolResult::error_kind(
@@ -346,7 +497,7 @@ async fn handle_reload_server(args: &Value, reload: &ReloadControl) -> CallToolR
 
     CallToolResult::json(&json!({
         "reloading": true,
-        "binary": executable.display().to_string(),
+        "binary_path": executable.display().to_string(),
         "running_version": running_version,
         "candidate_version": disk_version,
         "arguments_preserved": true,
@@ -571,19 +722,109 @@ mod reload_tests {
         assert!(control.is_enabled());
 
         let plan = ReloadPlan {
-            executable: PathBuf::from("konnect"),
+            binary_path: std::env::current_exe().unwrap(),
+            #[cfg(unix)]
+            executable: File::open(std::env::current_exe().unwrap()).unwrap(),
+            #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+            identity: {
+                let path = std::env::current_exe().unwrap();
+                let file = File::open(&path).unwrap();
+                ExecutableIdentity::capture(&file, &path).unwrap()
+            },
             arguments: vec![OsString::from("--config"), OsString::from("custom.toml")],
         };
         control.request(plan).expect("first request queues");
         assert!(control
             .request(ReloadPlan {
-                executable: PathBuf::from("other"),
+                binary_path: std::env::current_exe().unwrap(),
+                #[cfg(unix)]
+                executable: File::open(std::env::current_exe().unwrap()).unwrap(),
+                #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+                identity: {
+                    let path = std::env::current_exe().unwrap();
+                    let file = File::open(&path).unwrap();
+                    ExecutableIdentity::capture(&file, &path).unwrap()
+                },
                 arguments: Vec::new(),
             })
             .is_err());
         let queued = control.take().expect("queued request");
         assert_eq!(queued.arguments[0], "--config");
         assert!(control.take().is_none());
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[test]
+    fn an_open_executable_handle_can_be_invoked_after_its_path_is_irrelevant() {
+        let directory = tempfile::tempdir().unwrap();
+        let copied_path = directory.path().join("reload-candidate");
+        std::fs::copy(std::env::current_exe().unwrap(), &copied_path).unwrap();
+        let executable = File::open(&copied_path).unwrap();
+        std::fs::remove_file(&copied_path).unwrap();
+        let output = std::process::Command::new(executable_handle_path(&executable))
+            .arg("--list")
+            .output()
+            .expect("the open test executable must be invokable through its descriptor");
+
+        assert!(output.status.success());
+    }
+
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+    #[test]
+    fn a_non_linux_unix_handoff_refuses_a_replaced_candidate() {
+        let directory = tempfile::tempdir().unwrap();
+        let copied_path = directory.path().join("reload-candidate");
+        let current = std::env::current_exe().unwrap();
+        std::fs::copy(&current, &copied_path).unwrap();
+        let executable = File::open(&copied_path).unwrap();
+        let identity = ExecutableIdentity::capture(&executable, &copied_path).unwrap();
+        let plan = ReloadPlan {
+            binary_path: copied_path.clone(),
+            executable,
+            identity,
+            arguments: Vec::new(),
+        };
+
+        assert_eq!(plan.validated_exec_path().unwrap(), copied_path);
+        std::fs::remove_file(&copied_path).unwrap();
+        std::fs::copy(current, &copied_path).unwrap();
+        assert!(plan.validated_exec_path().is_err());
+    }
+
+    #[test]
+    fn reload_version_policy_covers_upgrade_equal_downgrade_and_unknown() {
+        assert_eq!(validate_reload_version("0.12.0", "0.11.1", false), Ok(()));
+        assert_eq!(
+            validate_reload_version("0.11.0", "0.11.1", true),
+            Err(ReloadVersionRefusal::Downgrade)
+        );
+        assert_eq!(
+            validate_reload_version("0.11.1", "0.11.1", false),
+            Err(ReloadVersionRefusal::SameVersionNeedsOptIn)
+        );
+        assert_eq!(validate_reload_version("0.11.1", "0.11.1", true), Ok(()));
+        assert_eq!(
+            validate_reload_version("development", "0.11.1", true),
+            Err(ReloadVersionRefusal::Uncomparable)
+        );
+    }
+
+    #[test]
+    fn reload_preserves_every_original_argument_except_argv_zero() {
+        let arguments = reload_arguments([
+            OsString::from("konnect"),
+            OsString::from("--config"),
+            OsString::from("custom.toml"),
+            OsString::from("--stdio"),
+        ]);
+
+        assert_eq!(
+            arguments,
+            ["--config", "custom.toml", "--stdio"]
+                .into_iter()
+                .map(OsString::from)
+                .collect::<Vec<_>>()
+        );
     }
 
     #[tokio::test]

--- a/crates/konnect-core/src/router/meta_tools.rs
+++ b/crates/konnect-core/src/router/meta_tools.rs
@@ -1,10 +1,13 @@
-//! The 7 always-visible meta-tools.
+//! The 7 cross-platform meta-tools, plus an optional Unix stdio reload tool.
 //!
 //! Discovery / routing:
 //!   list_toolboxes()          — show every toolset with descriptions and load state
 //!   load_toolset(name)        — activate a toolset, expose its tools in tools/list
 //!   unload_toolset(name)      — deactivate a toolset, remove its tools from tools/list
 //!   get_active_toolsets()     — list currently loaded toolsets
+//!
+//! Maintenance (Unix, stdio-only):
+//!   reload_server(confirm)    — re-exec after the transport flushes the reply
 //!
 //! Observability:
 //!   get_recent_calls(limit?)  — last N tool calls (newest first) with timing + status
@@ -19,10 +22,58 @@ use crate::mcp::error::ToolErrorKind;
 use crate::mcp::protocol::{CallToolResult, McpToolDescription};
 use crate::tools::ToolContext;
 use serde_json::{json, Value};
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+use std::sync::{Arc, Mutex};
 
-/// Return the 7 meta-tool MCP descriptions (always in the tools/list response).
+#[derive(Debug, Clone)]
+pub struct ReloadPlan {
+    pub executable: PathBuf,
+    pub arguments: Vec<OsString>,
+}
+
+/// One-shot handoff between the core handler and the stdio transport. The
+/// handler validates and queues a reload; the transport performs it only after
+/// the JSON-RPC response and notifications have been flushed.
+#[derive(Debug, Clone, Default)]
+pub struct ReloadControl {
+    enabled: Arc<AtomicBool>,
+    pending: Arc<Mutex<Option<ReloadPlan>>>,
+}
+
+impl ReloadControl {
+    pub fn enable(&self) {
+        self.enabled.store(true, AtomicOrdering::Release);
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(AtomicOrdering::Acquire)
+    }
+
+    #[cfg(any(unix, test))]
+    fn request(&self, plan: ReloadPlan) -> Result<(), &'static str> {
+        let mut pending = self.pending.lock().map_err(|_| "reload state poisoned")?;
+        if pending.is_some() {
+            return Err("a reload is already pending");
+        }
+        *pending = Some(plan);
+        Ok(())
+    }
+
+    pub fn take(&self) -> Option<ReloadPlan> {
+        self.pending.lock().ok()?.take()
+    }
+}
+
+/// Return the always-visible meta-tool descriptions. `reload_server` is added
+/// only for a Unix server running stdio exclusively.
 pub fn meta_tool_descriptions() -> Vec<McpToolDescription> {
-    vec![
+    meta_tool_descriptions_for(false)
+}
+
+pub fn meta_tool_descriptions_for(reload_enabled: bool) -> Vec<McpToolDescription> {
+    let descriptions = vec![
         McpToolDescription {
             name: "list_toolboxes".to_string(),
             description:
@@ -135,7 +186,41 @@ pub fn meta_tool_descriptions() -> Vec<McpToolDescription> {
                 "required": []
             }),
         },
-    ]
+    ];
+
+    #[cfg(unix)]
+    {
+        let mut descriptions = descriptions;
+        if reload_enabled {
+            descriptions.push(McpToolDescription {
+            name: "reload_server".to_string(),
+            description: "Replace this Unix stdio server with the verified Konnect binary now on disk while preserving the client-owned pipes and original command-line arguments. The transport stops accepting requests, flushes this response, and then performs the one-way exec. Loaded toolsets reset to startup state. Same-version development builds require allow_same_version=true."
+                .to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "confirm": {
+                        "type": "boolean",
+                        "description": "Must be true. Guards against an accidental reload mid-task."
+                    },
+                    "allow_same_version": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Explicitly permit a same-version development rebuild. Downgrades are always refused."
+                    }
+                },
+                "required": ["confirm"]
+            }),
+            });
+        }
+        descriptions
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = reload_enabled;
+        descriptions
+    }
 }
 
 /// Attempt to handle a meta-tool call. Returns `None` if the name is not a meta-tool.
@@ -144,6 +229,17 @@ pub async fn handle_meta_tool(
     args: &Value,
     ctx: &std::sync::Arc<ToolContext>,
 ) -> Option<CallToolResult> {
+    handle_meta_tool_with_reload(name, args, ctx, &ReloadControl::default()).await
+}
+
+pub async fn handle_meta_tool_with_reload(
+    name: &str,
+    args: &Value,
+    ctx: &std::sync::Arc<ToolContext>,
+    reload: &ReloadControl,
+) -> Option<CallToolResult> {
+    #[cfg(not(unix))]
+    let _ = reload;
     match name {
         "list_toolboxes" => Some(handle_list_toolboxes(ctx).await),
         "load_toolset" => Some(handle_load_toolset(args, ctx).await),
@@ -152,8 +248,110 @@ pub async fn handle_meta_tool(
         "get_recent_calls" => Some(handle_get_recent_calls(args, ctx).await),
         "server_stats" => Some(handle_server_stats(ctx).await),
         "get_installation_info" => Some(handle_get_installation_info(ctx).await),
+        #[cfg(unix)]
+        "reload_server" if reload.is_enabled() => Some(handle_reload_server(args, reload).await),
         _ => None,
     }
+}
+
+#[cfg(unix)]
+async fn handle_reload_server(args: &Value, reload: &ReloadControl) -> CallToolResult {
+    if args.get("confirm").and_then(Value::as_bool) != Some(true) {
+        return CallToolResult::error_kind(
+            ToolErrorKind::InvalidArgument {
+                field: "confirm".to_string(),
+                reason: "must be true".to_string(),
+            },
+            "reload_server requires confirm=true.",
+        );
+    }
+
+    let executable = match std::env::current_exe() {
+        Ok(path) => path,
+        Err(error) => {
+            return CallToolResult::error_kind(
+                ToolErrorKind::HandlerError {
+                    reason: format!("cannot determine current executable: {error}"),
+                },
+                format!("reload_server could not find its own binary: {error}"),
+            )
+        }
+    };
+
+    let disk_version = match crate::runtime_info::probe_konnect_version(&executable).await {
+        Ok(version) => version,
+        Err(status) => {
+            return CallToolResult::error_kind(
+                ToolErrorKind::HandlerError {
+                    reason: format!("candidate probe failed: {status}"),
+                },
+                format!(
+                "reload_server refused the binary at {} because its version probe was {status}.",
+                executable.display()
+            ),
+            )
+        }
+    };
+    let running_version = env!("CARGO_PKG_VERSION");
+    match crate::runtime_info::compare_konnect_versions(&disk_version, running_version) {
+        Some(std::cmp::Ordering::Less) => {
+            return CallToolResult::error_kind(
+                ToolErrorKind::InvalidArgument {
+                    field: "binary".to_string(),
+                    reason: format!(
+                        "on-disk version {disk_version} is older than running version {running_version}"
+                    ),
+                },
+                "reload_server refuses to downgrade the serving process.",
+            )
+        }
+        Some(std::cmp::Ordering::Equal)
+            if args.get("allow_same_version").and_then(Value::as_bool) != Some(true) =>
+        {
+            return CallToolResult::error_kind(
+                ToolErrorKind::InvalidArgument {
+                    field: "allow_same_version".to_string(),
+                    reason: format!(
+                        "the candidate and running process both report {running_version}"
+                    ),
+                },
+                "Set allow_same_version=true only when intentionally loading a development rebuild.",
+            )
+        }
+        None => {
+            return CallToolResult::error_kind(
+                ToolErrorKind::HandlerError {
+                    reason: format!(
+                        "cannot compare candidate version {disk_version} with running version {running_version}"
+                    ),
+                },
+                "reload_server could not prove that the candidate is not a downgrade.",
+            )
+        }
+        _ => {}
+    }
+
+    let plan = ReloadPlan {
+        executable: executable.clone(),
+        arguments: std::env::args_os().skip(1).collect(),
+    };
+    if let Err(reason) = reload.request(plan) {
+        return CallToolResult::error_kind(
+            ToolErrorKind::HandlerError {
+                reason: reason.to_string(),
+            },
+            format!("reload_server could not queue the reload: {reason}"),
+        );
+    }
+
+    CallToolResult::json(&json!({
+        "reloading": true,
+        "binary": executable.display().to_string(),
+        "running_version": running_version,
+        "candidate_version": disk_version,
+        "arguments_preserved": true,
+        "toolsets_reset": true,
+    }))
 }
 
 async fn handle_list_toolboxes(ctx: &std::sync::Arc<ToolContext>) -> CallToolResult {
@@ -337,4 +535,77 @@ async fn handle_get_active_toolsets(ctx: &std::sync::Arc<ToolContext>) -> CallTo
             .filter_map(|t| t["tool_count"].as_u64())
             .sum::<u64>()
     }))
+}
+
+#[cfg(test)]
+mod reload_tests {
+    use super::*;
+    use crate::router::ToolRouter;
+    use crate::tools::ServerConfig;
+
+    fn context() -> Arc<ToolContext> {
+        Arc::new(ToolContext::new(
+            ServerConfig::default(),
+            Arc::new(ToolRouter::new()),
+        ))
+    }
+
+    #[test]
+    fn reload_registration_is_capability_gated() {
+        assert!(!meta_tool_descriptions_for(false)
+            .iter()
+            .any(|tool| tool.name == "reload_server"));
+
+        let enabled = meta_tool_descriptions_for(true);
+        assert_eq!(
+            enabled.iter().any(|tool| tool.name == "reload_server"),
+            cfg!(unix)
+        );
+    }
+
+    #[test]
+    fn reload_control_is_a_one_shot_handoff() {
+        let control = ReloadControl::default();
+        assert!(!control.is_enabled());
+        control.enable();
+        assert!(control.is_enabled());
+
+        let plan = ReloadPlan {
+            executable: PathBuf::from("konnect"),
+            arguments: vec![OsString::from("--config"), OsString::from("custom.toml")],
+        };
+        control.request(plan).expect("first request queues");
+        assert!(control
+            .request(ReloadPlan {
+                executable: PathBuf::from("other"),
+                arguments: Vec::new(),
+            })
+            .is_err());
+        let queued = control.take().expect("queued request");
+        assert_eq!(queued.arguments[0], "--config");
+        assert!(control.take().is_none());
+    }
+
+    #[tokio::test]
+    async fn reload_is_not_dispatched_when_disabled() {
+        let control = ReloadControl::default();
+        assert!(
+            handle_meta_tool_with_reload("reload_server", &json!({}), &context(), &control)
+                .await
+                .is_none()
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reload_requires_explicit_confirmation_before_any_probe() {
+        let control = ReloadControl::default();
+        control.enable();
+        let result =
+            handle_meta_tool_with_reload("reload_server", &json!({}), &context(), &control)
+                .await
+                .expect("enabled Unix reload dispatches");
+        assert!(result.is_error);
+        assert!(control.take().is_none());
+    }
 }

--- a/crates/konnect-core/src/runtime_info.rs
+++ b/crates/konnect-core/src/runtime_info.rs
@@ -237,7 +237,7 @@ pub(crate) async fn probe_konnect_version(path: &Path) -> Result<String, &'stati
     probe.version.ok_or(probe.status)
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, test))]
 pub(crate) fn compare_konnect_versions(candidate: &str, running: &str) -> Option<Ordering> {
     stable_version_cmp(candidate, running)
 }

--- a/crates/konnect-core/src/runtime_info.rs
+++ b/crates/konnect-core/src/runtime_info.rs
@@ -228,6 +228,20 @@ async fn probe_command_version(path: &Path, command_kind: VersionCommand) -> Ver
     }
 }
 
+/// Probe a Konnect executable for the version it reports. Reload validation
+/// uses the same parser and timeout as installation diagnostics so the two
+/// paths cannot disagree about whether a candidate is runnable.
+#[cfg(unix)]
+pub(crate) async fn probe_konnect_version(path: &Path) -> Result<String, &'static str> {
+    let probe = probe_command_version(path, VersionCommand::Konnect).await;
+    probe.version.ok_or(probe.status)
+}
+
+#[cfg(unix)]
+pub(crate) fn compare_konnect_versions(candidate: &str, running: &str) -> Option<Ordering> {
+    stable_version_cmp(candidate, running)
+}
+
 fn parse_konnect_version(line: &str) -> Option<&str> {
     let version = line.strip_prefix("konnect ")?.trim();
     (!version.is_empty() && !version.chars().any(char::is_whitespace)).then_some(version)

--- a/crates/konnect/src/ffi.rs
+++ b/crates/konnect/src/ffi.rs
@@ -75,6 +75,7 @@ pub unsafe extern "C" fn kicad_plugin_init(config_path: *const c_char) -> c_int 
         match McpHandler::new_with_config_resolution(server_config, config_resolution).await {
             Ok(handler) => match config.transport {
                 TransportMode::Stdio => {
+                    handler.enable_stdio_reload();
                     let _ = crate::transport::stdio::run_stdio(handler).await;
                 }
                 TransportMode::Http => {

--- a/crates/konnect/src/ffi.rs
+++ b/crates/konnect/src/ffi.rs
@@ -75,8 +75,11 @@ pub unsafe extern "C" fn kicad_plugin_init(config_path: *const c_char) -> c_int 
         match McpHandler::new_with_config_resolution(server_config, config_resolution).await {
             Ok(handler) => match config.transport {
                 TransportMode::Stdio => {
-                    handler.enable_stdio_reload();
-                    let _ = crate::transport::stdio::run_stdio(handler).await;
+                    // This server is embedded in the host process. Even on
+                    // Unix stdio, current_exe() names that host (for example
+                    // KiCad), not the Konnect cdylib, so in-place reload is a
+                    // standalone-binary capability and is not enabled here.
+                    run_embedded_stdio(handler).await;
                 }
                 TransportMode::Http => {
                     let _ = crate::transport::http::run_http(handler, &config.http_address).await;
@@ -86,7 +89,7 @@ pub unsafe extern "C" fn kicad_plugin_init(config_path: *const c_char) -> c_int 
                     let http_addr = config.http_address.clone();
                     tokio::select! {
                         _ = crate::transport::http::run_http(handler_http, &http_addr) => {},
-                        _ = crate::transport::stdio::run_stdio(handler) => {},
+                        _ = run_embedded_stdio(handler) => {},
                     }
                 }
             },
@@ -97,6 +100,23 @@ pub unsafe extern "C" fn kicad_plugin_init(config_path: *const c_char) -> c_int 
     });
 
     RUNTIME.set(rt).is_ok() as c_int
+}
+
+async fn run_embedded_stdio(handler: konnect_core::mcp::handler::McpHandler) {
+    match crate::transport::stdio::run_stdio(handler).await {
+        Ok(crate::transport::stdio::StdioExit::Eof) => {}
+        #[cfg(unix)]
+        Ok(crate::transport::stdio::StdioExit::Reload(plan)) => {
+            // Defense in depth: embedded handlers never enable this request.
+            // If that invariant regresses, consume and refuse the handoff
+            // instead of replacing the KiCad host process.
+            eprintln!(
+                "kicad_plugin_init: refused an embedded reload request for {}",
+                plan.binary_path.display()
+            );
+        }
+        Err(error) => eprintln!("kicad_plugin_init: stdio transport failed: {error}"),
+    }
 }
 
 /// Return the plugin version string.

--- a/crates/konnect/src/main.rs
+++ b/crates/konnect/src/main.rs
@@ -185,6 +185,7 @@ async fn main() -> Result<()> {
 
     match config.transport {
         TransportMode::Stdio => {
+            handler.enable_stdio_reload();
             transport::stdio::run_stdio(handler).await?;
         }
         TransportMode::Http => {

--- a/crates/konnect/src/main.rs
+++ b/crates/konnect/src/main.rs
@@ -186,7 +186,17 @@ async fn main() -> Result<()> {
     match config.transport {
         TransportMode::Stdio => {
             handler.enable_stdio_reload();
-            transport::stdio::run_stdio(handler).await?;
+            match transport::stdio::run_stdio(handler).await? {
+                transport::stdio::StdioExit::Eof => {}
+                #[cfg(unix)]
+                transport::stdio::StdioExit::Reload(plan) => {
+                    // exec does not run destructors. Release the old process's
+                    // run-registry pair explicitly so the replacement can
+                    // register the same PID without leaving stale state.
+                    drop(_run_record);
+                    exec_reload(plan)?;
+                }
+            }
         }
         TransportMode::Http => {
             transport::http::run_http(handler, &config.http_address).await?;
@@ -212,6 +222,25 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Replace the standalone process through the platform-specific validated
+/// handoff selected by the handler. Keeping this in the binary entry point
+/// makes the embedded library structurally incapable of invoking it.
+#[cfg(unix)]
+fn exec_reload(plan: konnect_core::router::meta_tools::ReloadPlan) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+
+    let executable = plan
+        .validated_exec_path()
+        .map_err(|reason| anyhow::anyhow!("reload_server refused final handoff: {reason}"))?;
+    let error = std::process::Command::new(executable)
+        .args(&plan.arguments)
+        .exec();
+    Err(anyhow::anyhow!(
+        "reload_server failed to exec {}: {error}",
+        plan.binary_path.display()
+    ))
 }
 
 /// Help for one subcommand, or the whole program.

--- a/crates/konnect/src/transport/stdio.rs
+++ b/crates/konnect/src/transport/stdio.rs
@@ -5,9 +5,15 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info};
 
+pub enum StdioExit {
+    Eof,
+    #[cfg(unix)]
+    Reload(konnect_core::router::meta_tools::ReloadPlan),
+}
+
 /// Run the MCP server over STDIO (stdin/stdout).
 /// All logging must go to stderr — stdout is reserved for the MCP protocol.
-pub async fn run_stdio(handler: McpHandler) -> Result<()> {
+pub async fn run_stdio(handler: McpHandler) -> Result<StdioExit> {
     info!("Starting STDIO transport");
 
     let stdin = tokio::io::stdin();
@@ -77,23 +83,15 @@ pub async fn run_stdio(handler: McpHandler) -> Result<()> {
             stdout.flush().await?;
         }
 
-        // The handler only queues a reload; the stdio transport owns the
-        // irreversible step. Reaching this point proves the response and all
-        // synchronous notifications were flushed, and we exec before reading
-        // another request. That closes the old timer window where a second
-        // mutation could be interrupted before its guards were dropped.
+        // The handler only queues a reload. Reaching this point proves the
+        // response and all synchronous notifications were flushed. Return the
+        // sealed handoff before reading another request so the standalone
+        // process can release its run record and perform the exec.
         #[cfg(unix)]
         if let Some(plan) = handler.take_reload_request() {
-            use std::os::unix::process::CommandExt;
-            let error = std::process::Command::new(&plan.executable)
-                .args(&plan.arguments)
-                .exec();
-            return Err(anyhow::anyhow!(
-                "reload_server failed to exec {}: {error}",
-                plan.executable.display()
-            ));
+            return Ok(StdioExit::Reload(plan));
         }
     }
 
-    Ok(())
+    Ok(StdioExit::Eof)
 }

--- a/crates/konnect/src/transport/stdio.rs
+++ b/crates/konnect/src/transport/stdio.rs
@@ -76,6 +76,23 @@ pub async fn run_stdio(handler: McpHandler) -> Result<()> {
             stdout.write_all(json.as_bytes()).await?;
             stdout.flush().await?;
         }
+
+        // The handler only queues a reload; the stdio transport owns the
+        // irreversible step. Reaching this point proves the response and all
+        // synchronous notifications were flushed, and we exec before reading
+        // another request. That closes the old timer window where a second
+        // mutation could be interrupted before its guards were dropped.
+        #[cfg(unix)]
+        if let Some(plan) = handler.take_reload_request() {
+            use std::os::unix::process::CommandExt;
+            let error = std::process::Command::new(&plan.executable)
+                .args(&plan.arguments)
+                .exec();
+            return Err(anyhow::anyhow!(
+                "reload_server failed to exec {}: {error}",
+                plan.executable.display()
+            ));
+        }
     }
 
     Ok(())

--- a/crates/konnect/tests/doc_tool_counts.rs
+++ b/crates/konnect/tests/doc_tool_counts.rs
@@ -34,6 +34,8 @@ fn read(rel: &str) -> String {
 fn counts() -> (usize, usize, usize) {
     let toolsets = registry::ALL_TOOLSETS.len();
     let registered: usize = registry::ALL_TOOLSETS.iter().map(|t| t.tool_count).sum();
+    // Documentation quotes the cross-platform baseline. Unix stdio adds the
+    // optional reload_server tool at runtime without changing that baseline.
     let meta = konnect_core::router::meta_tools::meta_tool_descriptions().len();
     (toolsets, registered, meta)
 }

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -20,8 +20,9 @@ Compatibility notes for removed or narrowed arguments are recorded in
 ## Meta-tools (always visible)
 
 Seven cross-platform tools, grouped into *discovery/routing*, *observability*,
-and *runtime diagnostics*. A Unix server running exclusively over stdio also
-advertises `reload_server`; HTTP, mixed-transport, and Windows servers do not.
+and *runtime diagnostics*. The standalone Unix executable running exclusively
+over stdio also advertises `reload_server`; embedded, HTTP, mixed-transport,
+and Windows servers do not.
 
 ### Discovery / routing
 
@@ -49,7 +50,7 @@ advertises `reload_server`; HTTP, mixed-transport, and Windows servers do not.
 
 | Tool | Purpose |
 |------|---------|
-| `reload_server` | After explicit confirmation, validate the on-disk Konnect binary, preserve the original argv (including `--config`), flush the reply, stop accepting requests, and replace the current Unix stdio process image. Same-version development rebuilds require `allow_same_version=true`; downgrades are refused. |
+| `reload_server` | After explicit confirmation, open and validate the on-disk Konnect binary, preserve the original argv (including `--config`), flush the reply, stop accepting requests, release process bookkeeping, recheck the candidate identity at the final handoff, and replace the current standalone Unix stdio process image. Linux executes the open file directly. Same-version development rebuilds require `allow_same_version=true`; downgrades are refused. |
 
 ---
 

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -19,7 +19,9 @@ Compatibility notes for removed or narrowed arguments are recorded in
 
 ## Meta-tools (always visible)
 
-Seven tools, grouped into *discovery/routing*, *observability*, and *runtime diagnostics*.
+Seven cross-platform tools, grouped into *discovery/routing*, *observability*,
+and *runtime diagnostics*. A Unix server running exclusively over stdio also
+advertises `reload_server`; HTTP, mixed-transport, and Windows servers do not.
 
 ### Discovery / routing
 
@@ -42,6 +44,12 @@ Seven tools, grouped into *discovery/routing*, *observability*, and *runtime dia
 | Tool | Purpose |
 |------|---------|
 | `get_installation_info` | Report the serving build version and commit, executable path, verified install source, on-disk binary version, KiCad CLI version, redacted IPC endpoint, proven stale-process evidence, and platform-specific restart guidance. |
+
+### Unix stdio maintenance
+
+| Tool | Purpose |
+|------|---------|
+| `reload_server` | After explicit confirmation, validate the on-disk Konnect binary, preserve the original argv (including `--config`), flush the reply, stop accepting requests, and replace the current Unix stdio process image. Same-version development rebuilds require `allow_same_version=true`; downgrades are refused. |
 
 ---
 


### PR DESCRIPTION
Reconstructs #176 on current `main`, preserving Jean-Yves POCHEZ's original authorship while implementing the safety rework requested in review.

## What changed

- Keeps the existing seven meta-tools as the cross-platform baseline.
- Advertises and dispatches `reload_server` only from the standalone Unix executable when it runs exclusively over stdio.
- Does not expose the tool on Windows, HTTP, mixed HTTP+stdio, or embedded/KiCad-hosted sessions.
- Preserves every original argument after `argv[0]`, including an explicit `--config` path.
- Opens the installed executable once and proves its version before queuing the handoff.
- On Linux/Android, probes and executes the already-open file through `/proc/self/fd`, so a concurrent pathname replacement cannot change the selected executable.
- On macOS and other Unix targets without a portable `fexecve`, records device, inode, length, and modification time and revalidates both the open file and named path immediately before `exec`; ordinary atomic build/install replacement is refused.
- Refuses downgrades and requires `allow_same_version=true` for an intentional same-version development rebuild.
- Queues a one-shot reload plan instead of starting a timer inside the handler.
- Flushes the response and synchronous notifications, stops accepting requests, releases the run-registry record, and only then performs the one-way `exec`.
- Keeps the irreversible exec function in the standalone binary. The embedded library explicitly refuses any impossible reload handoff as defense in depth.

## Why the transport handoff matters

The original 250 ms timer allowed the stdio loop to accept a second mutation before `exec`, potentially interrupting a write before cleanup guards ran. The transport now returns a sealed handoff before reading another request. The standalone entry point drops its run-record guard before `exec`, so the replacement process can register the same PID cleanly.

## Evidence

Windows-local evidence:

- Focused reload tests cover capability gating, one-shot handoff, disabled dispatch, upgrade/equal/downgrade policy, and exact argument preservation.
- Negative control: temporarily neutralizing the downgrade refusal makes the version-policy regression test fail; restoring the guard makes it pass.
- Full gate passed:
  - `cargo fmt --all -- --check`
  - `cargo clippy --workspace --locked --all-targets -- -D warnings`
  - `cargo test --workspace --locked --lib --tests`
  - `cargo test --workspace --locked --doc`

Hosted Unix tests exercise the platform-specific handoff guards:

- Linux copies and opens the test executable, removes its pathname, and proves the open executable can still be invoked through its descriptor.
- macOS captures the candidate identity, proves an unchanged candidate is accepted, atomically replaces the named candidate, and proves the final handoff is refused.

## Risk and rollback

The tool is absent unless the process proves the supported capability combination. The irreversible action requires `confirm=true`; same-version builds require a second explicit opt-in. The PR contains the preserved contributor commit plus one focused safety/adaptation commit, either of which can be reverted normally.

Supersedes #176.