### PR TITLE
test(navigation): complete unavailable capability matrix

### DIFF
--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -3625,7 +3625,9 @@ fn editor_capabilities(
         mutate_selection: selection,
         activate_document: no_activation.clone(),
         activate_sheet: no_activation,
-        reveal_object: no_reveal,
+        reveal_object: no_reveal.clone(),
+        center_object: no_reveal.clone(),
+        fit_view: no_reveal,
         cross_probe: no_cross_probe,
     }
 }

--- a/crates/konnect-ipc/src/types.rs
+++ b/crates/konnect-ipc/src/types.rs
@@ -46,6 +46,8 @@ pub struct IpcEditorCapabilities {
     pub activate_document: IpcCapability,
     pub activate_sheet: IpcCapability,
     pub reveal_object: IpcCapability,
+    pub center_object: IpcCapability,
+    pub fit_view: IpcCapability,
     pub cross_probe: IpcCapability,
 }
 

--- a/crates/konnect-ipc/tests/mock_server_test.rs
+++ b/crates/konnect-ipc/tests/mock_server_test.rs
@@ -211,6 +211,23 @@ fn editor_state_observation_keeps_live_sheet_identity_and_unsupported_context_ho
         schematic.capabilities.observe_active_context.availability,
         konnect_ipc::IpcCapabilityAvailability::Unsupported
     );
+    for capability in [
+        &schematic.capabilities.activate_document,
+        &schematic.capabilities.activate_sheet,
+        &schematic.capabilities.reveal_object,
+        &schematic.capabilities.center_object,
+        &schematic.capabilities.fit_view,
+    ] {
+        assert_eq!(
+            capability.availability,
+            konnect_ipc::IpcCapabilityAvailability::Unsupported
+        );
+        assert_eq!(capability.evidence_source, "konnect_bundled_kicad_protocol");
+        assert!(capability
+            .reason
+            .as_deref()
+            .is_some_and(|reason| { reason.contains("no stable typed") }));
+    }
 
     let pcb = &state.editors[1];
     assert_eq!(pcb.editor, konnect_ipc::IpcEditorKind::Pcb);


### PR DESCRIPTION
Part of #395.

This is the narrow accounting replacement for cumulative draft #400. The approved Navigation MVP explicitly rejects a public activation tool whose only correct KiCad 10 behavior is `unsupported_capability`, so this PR does **not** publish that tool.

## Retained value from #400

- Adds separate `center_object` and `fit_view` entries to the editor capability model.
- Reports both as unavailable from the bundled KiCad protocol, alongside exact document/sheet activation and reveal.
- Extends the hermetic editor-state test to prove all five unavailable capabilities carry explicit protocol evidence and a reason.

## Intentionally excluded

- No `activate_editor_context` public tool.
- No `RunAction`, mouse/keyboard, window-order, or selection-implies-reveal fallback.
- No public-tool count or documentation churn.

## Evidence

- Focused editor-state capability test — passed
- `cargo xtask fix-doc-counts --check` — 21 toolsets, 225 registered, 232 total; no changes needed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --locked --all-targets -- -D warnings` — passed
- `cargo test --workspace --locked --lib --tests` — passed
- `cargo test --workspace --locked --doc` — passed

Derived from the generally useful capability-model portion of @dubesinhower's #400 / `e87914e6`; original authorship is preserved.