### PR TITLE
feat(navigation): resolve exact editor targets

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -320,7 +320,7 @@ Source: [`crates/konnect-core/src/observability.rs`](crates/konnect-core/src/obs
 
 ## Tool Routing (Starter Kit + On-Demand Loading)
 
-The server does NOT expose all 223 tools (230 total with the 7 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
+The server does NOT expose all 224 tools (231 total with the 7 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
 
 - **Startup**: only `STARTER_KIT` toolsets are pre-loaded (see `router/registry.rs::STARTER_KIT`). Currently: `project`, `config`. Combined with the 7 meta-tools, baseline `tools/list` is 21 tools ≈ 2K tokens.
 - **On demand**: the LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose a toolset's tools in subsequent `tools/list` responses. `unload_toolset(name)` prunes them when the task shifts.
@@ -395,9 +395,9 @@ convention for other `kicad-cli`-calling code.
 
 ## Current Stats
 
-- **21 toolsets, 223 tools** + 7 meta-tools (4 routing + 2 observability + 1 runtime diagnostic — see `tool-directory.md`)
+- **21 toolsets, 224 tools** + 7 meta-tools (4 routing + 2 observability + 1 runtime diagnostic — see `tool-directory.md`)
 - Baseline `tools/list`: 21 tools / ~2K tokens (starter kit + meta-tools)
-- Full-catalog `tools/list` (all loaded): 230 tools (223 registered + 7 meta) / ~25K tokens
+- Full-catalog `tools/list` (all loaded): 231 tools (224 registered + 7 meta) / ~25K tokens
 - **0 IPC stubs** (all protobuf methods implemented)
 - **0 unimplemented tools**
 - **Specctra DSN/SES are PCB-editor operations**, not `kicad-cli` commands.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Rust binary — that lets Claude and other AI assistants design schematics and PCBs
 through the [Model Context Protocol](https://modelcontextprotocol.io) (MCP).
 
-**223 tools across 21 on-demand toolsets.** Schematic capture, PCB layout and
+**224 tools across 21 on-demand toolsets.** Schematic capture, PCB layout and
 routing, ERC/DRC, design-review audits, JLCPCB part search, reference
 circuits, and a full manufacturing export pipeline — with bundled skills and agents
 that teach Claude KiCAD conventions out of the box.
@@ -70,7 +70,7 @@ through its own S-expression engine with atomic writes (write, fsync, rename), U
 preservation, and round-trip tests — no third-party schematic library with known
 gaps, no text-manipulation workarounds.
 
-**Context economy is a feature.** Exposing all 223 tools to an LLM costs roughly 23K
+**Context economy is a feature.** Exposing all 224 tools to an LLM costs roughly 23K
 tokens of context on every listing. Konnect's router loads a starter kit (~2K
 tokens) and lets the model pull in toolsets on demand — plus built-in observability
 (`get_recent_calls`, `server_stats`, JSONL call logs) so the model can diagnose its

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -28,7 +28,7 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         name: "editor_navigation",
         description: "Observe and semantically navigate exact KiCad editor, document, sheet, selection, and cross-probe context",
         category: "project",
-        tool_count: 2,
+        tool_count: 3,
     },
     ToolsetMeta {
         name: "sch_components",

--- a/crates/konnect-core/src/tools/editor_navigation.rs
+++ b/crates/konnect-core/src/tools/editor_navigation.rs
@@ -13,6 +13,11 @@ use konnect_ipc::{
     IpcSheetInstancePath,
 };
 use serde_json::json;
+use std::path::PathBuf;
+
+use super::navigation_target::{
+    resolve_navigation_target, NavigationTargetErrorKind, NavigationTargetRequest,
+};
 
 pub fn tools() -> Vec<ToolDef> {
     vec![
@@ -46,6 +51,25 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["editor", "project_name", "project_path"]
             }),
             |args, ctx| async move { handle_get_editor_selection(args, ctx).await }
+        ),
+        tool!(
+            "resolve_navigation_target",
+            "Deterministically resolve one exact saved KiCad object in an explicitly open project, document, editor, and schematic hierarchy instance. Stable KIID/UUID identity is primary; a human reference is accepted only when it resolves uniquely and ambiguity is returned with candidates.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "editor": { "type": "string", "enum": ["schematic", "pcb"] },
+                    "project_name": { "type": "string" },
+                    "project_path": { "type": "string" },
+                    "document_path": { "type": "string", "description": "Exact saved .kicad_sch or .kicad_pcb document" },
+                    "sheet_instance_path": { "type": "array", "items": { "type": "string" } },
+                    "sheet_path_human_readable": { "type": "string" },
+                    "object_kiid": { "type": "string", "description": "Preferred stable KIID/UUID" },
+                    "human_reference": { "type": "string", "description": "Fallback reference such as C10; must resolve uniquely" }
+                },
+                "required": ["editor", "project_name", "project_path", "document_path"]
+            }),
+            |args, ctx| async move { handle_resolve_navigation_target(args, ctx).await }
         ),
     ]
 }
@@ -283,6 +307,151 @@ fn selection_error_result(error: anyhow::Error) -> CallToolResult {
     }
 }
 
