### PR TITLE
fix(board): refuse stale locked file fallbacks

### DIFF
--- a/crates/konnect-core/src/mcp/error.rs
+++ b/crates/konnect-core/src/mcp/error.rs
@@ -69,7 +69,7 @@ pub enum ToolErrorKind {
     StaleTarget { target: String, reason: String },
     /// A board was live earlier in this server process, but IPC is now gone;
     /// its saved file may be stale relative to lost editor state.
-    UnsafeFileFallback { path: String },
+    UnsafeFileFallback { path: String, reason: String },
     /// KiCad answered, and its open-document list could not be read as a
     /// complete set of comparable board identities — so whether it holds this
     /// board is unknown, and neither a live edit nor a file edit is safe.
@@ -230,7 +230,10 @@ mod tests {
                 target: "p".into(),
                 reason: "r".into(),
             },
-            ToolErrorKind::UnsafeFileFallback { path: "p".into() },
+            ToolErrorKind::UnsafeFileFallback {
+                path: "p".into(),
+                reason: "r".into(),
+            },
             ToolErrorKind::AmbiguousOpenBoard { path: "p".into() },
             ToolErrorKind::HandlerError { reason: "r".into() },
         ];

--- a/crates/konnect-core/src/mcp/handler.rs
+++ b/crates/konnect-core/src/mcp/handler.rs
@@ -368,22 +368,40 @@ impl McpHandler {
                     )
                 }
                 Err(e) if kicad_editor_locked_path(&e).is_some() => {
-                    let path = kicad_editor_locked_path(&e)
-                        .expect("guard matched")
-                        .display()
-                        .to_string();
-                    (
-                        CallToolResult::error_kind(
-                            ToolErrorKind::Conflict {
-                                paths: vec![path.clone()],
-                            },
-                            format!(
-                                "Schematic '{path}' has a KiCad editor lock. Close Eeschema, or resolve a stale lock only after confirming no editor owns the file, then retry."
+                    let locked = kicad_editor_locked_path(&e).expect("guard matched");
+                    let path = locked.display().to_string();
+                    if locked
+                        .extension()
+                        .is_some_and(|extension| extension.eq_ignore_ascii_case("kicad_pcb"))
+                    {
+                        let reason = kicad_board_lock_reason(&e).to_string();
+                        (
+                            CallToolResult::error_kind(
+                                ToolErrorKind::UnsafeFileFallback {
+                                    path: path.clone(),
+                                    reason: reason.clone(),
+                                },
+                                format!(
+                                    "Board '{path}' cannot be replaced safely ({reason}): a KiCad editor lock appeared before the committed write, so saved-file authority cannot be proven. Konnect did not modify it. Close or recover Pcbnew, reconcile any unsaved work, and save the authoritative state. Retry only after confirming that no KiCad process owns the board and the lock is gone."
+                                ),
                             ),
-                        ),
-                        CallStatus::Error,
-                        Some("conflict".to_string()),
-                    )
+                            CallStatus::Error,
+                            Some("unsafe_file_fallback".to_string()),
+                        )
+                    } else {
+                        (
+                            CallToolResult::error_kind(
+                                ToolErrorKind::Conflict {
+                                    paths: vec![path.clone()],
+                                },
+                                format!(
+                                    "Schematic '{path}' has a KiCad editor lock. Close Eeschema, or resolve a stale lock only after confirming no editor owns the file, then retry."
+                                ),
+                            ),
+                            CallStatus::Error,
+                            Some("conflict".to_string()),
+                        )
+                    }
                 }
                 Err(e) => {
                     warn!(tool = %name, error = %e, "tool handler returned anyhow::Error");
@@ -472,6 +490,22 @@ fn kicad_editor_locked_path(error: &anyhow::Error) -> Option<&std::path::Path> {
         }
     }
     None
+}
+
+fn kicad_board_lock_reason(error: &anyhow::Error) -> &'static str {
+    for cause in error.chain() {
+        if let Some(konnect_sexp::SexpError::KiCadEditorLocked {
+            inspection_error, ..
+        }) = cause.downcast_ref::<konnect_sexp::SexpError>()
+        {
+            return if inspection_error.is_some() {
+                "kicad_lock_unreadable"
+            } else {
+                "kicad_lock_present"
+            };
+        }
+    }
+    "kicad_lock_present"
 }
 
 /// Sum of content bytes in a `CallToolResult` — used for observability size
