### PR TITLE
fix(ipc): preserve exact typed board binding

### DIFF
--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -704,9 +704,13 @@ impl KiCadIpcClient {
                 requested: "<unspecified>".to_string(),
             })),
             [document] => {
-                if let Ok(path) = board_document_identity(document) {
-                    self.bind_board(path, document.clone())?;
-                }
+                let path = board_document_identity(document).map_err(|reason| {
+                    anyhow::Error::new(BoardTargetError::UnresolvedDocumentIdentities {
+                        requested: "<unspecified>".to_string(),
+                        reasons: vec![reason],
+                    })
+                })?;
+                self.bind_board(path, document.clone())?;
                 Ok(document.clone())
             }
             _ => Err(anyhow::Error::new(BoardTargetError::AmbiguousDocument {
@@ -737,14 +741,23 @@ impl KiCadIpcClient {
         requested: PathBuf,
         document: kiapi::common::types::DocumentSpecifier,
     ) -> Result<()> {
-        *self
+        let mut bound = self
             .bound_board
             .lock()
-            .map_err(|_| anyhow::anyhow!("bound board target lock is poisoned"))? =
-            Some(BoundBoardTarget {
-                requested,
-                document,
-            });
+            .map_err(|_| anyhow::anyhow!("bound board target lock is poisoned"))?;
+        if let Some(previous) = bound.as_ref() {
+            if previous.document != document {
+                return Err(anyhow::Error::new(BoardTargetError::StaleDocument {
+                    requested: requested.display().to_string(),
+                    previously_bound: board_document_label(&previous.document),
+                    open_documents: vec![board_document_label(&document)],
+                }));
+            }
+        }
+        *bound = Some(BoundBoardTarget {
+            requested,
+            document,
+        });
         Ok(())
     }
 

--- a/crates/konnect-ipc/tests/mock_server_test.rs
+++ b/crates/konnect-ipc/tests/mock_server_test.rs
@@ -1908,3 +1908,141 @@ fn verified_trace_delete_refuses_success_when_readback_still_contains_the_segmen
 
     assert!(error.contains("read-back still reports it"), "{error}");
 }
+
+#[test]
+fn generic_helpers_refuse_unbound_ambiguous_or_unidentifiable_documents() {
+    let mut unidentifiable = doc_for("unknown.kicad_pcb");
+    unidentifiable.project = None;
+    for (documents, expected) in [
+        (vec![], "wrong"),
+        (
+            vec![doc_for("a.kicad_pcb"), doc_for("b.kicad_pcb")],
+            "multiple",
+        ),
+        (vec![unidentifiable], "unresolved"),
+    ] {
+        let mock = spawn_mock(move |request| {
+            let message = request.message.unwrap();
+            assert!(
+                message.type_url.ends_with("GetOpenDocuments"),
+                "must refuse before command"
+            );
+            Some(reply_with(builders::pack_any(
+                &kiapi::common::commands::GetOpenDocumentsResponse {
+                    documents: documents.clone(),
+                },
+                "kiapi.common.commands.GetOpenDocumentsResponse",
+            )))
+        });
+        let client = KiCadIpcClient::new(&mock.url);
+        let failure =
+            konnect_ipc::IpcFailure::from_error(client.create_items(vec![any_item()]).unwrap_err());
+        match (expected, failure) {
+            (
+                "wrong",
+                konnect_ipc::IpcFailure::Target {
+                    error: konnect_ipc::BoardTargetError::NoOpenDocuments { .. },
+                    ..
+                },
+            )
+            | (
+                "multiple",
+                konnect_ipc::IpcFailure::Target {
+                    error: konnect_ipc::BoardTargetError::AmbiguousDocument { .. },
+                    ..
+                },
+            )
+            | (
+                "unresolved",
+                konnect_ipc::IpcFailure::Target {
+                    error: konnect_ipc::BoardTargetError::UnresolvedDocumentIdentities { .. },
+                    ..
+                },
+            ) => {}
+            (_, other) => panic!("unexpected classification: {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn repeating_lookup_cannot_replace_the_bound_typed_document() {
+    let observations = std::sync::atomic::AtomicUsize::new(0);
+    let mock = spawn_mock(move |request| {
+        assert!(request
+            .message
+            .unwrap()
+            .type_url
+            .ends_with("GetOpenDocuments"));
+        let mut doc = doc_for("target.kicad_pcb");
+        if observations.fetch_add(1, std::sync::atomic::Ordering::SeqCst) > 0 {
+            doc.project.as_mut().unwrap().name = "replacement".into();
+        }
+        Some(reply_with(builders::pack_any(
+            &kiapi::common::commands::GetOpenDocumentsResponse {
+                documents: vec![doc],
+            },
+            "kiapi.common.commands.GetOpenDocumentsResponse",
+        )))
+    });
+    let client = KiCadIpcClient::new(&mock.url);
+    client
+        .find_open_board(&mock_board("target.kicad_pcb"))
+        .unwrap();
+    let failure = konnect_ipc::IpcFailure::from_error(
+        client
+            .find_open_board(&mock_board("target.kicad_pcb"))
+            .unwrap_err(),
+    );
+    assert!(matches!(
+        failure,
+        konnect_ipc::IpcFailure::Target {
+            error: konnect_ipc::BoardTargetError::StaleDocument { .. },
+            ..
+        }
+    ));
+}
+
+#[test]
+fn generic_reobservation_cannot_replace_the_bound_typed_document() {
+    let observations = std::sync::atomic::AtomicUsize::new(0);
+    let mock = spawn_mock(move |request| {
+        let message = request.message.unwrap();
+        if message.type_url.ends_with("GetItems") {
+            return Some(reply_with(builders::pack_any(
+                &kiapi::common::commands::GetItemsResponse {
+                    header: None,
+                    status: kiapi::common::types::ItemRequestStatus::IrsOk as i32,
+                    items: vec![],
+                },
+                "kiapi.common.commands.GetItemsResponse",
+            )));
+        }
+        assert!(message.type_url.ends_with("GetOpenDocuments"));
+        let mut doc = doc_for("target.kicad_pcb");
+        if observations.fetch_add(1, std::sync::atomic::Ordering::SeqCst) > 0 {
+            doc.project.as_mut().unwrap().name = "replacement".into();
+        }
+        Some(reply_with(builders::pack_any(
+            &kiapi::common::commands::GetOpenDocumentsResponse {
+                documents: vec![doc],
+            },
+            "kiapi.common.commands.GetOpenDocumentsResponse",
+        )))
+    });
+    let client = KiCadIpcClient::new(&mock.url);
+    client
+        .find_open_board(&mock_board("target.kicad_pcb"))
+        .unwrap();
+    let failure = konnect_ipc::IpcFailure::from_error(
+        client
+            .get_items(kiapi::common::types::KiCadObjectType::KotPcbFootprint)
+            .unwrap_err(),
+    );
+    assert!(matches!(
+        failure,
+        konnect_ipc::IpcFailure::Target {
+            error: konnect_ipc::BoardTargetError::StaleDocument { .. },
+            ..
+        }
+    ));
+}


### PR DESCRIPTION
Closes #384

## Why this follow-up exists

PR #480 established requested-board binding, but independent post-merge testing by @dubesinhower found two deterministic gaps on its exact merged head:

- repeated generic lookup could replace an existing binding with a different full typed `DocumentSpecifier` that represented the same file identity;
- the unbound single-document path ignored a failed identity resolution and could allow a generic mutation to reach `CreateItems`.

## What changed

- Preserve an existing typed board binding unless the complete `DocumentSpecifier` is unchanged; a changed typed identity now returns `StaleDocument`.
- Propagate an unresolved identity in the unbound single-document path as `UnresolvedDocumentIdentities` before mutation.
- Preserve @dubesinhower's three focused reproduction tests and commit authorship.

## Evidence

Before the implementation commit, all three new tests failed against merged `main` with the reported behavior. After the fix, all three pass.

The complete local gate passes:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo test --workspace --locked --lib --tests`
- `cargo test --workspace --locked --doc`

This is a deterministic protocol-level correction. It does not claim additional live multi-board GUI coverage.

## Rollback

Revert the two focused commits in this PR: the reproduction tests and the minimal binding correction.