+async fn handle_resolve_navigation_target(
+    args: &serde_json::Value,
+    ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let request = match parse_navigation_target_request(args) {
+        Ok(request) => request,
+        Err(result) => return Ok(result),
+    };
+    let live_document = IpcEditorDocument {
+        editor: request.editor,
+        project: Some(request.project.clone()),
+        document_path: (request.editor == IpcEditorKind::Pcb)
+            .then(|| request.document_path.display().to_string()),
+        sheet_instance_path: request.sheet_instance_path.clone(),
+    };
+    let address = ctx.config.ipc_address.clone();
+    if address.is_empty() {
+        return Ok(editor_unavailable("no KiCad IPC endpoint is configured"));
+    }
+    let observed = tokio::task::spawn_blocking(move || {
+        konnect_ipc::KiCadIpcClient::new(address).observe_exact_open_document(&live_document)
+    })
+    .await?;
+    let observed = match observed {
+        Ok(observed) => observed,
+        Err(error) => return Ok(selection_error_result(error)),
+    };
+
+    let resolved = tokio::task::spawn_blocking(move || resolve_navigation_target(&request)).await?;
+    match resolved {
+        Ok(target) => Ok(CallToolResult::json(&json!({
+            "target": target,
+            "live_context_evidence": {
+                "source": "kicad_ipc_get_open_documents",
+                "document": observed
+            }
+        }))),
+        Err(error) => Ok(navigation_target_error_result(error)),
+    }
+}
+
+fn parse_navigation_target_request(
+    args: &serde_json::Value,
+) -> Result<NavigationTargetRequest, CallToolResult> {
+    let editor = match require_str(args, "editor")? {
+        "schematic" => IpcEditorKind::Schematic,
+        "pcb" => IpcEditorKind::Pcb,
+        _ => return Err(invalid_arg("editor", "expected 'schematic' or 'pcb'")),
+    };
+    let project_name = require_str(args, "project_name")?;
+    let project_path = require_str(args, "project_path")?;
+    let document_path = require_str(args, "document_path")?;
+    if project_name.is_empty() || project_path.is_empty() || document_path.is_empty() {
+        return Err(invalid_arg(
+            "project_name",
+            "project and document identity strings must not be empty",
+        ));
+    }
+
+    let sheet_instance_path = match editor {
+        IpcEditorKind::Pcb => {
+            if !args["sheet_instance_path"].is_null()
+                || !args["sheet_path_human_readable"].is_null()
+            {
+                return Err(invalid_arg(
+                    "sheet_instance_path",
+                    "PCB targets cannot carry schematic sheet identity",
+                ));
+            }
+            None
+        }
+        IpcEditorKind::Schematic => {
+            let ids = require_array(args, "sheet_instance_path")?
+                .iter()
+                .map(|value| value.as_str().map(str::to_string))
+                .collect::<Option<Vec<_>>>()
+                .ok_or_else(|| {
+                    invalid_arg("sheet_instance_path", "every entry must be a string")
+                })?;
+            if ids.is_empty() || ids.iter().any(String::is_empty) {
+                return Err(invalid_arg(
+                    "sheet_instance_path",
+                    "must contain non-empty root-to-leaf KIIIDs",
+                ));
+            }
+            Some(IpcSheetInstancePath {
+                kiids: ids,
+                human_readable: opt_str(args, "sheet_path_human_readable")
+                    .unwrap_or("")
+                    .to_string(),
+            })
+        }
+    };
+    let object_kiid = opt_str(args, "object_kiid").map(str::to_string);
+    let human_reference = opt_str(args, "human_reference").map(str::to_string);
+    if object_kiid.as_deref().is_some_and(str::is_empty)
+        || human_reference.as_deref().is_some_and(str::is_empty)
+        || object_kiid.is_some() == human_reference.is_some()
+    {
+        return Err(invalid_arg(
+            "object_kiid",
+            "provide exactly one non-empty object_kiid or human_reference",
+        ));
+    }
+    Ok(NavigationTargetRequest {
+        editor,
+        project: IpcProjectIdentity {
+            name: project_name.to_string(),
+            path: project_path.to_string(),
+        },
+        document_path: PathBuf::from(document_path),
+        sheet_instance_path,
+        object_kiid,
+        human_reference,
+    })
+}
+
+fn navigation_target_error_result(
+    error: super::navigation_target::NavigationTargetError,
+) -> CallToolResult {
+    let kind = match error.kind {
+        NavigationTargetErrorKind::WrongProject => ToolErrorKind::WrongProject {
+            requested: error.target.clone(),
+            open_projects: error.candidates.clone(),
+        },
+        NavigationTargetErrorKind::WrongDocument => ToolErrorKind::WrongDocument {
+            requested: error.target.clone(),
+            open_documents: error.candidates.clone(),
+        },
+        NavigationTargetErrorKind::WrongSheetInstance => ToolErrorKind::WrongSheetInstance {
+            requested: error.target.clone(),
+            open_sheet_instances: error.candidates.clone(),
+        },
+        NavigationTargetErrorKind::AmbiguousTarget => ToolErrorKind::AmbiguousTarget {
+            target: error.target.clone(),
+            candidates: error.candidates.clone(),
+        },
+        NavigationTargetErrorKind::StaleTarget => ToolErrorKind::StaleTarget {
+            target: error.target.clone(),
+            reason: error.reason.clone(),
+        },
+    };
+    CallToolResult::error_kind(kind, error.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -436,10 +605,57 @@ mod tests {
         url
     }
 
+    fn spawn_open_board_mock(project_path: String) -> String {
+        static NEXT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let url = format!(
+            "inproc://navigation-resolver-core-{}",
+            NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        );
+        let socket = nng::Socket::new(nng::Protocol::Rep0).expect("mock socket");
+        socket.listen(&url).expect("listen");
+        std::thread::spawn(move || {
+            let message = socket.recv().expect("request");
+            let request =
+                kiapi::common::ApiRequest::decode(message.as_slice()).expect("decode request");
+            assert!(request
+                .message
+                .as_ref()
+                .is_some_and(|message| message.type_url.ends_with("GetOpenDocuments")));
+            let response = kiapi::common::ApiResponse {
+                status: Some(kiapi::common::ApiResponseStatus {
+                    status: kiapi::common::ApiStatusCode::AsOk as i32,
+                    error_message: String::new(),
+                }),
+                header: None,
+                message: Some(builders::pack_any(
+                    &kiapi::common::commands::GetOpenDocumentsResponse {
+                        documents: vec![kiapi::common::types::DocumentSpecifier {
+                            r#type: kiapi::common::types::DocumentType::DoctypePcb as i32,
+                            identifier: Some(
+                                kiapi::common::types::document_specifier::Identifier::BoardFilename(
+                                    "layout.kicad_pcb".to_string(),
+                                ),
+                            ),
+                            project: Some(kiapi::common::types::ProjectSpecifier {
+                                name: "nav".to_string(),
+                                path: project_path,
+                            }),
+                        }],
+                    },
+                    "kiapi.common.commands.GetOpenDocumentsResponse",
+                )),
+            };
+            socket
+                .send(nng::Message::from(response.encode_to_vec().as_slice()))
+                .expect("response");
+        });
+        url
+    }
+
     #[test]
     fn public_tool_is_read_only_and_takes_no_required_arguments() {
         let definitions = tools();
-        assert_eq!(definitions.len(), 2);
+        assert_eq!(definitions.len(), 3);
         let state = definitions
             .iter()
             .find(|tool| tool.name == "get_editor_state")
@@ -452,6 +668,14 @@ mod tests {
         assert_eq!(
             selection.input_schema["required"],
             json!(["editor", "project_name", "project_path"])
+        );
+        let resolver = definitions
+            .iter()
+            .find(|tool| tool.name == "resolve_navigation_target")
+            .expect("resolver tool");
+        assert_eq!(
+            resolver.input_schema["required"],
+            json!(["editor", "project_name", "project_path", "document_path"])
         );
     }
 
@@ -555,6 +779,70 @@ mod tests {
         assert_eq!(
             extract_error_kind(&result).as_deref(),
             Some("wrong_sheet_instance")
+        );
+    }
+
+    #[test]
+    fn resolver_parser_requires_exactly_one_identifier() {
+        let base = json!({
+            "editor": "pcb",
+            "project_name": "navigation",
+            "project_path": r"C:\design",
+            "document_path": r"C:\design\navigation.kicad_pcb"
+        });
+        let missing = parse_navigation_target_request(&base).expect_err("identifier required");
+        assert_eq!(
+            extract_error_kind(&missing).as_deref(),
+            Some("invalid_argument")
+        );
+
+        let mut both = base;
+        both["object_kiid"] = json!("id");
+        both["human_reference"] = json!("C10");
+        let ambiguous = parse_navigation_target_request(&both).expect_err("one identifier only");
+        assert_eq!(
+            extract_error_kind(&ambiguous).as_deref(),
+            Some("invalid_argument")
+        );
+    }
+
+    #[tokio::test]
+    async fn public_resolver_keeps_live_and_structural_evidence_separate() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("nav.kicad_pro"), "{}").unwrap();
+        let board = temp.path().join("layout.kicad_pcb");
+        std::fs::write(
+            &board,
+            "(kicad_pcb (footprint \"Capacitor:C\" (layer \"F.Cu\") (at 1 2) \
+             (uuid \"fp-c10\") (property \"Reference\" \"C10\")))",
+        )
+        .unwrap();
+        let project_path = temp.path().display().to_string();
+        let result = handle_resolve_navigation_target(
+            &json!({
+                "editor": "pcb",
+                "project_name": "nav",
+                "project_path": project_path.clone(),
+                "document_path": board.display().to_string(),
+                "human_reference": "C10"
+            }),
+            &context(spawn_open_board_mock(project_path)),
+        )
+        .await
+        .expect("handler result");
+        assert!(!result.is_error);
+        let ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text result");
+        };
+        let body: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(body["target"]["object"]["kiid"], "fp-c10");
+        assert_eq!(
+            body["target"]["structural_evidence"]["source"],
+            "saved_kicad_structure"
+        );
+        assert_eq!(
+            body["live_context_evidence"]["source"],
+            "kicad_ipc_get_open_documents"
         );
     }
 }

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -11,6 +11,7 @@ mod footprint_models;
 pub mod integration;
 pub mod library;
 pub mod manufacturing;
