### PR TITLE
feat(schematic): place symbols mirrored

### DIFF
--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -549,8 +549,8 @@ async fn handle_batch_place_components(
             Ok(uuid) => {
                 let (expected_x, expected_y) = snap_point(x, y, 1.27);
                 placements.push(super::sch_components::ComponentTargetUnit::placement(
-                    &uuid, &context, lib_id, expected_x, expected_y, rotation, reference, value,
-                    unit,
+                    &uuid, &context, lib_id, expected_x, expected_y, rotation, mirror, reference,
+                    value, unit,
                 ));
             }
             Err(e) => errors.push(error_text(&e)),

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -85,6 +85,7 @@ pub fn tools() -> Vec<ToolDef> {
                                 "lib_id": { "type": "string" },
                                 "x": { "type": "number" }, "y": { "type": "number" },
                                 "rotation": { "type": "number", "default": 0 },
+                                "mirror": { "type": "string", "enum": ["x", "y", "none"], "description": "Reflect the placed symbol about an axis, using eeschema's own vocabulary: 'x' negates screen-Y, 'y' negates screen-X. Omit (or 'none') for an unmirrored symbol. Mirroring is applied after rotation, and is not interchangeable with rotation 180 for a symbol whose pins are not symmetric." },
                                 "reference": { "type": "string" },
                                 "value": { "type": "string" },
                                 "unit": { "type": "integer", "default": 1 }
@@ -514,6 +515,19 @@ async fn handle_batch_place_components(
             continue;
         };
         let rotation = comp["rotation"].as_f64().unwrap_or(0.0);
+        // One malformed entry refuses only itself, as every other per-entry
+        // problem in this loop does; the batch is not abandoned because a
+        // caller misspelled one axis.
+        let mirror = match super::sch_components::mirror_arg(comp, "mirror") {
+            Ok(mirror) => mirror,
+            Err(_) => {
+                errors.push(format!(
+                    "Invalid 'mirror' for '{}': expected \"x\", \"y\" or \"none\"",
+                    lib_id
+                ));
+                continue;
+            }
+        };
         let reference = comp["reference"].as_str().unwrap_or("?");
         let value = comp["value"].as_str();
         let unit = comp["unit"].as_f64().unwrap_or(1.0) as u32;
@@ -526,6 +540,7 @@ async fn handle_batch_place_components(
             x,
             y,
             rotation,
+            mirror,
             reference,
             value,
             unit,
@@ -1966,6 +1981,48 @@ mod batch_place_and_connect_tests {
         assert!(sch.symbols.by_reference("R1").is_some());
         assert!(sch.symbols.by_reference("R3").is_some());
         assert!(sch.symbols.by_reference("R2").is_none());
+    }
+
+    /// Per-component `mirror` reaches the file, and a misspelled axis refuses
+    /// only its own entry — the batch's other placements still land, as they
+    /// do for every other per-item problem here. Silently placing the third
+    /// symbol unmirrored would be the failure the argument exists to end
+    /// (#450).
+    #[tokio::test]
+    async fn batch_place_components_mirrors_per_component_and_refuses_a_bad_axis() {
+        let (_d, path) = seeded_schematic();
+        let result = handle_batch_place_components(
+            &json!({
+                "schematic": path.display().to_string(),
+                "components": [
+                    { "lib_id": "Device:R", "x": 100.0, "y": 100.0, "reference": "R1" },
+                    { "lib_id": "Device:R", "x": 110.0, "y": 100.0, "reference": "R2", "mirror": "y" },
+                    { "lib_id": "Device:R", "x": 120.0, "y": 100.0, "reference": "R3", "mirror": "Y" }
+                ]
+            }),
+            &test_ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error, "{result:?}");
+        let body = match &result.content[0] {
+            crate::mcp::protocol::ToolContent::Text { text } => text.clone(),
+            _ => panic!("expected text"),
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed["placed_count"], 2);
+        assert_eq!(parsed["errors"].as_array().unwrap().len(), 1);
+
+        let sch = cse::Schematic::load(&path).unwrap();
+        assert!(sch.symbols.by_reference("R3").is_none());
+        assert_eq!(
+            sch.symbols.by_reference("R1").unwrap().mirror.as_deref(),
+            None
+        );
+        assert_eq!(
+            sch.symbols.by_reference("R2").unwrap().mirror.as_deref(),
+            Some("y")
+        );
     }
 
     #[tokio::test]

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -7061,6 +7061,21 @@ mod multi_unit_component_tests {
         assert_eq!(placed[1].rotation, 270.0);
     }
 
+    /// The same real eeschema save as [`eeschema_fixture`], but written under
+    /// the file stem its own instance paths name (`ecc83-pp`). Placement
+    /// preflights the project name against those paths and rightly refuses a
+    /// mismatch, so a placement test needs the two to agree.
+    fn eeschema_placement_fixture() -> (tempfile::TempDir, std::path::PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("ecc83-pp.kicad_sch");
+        std::fs::write(
+            &path,
+            include_str!("../../tests/fixtures/ecc83_multiunit.kicad_sch"),
+        )
+        .unwrap();
+        (directory, path)
+    }
+
     /// A misspelled axis is a caller asking for a reflection. Placing the
     /// symbol unmirrored and reporting success is exactly the failure this
     /// argument exists to end, so the placement refuses and writes nothing.
@@ -7087,14 +7102,18 @@ mod multi_unit_component_tests {
 
     /// `"none"` is the explicit way to say unmirrored. It must place the
     /// symbol without a `(mirror ...)` token at all — eeschema has no
-    /// `(mirror none)` and would not load one.
+    /// `(mirror none)` and would not load one. Placed into a real eeschema
+    /// save, which already carries mirrored symbols of its own, so the
+    /// assertion has to be scoped to the symbol this test placed.
     #[tokio::test]
     async fn placing_with_mirror_none_writes_no_token() {
-        let (_directory, path) = fixture();
+        let (_directory, path) = eeschema_placement_fixture();
+        let before = std::fs::read_to_string(&path).unwrap();
+        let mirrors_before = before.matches("(mirror ").count();
         let result = handle_add_schematic_component(
             &json!({
                 "schematic": path,
-                "lib_id": "Device:R",
+                "lib_id": "ecc83-pp:R",
                 "x": 100.0,
                 "y": 40.0,
                 "reference": "R8",
@@ -7105,10 +7124,24 @@ mod multi_unit_component_tests {
         .await
         .unwrap();
         assert!(!result.is_error, "{result:?}");
-        let source = std::fs::read_to_string(&path).unwrap();
-        assert!(
-            !source.contains("(mirror"),
-            "no mirror token may be written"
+        let committed = cse::Schematic::load(&path).unwrap();
+        assert_eq!(
+            committed
+                .symbols
+                .iter()
+                .find(|symbol| symbol.reference() == Some("R8"))
+                .expect("placed symbol")
+                .mirror,
+            None,
+            "\"none\" must leave the symbol without a mirror token"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path)
+                .unwrap()
+                .matches("(mirror ")
+                .count(),
+            mirrors_before,
+            "no mirror token may be added, and none of the file's own may be lost"
         );
     }
 
@@ -7118,11 +7151,11 @@ mod multi_unit_component_tests {
     /// a mirrored symbol's fields sat on its unmirrored side.
     #[tokio::test]
     async fn placing_mirrored_reflects_the_body_and_its_field_anchors() {
-        let (_directory, path) = fixture();
+        let (_directory, path) = eeschema_placement_fixture();
         for (reference, x, mirror) in [("R8", 100.0, None), ("R9", 140.0, Some("y"))] {
             let mut args = json!({
                 "schematic": path,
-                "lib_id": "Device:R",
+                "lib_id": "ecc83-pp:R",
                 "x": x,
                 "y": 40.0,
                 "reference": reference
@@ -7135,9 +7168,18 @@ mod multi_unit_component_tests {
                 .unwrap();
             assert!(!result.is_error, "placement failed for {reference}");
         }
-        let source = std::fs::read_to_string(&path).unwrap();
-        assert_eq!(source.matches("(mirror y)").count(), 1);
         let committed = cse::Schematic::load(&path).unwrap();
+        let mirror_of = |reference: &str| -> Option<String> {
+            committed
+                .symbols
+                .iter()
+                .find(|symbol| symbol.reference() == Some(reference))
+                .expect("placed symbol")
+                .mirror
+                .clone()
+        };
+        assert_eq!(mirror_of("R8"), None);
+        assert_eq!(mirror_of("R9"), Some("y".to_string()));
         let field_x = |reference: &str| -> f64 {
             let symbol = committed
                 .symbols

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -96,6 +96,7 @@ pub fn tools() -> Vec<ToolDef> {
                     "x": { "type": "number", "description": "X position in mm" },
                     "y": { "type": "number", "description": "Y position in mm" },
                     "rotation": { "type": "number", "description": "Rotation in degrees (0/90/180/270)", "default": 0 },
+                    "mirror": { "type": "string", "enum": ["x", "y", "none"], "description": "Reflect the placed symbol about an axis, using eeschema's own vocabulary: 'x' negates screen-Y, 'y' negates screen-X. Omit (or 'none') for an unmirrored symbol. Mirroring is applied after rotation, and is not interchangeable with rotation 180 for a symbol whose pins are not symmetric." },
                     "reference": { "type": "string", "description": "Optional override for reference designator" },
                     "value": { "type": "string", "description": "Optional override for value field" },
                     "unit": { "type": "integer", "description": "Unit number for multi-unit symbols (gate/part selection). Default 1.", "default": 1 }
@@ -552,6 +553,10 @@ async fn handle_add_schematic_component(
         Err(e) => return Ok(e),
     };
     let rotation = opt_f64(args, "rotation").unwrap_or(0.0);
+    let mirror = match mirror_arg(args, "mirror") {
+        Ok(mirror) => mirror,
+        Err(e) => return Ok(e),
+    };
     let reference = opt_str(args, "reference");
     let value = opt_str(args, "value");
     let unit = opt_f64(args, "unit").unwrap_or(1.0) as u32;
@@ -585,6 +590,7 @@ async fn handle_add_schematic_component(
         x,
         y,
         rotation,
+        mirror,
         ref_str,
         value,
         unit,
@@ -618,6 +624,39 @@ async fn handle_add_schematic_component(
     Ok(CallToolResult::json(&result))
 }
 
+/// Read a placement `mirror` argument in eeschema's own vocabulary.
+///
+/// `"x"` and `"y"` are the axis names the file format uses; `"none"` and an
+/// absent argument both mean unmirrored, which eeschema records by omitting
+/// the token rather than writing one. Anything else is refused rather than
+/// silently dropped: a caller that misspells the axis is asking for a
+/// reflection, and placing the symbol unmirrored while reporting success is
+/// the failure this argument exists to end.
+///
+/// Returns `Ok(None)` for unmirrored so it can be handed straight to
+/// [`cse::Symbol::set_mirror`].
+pub(crate) fn mirror_arg<'a>(
+    args: &'a serde_json::Value,
+    key: &str,
+) -> Result<Option<&'a str>, CallToolResult> {
+    match &args[key] {
+        serde_json::Value::Null => Ok(None),
+        serde_json::Value::String(axis) => match axis.as_str() {
+            "x" => Ok(Some("x")),
+            "y" => Ok(Some("y")),
+            "none" => Ok(None),
+            other => Err(crate::tools::invalid_arg(
+                key,
+                &format!("expected \"x\", \"y\" or \"none\", got {other:?}"),
+            )),
+        },
+        _ => Err(crate::tools::invalid_arg(
+            key,
+            "expected a string: \"x\", \"y\" or \"none\"",
+        )),
+    }
+}
+
 /// Place one symbol into `sch`: embeds the lib_symbols definition, validates
 /// the unit, and adds the positioned instance. Does not write the file --
 /// callers own the read/write cycle (single-add and batch-add alike).
@@ -630,6 +669,7 @@ pub(crate) fn place_one_component(
     x: f64,
     y: f64,
     rotation: f64,
+    mirror: Option<&str>,
     reference: &str,
     value: Option<&str>,
     unit: u32,
@@ -659,6 +699,7 @@ pub(crate) fn place_one_component(
     // Build the Symbol struct
     let mut sym = cse::Symbol::new(lib_id, x, y);
     sym.at.rotation = Some(rotation);
+    sym.set_mirror(mirror);
     sym.unit = unit;
 
     // Reference and Value go where the library anchors them, carried through
@@ -671,12 +712,16 @@ pub(crate) fn place_one_component(
     // #PWR designator is never shown on the sheet.
     let hide_reference = lib_id.starts_with("power:") || reference.starts_with("#PWR");
     let anchors = cse::library::field_anchors(sch, lib_id);
+    // The anchors follow the placement, mirror included: a mirrored body puts
+    // its Reference and Value where the reflection lands them, exactly as a
+    // rotated body already did (#101). Hardcoding `false` here left a mirrored
+    // symbol's fields sitting on the unmirrored side of it.
     let t = konnect_sexp::geometry::PinTransform {
         comp_x: x,
         comp_y: y,
         rotation_deg: rotation,
-        mirror_x: false,
-        mirror_y: false,
+        mirror_x: mirror == Some("x"),
+        mirror_y: mirror == Some("y"),
     };
     let (ref_x, ref_y, ref_rot) =
         crate::tools::field_at(anchors.reference_at, crate::tools::FALLBACK_REFERENCE_AT, t);
@@ -1277,12 +1322,15 @@ fn component_mutation_readback_from_schematic(
                 );
             }
         }
+        let unit_mirror = symbol.mirror.as_deref().unwrap_or("");
         units.push(json!({
             "uuid": symbol.uuid,
             "unit": symbol.unit,
             "x": symbol.at.x,
             "y": symbol.at.y,
             "rotation": symbol.at.rotation.unwrap_or(0.0),
+            "mirror_x": unit_mirror.contains('x'),
+            "mirror_y": unit_mirror.contains('y'),
             "lib_id": symbol.lib_id,
             "fields": fields,
             "field_placements": field_placements,
@@ -1292,6 +1340,7 @@ fn component_mutation_readback_from_schematic(
     }
     let anchor = observed[0];
     let fields = units[0]["fields"].clone();
+    let anchor_mirror = anchor.mirror.as_deref().unwrap_or("");
     Ok(json!({
         "schematic": committed.filepath().display().to_string(),
         "reference": reference,
@@ -1303,6 +1352,8 @@ fn component_mutation_readback_from_schematic(
         "x": anchor.at.x,
         "y": anchor.at.y,
         "rotation": anchor.at.rotation.unwrap_or(0.0),
+        "mirror_x": anchor_mirror.contains('x'),
+        "mirror_y": anchor_mirror.contains('y'),
         "unit_count": units.len(),
         "units": units,
         "fields": fields
@@ -1344,6 +1395,8 @@ fn copy_component_observation(result: &mut serde_json::Value, observed: &serde_j
         "x",
         "y",
         "rotation",
+        "mirror_x",
+        "mirror_y",
         "unit_count",
         "units",
         "fields",
@@ -7006,6 +7059,129 @@ mod multi_unit_component_tests {
         placed.sort_by_key(|instance| instance.unit);
         assert_eq!(placed[0].rotation, 90.0);
         assert_eq!(placed[1].rotation, 270.0);
+    }
+
+    /// A misspelled axis is a caller asking for a reflection. Placing the
+    /// symbol unmirrored and reporting success is exactly the failure this
+    /// argument exists to end, so the placement refuses and writes nothing.
+    #[tokio::test]
+    async fn placing_with_an_unknown_mirror_axis_refuses_without_writing() {
+        let (_directory, path) = fixture();
+        let before = std::fs::read_to_string(&path).unwrap();
+        let result = handle_add_schematic_component(
+            &json!({
+                "schematic": path,
+                "lib_id": "Device:R",
+                "x": 100.0,
+                "y": 40.0,
+                "reference": "R8",
+                "mirror": "Y"
+            }),
+            &context(),
+        )
+        .await
+        .unwrap();
+        assert!(result.is_error);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), before);
+    }
+
+    /// `"none"` is the explicit way to say unmirrored. It must place the
+    /// symbol without a `(mirror ...)` token at all — eeschema has no
+    /// `(mirror none)` and would not load one.
+    #[tokio::test]
+    async fn placing_with_mirror_none_writes_no_token() {
+        let (_directory, path) = fixture();
+        let result = handle_add_schematic_component(
+            &json!({
+                "schematic": path,
+                "lib_id": "Device:R",
+                "x": 100.0,
+                "y": 40.0,
+                "reference": "R8",
+                "mirror": "none"
+            }),
+            &context(),
+        )
+        .await
+        .unwrap();
+        assert!(!result.is_error, "{result:?}");
+        let source = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !source.contains("(mirror"),
+            "no mirror token may be written"
+        );
+    }
+
+    /// The placement argument, and the #101 half of it: a mirrored body puts
+    /// its Reference and Value where the reflection lands them. The site that
+    /// builds this transform hardcoded `mirror_x: false, mirror_y: false`, so
+    /// a mirrored symbol's fields sat on its unmirrored side.
+    #[tokio::test]
+    async fn placing_mirrored_reflects_the_body_and_its_field_anchors() {
+        let (_directory, path) = fixture();
+        for (reference, x, mirror) in [("R8", 100.0, None), ("R9", 140.0, Some("y"))] {
+            let mut args = json!({
+                "schematic": path,
+                "lib_id": "Device:R",
+                "x": x,
+                "y": 40.0,
+                "reference": reference
+            });
+            if let Some(mirror) = mirror {
+                args["mirror"] = json!(mirror);
+            }
+            let result = handle_add_schematic_component(&args, &context())
+                .await
+                .unwrap();
+            assert!(!result.is_error, "placement failed for {reference}");
+        }
+        let source = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(source.matches("(mirror y)").count(), 1);
+        let committed = cse::Schematic::load(&path).unwrap();
+        let field_x = |reference: &str| -> f64 {
+            let symbol = committed
+                .symbols
+                .iter()
+                .find(|symbol| symbol.reference() == Some(reference))
+                .expect("placed symbol");
+            let property = symbol
+                .properties
+                .iter()
+                .find(|property| property.name == "Reference")
+                .expect("Reference property");
+            property
+                .sub_nodes
+                .iter()
+                .filter(|node| node.tag() == Some("at"))
+                .find_map(cse::At::from_sexp)
+                .expect("Reference carries an (at ...) node")
+                .x
+        };
+        let origin_x = |reference: &str| -> f64 {
+            committed
+                .symbols
+                .iter()
+                .find(|symbol| symbol.reference() == Some(reference))
+                .expect("placed symbol")
+                .at
+                .x
+        };
+        // Compare each anchor against its own origin, not against the other
+        // placement: the requested coordinates snap to the 1.27mm grid, so
+        // the two origins are not the 40mm apart they were asked for, and a
+        // test comparing raw field coordinates passes whatever the transform
+        // does.
+        let plain = field_x("R8") - origin_x("R8");
+        let mirrored = field_x("R9") - origin_x("R9");
+        assert!(
+            plain.abs() > 1e-6,
+            "the unmirrored anchor must be off-origin for this comparison to mean anything"
+        );
+        assert!(
+            (mirrored + plain).abs() < 1e-6,
+            "(mirror y) must negate the Reference anchor's screen-X: \
+             unmirrored {plain}, mirrored {mirrored}"
+        );
     }
 
     /// The delta arithmetic can push a trailing unit past 360° — a unit at

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -602,7 +602,7 @@ async fn handle_add_schematic_component(
 
     let (expected_x, expected_y) = snap_point(x, y, 1.27);
     let placement = ComponentTargetUnit::placement(
-        &uuid, &context, &lib_id, expected_x, expected_y, rotation, ref_str, value, unit,
+        &uuid, &context, &lib_id, expected_x, expected_y, rotation, mirror, ref_str, value, unit,
     );
     sch.overwrite()?;
 
@@ -789,6 +789,9 @@ pub(crate) struct ComponentTargetUnit {
     x: f64,
     y: f64,
     rotation: f64,
+    /// The placement's `(mirror ...)` axis, bound like rotation so a
+    /// reflection that fails to reach the file cannot pass the readback.
+    mirror: Option<String>,
     instances: Vec<(String, String)>,
 }
 
@@ -802,6 +805,7 @@ impl ComponentTargetUnit {
         x: f64,
         y: f64,
         rotation: f64,
+        mirror: Option<&str>,
         reference: &str,
         value: Option<&str>,
         unit: u32,
@@ -819,6 +823,7 @@ impl ComponentTargetUnit {
             x,
             y,
             rotation,
+            mirror: mirror.map(str::to_owned),
             fields: BTreeMap::from([
                 ("Reference".to_owned(), reference.to_owned()),
                 (
@@ -922,6 +927,13 @@ fn verify_component_expectations(
                 unit["rotation"]
                     .as_f64()
                     .is_some_and(|v| (v - target.rotation).abs() < 1e-6),
+            ),
+            (
+                "mirror",
+                unit["mirror_x"].as_bool()
+                    == Some(target.mirror.as_deref().is_some_and(|m| m.contains('x')))
+                    && unit["mirror_y"].as_bool()
+                        == Some(target.mirror.as_deref().is_some_and(|m| m.contains('y'))),
             ),
             (
                 "instance_paths",
@@ -1083,6 +1095,10 @@ fn component_target_from_source(
             x: instance.x,
             y: instance.y,
             rotation: instance.rotation,
+            // Observed, not requested: rotate/move/delete do not change the
+            // mirror, so binding what the file already carries makes the
+            // readback assert they left it alone.
+            mirror: symbol.mirror.clone(),
             instances: instance_paths,
         });
     }
@@ -6198,6 +6214,7 @@ mod multi_unit_component_tests {
                 "x" => symbol.at.x += 1.27,
                 "y" => symbol.at.y += 1.27,
                 "rotation" => symbol.at.rotation = Some(symbol.at.rotation.unwrap_or(0.0) + 90.0),
+                "mirror" => symbol.set_mirror(Some("y")),
                 "project" | "path" => {
                     let previous = symbol.instance_paths();
                     symbol
@@ -6252,6 +6269,14 @@ mod multi_unit_component_tests {
     #[test]
     fn native_readback_intent_rotation() {
         native_readback_intent_mismatch("rotation");
+    }
+    /// A reflection that reaches the response but not the file — or one that
+    /// appears in the file without being asked for — must be caught by the
+    /// same readback that already guards rotation. Mirror was bound as
+    /// placement intent for exactly this (#450).
+    #[test]
+    fn native_readback_intent_mirror() {
+        native_readback_intent_mismatch("mirror");
     }
     #[test]
     fn native_readback_intent_project() {

--- a/crates/konnect-core/src/tools/sch_wiring.rs
+++ b/crates/konnect-core/src/tools/sch_wiring.rs
@@ -1696,6 +1696,9 @@ async fn handle_add_power_symbol(
         x,
         y,
         rotation,
+        // add_power_symbol takes no mirror; a power symbol is placed upright
+        // and the readback asserts nothing put a reflection on it.
+        None,
         &pwr_ref,
         Some(&power_net),
         1,

--- a/crates/konnect-core/src/tools/schematic_placement_tests.rs
+++ b/crates/konnect-core/src/tools/schematic_placement_tests.rs
@@ -373,6 +373,7 @@ fn native_placement_readback_refuses_wrong_document_and_missing_evidence() {
             symbol.at.x,
             symbol.at.y,
             symbol.at.rotation.unwrap_or(0.0),
+            symbol.mirror.as_deref(),
             symbol.reference().unwrap(),
             symbol.value_str(),
             symbol.unit,
@@ -438,6 +439,7 @@ fn native_placement_readback_requires_requested_values() {
             symbol.at.x + if mismatch == "x" { 1.27 } else { 0.0 },
             symbol.at.y + if mismatch == "y" { 1.27 } else { 0.0 },
             symbol.at.rotation.unwrap_or(0.0) + if mismatch == "rotation" { 90.0 } else { 0.0 },
+            symbol.mirror.as_deref(),
             symbol.reference().unwrap(),
             if mismatch == "Value" {
                 Some("wrong-value")

--- a/crates/konnect-schematic-editor/src/schematic/symbol.rs
+++ b/crates/konnect-schematic-editor/src/schematic/symbol.rs
@@ -375,6 +375,18 @@ impl Symbol {
     pub fn set_rotation(&mut self, rot: f64) {
         self.at.rotation = Some(rot);
     }
+
+    /// Set or clear the placement mirror. `Some("x")` / `Some("y")` write
+    /// eeschema's `(mirror x)` / `(mirror y)`; `None` removes the token
+    /// entirely, which is how eeschema records an unmirrored symbol — it does
+    /// not write `(mirror none)`.
+    ///
+    /// The axes are mutually exclusive in eeschema: a symbol carries at most
+    /// one `SYM_MIRROR_*` flag, and mirroring about both axes is rotation by
+    /// 180 degrees, which belongs in `at`.
+    pub fn set_mirror(&mut self, mirror: Option<&str>) {
+        self.mirror = mirror.map(str::to_owned);
+    }
 }
 
 impl std::fmt::Display for Symbol {

--- a/docs/API_MIGRATIONS.md
+++ b/docs/API_MIGRATIONS.md
@@ -3,6 +3,55 @@
 Konnect's tool schemas are public API. This file records intentional argument
 removals and the supported replacement workflow.
 
+## Unreleased: mirrored schematic placement (minor release)
+
+`add_schematic_component` and every entry of `batch_place_components` accept a
+new optional `mirror`, and the schematic component responses gain two boolean
+fields. Nothing is renamed or removed, and omitting `mirror` reproduces the
+previous behaviour exactly: no `(mirror …)` token is written and the symbol is
+placed upright.
+
+`mirror` uses the file format's own vocabulary — `"x"`, `"y"` or `"none"`.
+`"x"` negates screen-Y and `"y"` negates screen-X, which is eeschema's meaning
+for the tokens it writes, and `"none"` is the explicit spelling of unmirrored,
+which KiCad records by omitting the token rather than writing one. There is
+deliberately no way to ask for both axes: KiCad stores at most one mirror flag
+per symbol and reflecting both is rotation 180, so a pair of booleans would let
+a caller request a state the format cannot hold. Mirroring is applied after
+rotation, and it does not substitute for rotation 180 on a symbol whose pins
+are not symmetric — 180 keeps every pin's coordinates correct but reverses
+their visual order along the body.
+
+Any other value is refused rather than dropped. `add_schematic_component`
+returns `invalid_argument` naming `mirror` and writes nothing;
+`batch_place_components` refuses only the offending entry, reporting it in
+`errors` and placing the rest, as it already does for every other per-entry
+problem. A caller who misspells the axis is asking for a reflection, so placing
+the symbol upright and reporting success is the failure this argument exists to
+end.
+
+A placement's field anchors follow the mirror. `Reference` and `Value` are
+positioned through the same transform as the symbol body, which previously
+hardcoded an unmirrored frame, so a mirrored symbol's field text sat on its
+unmirrored side (#101).
+
+Responses add `mirror_x` and `mirror_y`, at the top level and in each `units[]`
+entry, for every tool that shares the committed-file component readback:
+`add_schematic_component`, `batch_place_components`, `add_power_symbol`,
+`edit_schematic_component`, `move_schematic_component`,
+`rotate_schematic_component` and `add_component_annotation`. Both are read from
+the reparsed committed schematic beside `x`, `y`, `rotation`, `lib_id` and
+`units[].field_placements` — never echoed from the request — and the requested
+axis is bound as placement intent, so a reflection that did not reach the file
+refuses with `stale_target` rather than reporting success. The mutations that
+do not change a reflection bind the axis the file already carries, which makes
+them assert they left an existing one alone; `add_power_symbol` binds none,
+because a power symbol is placed upright.
+
+No tool mirrors an already-placed symbol: changing a placement's reflection
+still means deleting it and placing it again. This additive change is planned
+for the next minor release; no tool or argument was renamed or removed.
+
 ## Unreleased: `add_mounting_hole` uses KiCad's shipped footprint names (minor release)
 
 `add_mounting_hole` wrote `MountingHole:MountingHole_{drill:.1}mm`. KiCad 10


### PR DESCRIPTION
## Summary

Symbols can be placed mirrored. `add_schematic_component` and `batch_place_components` take an optional `mirror` of `"x"`, `"y"` or `"none"`.

Konnect already modelled mirroring completely on the read side and could never write it. The model carries `mirror`, the parser reads `(mirror x|y)`, the serializer emits it in eeschema's own field order, `geometry.rs` implements the transform with eeschema's exact semantics, and both `list_schematic_components` and `get_schematic_pin_locations` report through it. What was missing was any *assignment*: `Symbol::mirror` was initialised to `None` and never set to `Some(...)` outside the parser, so a mirrored schematic round-tripped losslessly while one authored through Konnect could never contain a mirror.

Part of #450

### Acceptance mapping

| owned by | acceptance |
|---|---|
| **this PR** | mirrored *placement*: a `mirror` argument on `add_schematic_component` and `batch_place_components`, the axis written to the file, and the placement's `PinTransform` carrying it so field anchors follow a reflected body. |
| **successor `feat/450-mirror-schematic-component`** | *mutation* of an already-placed symbol — a `mirror_schematic_component` alongside `rotate_schematic_component` — and the `sch_components` toolset-capacity question that adding a tool raises. That PR is the terminal change and will carry `Closes #450`. |

The successor plan is recorded on #450 itself so the issue stays the source of truth.

## Approach

Three changes, no new geometry:

- `Symbol::set_mirror(Option<&str>)` — `None` removes the token, because eeschema records an unmirrored symbol by omitting it and has no `(mirror none)`.
- `mirror_arg` reads the argument in the file format's own vocabulary rather than inventing one. An unknown axis is refused through `invalid_arg`, not dropped: a caller that misspells the axis is asking for a reflection, and placing the symbol unmirrored while reporting success is exactly the failure this argument exists to end. In the batch a bad axis refuses only its own entry, as every other per-item problem in that loop already does.
- The placement's `PinTransform` takes the requested mirror instead of the hardcoded `mirror_x: false, mirror_y: false`, so Reference and Value follow a reflected body the way they already follow a rotated one (#101).

`ComponentTargetUnit` binds the axis as placement intent alongside `x`, `y` and `rotation`, and `verify_component_expectations` compares it against the committed readback, so a reflection that failed to write cannot return success. The from-source constructor records the axis the file already carries, which makes `rotate`, `move` and `delete` assert they left an existing reflection alone rather than fail on any symbol that has one. `add_power_symbol` binds `None`: a power symbol is placed upright and now says so.

The axes are mutually exclusive, which is why the argument is one enum rather than two booleans: eeschema stores at most one `SYM_MIRROR_*` flag, and mirroring about both axes is rotation by 180°, which belongs in `at`. The response keeps the existing `mirror_x` / `mirror_y` booleans and now reports them from the committed readback, per unit and at the top level.

**Why rotation 180° is not a substitute.** It is exact for a single-input symbol, but it reverses the *visual* order of a multi-pin symbol's pins: a 4-input NAND drawn output-left renders its inputs 5,4,3,2 instead of 2,3,4,5. Pin numbers and the netlist stay correct — only the drawing is wrong. That matters when the deliverable is the reproduced drawing, which is where this came from: transcribing hand-drawn sheets whose gates appear in all four rotations and mirrored.

### One thing left out, and a question

I did **not** add a `mirror_schematic_component` alongside `rotate_schematic_component`, although the issue proposes one and mirroring an already-placed symbol currently needs a delete and re-place.

`sch_components` is at `MAX_TOOLS_PER_TOOLSET` (20), and that constant says *"don't raise this number without a conversation"*. Rather than raise it, split the toolset, or file the tool somewhere it does not belong, this PR stops at the placement arguments — one reviewable outcome, no tool-count churn, no `tool-directory.md` or registry changes.

Where would you like it to live? I am happy to follow up with the mutation tool once that is settled.

## Branch and dependencies

Base branch: `main`. Reconstructed once onto `4a5dd41e470c9b2a12ce56457d7d2240fe7e80d8`, the merge of #489 and current `main` at the time of the push.

Depends on: **#489, now merged.** This PR was held behind it on the maintainers' sequencing because both change `sch_components.rs`. It carries none of #489's commits — only its own mirror-placement work on top of them.

Series order: **#489 → this PR → #499**, the order set on 2026-09-09. After this one, the successor `feat/450-mirror-schematic-component` owns mutation of an already-placed symbol and is the terminal `Closes #450`.

Unique commits: **four.**

| commit | what it owns |
|---|---|
| `feat(schematic): place symbols mirrored` | the `mirror` argument, `Symbol::set_mirror`, and the placement `PinTransform` carrying the axis |
| `test(schematic): place mirror fixtures from the file's own lib_symbols` | the CI fix — the tests were the platform-dependent part, not the change |
| `fix(schematic): bind the placement mirror as verified intent` | the axis bound as placement intent, so a reflection that did not reach the file cannot return success |
| `docs(api): record the placement mirror contract` | the `docs/API_MIGRATIONS.md` entry asked for on 2026-09-10 |

Next PR to promote after this one: #499, which writes pre-commit validation against the final shape of these handlers.

## Compatibility and safety

- **Public API additions only.** A new optional `mirror` property on two existing tool schemas. Omitting it is exactly the previous behaviour, and every existing call keeps its meaning.
- **Response additions only.** `mirror_x` / `mirror_y` now appear on the component mutation readback, per unit and at the top level. Both names already exist elsewhere in the API (`list_schematic_components`, `get_schematic_component`) and carry the same meaning here. Nothing was renamed or removed.
- **File mutations** go through the existing schematic write path unchanged; the only new write is one `(mirror x|y)` token on the placed symbol, in the position the serializer already emitted it from a parsed file.
- **Durable migration record.** `docs/API_MIGRATIONS.md` gains `## Unreleased: mirrored schematic placement (minor release)`, inserted above the existing entries and preserving every one now on `main` — the file is byte-identical to `main` once the new entry is removed. It records the accepted values, that omitting `mirror` is exactly the previous behaviour, why there is no both-axes spelling, what an unknown axis refuses, and that `mirror_x`/`mirror_y` are read from the reparsed committed file and bound as intent.
- No new tool, so no registry `tool_count`, `tool-directory.md`, DEV.md or README count changes. `cargo xtask fix-doc-counts --check` reports documentation already current.
- Rollback is reverting the commit; no format migration is involved, and a file written by this code is one eeschema already writes.

## Validation

```
cargo fmt --all -- --check                                        clean
cargo test --workspace --locked --lib --tests                     pass (1195 tests in konnect-core, 0 failed)
cargo test --workspace --locked --doc                             pass
cargo clippy --workspace --locked --all-targets -- -D warnings    clean
```

The exact head under review is `16c9a0b52e14efaa721cdaf0bbe6c117a519907a`, on base `4a5dd41`. The four commands above were also re-run under `env -i` with an empty `HOME` and `KICAD10_SYMBOL_DIR` / `KICAD10_FOOTPRINT_DIR` unset — a bare runner in one command — and pass there too.

All ten required checks pass on the exact head under review, `16c9a0b52e14efaa721cdaf0bbe6c117a519907a`, on macOS, Ubuntu and Windows.

**Every new guard was neutered and watched to fail** before being trusted:

| guard removed | test that must fail | result |
|---|---|---|
| `mirror_arg` accepts any axis | `placing_with_an_unknown_mirror_axis_refuses_without_writing` | FAILED |
| placement stops calling `set_mirror` | `placing_mirrored_reflects_the_body_and_its_field_anchors` | FAILED |
| `PinTransform` back to hardcoded `false` | `placing_mirrored_reflects_the_body_and_its_field_anchors` | FAILED |
| batch stops passing `mirror` | `batch_place_components_mirrors_per_component_and_refuses_a_bad_axis` | FAILED |
| batch skips validation | `batch_place_components_mirrors_per_component_and_refuses_a_bad_axis` | FAILED |
| mirror dropped from the readback comparison | `native_readback_intent_mirror` | FAILED |

Re-neutered after the reconstruction, because the merge with #489 rewrote the block both changes touch:

| guard removed | tests that must fail | result |
|---|---|---|
| `mirror_x` / `mirror_y` forced to `false` in `component_mutation_readback_from_schematic` | `native_readback_intent_mirror`, `placing_mirrored_reflects_the_body_and_its_field_anchors`, `batch_place_components_mirrors_per_component_and_refuses_a_bad_axis`, and #489's `field_placement_moves_the_text_and_keeps_its_value`, `field_placement_hides_then_shows_a_field`, `field_placement_never_rewrites_a_value_that_looks_like_a_placement` | 6 FAILED, with `post-write mirror differs from bound intent for UUID …` |
| #489's `field_placements` insert dropped from the same block | six `field_placement_*` tests | 6 FAILED |

The second row is there on purpose: it proves the conflict resolution kept #489's half live rather than merely compiling beside it. The first row shows the binding reaches beyond the mirror tests — with the observed axis lost, every mutation on a symbol the fixture already mirrors refuses, which is the guard working.

Two things worth flagging rather than burying.

**A first push failed CI on Linux and Windows and the tests were the platform-dependent part, not the change.** They resolved `Device:R` through the installed KiCad symbol libraries, so they passed on a machine with KiCad and failed on every runner without one. They now place `ecc83-pp:R`, which the real eeschema fixture already embeds — `ensure_lib_symbol` returns on an embedded symbol before consulting any library source. Confirmed by running them with `HOME` and `KICAD10_SYMBOL_DIR` pointed at an empty directory.

**I did not add a `"mirror"` case to `native_placement_readback_requires_requested_values`.** I tried, then neutered the guard and watched the test pass anyway. That matrix asserts only that the readback returns `kind: "stale_target"`, and its fixture trips `component UUID … has a conflicting instance reference` before any field comparison runs — a control arm where *nothing* differs also passes. So it is currently vacuous for `unit`, `lib_id`, `x`, `y`, `rotation` and `Value` too. I left it alone rather than widen this PR, and did not add a case that would have looked like coverage while proving nothing. Happy to open a separate issue if that is useful.

The field-anchor test was wrong on its first pass and is worth flagging: it compared the two placements' raw Reference coordinates against the 40 mm the caller asked for, but the origins snap to the 1.27 mm grid and land 39.37 mm apart, so the assertion passed with the transform neutered. It now compares each anchor against **its own** origin and asserts the reflection exactly negates it — `+2.032` unmirrored, `−2.032` with `(mirror y)`.

**Verified against real KiCad (10.0.6), not only in-process.** A `74xx:74HC00` placed three ways, then read back:

| placement | inputs 1,2 | output 3 |
|---|---|---|
| unmirrored | x = 52.07 (left) | x = 67.31 (right) |
| `mirror: "y"` | x = 107.95 (**right**) | x = 92.71 (**left**) |
| `mirror: "x"` | pins 1 and 2 **swapped in Y** | unchanged in x |

which is `SYM_MIRROR_Y` negating screen-X and `SYM_MIRROR_X` negating screen-Y, as `geometry.rs` documents. Then:

- `kicad-cli sch export netlist` loads the file and lists all three placements;
- `kicad-cli sch upgrade --force` — KiCad's own writer — round-trips both `(mirror x)` and `(mirror y)` unchanged;
- `mirror: "none"` writes no token at all.

The clearing path was also exercised against `tests/fixtures/ecc83_multiunit.kicad_sch`, a real eeschema save whose `P3` and `C1` are genuinely mirrored, during development of the mutation tool that this PR ultimately left out.

**Not run:** Windows and Linux; no environment here. Nothing in the change is platform-dependent — it is one token in the schematic writer — and hosted CI covers the build and test matrix.

## Review checklist

- [x] The diff is focused and contains no generated output, personal data, or unrelated cleanup.
- [x] The branch includes current `upstream/main`, has no merge conflicts, and CI passed on this exact head (all ten checks green on `16c9a0b`).
- [x] The branch was based on latest `upstream/main`, not a release tag.
- [x] The PR shows only its unique commits and diff; dependencies and series position are explicit.
- [x] New names follow `docs/NAMING_CONVENTIONS.md`; no public renames.
- [x] New behavior and failure paths have regression coverage.
- [x] File mutations are atomic and preserve unrelated content.
- [x] IPC mutations — none in this change.
- [x] No tools added or removed, so no counts or docs to update; the additive argument is recorded in `docs/API_MIGRATIONS.md`.