@@ -765,6 +799,42 @@ mod required_argument_dispatch_tests {
             json!([schematic.display().to_string()])
         );
         assert_eq!(std::fs::read_to_string(schematic).unwrap(), source);
+        assert!(lock.exists());
+    }
+
+    #[tokio::test]
+    async fn a_kicad_board_lock_is_a_typed_unsafe_file_fallback() {
+        let handler = handler().await;
+        let directory = tempfile::tempdir().unwrap();
+        let board = directory.path().join("locked.kicad_pcb");
+        let lock = directory.path().join("~locked.kicad_pcb.lck");
+        let source = "(kicad_pcb (version 20240108) (generator pcbnew))\n";
+        std::fs::write(&board, source).unwrap();
+        std::fs::write(&lock, "lock ownership cannot be inferred").unwrap();
+
+        let (result, status, kind) = handler
+            .dispatch_tool(
+                "add_mounting_hole",
+                &json!({
+                    "board": board.display().to_string(),
+                    "x": 10.0,
+                    "y": 10.0,
+                    "reference": "H1"
+                }),
+            )
+            .await;
+
+        assert!(result.is_error);
+        assert_eq!(status, CallStatus::Error);
+        assert_eq!(kind.as_deref(), Some("unsafe_file_fallback"));
+        let text = match result.content.first() {
+            Some(ToolContent::Text { text }) => text,
+            other => panic!("expected text, got {other:?}"),
+        };
+        let body: Value = serde_json::from_str(text).unwrap();
+        assert_eq!(body["error"]["kind"], "unsafe_file_fallback");
+        assert_eq!(body["error"]["reason"], "kicad_lock_present");
+        assert_eq!(std::fs::read_to_string(&board).unwrap(), source);
         assert!(lock.exists());
     }
 }