+pub(crate) mod navigation_target;
 pub mod pcb_board;
 pub mod pcb_components;
 pub mod pcb_export;

--- a/crates/konnect-core/src/tools/navigation_target.rs
+++ b/crates/konnect-core/src/tools/navigation_target.rs
@@ -1,0 +1,646 @@
+//! Pure deterministic navigation-target resolution.
+//!
+//! This module reads saved KiCad structure only. Live editor/document proof is
+//! performed separately by `editor_navigation` so results never blur file
+//! evidence with IPC evidence.
+
+use konnect_ipc::{IpcEditorKind, IpcProjectIdentity, IpcSheetInstancePath};
+use konnect_sexp::SexpNode;
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NavigationTargetRequest {
+    pub editor: IpcEditorKind,
+    pub project: IpcProjectIdentity,
+    pub document_path: PathBuf,
+    pub sheet_instance_path: Option<IpcSheetInstancePath>,
+    pub object_kiid: Option<String>,
+    pub human_reference: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct ResolvedNavigationObject {
+    pub kiid: String,
+    pub object_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub human_reference: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct NavigationStructuralEvidence {
+    pub source: String,
+    pub project_file: String,
+    pub document_path: String,
+    pub resolver: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct ResolvedNavigationTarget {
+    pub project: IpcProjectIdentity,
+    pub editor: IpcEditorKind,
+    pub document_path: String,
+    pub sheet_instance_path: Option<IpcSheetInstancePath>,
+    pub object: ResolvedNavigationObject,
+    pub structural_evidence: NavigationStructuralEvidence,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NavigationTargetErrorKind {
+    WrongProject,
+    WrongDocument,
+    WrongSheetInstance,
+    AmbiguousTarget,
+    StaleTarget,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NavigationTargetError {
+    pub kind: NavigationTargetErrorKind,
+    pub target: String,
+    pub candidates: Vec<String>,
+    pub reason: String,
+}
+
+impl std::fmt::Display for NavigationTargetError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "cannot resolve navigation target '{}': {}",
+            self.target, self.reason
+        )
+    }
+}
+
+impl std::error::Error for NavigationTargetError {}
+
+pub(crate) fn resolve_navigation_target(
+    request: &NavigationTargetRequest,
+) -> Result<ResolvedNavigationTarget, NavigationTargetError> {
+    let project_file = PathBuf::from(&request.project.path)
+        .join(&request.project.name)
+        .with_extension("kicad_pro");
+    if !project_file.is_file() {
+        return Err(target_error(
+            NavigationTargetErrorKind::WrongProject,
+            &request.project.name,
+            Vec::new(),
+            format!(
+                "the explicit project file '{}' does not exist",
+                project_file.display()
+            ),
+        ));
+    }
+    if !request.document_path.is_file() {
+        return Err(target_error(
+            NavigationTargetErrorKind::StaleTarget,
+            &request.document_path.display().to_string(),
+            Vec::new(),
+            "the saved document no longer exists".to_string(),
+        ));
+    }
+
+    let (tree, instance_path) = match request.editor {
+        IpcEditorKind::Schematic => {
+            if !has_extension(&request.document_path, "kicad_sch") {
+                return Err(wrong_document(request, "expected a .kicad_sch document"));
+            }
+            let requested_instance = request.sheet_instance_path.as_ref().ok_or_else(|| {
+                target_error(
+                    NavigationTargetErrorKind::WrongSheetInstance,
+                    &request.document_path.display().to_string(),
+                    Vec::new(),
+                    "schematic resolution requires an explicit instance path".to_string(),
+                )
+            })?;
+            validate_schematic_context(request, &project_file, requested_instance)?;
+            let (_, tree) = konnect_sexp::schematic::read_schematic(&request.document_path)
+                .map_err(|error| {
+                    target_error(
+                        NavigationTargetErrorKind::StaleTarget,
+                        &request.document_path.display().to_string(),
+                        Vec::new(),
+                        format!("saved schematic cannot be parsed: {error}"),
+                    )
+                })?;
+            (tree, Some(requested_instance.clone()))
+        }
+        IpcEditorKind::Pcb => {
+            if !has_extension(&request.document_path, "kicad_pcb") {
+                return Err(wrong_document(request, "expected a .kicad_pcb document"));
+            }
+            if request.sheet_instance_path.is_some() {
+                return Err(target_error(
+                    NavigationTargetErrorKind::WrongSheetInstance,
+                    &request.document_path.display().to_string(),
+                    Vec::new(),
+                    "PCB targets cannot carry a schematic instance path".to_string(),
+                ));
+            }
+            let source = std::fs::read_to_string(&request.document_path).map_err(|error| {
+                target_error(
+                    NavigationTargetErrorKind::StaleTarget,
+                    &request.document_path.display().to_string(),
+                    Vec::new(),
+                    format!("saved PCB cannot be read: {error}"),
+                )
+            })?;
+            let tree = konnect_sexp::parse_sexp(&source).map_err(|error| {
+                target_error(
+                    NavigationTargetErrorKind::StaleTarget,
+                    &request.document_path.display().to_string(),
+                    Vec::new(),
+                    format!("saved PCB cannot be parsed: {error}"),
+                )
+            })?;
+            (tree, None)
+        }
+    };
+
+    let object = resolve_object(request, &tree)?;
+    Ok(ResolvedNavigationTarget {
+        project: request.project.clone(),
+        editor: request.editor,
+        document_path: request.document_path.display().to_string(),
+        sheet_instance_path: instance_path,
+        object,
+        structural_evidence: NavigationStructuralEvidence {
+            source: "saved_kicad_structure".to_string(),
+            project_file: project_file.display().to_string(),
+            document_path: request.document_path.display().to_string(),
+            resolver: if request.object_kiid.is_some() {
+                "exact_kiid".to_string()
+            } else {
+                "unique_human_reference".to_string()
+            },
+        },
+    })
+}
+
+fn validate_schematic_context(
+    request: &NavigationTargetRequest,
+    project_file: &Path,
+    requested_instance: &IpcSheetInstancePath,
+) -> Result<(), NavigationTargetError> {
+    let ownership = super::resolve_schematic_ownership(&request.document_path)
+        .map_err(|error| map_schematic_ownership_error(&request.document_path, error))?;
+    if let Some(owner) = &ownership {
+        if canonical(&owner.project_file) != canonical(project_file) {
+            return Err(target_error(
+                NavigationTargetErrorKind::WrongProject,
+                &request.project.name,
+                vec![owner.project_file.display().to_string()],
+                "the saved hierarchy belongs to another project".to_string(),
+            ));
+        }
+    } else if canonical(&project_file.with_extension("kicad_sch"))
+        != canonical(&request.document_path)
+    {
+        return Err(wrong_document(
+            request,
+            "the schematic is not reachable from the explicit project root",
+        ));
+    }
+
+    let mut schematic =
+        konnect_schematic_editor::Schematic::load(&request.document_path).map_err(|error| {
+            target_error(
+                NavigationTargetErrorKind::StaleTarget,
+                &request.document_path.display().to_string(),
+                Vec::new(),
+                format!("saved schematic cannot be loaded: {error}"),
+            )
+        })?;
+    let context =
+        super::sheet_instance_context(&request.document_path, &mut schematic).map_err(|error| {
+            target_error(
+                NavigationTargetErrorKind::StaleTarget,
+                &request.document_path.display().to_string(),
+                Vec::new(),
+                error.to_string(),
+            )
+        })?;
+    if context.project_name != request.project.name {
+        return Err(target_error(
+            NavigationTargetErrorKind::WrongProject,
+            &request.project.name,
+            vec![context.project_name],
+            "schematic instance metadata names another project".to_string(),
+        ));
+    }
+    super::validate_sheet_instance_state(&request.document_path, &schematic, &context).map_err(
+        |error| {
+            target_error(
+                NavigationTargetErrorKind::StaleTarget,
+                &request.document_path.display().to_string(),
+                Vec::new(),
+                error.to_string(),
+            )
+        },
+    )?;
+
+    let requested = format!("/{}", requested_instance.kiids.join("/"));
+    if !context.instance_paths.contains(&requested) {
+        return Err(target_error(
+            NavigationTargetErrorKind::WrongSheetInstance,
+            &requested,
+            context.instance_paths,
+            "the requested hierarchy instance does not own this schematic document".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn map_schematic_ownership_error(
+    target: &Path,
+    error: super::SchematicTargetError,
+) -> NavigationTargetError {
+    let reason = error.to_string();
+    let (kind, candidates) = match error {
+        super::SchematicTargetError::ProjectConflict { roots, .. } => (
+            NavigationTargetErrorKind::AmbiguousTarget,
+            roots
+                .into_iter()
+                .map(|root| root.display().to_string())
+                .collect(),
+        ),
+        super::SchematicTargetError::DiscoveryFailed { .. }
+        | super::SchematicTargetError::StaleTarget { .. } => {
+            (NavigationTargetErrorKind::StaleTarget, Vec::new())
+        }
+    };
+    target_error(kind, &target.display().to_string(), candidates, reason)
+}
+
+fn resolve_object(
+    request: &NavigationTargetRequest,
+    tree: &SexpNode,
+) -> Result<ResolvedNavigationObject, NavigationTargetError> {
+    match (&request.object_kiid, &request.human_reference) {
+        (Some(kiid), None) => resolve_by_kiid(request, tree, kiid),
+        (None, Some(reference)) => resolve_by_reference(request, tree, reference),
+        _ => Err(target_error(
+            NavigationTargetErrorKind::StaleTarget,
+            &request.document_path.display().to_string(),
+            Vec::new(),
+            "provide exactly one of object_kiid or human_reference".to_string(),
+        )),
+    }
+}
+
+fn resolve_by_kiid(
+    request: &NavigationTargetRequest,
+    tree: &SexpNode,
+    kiid: &str,
+) -> Result<ResolvedNavigationObject, NavigationTargetError> {
+    let mut candidates = Vec::new();
+    collect_uuid_objects(tree, request.editor, &mut candidates);
+    let matches = candidates
+        .into_iter()
+        .filter(|object| object.kiid == kiid)
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [target] => Ok(target.clone()),
+        [] => Err(target_error(
+            NavigationTargetErrorKind::StaleTarget,
+            kiid,
+            Vec::new(),
+            "no object with this KIID exists in the exact saved document".to_string(),
+        )),
+        many => Err(target_error(
+            NavigationTargetErrorKind::AmbiguousTarget,
+            kiid,
+            many.iter()
+                .map(|object| format!("{}:{}", object.object_type, object.kiid))
+                .collect(),
+            "the saved document contains a duplicate KIID".to_string(),
+        )),
+    }
+}
+
+fn resolve_by_reference(
+    request: &NavigationTargetRequest,
+    tree: &SexpNode,
+    reference: &str,
+) -> Result<ResolvedNavigationObject, NavigationTargetError> {
+    let mut candidates = match request.editor {
+        IpcEditorKind::Schematic => konnect_sexp::schematic::extract_symbol_instances(tree)
+            .into_iter()
+            .filter(|symbol| symbol.reference == reference)
+            .map(|symbol| ResolvedNavigationObject {
+                kiid: symbol.uuid.unwrap_or_default(),
+                object_type: "schematic_symbol".to_string(),
+                human_reference: Some(symbol.reference),
+            })
+            .collect::<Vec<_>>(),
+        IpcEditorKind::Pcb => konnect_sexp::board::footprints(tree)
+            .into_iter()
+            .filter_map(|footprint| {
+                let observed = footprint_reference(footprint)?;
+                (observed == reference).then(|| ResolvedNavigationObject {
+                    kiid: footprint.find_str("uuid").unwrap_or_default().to_string(),
+                    object_type: "pcb_footprint".to_string(),
+                    human_reference: Some(observed),
+                })
+            })
+            .collect::<Vec<_>>(),
+    };
+    candidates.sort_by(|left, right| left.kiid.cmp(&right.kiid));
+    if candidates.iter().any(|candidate| candidate.kiid.is_empty()) {
+        return Err(target_error(
+            NavigationTargetErrorKind::StaleTarget,
+            reference,
+            Vec::new(),
+            "a matching saved object has no stable KIID".to_string(),
+        ));
+    }
+    match candidates.as_slice() {
+        [target] => Ok(target.clone()),
+        [] => Err(target_error(
+            NavigationTargetErrorKind::StaleTarget,
+            reference,
+            Vec::new(),
+            "the human reference does not exist in the exact saved document".to_string(),
+        )),
+        many => Err(target_error(
+            NavigationTargetErrorKind::AmbiguousTarget,
+            reference,
+            many.iter()
+                .map(|object| format!("{}:{}", object.object_type, object.kiid))
+                .collect(),
+            "the human reference resolves to more than one object".to_string(),
+        )),
+    }
+}
+
+fn collect_uuid_objects(
+    node: &SexpNode,
+    editor: IpcEditorKind,
+    output: &mut Vec<ResolvedNavigationObject>,
+) {
+    let Some(children) = node.children() else {
+        return;
+    };
+    let head = node.head().unwrap_or("");
+    if head == "lib_symbols" {
+        return;
+    }
+    if !matches!(head, "kicad_sch" | "kicad_pcb") {
+        if let Some(kiid) = node.find_str("uuid").filter(|id| !id.is_empty()) {
+            output.push(ResolvedNavigationObject {
+                kiid: kiid.to_string(),
+                object_type: object_type(editor, head),
+                human_reference: match editor {
+                    IpcEditorKind::Schematic if head == "symbol" => node
+                        .find_all("property")
+                        .into_iter()
+                        .find(|property| {
+                            property.get(1).and_then(SexpNode::as_str) == Some("Reference")
+                        })
+                        .and_then(|property| property.get(2))
+                        .and_then(SexpNode::as_str)
+                        .map(str::to_string),
+                    IpcEditorKind::Pcb if head == "footprint" => footprint_reference(node),
+                    _ => None,
+                },
+            });
+        }
+    }
+    for child in children.iter().skip(1) {
+        if child.head() != Some("uuid") {
+            collect_uuid_objects(child, editor, output);
+        }
+    }
+}
+
+fn object_type(editor: IpcEditorKind, head: &str) -> String {
+    let prefix = editor.as_str();
+    let kind = match (editor, head) {
+        (IpcEditorKind::Schematic, "symbol") => "symbol",
+        (IpcEditorKind::Pcb, "footprint") => "footprint",
+        (_, "property") => "field",
+        (_, other) if !other.is_empty() => other,
+        _ => "object",
+    };
+    format!("{prefix}_{kind}")
+}
+
+fn footprint_reference(footprint: &SexpNode) -> Option<String> {
+    footprint
+        .find_all("property")
+        .into_iter()
+        .find(|property| property.get(1).and_then(SexpNode::as_str) == Some("Reference"))
+        .and_then(|property| property.get(2))
+        .and_then(SexpNode::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            footprint
+                .find_all("fp_text")
+                .into_iter()
+                .find(|text| text.get(1).and_then(SexpNode::as_str) == Some("reference"))
+                .and_then(|text| text.get(2))
+                .and_then(SexpNode::as_str)
+                .map(str::to_string)
+        })
+}
+
+fn wrong_document(request: &NavigationTargetRequest, reason: &str) -> NavigationTargetError {
+    target_error(
+        NavigationTargetErrorKind::WrongDocument,
+        &request.document_path.display().to_string(),
+        Vec::new(),
+        reason.to_string(),
+    )
+}
+
+fn target_error(
+    kind: NavigationTargetErrorKind,
+    target: &str,
+    candidates: Vec<String>,
+    reason: String,
+) -> NavigationTargetError {
+    NavigationTargetError {
+        kind,
+        target: target.to_string(),
+        candidates,
+        reason,
+    }
+}
+
+fn has_extension(path: &Path, extension: &str) -> bool {
+    path.extension()
+        .and_then(|value| value.to_str())
+        .is_some_and(|value| value.eq_ignore_ascii_case(extension))
+}
+
+fn canonical(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write(path: &Path, source: &str) {
+        fs::write(path, source).expect("write fixture");
+    }
+
+    #[test]
+    fn schematic_ownership_failures_preserve_current_conflict_and_discovery_semantics() {
+        let target = PathBuf::from("child.kicad_sch");
+        let conflict = map_schematic_ownership_error(
+            &target,
+            super::super::SchematicTargetError::ProjectConflict {
+                target: target.clone(),
+                roots: vec![PathBuf::from("a.kicad_sch"), PathBuf::from("b.kicad_sch")],
+            },
+        );
+        assert_eq!(conflict.kind, NavigationTargetErrorKind::AmbiguousTarget);
+        assert_eq!(conflict.candidates.len(), 2);
+
+        let discovery = map_schematic_ownership_error(
+            &target,
+            super::super::SchematicTargetError::DiscoveryFailed {
+                directory: PathBuf::from("."),
+                reason: "unreadable".to_string(),
+            },
+        );
+        assert_eq!(discovery.kind, NavigationTargetErrorKind::StaleTarget);
+        assert!(discovery.candidates.is_empty());
+    }
+
+    fn project(root: &Path) -> IpcProjectIdentity {
+        IpcProjectIdentity {
+            name: "nav".to_string(),
+            path: root.display().to_string(),
+        }
+    }
+
+    fn schematic_request(root: &Path) -> NavigationTargetRequest {
+        NavigationTargetRequest {
+            editor: IpcEditorKind::Schematic,
+            project: project(root),
+            document_path: root.join("nav.kicad_sch"),
+            sheet_instance_path: Some(IpcSheetInstancePath {
+                kiids: vec!["root".to_string()],
+                human_readable: "/".to_string(),
+            }),
+            object_kiid: Some("sym-c10".to_string()),
+            human_reference: None,
+        }
+    }
+
+    fn fixture(root: &Path, symbols: &str) {
+        write(&root.join("nav.kicad_pro"), "{}");
+        write(
+            &root.join("nav.kicad_sch"),
+            &format!(
+                "(kicad_sch (uuid \"root\") {symbols} (sheet_instances (path \"/\" (page \"1\"))))"
+            ),
+        );
+    }
+
+    fn symbol(reference: &str, uuid: &str) -> String {
+        format!(
+            "(symbol (lib_id \"Device:C\") (at 10 10 0) (uuid \"{uuid}\") \
+             (property \"Reference\" \"{reference}\") \
+             (instances (project \"nav\" (path \"/root\" (reference \"{reference}\") (unit 1)))))"
+        )
+    }
+
+    #[test]
+    fn exact_schematic_kiid_resolves_with_separate_structural_evidence() {
+        let temp = tempfile::tempdir().unwrap();
+        fixture(temp.path(), &symbol("C10", "sym-c10"));
+        let target = resolve_navigation_target(&schematic_request(temp.path())).unwrap();
+        assert_eq!(target.object.kiid, "sym-c10");
+        assert_eq!(target.object.object_type, "schematic_symbol");
+        assert_eq!(target.structural_evidence.source, "saved_kicad_structure");
+        assert_eq!(target.structural_evidence.resolver, "exact_kiid");
+    }
+
+    #[test]
+    fn unique_human_reference_resolves_but_duplicates_return_candidates() {
+        let temp = tempfile::tempdir().unwrap();
+        fixture(temp.path(), &symbol("C10", "sym-c10"));
+        let mut request = schematic_request(temp.path());
+        request.object_kiid = None;
+        request.human_reference = Some("C10".to_string());
+        assert_eq!(
+            resolve_navigation_target(&request).unwrap().object.kiid,
+            "sym-c10"
+        );
+
+        fixture(
+            temp.path(),
+            &format!("{} {}", symbol("C10", "sym-a"), symbol("C10", "sym-b")),
+        );
+        let error = resolve_navigation_target(&request).unwrap_err();
+        assert_eq!(error.kind, NavigationTargetErrorKind::AmbiguousTarget);
+        assert_eq!(error.candidates.len(), 2);
+    }
+
+    #[test]
+    fn missing_stale_wrong_project_and_wrong_sheet_fail_closed() {
+        let temp = tempfile::tempdir().unwrap();
+        fixture(temp.path(), &symbol("C10", "sym-c10"));
+
+        let mut missing = schematic_request(temp.path());
+        missing.object_kiid = Some("gone".to_string());
+        assert_eq!(
+            resolve_navigation_target(&missing).unwrap_err().kind,
+            NavigationTargetErrorKind::StaleTarget
+        );
+
+        let mut wrong_project = schematic_request(temp.path());
+        wrong_project.project.name = "other".to_string();
+        assert_eq!(
+            resolve_navigation_target(&wrong_project).unwrap_err().kind,
+            NavigationTargetErrorKind::WrongProject
+        );
+
+        let mut wrong_sheet = schematic_request(temp.path());
+        wrong_sheet.sheet_instance_path = Some(IpcSheetInstancePath {
+            kiids: vec!["other-root".to_string()],
+            human_readable: "/other".to_string(),
+        });
+        assert_eq!(
+            resolve_navigation_target(&wrong_sheet).unwrap_err().kind,
+            NavigationTargetErrorKind::WrongSheetInstance
+        );
+    }
+
+    #[test]
+    fn exact_board_footprint_and_unique_reference_resolve() {
+        let temp = tempfile::tempdir().unwrap();
+        write(&temp.path().join("nav.kicad_pro"), "{}");
+        let board = temp.path().join("layout.kicad_pcb");
+        write(
+            &board,
+            "(kicad_pcb (footprint \"Capacitor:C\" (layer \"F.Cu\") (at 1 2) \
+             (uuid \"fp-c10\") (property \"Reference\" \"C10\")))",
+        );
+        let mut request = NavigationTargetRequest {
+            editor: IpcEditorKind::Pcb,
+            project: project(temp.path()),
+            document_path: board,
+            sheet_instance_path: None,
+            object_kiid: Some("fp-c10".to_string()),
+            human_reference: None,
+        };
+        assert_eq!(
+            resolve_navigation_target(&request)
+                .unwrap()
+                .object
+                .object_type,
+            "pcb_footprint"
+        );
+        request.object_kiid = None;
+        request.human_reference = Some("C10".to_string());
+        assert_eq!(
+            resolve_navigation_target(&request).unwrap().object.kiid,
+            "fp-c10"
+        );
+    }
+}

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -829,6 +829,19 @@ impl KiCadIpcClient {
         })
     }
 
+    /// Prove that one exact editor/document/sheet identity is currently open.
+    ///
+    /// This is the read-only context gate used by semantic target resolution;
+    /// it shares the same no-fallback matching rules as selection observation
+    /// without issuing a selection query.
+    pub fn observe_exact_open_document(
+        &self,
+        requested: &IpcEditorDocument,
+    ) -> Result<IpcEditorDocument> {
+        let document = self.resolve_selection_document(requested)?;
+        editor_document_from_specifier(requested.editor, document)
+    }
+
     fn resolve_selection_document(
         &self,
         requested: &IpcEditorDocument,

--- a/docs/KICAD_INTEGRATION.md
+++ b/docs/KICAD_INTEGRATION.md
@@ -62,6 +62,15 @@ schematic protobuf currently decodes line and label selections. Schematic
 symbols and other unmodelled types remain explicitly unsupported until KiCad
 provides stable typed serialization for them.
 
+Navigation target resolution keeps two evidence channels in the same result
+without merging them. `GetOpenDocuments` proves that the exact requested live
+project/document/sheet context is still addressable; the saved `.kicad_sch` or
+`.kicad_pcb` structure proves object KIID and human-reference identity. Stable
+KIID lookup is primary. A reference such as `C10` is accepted only when one
+object matches in the exact document and sheet instance; duplicates return
+structured candidates, and stale project ownership or symbol-instance paths
+fail closed before any editor mutation.
+
 ## Schematic-To-Board Sync
 
 `update_pcb_from_schematic` in `tools/pcb_sync.rs` is live-IPC-only. It uses

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -309,7 +309,7 @@ callable tools, the fix is to make the *first* listing complete:
 ```
 
 in `konnect.toml` in the working directory, or a `settings.json` beside the binary. Every toolset is then loaded at
-startup, so `tools/list` carries all 230 tools from the first call.
+startup, so `tools/list` carries all 231 tools from the first call.
 
 It is off by default because it costs what the router exists to save: roughly
 25K tokens per listing instead of ~2K. Turn it on only if your client needs it.

--- a/packaging/metadata.json
+++ b/packaging/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://go.kicad.org/pcm/schemas/v1",
   "name": "Konnect",
-  "description": "AI-assisted PCB design via the Model Context Protocol. Enables Claude and other AI assistants to design schematics and PCBs with 223 tools organized into on-demand toolsets.",
+  "description": "AI-assisted PCB design via the Model Context Protocol. Enables Claude and other AI assistants to design schematics and PCBs with 224 tools organized into on-demand toolsets.",
   "description_full": "Konnect exposes a complete set of KiCAD design tools to AI assistants via the Model Context Protocol (MCP). It supports schematic editing, PCB layout, local Freerouting MCP routing, library management, JLCPCB part search, ERC/DRC, design review audits, and full export pipelines. Tools are organized into 21 toolsets loaded on demand so the AI only sees relevant tools at once.",
   "identifier": "com.github.mixelpixx.konnect",
   "type": "plugin",

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "identifier": "com.github.mixelpixx.konnect",
   "name": "Konnect",
-  "description": "AI-assisted PCB design via the Model Context Protocol. 223 tools for schematic editing, PCB layout, routing, design review, and manufacturing export.",
+  "description": "AI-assisted PCB design via the Model Context Protocol. 224 tools for schematic editing, PCB layout, routing, design review, and manufacturing export.",
   "runtime": {
     "type": "exec"
   },

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -13,7 +13,7 @@ Compatibility notes for removed or narrowed arguments are recorded in
 ## Overview
 
 - **21 toolsets** organized into 10 categories
-- **223 registered tools** + **7 always-visible meta-tools** = **230 total**
+- **224 registered tools** + **7 always-visible meta-tools** = **231 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -61,7 +61,7 @@ Seven tools, grouped into *discovery/routing*, *observability*, and *runtime dia
 | `snapshot_project` | Export the schematic and PCB to PDF as a timestamped snapshot/checkpoint. Useful before major edits. |
 | `open_schematic_viewer` | Launch the live schematic viewer (SVG with auto-refresh on file change). Use after placing components so the user can see changes in real time. |
 
-### `editor_navigation` · 2 tools
+### `editor_navigation` · 3 tools
 **Purpose:** Observe and semantically navigate exact KiCad editor, document, sheet, selection, and cross-probe context.
 **Source:** [`crates/konnect-core/src/tools/editor_navigation.rs`](crates/konnect-core/src/tools/editor_navigation.rs)
 
@@ -69,6 +69,7 @@ Seven tools, grouped into *discovery/routing*, *observability*, and *runtime dia
 |------|-------------|
 | `get_editor_state` | Observe the configured KiCad IPC endpoint's running version, addressable schematic/PCB editors, exact open document identities, capability availability, and explicit active-context limitations. |
 | `get_editor_selection` | Read the selection from one exact editor, project, document, and hierarchical sheet instance with stable KIID/UUID identities and document-readback freshness checks. |
+| `resolve_navigation_target` | Resolve an exact open project/document/sheet object by stable KIID, or by a human reference only when saved KiCad structure yields one unambiguous candidate. |
 
 ---
 


### PR DESCRIPTION
Part of #395.

This reconstructs the unique N3 work from draft PR #398 directly on current `main`, after N2 landed in #491. It does not carry forward the old cumulative branch history.

## What this adds

- `resolve_navigation_target` for deterministic, read-only target resolution
- exact project, editor, document, and schematic sheet-instance identity
- stable KIID/UUID-first resolution
- human-reference resolution only when exactly one saved object matches
- separate live IPC context evidence and saved-structure evidence
- structured refusal for wrong or stale context, duplicate identities, ambiguous references, missing objects, and unsupported identities

## Current-main adaptation

Issue #189 replaced the old `AmbiguousProject` ownership error with the stronger `ProjectConflict` and `DiscoveryFailed` contract. This reconstruction maps:

- `ProjectConflict` to an ambiguous-target refusal with every candidate root
- `DiscoveryFailed` and `StaleTarget` to stale-target refusals because structural ownership evidence is unavailable

A focused regression test pins both mappings.

## Deliberate boundaries

- no selection mutation
- no activation or reveal
- no cross-probe operation
- no raw `RunAction` surface

Original authorship from `dubesinhower` is preserved.

## Evidence

- `cargo test -p konnect-core navigation_target --lib` — 5 passed
- `cargo test -p konnect-core editor_navigation --lib` — 8 passed
- `cargo test -p konnect-ipc --test mock_server_test` — 52 passed, 1 intentionally ignored
- `cargo xtask fix-doc-counts --check` — current at 224 registered / 231 total tools
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --locked --all-targets -- -D warnings` — passed
- `cargo test --workspace --locked --lib --tests` — passed
- `cargo test --workspace --locked --doc` — passed

N4 will be reconstructed only after this PR merges.