--- a/crates/konnect-core/src/tools/pcb_board.rs
+++ b/crates/konnect-core/src/tools/pcb_board.rs
@@ -222,7 +222,7 @@ impl NoLiveBoard {
         match self {
             Self::Unreachable => json!({
                 "kind": "transport_unreachable",
-                "message": "KiCad IPC is unreachable."
+                "message": "KiCad IPC is unreachable and no exact-board sibling lock was present."
             }),
             Self::NotOpen(answer) => json!({
                 "kind": "board_not_open",
@@ -236,7 +236,7 @@ impl NoLiveBoard {
     pub(crate) fn warning(&self) -> String {
         let observed = match self {
             Self::Unreachable => {
-                "KiCad IPC was unreachable, so Konnect could not contact a live editor.".to_string()
+                "KiCad IPC was unreachable, so Konnect could not contact a live editor; no exact-board sibling lock was present.".to_string()
             }
             Self::NotOpen(answer) => format!("KiCad was reachable, and {answer}"),
         };
@@ -289,6 +289,7 @@ where
             if ctx.board_session.was_observed_live(board_path) {
                 Ok(BoardWrite::Refused(unsafe_file_fallback(
                     board_path,
+                    "board_previously_observed_live",
                     "Konnect previously reached KiCad with this board open, and KiCad no longer \
                      has it open.",
                 )))
@@ -300,9 +301,12 @@ where
             crate::tools::ipc_target_error_result(&error),
         )),
         Err(konnect_ipc::IpcFailure::Unreachable(_)) => {
-            if ctx.board_session.was_observed_live(board_path) {
+            if let Some(refusal) = board_lock_refusal(board_path) {
+                Ok(BoardWrite::Refused(refusal))
+            } else if ctx.board_session.was_observed_live(board_path) {
                 Ok(BoardWrite::Refused(unsafe_file_fallback(
                     board_path,
+                    "board_previously_observed_live",
                     "Konnect previously reached KiCad with this board open, but IPC is now \
                      unreachable.",
                 )))
@@ -313,12 +317,17 @@ where
     }
 }
 
-/// The refusal both gates share: `situation` names what changed since this
-/// server saw KiCad holding the board, and the rest is the same advice.
-fn unsafe_file_fallback(board_path: &std::path::Path, situation: &str) -> CallToolResult {
+/// The refusal both gates share. `reason` is stable machine-readable evidence;
+/// `situation` explains that evidence and the recovery boundary to a person.
+fn unsafe_file_fallback(
+    board_path: &std::path::Path,
+    reason: &str,
+    situation: &str,
+) -> CallToolResult {
     CallToolResult::error_kind(
         ToolErrorKind::UnsafeFileFallback {
             path: board_path.display().to_string(),
+            reason: reason.to_string(),
         },
         format!(
             "{situation} The saved board file may be older than unsaved editor state, so \
@@ -327,6 +336,44 @@ fn unsafe_file_fallback(board_path: &std::path::Path, situation: &str) -> CallTo
              restart Konnect only after confirming that the saved file is authoritative."
         ),
     )
+}
+
+/// A KiCad sibling lock is persistent evidence that the saved board may not be
+/// authoritative even when this server has never reached the editor. Lock
+/// contents do not prove process ownership or freshness, so both an observed
+/// lock and an inspection failure veto the unreachable-IPC file fallback.
+fn board_lock_refusal(board_path: &std::path::Path) -> Option<CallToolResult> {
+    board_lock_refusal_with(board_path, |path| {
+        std::fs::symlink_metadata(path).map(|_| ())
+    })
+}
+
+fn board_lock_refusal_with(
+    board_path: &std::path::Path,
+    inspect: impl FnOnce(&std::path::Path) -> std::io::Result<()>,
+) -> Option<CallToolResult> {
+    let lock_path = konnect_sexp::writer::kicad_editor_lock_path(board_path)?;
+    match inspect(&lock_path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Ok(()) => Some(unsafe_file_fallback(
+            board_path,
+            "kicad_lock_present",
+            &format!(
+                "KiCad sibling lock '{}' is present; its contents cannot prove whether an editor \
+                 still owns newer in-memory state.",
+                lock_path.display()
+            ),
+        )),
+        Err(error) => Some(unsafe_file_fallback(
+            board_path,
+            "kicad_lock_unreadable",
+            &format!(
+                "KiCad sibling lock '{}' could not be inspected ({error}); its absence cannot be \
+                 established.",
+                lock_path.display()
+            ),
+        )),
+    }
 }
 
 /// Refuse a direct file edit when KiCAD is reachable AND holds this very
@@ -353,6 +400,7 @@ pub(crate) async fn refuse_if_board_open_in_kicad(
             Ok(ctx.board_session.was_observed_live(board_path).then(|| {
                 unsafe_file_fallback(
                     board_path,
+                    "board_previously_observed_live",
                     "Konnect previously reached KiCad with this board open, and KiCad no longer \
                      has it open.",
                 )
@@ -362,12 +410,15 @@ pub(crate) async fn refuse_if_board_open_in_kicad(
             Ok(Some(crate::tools::ipc_target_error_result(&error)))
         }
         Err(konnect_ipc::IpcFailure::Unreachable(_)) => {
-            Ok(ctx.board_session.was_observed_live(board_path).then(|| {
-                unsafe_file_fallback(
-                    board_path,
-                    "Konnect previously reached KiCad with this board open, but IPC is now \
-                     unreachable.",
-                )
+            Ok(board_lock_refusal(board_path).or_else(|| {
+                ctx.board_session.was_observed_live(board_path).then(|| {
+                    unsafe_file_fallback(
+                        board_path,
+                        "board_previously_observed_live",
+                        "Konnect previously reached KiCad with this board open, but IPC is now \
+                         unreachable.",
+                    )
+                })
             }))
         }
     }
@@ -385,9 +436,10 @@ pub(crate) const DEFAULT_ZONE_MIN_WIDTH_MM: f64 = 0.2;
 /// preflight established only that no live KiCad is holding this board.
 const FILE_ONLY_EDIT_WARNING: &str =
     "No live KiCad is holding this board, and it has not been observed live during the current \
-     Konnect server session, so Konnect edited the saved board file directly. If KiCad crashed \
-     or was force-quit before this server started, reconcile any unsaved work before relying on \
-     this change. Reload the file in KiCad before editing it there.";
+     Konnect server session, and no KiCad sibling lock was present, so Konnect edited the saved \
+     board file directly. If KiCad crashed or was force-quit before this server started without \
+     leaving a lock, reconcile any unsaved work before relying on this change. Reload the file in \
+     KiCad before editing it there.";
 
 /// The `pad_connection` argument in both the representations it needs: the IPC
 /// enum and the token KiCad's `(connect_pads …)` takes.
@@ -2813,6 +2865,102 @@ mod board_session_safety_tests {
         assert!(matches!(outcome, BoardWrite::File(_)));
     }
 
+    fn error_reason(result: &CallToolResult) -> String {
+        let text = match &result.content[0] {
+            crate::mcp::protocol::ToolContent::Text { text } => text,
+            other => panic!("expected text result, got {other:?}"),
+        };
+        let body: serde_json::Value = serde_json::from_str(text).unwrap();
+        body["error"]["reason"]
+            .as_str()
+            .expect("structured refusal reason")
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn any_exact_board_lock_refuses_both_offline_fallback_gates_without_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let before = std::fs::read(&board).unwrap();
+        let lock = konnect_sexp::writer::kicad_editor_lock_path(&board).unwrap();
+        let ctx = ctx_talking_to(String::new());
+
+        for body in [
+            r#"{"username":"test","hostname":"host"}"#,
+            r#"{"username":"former","hostname":"retired"}"#,
+            "not parseable lock data",
+        ] {
+            std::fs::write(&lock, body).unwrap();
+            let outcome = attempt_ipc_write(&ctx, &board, "test write", |_| Ok(()))
+                .await
+                .unwrap();
+            let BoardWrite::Refused(result) = outcome else {
+                panic!("an exact sibling lock must refuse file mode")
+            };
+            assert_eq!(
+                crate::mcp::error::extract_error_kind(&result).as_deref(),
+                Some("unsafe_file_fallback")
+            );
+            assert_eq!(error_reason(&result), "kicad_lock_present");
+            assert_eq!(std::fs::read(&board).unwrap(), before);
+        }
+
+        let guarded = refuse_if_board_open_in_kicad(&ctx, &board, "file-only test write")
+            .await
+            .unwrap()
+            .expect("the file-only gate must honor the same exact lock");
+        assert_eq!(
+            crate::mcp::error::extract_error_kind(&guarded).as_deref(),
+            Some("unsafe_file_fallback")
+        );
+        assert_eq!(error_reason(&guarded), "kicad_lock_present");
+        assert_eq!(std::fs::read(&board).unwrap(), before);
+    }
+
+    #[tokio::test]
+    async fn a_lock_for_another_board_does_not_taint_the_requested_board() {
+        let dir = tempfile::tempdir().unwrap();
+        let requested = super::mounting_hole_tests::blank_board(dir.path());
+        let other = dir.path().join("other.kicad_pcb");
+        std::fs::write(&other, "(kicad_pcb)\n").unwrap();
+        let other_lock = konnect_sexp::writer::kicad_editor_lock_path(&other).unwrap();
+        std::fs::write(other_lock, "locked").unwrap();
+        let ctx = ctx_talking_to(String::new());
+
+        let outcome = attempt_ipc_write(&ctx, &requested, "test write", |_| Ok(()))
+            .await
+            .unwrap();
+
+        assert!(matches!(outcome, BoardWrite::File(_)));
+        assert!(
+            refuse_if_board_open_in_kicad(&ctx, &requested, "file-only test write")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn an_uninspectable_exact_board_lock_fails_closed_with_distinct_evidence() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = super::mounting_hole_tests::blank_board(dir.path());
+        let before = std::fs::read(&board).unwrap();
+        let result = board_lock_refusal_with(&board, |_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "mock access denied",
+            ))
+        })
+        .expect("inspection failure must refuse");
+
+        assert_eq!(
+            crate::mcp::error::extract_error_kind(&result).as_deref(),
+            Some("unsafe_file_fallback")
+        );
+        assert_eq!(error_reason(&result), "kicad_lock_unreadable");
+        assert_eq!(std::fs::read(&board).unwrap(), before);
+    }
+
     #[tokio::test]
     async fn a_file_only_guard_blocks_a_previously_live_board_after_transport_loss() {
         let dir = tempfile::tempdir().unwrap();
@@ -3912,11 +4060,12 @@ mod zone_net_format_tests {
             body["fallback_reason"],
             json!({
                 "kind": "transport_unreachable",
-                "message": "KiCad IPC is unreachable."
+                "message": "KiCad IPC is unreachable and no exact-board sibling lock was present."
             })
         );
         let warning = body["warning"].as_str().expect("a fallback must warn");
         assert!(warning.contains("IPC was unreachable"), "{warning}");
+        assert!(warning.contains("no exact-board sibling lock"), "{warning}");
         assert!(
             warning.contains("current Konnect server session"),
             "{warning}"

--- a/crates/konnect-schematic-editor/src/schematic/mod.rs
+++ b/crates/konnect-schematic-editor/src/schematic/mod.rs
@@ -623,9 +623,9 @@ fn map_sexp_error(error: konnect_sexp::SexpError) -> crate::error::Error {
     match error {
         konnect_sexp::SexpError::Io(error) => crate::error::Error::Io(error),
         konnect_sexp::SexpError::Conflict { path } => crate::error::Error::Conflict(path),
-        konnect_sexp::SexpError::KiCadEditorLocked { path, lock_path } => {
-            crate::error::Error::KiCadEditorLocked { path, lock_path }
-        }
+        konnect_sexp::SexpError::KiCadEditorLocked {
+            path, lock_path, ..
+        } => crate::error::Error::KiCadEditorLocked { path, lock_path },
         error => crate::error::Error::Io(std::io::Error::other(error)),
     }
 }

--- a/crates/konnect-sexp/src/error.rs
+++ b/crates/konnect-sexp/src/error.rs
@@ -22,13 +22,20 @@ pub enum SexpError {
     #[error("write conflict: {path} changed since it was read")]
     Conflict { path: PathBuf },
 
-    /// KiCad owns, or may still own, the schematic through its sibling lock.
+    /// KiCad owns, or may still own, the design document through its sibling
+    /// lock.
     ///
     /// KiCad lock files identify only a username and hostname, so their
     /// presence cannot be distinguished reliably from a stale lock. Writers
     /// must fail closed and leave both the document and the lock untouched.
     #[error("KiCad editor lock blocks write to {path}: {lock_path}")]
-    KiCadEditorLocked { path: PathBuf, lock_path: PathBuf },
+    KiCadEditorLocked {
+        path: PathBuf,
+        lock_path: PathBuf,
+        /// Inspection failures are retained so callers can distinguish an
+        /// observed lock from a lock whose absence could not be established.
+        inspection_error: Option<String>,
+    },
 
     /// A revision-aware command found that one of its target items no longer
     /// matches the exact item revision on which the command was prepared.

--- a/crates/konnect-sexp/src/transaction.rs
+++ b/crates/konnect-sexp/src/transaction.rs
@@ -7,7 +7,7 @@
 //! explicit resolution.
 
 use crate::writer::{
-    ensure_kicad_schematic_is_closed, open_document_lock, read_string_unlocked,
+    ensure_kicad_design_document_is_closed, open_document_lock, read_string_unlocked,
     sync_parent_directory, write_atomic_unlocked, write_new_atomic_unlocked,
 };
 use crate::SexpError;
@@ -652,7 +652,7 @@ fn lock_entries(root: &Path, entries: &[JournalEntry]) -> Result<Vec<std::fs::Fi
 
 fn ensure_entries_are_closed(root: &Path, entries: &[JournalEntry]) -> Result<(), SexpError> {
     for entry in entries {
-        ensure_kicad_schematic_is_closed(&root.join(&entry.path))?;
+        ensure_kicad_design_document_is_closed(&root.join(&entry.path))?;
     }
     Ok(())
 }

--- a/crates/konnect-sexp/src/writer.rs
+++ b/crates/konnect-sexp/src/writer.rs
@@ -110,7 +110,15 @@ pub fn write_atomic(path: &Path, content: &str) -> Result<(), SexpError> {
 }
 
 pub(crate) fn write_atomic_unlocked(path: &Path, content: &str) -> Result<(), SexpError> {
-    ensure_kicad_schematic_is_closed(path)?;
+    write_atomic_unlocked_with(path, content, || {})
+}
+
+fn write_atomic_unlocked_with(
+    path: &Path,
+    content: &str,
+    before_replace: impl FnOnce(),
+) -> Result<(), SexpError> {
+    ensure_kicad_design_document_is_closed(path)?;
     let (tmp_path, mut file) = create_scratch_file(path)?;
 
     // Remove the scratch file unless the rename below succeeds.
@@ -127,7 +135,8 @@ pub(crate) fn write_atomic_unlocked(path: &Path, content: &str) -> Result<(), Se
 
     // A lock may have appeared while the scratch file was being written.
     // Recheck at the last refusal point before replacing the document.
-    ensure_kicad_schematic_is_closed(path)?;
+    before_replace();
+    ensure_kicad_design_document_is_closed(path)?;
     std::fs::rename(&tmp_path, path)?;
     cleanup.disarm();
     sync_parent_directory(path.parent().unwrap_or_else(|| Path::new(".")))?;
@@ -205,39 +214,72 @@ pub(crate) fn open_document_lock(path: &Path) -> Result<std::fs::File, SexpError
     open_lock_file(&lock_path)
 }
 
-/// Refuse a `.kicad_sch` mutation while KiCad's sibling lock is present.
+/// Refuse a `.kicad_sch` or `.kicad_pcb` mutation while KiCad's sibling lock
+/// is present.
 ///
 /// KiCad 10 writes only `username` and `hostname` into this file. There is no
 /// PID, process start time, or document token with which to prove that a lock
 /// is stale, especially for another host. Its contents are therefore neither
 /// parsed nor trusted: any filesystem entry at the lock path blocks the write.
-/// Reads and non-schematic writes are unaffected.
-pub(crate) fn ensure_kicad_schematic_is_closed(path: &Path) -> Result<(), SexpError> {
-    let Some(lock_path) = kicad_schematic_lock_path(path) else {
+/// Reads and non-design-document writes are unaffected.
+pub(crate) fn ensure_kicad_design_document_is_closed(path: &Path) -> Result<(), SexpError> {
+    let Some(lock_path) = kicad_editor_lock_path(path) else {
         return Ok(());
     };
 
-    match std::fs::symlink_metadata(&lock_path) {
+    ensure_kicad_design_document_is_closed_with(path, &lock_path, |path| {
+        std::fs::symlink_metadata(path).map(|_| ())
+    })
+}
+
+fn ensure_kicad_design_document_is_closed_with(
+    path: &Path,
+    lock_path: &Path,
+    inspect: impl FnOnce(&Path) -> std::io::Result<()>,
+) -> Result<(), SexpError> {
+    match inspect(lock_path) {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Ok(_) | Err(_) => Err(SexpError::KiCadEditorLocked {
+        Ok(()) => Err(SexpError::KiCadEditorLocked {
             path: path.to_path_buf(),
-            lock_path,
+            lock_path: lock_path.to_path_buf(),
+            inspection_error: None,
+        }),
+        Err(error) => Err(SexpError::KiCadEditorLocked {
+            path: path.to_path_buf(),
+            lock_path: lock_path.to_path_buf(),
+            inspection_error: Some(error.to_string()),
         }),
     }
 }
 
-fn kicad_schematic_lock_path(path: &Path) -> Option<PathBuf> {
-    let is_schematic = path
-        .extension()
-        .and_then(OsStr::to_str)
-        .is_some_and(|extension| extension.eq_ignore_ascii_case("kicad_sch"));
-    if !is_schematic {
+/// KiCad's sibling editor-lock path for a schematic or board document:
+/// `~<filename>.lck` in the same directory.
+///
+/// This derives identity only; callers decide what an observed or unreadable
+/// lock means for their operation. Other file types return `None` so a caller
+/// cannot accidentally treat an unrelated tilde file as editor state.
+pub fn kicad_editor_lock_path(path: &Path) -> Option<PathBuf> {
+    let resolved = path.canonicalize().unwrap_or_else(|_| {
+        path.parent()
+            .and_then(|parent| parent.canonicalize().ok())
+            .and_then(|parent| path.file_name().map(|name| parent.join(name)))
+            .unwrap_or_else(|| path.to_path_buf())
+    });
+    let is_design_document =
+        resolved
+            .extension()
+            .and_then(OsStr::to_str)
+            .is_some_and(|extension| {
+                extension.eq_ignore_ascii_case("kicad_sch")
+                    || extension.eq_ignore_ascii_case("kicad_pcb")
+            });
+    if !is_design_document {
         return None;
     }
     let mut name = OsString::from("~");
-    name.push(path.file_name()?);
+    name.push(resolved.file_name()?);
     name.push(".lck");
-    Some(path.with_file_name(name))
+    Some(resolved.with_file_name(name))
 }
 
 fn open_lock_file(lock_path: &Path) -> Result<std::fs::File, SexpError> {
@@ -359,7 +401,7 @@ pub fn write_new_atomic(path: &Path, content: &str) -> Result<(), SexpError> {
 }
 
 pub(crate) fn write_new_atomic_unlocked(path: &Path, content: &str) -> Result<(), SexpError> {
-    ensure_kicad_schematic_is_closed(path)?;
+    ensure_kicad_design_document_is_closed(path)?;
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     let mut temporary = tempfile::Builder::new()
         .prefix(".konnect-")
@@ -367,7 +409,7 @@ pub(crate) fn write_new_atomic_unlocked(path: &Path, content: &str) -> Result<()
     temporary.write_all(content.as_bytes())?;
     temporary.flush()?;
     temporary.as_file().sync_all()?;
-    ensure_kicad_schematic_is_closed(path)?;
+    ensure_kicad_design_document_is_closed(path)?;
     temporary
         .persist_noclobber(path)
         .map_err(|error| SexpError::Io(error.error))?;
@@ -1241,6 +1283,22 @@ mod atomic_write_tests {
     }
 
     #[test]
+    fn kicad_editor_lock_path_is_exact_for_schematics_and_boards() {
+        assert_eq!(
+            kicad_editor_lock_path(Path::new("project/design.kicad_sch")),
+            Some(PathBuf::from("project/~design.kicad_sch.lck"))
+        );
+        assert_eq!(
+            kicad_editor_lock_path(Path::new("project/design.kicad_pcb")),
+            Some(PathBuf::from("project/~design.kicad_pcb.lck"))
+        );
+        assert_eq!(
+            kicad_editor_lock_path(Path::new("project/design.kicad_pro")),
+            None
+        );
+    }
+
+    #[test]
     fn conditional_write_rejects_a_kicad_schematic_lock() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("design.kicad_sch");
@@ -1262,8 +1320,10 @@ mod atomic_write_tests {
             error,
             SexpError::KiCadEditorLocked {
                 path: blocked_path,
-                lock_path
-            } if blocked_path.ends_with("design.kicad_sch") && lock_path == lock
+                lock_path,
+                ..
+            } if blocked_path.ends_with("design.kicad_sch")
+                && lock_path.ends_with("~design.kicad_sch.lck")
         ));
     }
 
@@ -1300,16 +1360,63 @@ mod atomic_write_tests {
     }
 
     #[test]
-    fn kicad_lock_name_does_not_block_a_non_schematic_write() {
+    fn conditional_write_rejects_a_kicad_board_lock() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("design.kicad_pcb");
         let lock = directory.path().join("~design.kicad_pcb.lck");
         std::fs::write(&path, "expected").unwrap();
-        std::fs::write(lock, "not relevant to this shared writer").unwrap();
+        std::fs::write(&lock, "editor state cannot be proven stale").unwrap();
 
-        write_atomic_if_unchanged(&path, "expected", "edited").unwrap();
+        let error = write_atomic_if_unchanged(&path, "expected", "edited").unwrap_err();
 
-        assert_eq!(std::fs::read_to_string(path).unwrap(), "edited");
+        assert!(matches!(
+            error,
+            SexpError::KiCadEditorLocked {
+                path: blocked_path,
+                lock_path,
+                ..
+            } if blocked_path == path && lock_path.ends_with("~design.kicad_pcb.lck")
+        ));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "expected");
+    }
+
+    #[test]
+    fn an_uninspectable_board_lock_retains_distinct_evidence() {
+        let path = Path::new("design.kicad_pcb");
+        let lock = Path::new("~design.kicad_pcb.lck");
+
+        let error = ensure_kicad_design_document_is_closed_with(path, lock, |_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "mock access denied",
+            ))
+        })
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            SexpError::KiCadEditorLocked {
+                inspection_error: Some(message),
+                ..
+            } if message.contains("mock access denied")
+        ));
+    }
+
+    #[test]
+    fn a_lock_appearing_after_the_first_gate_blocks_atomic_replacement() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("design.kicad_pcb");
+        let lock = directory.path().join("~design.kicad_pcb.lck");
+        std::fs::write(&path, "expected").unwrap();
+
+        let error = write_atomic_unlocked_with(&path, "replacement", || {
+            std::fs::write(&lock, "appeared during write").unwrap();
+        })
+        .unwrap_err();
+
+        assert!(matches!(error, SexpError::KiCadEditorLocked { .. }));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "expected");
+        assert!(lock.exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Refuse cold-start direct-file board mutations when the exact requested board has a KiCad sibling lock, or when that lock cannot be inspected reliably. This reconstructs only the unique work from #391 on current `main`, after the exact-document binding foundation in #480 landed.

Closes #385.

## Design

- Derive `~<filename>.lck` from the canonical exact board path; unrelated-board locks do not taint the request.
- Check the lock before both unreachable-IPC fallback gates.
- Recheck immediately before atomic replacement, catching a lock that appears after preflight.
- Reuse the structured `unsafe_file_fallback` contract with stable `reason` evidence:
  - `kicad_lock_present`
  - `kicad_lock_unreadable`
- Keep lock absence as only the absence of this veto; all #480 IPC/session/path-identity gates still apply.
- Never parse ownership from lock contents, infer safety from age, remove a lock, or add a force bypass.
- Preserve the existing schematic-lock conflict behavior.

## Recovery contract

Refusals leave board bytes and the lock untouched. Guidance tells the user to close or recover Pcbnew, reconcile unsaved work, and save the authoritative board. It does not tell an agent to remove the lock or retry automatically.

## Evidence

- Full local gate passed:
  - `cargo fmt --all -- --check`
  - `cargo clippy --workspace --locked --all-targets -- -D warnings`
  - `cargo test --workspace --locked --lib --tests`
  - `cargo test --workspace --locked --doc`
- Deterministic coverage includes present, stale-looking/malformed, unreadable, absent, and other-board locks; both fallback gates; byte-identical refusal; canonical lock identity; and a lock appearing between preflight and atomic replacement.
- Negative control: temporarily disabling the preflight lock guard made `any_exact_board_lock_refuses_both_offline_fallback_gates_without_writing` fail.
- Windows/KiCad 10.0.6 observation: opening a disposable board created the exact sibling lock with hostname/username content; forced process exit left the lock behind.
- `BLOCKED` observation debt: the non-interactive harness could not exercise a clean GUI close, and macOS/Linux KiCad lock lifecycles were not exercised locally. Hosted CI will provide supported-platform compile and deterministic regression coverage, but these GUI lifecycle observations remain explicit validation debt.

## Compatibility and risk

This intentionally narrows cold-start behavior: a stale lock can cause a recoverable false-positive refusal. That is preferable to writing a saved board that may be older than unsaved editor state. Rollback is the single focused commit.

## Provenance

The unique implementation originated in #391 by @dubesinhower; authorship is preserved on the reconstructed commit. The error contract and tests were adjusted to match the accepted maintainer decision in #385 rather than replaying the old draft's `stale_target` response.