### PR TITLE
feat(navigation): resolve exact cross-probe targets

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -320,7 +320,7 @@ Source: [`crates/konnect-core/src/observability.rs`](crates/konnect-core/src/obs
 
 ## Tool Routing (Starter Kit + On-Demand Loading)
 
-The server does NOT expose all 225 tools (232 total with the 7 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
+The server does NOT expose all 226 tools (233 total with the 7 meta-tools) in `tools/list` by default — that would cost ~23K tokens of context on every listing. Instead:
 
 - **Startup**: only `STARTER_KIT` toolsets are pre-loaded (see `router/registry.rs::STARTER_KIT`). Currently: `project`, `config`. Combined with the 7 meta-tools, baseline `tools/list` is 21 tools ≈ 2K tokens.
 - **On demand**: the LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose a toolset's tools in subsequent `tools/list` responses. `unload_toolset(name)` prunes them when the task shifts.
@@ -395,9 +395,9 @@ convention for other `kicad-cli`-calling code.
 
 ## Current Stats
 
-- **21 toolsets, 225 tools** + 7 meta-tools (4 routing + 2 observability + 1 runtime diagnostic — see `tool-directory.md`)
+- **21 toolsets, 226 tools** + 7 meta-tools (4 routing + 2 observability + 1 runtime diagnostic — see `tool-directory.md`)
 - Baseline `tools/list`: 21 tools / ~2K tokens (starter kit + meta-tools)
-- Full-catalog `tools/list` (all loaded): 232 tools (225 registered + 7 meta) / ~25K tokens
+- Full-catalog `tools/list` (all loaded): 233 tools (226 registered + 7 meta) / ~25K tokens
 - **0 IPC stubs** (all protobuf methods implemented)
 - **0 unimplemented tools**
 - **Specctra DSN/SES are PCB-editor operations**, not `kicad-cli` commands.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Rust binary — that lets Claude and other AI assistants design schematics and PCBs
 through the [Model Context Protocol](https://modelcontextprotocol.io) (MCP).
 
-**225 tools across 21 on-demand toolsets.** Schematic capture, PCB layout and
+**226 tools across 21 on-demand toolsets.** Schematic capture, PCB layout and
 routing, ERC/DRC, design-review audits, JLCPCB part search, reference
 circuits, and a full manufacturing export pipeline — with bundled skills and agents
 that teach Claude KiCAD conventions out of the box.
@@ -70,7 +70,7 @@ through its own S-expression engine with atomic writes (write, fsync, rename), U
 preservation, and round-trip tests — no third-party schematic library with known
 gaps, no text-manipulation workarounds.
 
-**Context economy is a feature.** Exposing all 225 tools to an LLM costs roughly 23K
+**Context economy is a feature.** Exposing all 226 tools to an LLM costs roughly 23K
 tokens of context on every listing. Konnect's router loads a starter kit (~2K
 tokens) and lets the model pull in toolsets on demand — plus built-in observability
 (`get_recent_calls`, `server_stats`, JSONL call logs) so the model can diagnose its

--- a/crates/konnect-core/src/mcp/error.rs
+++ b/crates/konnect-core/src/mcp/error.rs
@@ -95,6 +95,13 @@ pub enum ToolErrorKind {
         before_kiids: Vec<String>,
         after_kiids: Vec<String>,
     },
+    /// Saved KiCad structure cannot prove one exact destination for a
+    /// cross-probe source object.
+    UnresolvedCrossProbeDestination {
+        source_kiid: String,
+        candidates: Vec<String>,
+        reason: String,
+    },
     /// A board was live earlier in this server process, but IPC is now gone;
     /// its saved file may be stale relative to lost editor state.
     UnsafeFileFallback { path: String, reason: String },
@@ -126,6 +133,7 @@ impl ToolErrorKind {
             Self::EditorUnavailable { .. } => "editor_unavailable",
             Self::UnsupportedCapability { .. } => "unsupported_capability",
             Self::ReadbackMismatch { .. } => "readback_mismatch",
+            Self::UnresolvedCrossProbeDestination { .. } => "unresolved_cross_probe_destination",
             Self::UnsafeFileFallback { .. } => "unsafe_file_fallback",
             Self::AmbiguousOpenBoard { .. } => "ambiguous_open_board",
             Self::HandlerError { .. } => "handler_error",
@@ -284,6 +292,11 @@ mod tests {
                 requested_kiids: vec!["b".into()],
                 before_kiids: vec!["a".into()],
                 after_kiids: vec!["a".into()],
+            },
+            ToolErrorKind::UnresolvedCrossProbeDestination {
+                source_kiid: "sym".into(),
+                candidates: vec!["fp-a".into(), "fp-b".into()],
+                reason: "ambiguous".into(),
             },
             ToolErrorKind::UnsafeFileFallback {
                 path: "p".into(),

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -28,7 +28,7 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         name: "editor_navigation",
         description: "Observe and semantically navigate exact KiCad editor, document, sheet, selection, and cross-probe context",
         category: "project",
-        tool_count: 4,
+        tool_count: 5,
     },
     ToolsetMeta {
         name: "sch_components",

--- a/crates/konnect-core/src/tools/cross_probe.rs
+++ b/crates/konnect-core/src/tools/cross_probe.rs
@@ -1,0 +1,533 @@
+//! Deterministic saved-structure cross-probe resolution.
+//!
+//! A KiCad PCB footprint carries the canonical schematic symbol path that
+//! created it. This resolver uses that stable linkage in both directions and
+//! requires the caller's explicit schematic hierarchy instance to agree.
+
+use super::navigation_target::{
+    resolve_navigation_target, NavigationTargetError, NavigationTargetRequest,
+    ResolvedNavigationTarget,
+};
+use konnect_ipc::{IpcEditorKind, IpcProjectIdentity, IpcSheetInstancePath};
+use konnect_sexp::SexpNode;
+use serde::Serialize;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CrossProbeDirection {
+    SchematicToPcb,
+    PcbToSchematic,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CrossProbeRequest {
+    pub project: IpcProjectIdentity,
+    pub schematic_document_path: PathBuf,
+    pub pcb_document_path: PathBuf,
+    pub schematic_sheet_instance_path: IpcSheetInstancePath,
+    pub source_editor: IpcEditorKind,
+    pub source_object_kiid: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct CrossProbeEvidence {
+    pub source: String,
+    pub schematic_symbol_path: String,
+    pub schematic_document_path: String,
+    pub pcb_document_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct CrossProbeResolution {
+    pub direction: CrossProbeDirection,
+    pub source: ResolvedNavigationTarget,
+    pub destination: ResolvedNavigationTarget,
+    pub evidence: CrossProbeEvidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CrossProbeError {
+    Target(NavigationTargetError),
+    UnresolvedDestination {
+        source_kiid: String,
+        reason: String,
+        candidates: Vec<String>,
+    },
+}
+
+impl std::fmt::Display for CrossProbeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Target(error) => error.fmt(formatter),
+            Self::UnresolvedDestination {
+                source_kiid,
+                reason,
+                ..
+            } => write!(
+                formatter,
+                "cannot resolve cross-probe destination for '{source_kiid}': {reason}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CrossProbeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Target(error) => Some(error),
+            Self::UnresolvedDestination { .. } => None,
+        }
+    }
+}
+
+impl From<NavigationTargetError> for CrossProbeError {
+    fn from(error: NavigationTargetError) -> Self {
+        Self::Target(error)
+    }
+}
+
+pub(crate) fn resolve_cross_probe(
+    request: &CrossProbeRequest,
+) -> Result<CrossProbeResolution, CrossProbeError> {
+    match request.source_editor {
+        IpcEditorKind::Schematic => resolve_schematic_to_pcb(request),
+        IpcEditorKind::Pcb => resolve_pcb_to_schematic(request),
+    }
+}
+
+fn resolve_schematic_to_pcb(
+    request: &CrossProbeRequest,
+) -> Result<CrossProbeResolution, CrossProbeError> {
+    let source = resolve_navigation_target(&NavigationTargetRequest {
+        editor: IpcEditorKind::Schematic,
+        project: request.project.clone(),
+        document_path: request.schematic_document_path.clone(),
+        sheet_instance_path: Some(request.schematic_sheet_instance_path.clone()),
+        object_kiid: Some(request.source_object_kiid.clone()),
+        human_reference: None,
+    })?;
+    if source.object.object_type != "schematic_symbol" {
+        return Err(unresolved(
+            request,
+            "only an exact schematic symbol can cross-probe to a footprint",
+            Vec::new(),
+        ));
+    }
+    let symbol_path =
+        expected_symbol_path(&request.schematic_sheet_instance_path, &source.object.kiid)?;
+    let board = read_tree(&request.pcb_document_path, request)?;
+    let matches = board
+        .find_all("footprint")
+        .into_iter()
+        .filter(|footprint| footprint.find_str("path") == Some(symbol_path.as_str()))
+        .filter_map(footprint_identity)
+        .collect::<Vec<_>>();
+    let (destination_kiid, destination_reference) = one_destination(request, &matches)?;
+    if source.object.human_reference.as_deref() != Some(destination_reference.as_str()) {
+        return Err(unresolved(
+            request,
+            "the linked footprint reference does not match the source symbol reference",
+            matches
+                .iter()
+                .map(|(kiid, reference)| format!("{reference}:{kiid}"))
+                .collect(),
+        ));
+    }
+    let destination = resolve_navigation_target(&NavigationTargetRequest {
+        editor: IpcEditorKind::Pcb,
+        project: request.project.clone(),
+        document_path: request.pcb_document_path.clone(),
+        sheet_instance_path: None,
+        object_kiid: Some(destination_kiid),
+        human_reference: None,
+    })?;
+    Ok(resolution(
+        CrossProbeDirection::SchematicToPcb,
+        request,
+        source,
+        destination,
+        symbol_path,
+    ))
+}
+
+fn resolve_pcb_to_schematic(
+    request: &CrossProbeRequest,
+) -> Result<CrossProbeResolution, CrossProbeError> {
+    let source = resolve_navigation_target(&NavigationTargetRequest {
+        editor: IpcEditorKind::Pcb,
+        project: request.project.clone(),
+        document_path: request.pcb_document_path.clone(),
+        sheet_instance_path: None,
+        object_kiid: Some(request.source_object_kiid.clone()),
+        human_reference: None,
+    })?;
+    if source.object.object_type != "pcb_footprint" {
+        return Err(unresolved(
+            request,
+            "only an exact PCB footprint can cross-probe to a symbol",
+            Vec::new(),
+        ));
+    }
+    let board = read_tree(&request.pcb_document_path, request)?;
+    let footprint = board
+        .find_all("footprint")
+        .into_iter()
+        .filter(|footprint| footprint.find_str("uuid") == Some(source.object.kiid.as_str()))
+        .collect::<Vec<_>>();
+    let [footprint] = footprint.as_slice() else {
+        return Err(unresolved(
+            request,
+            "the exact source footprint is missing or duplicated in saved structure",
+            footprint
+                .iter()
+                .filter_map(|item| item.find_str("uuid").map(str::to_string))
+                .collect(),
+        ));
+    };
+    let symbol_path = footprint.find_str("path").ok_or_else(|| {
+        unresolved(
+            request,
+            "the source footprint has no stable schematic symbol path",
+            Vec::new(),
+        )
+    })?;
+    let symbol_kiid = symbol_path
+        .split('/')
+        .rfind(|part| !part.is_empty())
+        .ok_or_else(|| {
+            unresolved(
+                request,
+                "the source footprint carries an empty schematic symbol path",
+                Vec::new(),
+            )
+        })?;
+    let expected = expected_symbol_path(&request.schematic_sheet_instance_path, symbol_kiid)?;
+    if expected != symbol_path {
+        return Err(unresolved(
+            request,
+            "the footprint linkage belongs to another hierarchical sheet instance",
+            vec![symbol_path.to_string(), expected],
+        ));
+    }
+    let destination = resolve_navigation_target(&NavigationTargetRequest {
+        editor: IpcEditorKind::Schematic,
+        project: request.project.clone(),
+        document_path: request.schematic_document_path.clone(),
+        sheet_instance_path: Some(request.schematic_sheet_instance_path.clone()),
+        object_kiid: Some(symbol_kiid.to_string()),
+        human_reference: None,
+    })?;
+    let source_reference = footprint_reference(footprint);
+    if source_reference.as_deref() != destination.object.human_reference.as_deref() {
+        return Err(unresolved(
+            request,
+            "the linked symbol reference does not match the source footprint reference",
+            source_reference.into_iter().collect(),
+        ));
+    }
+    Ok(resolution(
+        CrossProbeDirection::PcbToSchematic,
+        request,
+        source,
+        destination,
+        symbol_path.to_string(),
+    ))
+}
+
+fn resolution(
+    direction: CrossProbeDirection,
+    request: &CrossProbeRequest,
+    source: ResolvedNavigationTarget,
+    destination: ResolvedNavigationTarget,
+    symbol_path: String,
+) -> CrossProbeResolution {
+    CrossProbeResolution {
+        direction,
+        source,
+        destination,
+        evidence: CrossProbeEvidence {
+            source: "saved_kicad_footprint_symbol_path".to_string(),
+            schematic_symbol_path: symbol_path,
+            schematic_document_path: request.schematic_document_path.display().to_string(),
+            pcb_document_path: request.pcb_document_path.display().to_string(),
+        },
+    }
+}
+
+fn read_tree(path: &PathBuf, request: &CrossProbeRequest) -> Result<SexpNode, CrossProbeError> {
+    let source = std::fs::read_to_string(path).map_err(|error| {
+        unresolved(
+            request,
+            &format!("cannot read destination document: {error}"),
+            Vec::new(),
+        )
+    })?;
+    konnect_sexp::parse_sexp(&source).map_err(|error| {
+        unresolved(
+            request,
+            &format!("cannot parse destination document: {error}"),
+            Vec::new(),
+        )
+    })
+}
+
+fn expected_symbol_path(
+    sheet_instance: &IpcSheetInstancePath,
+    symbol_kiid: &str,
+) -> Result<String, CrossProbeError> {
+    if sheet_instance.kiids.is_empty() || symbol_kiid.is_empty() {
+        return Err(CrossProbeError::UnresolvedDestination {
+            source_kiid: symbol_kiid.to_string(),
+            reason: "schematic instance path and symbol KIID must be non-empty".to_string(),
+            candidates: Vec::new(),
+        });
+    }
+    let mut parts = sheet_instance
+        .kiids
+        .iter()
+        .skip(1)
+        .cloned()
+        .collect::<Vec<_>>();
+    parts.push(symbol_kiid.to_string());
+    Ok(format!("/{}", parts.join("/")))
+}
+
+fn footprint_identity(footprint: &SexpNode) -> Option<(String, String)> {
+    Some((
+        footprint.find_str("uuid")?.to_string(),
+        footprint_reference(footprint)?,
+    ))
+}
+
+fn footprint_reference(footprint: &SexpNode) -> Option<String> {
+    footprint
+        .find_all("property")
+        .into_iter()
+        .find(|property| property.get(1).and_then(SexpNode::as_str) == Some("Reference"))
+        .and_then(|property| property.get(2))
+        .and_then(SexpNode::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            footprint
+                .find_all("fp_text")
+                .into_iter()
+                .find(|text| text.get(1).and_then(SexpNode::as_str) == Some("reference"))
+                .and_then(|text| text.get(2))
+                .and_then(SexpNode::as_str)
+                .map(str::to_string)
+        })
+}
+
+fn one_destination(
+    request: &CrossProbeRequest,
+    matches: &[(String, String)],
+) -> Result<(String, String), CrossProbeError> {
+    match matches {
+        [destination] => Ok(destination.clone()),
+        [] => Err(unresolved(
+            request,
+            "no footprint carries the exact schematic symbol path",
+            Vec::new(),
+        )),
+        many => Err(unresolved(
+            request,
+            "more than one footprint carries the exact schematic symbol path",
+            many.iter()
+                .map(|(kiid, reference)| format!("{reference}:{kiid}"))
+                .collect(),
+        )),
+    }
+}
+
+fn unresolved(
+    request: &CrossProbeRequest,
+    reason: &str,
+    candidates: Vec<String>,
+) -> CrossProbeError {
+    CrossProbeError::UnresolvedDestination {
+        source_kiid: request.source_object_kiid.clone(),
+        reason: reason.to_string(),
+        candidates,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture(root: &std::path::Path, footprint_body: &str) -> CrossProbeRequest {
+        std::fs::write(root.join("nav.kicad_pro"), "{}").unwrap();
+        std::fs::write(
+            root.join("nav.kicad_sch"),
+            "(kicad_sch (uuid \"root\") \
+             (symbol (lib_id \"Device:C\") (at 1 2) (uuid \"sym-c10\") \
+               (property \"Reference\" \"C10\") \
+               (instances (project \"nav\" (path \"/root\" (reference \"C10\") (unit 1))))) \
+             (sheet_instances (path \"/\" (page \"1\"))))",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("nav.kicad_pcb"),
+            format!("(kicad_pcb {footprint_body})"),
+        )
+        .unwrap();
+        CrossProbeRequest {
+            project: IpcProjectIdentity {
+                name: "nav".to_string(),
+                path: root.display().to_string(),
+            },
+            schematic_document_path: root.join("nav.kicad_sch"),
+            pcb_document_path: root.join("nav.kicad_pcb"),
+            schematic_sheet_instance_path: IpcSheetInstancePath {
+                kiids: vec!["root".to_string()],
+                human_readable: "/".to_string(),
+            },
+            source_editor: IpcEditorKind::Schematic,
+            source_object_kiid: "sym-c10".to_string(),
+        }
+    }
+
+    fn footprint(uuid: &str, path: &str, reference: &str) -> String {
+        format!(
+            "(footprint \"Capacitor:C\" (layer \"F.Cu\") (at 1 2) \
+             (uuid \"{uuid}\") (property \"Reference\" \"{reference}\") (path \"{path}\"))"
+        )
+    }
+
+    #[test]
+    fn exact_symbol_and_footprint_cross_probe_in_both_directions() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut request = fixture(temp.path(), &footprint("fp-c10", "/sym-c10", "C10"));
+        let forward = resolve_cross_probe(&request).unwrap();
+        assert_eq!(forward.destination.object.kiid, "fp-c10");
+        assert_eq!(forward.evidence.source, "saved_kicad_footprint_symbol_path");
+
+        request.source_editor = IpcEditorKind::Pcb;
+        request.source_object_kiid = "fp-c10".to_string();
+        let reverse = resolve_cross_probe(&request).unwrap();
+        assert_eq!(reverse.destination.object.kiid, "sym-c10");
+        assert_eq!(reverse.direction, CrossProbeDirection::PcbToSchematic);
+    }
+
+    #[test]
+    fn navigation_mvp_resolves_c10_then_its_exact_footprint_by_stable_linkage() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut request = fixture(temp.path(), &footprint("fp-c10", "/sym-c10", "C10"));
+        let symbol = resolve_navigation_target(&NavigationTargetRequest {
+            editor: IpcEditorKind::Schematic,
+            project: request.project.clone(),
+            document_path: request.schematic_document_path.clone(),
+            sheet_instance_path: Some(request.schematic_sheet_instance_path.clone()),
+            object_kiid: None,
+            human_reference: Some("C10".to_string()),
+        })
+        .unwrap();
+        assert_eq!(symbol.object.kiid, "sym-c10");
+        assert_eq!(
+            symbol.structural_evidence.resolver,
+            "unique_human_reference"
+        );
+
+        request.source_object_kiid = symbol.object.kiid;
+        let footprint = resolve_cross_probe(&request).unwrap();
+        assert_eq!(footprint.destination.object.kiid, "fp-c10");
+        assert_eq!(footprint.evidence.schematic_symbol_path, "/sym-c10");
+    }
+
+    #[test]
+    fn hierarchical_symbol_path_includes_the_exact_sheet_instance() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("nav.kicad_pro"), "{}").unwrap();
+        std::fs::write(
+            temp.path().join("nav.kicad_sch"),
+            "(kicad_sch (uuid \"root\") \
+             (sheet (at 1 1) (size 10 10) (uuid \"sheet-a\") \
+               (property \"Sheetname\" \"Child\") \
+               (property \"Sheetfile\" \"child.kicad_sch\")) \
+             (sheet_instances (path \"/\" (page \"1\"))))",
+        )
+        .unwrap();
+        std::fs::write(
+            temp.path().join("child.kicad_sch"),
+            "(kicad_sch (uuid \"child-file\") \
+             (symbol (lib_id \"Device:C\") (at 1 2) (uuid \"sym-c10\") \
+               (property \"Reference\" \"C10\") \
+               (instances (project \"nav\" (path \"/root/sheet-a\" (reference \"C10\") (unit 1))))) \
+             (sheet_instances (path \"/root/sheet-a\" (page \"2\"))))",
+        )
+        .unwrap();
+        std::fs::write(
+            temp.path().join("nav.kicad_pcb"),
+            format!(
+                "(kicad_pcb {})",
+                footprint("fp-c10", "/sheet-a/sym-c10", "C10")
+            ),
+        )
+        .unwrap();
+        let request = CrossProbeRequest {
+            project: IpcProjectIdentity {
+                name: "nav".to_string(),
+                path: temp.path().display().to_string(),
+            },
+            schematic_document_path: temp.path().join("child.kicad_sch"),
+            pcb_document_path: temp.path().join("nav.kicad_pcb"),
+            schematic_sheet_instance_path: IpcSheetInstancePath {
+                kiids: vec!["root".to_string(), "sheet-a".to_string()],
+                human_readable: "/Child".to_string(),
+            },
+            source_editor: IpcEditorKind::Schematic,
+            source_object_kiid: "sym-c10".to_string(),
+        };
+        let resolved = resolve_cross_probe(&request).unwrap();
+        assert_eq!(resolved.evidence.schematic_symbol_path, "/sheet-a/sym-c10");
+        assert_eq!(resolved.destination.object.kiid, "fp-c10");
+    }
+
+    #[test]
+    fn missing_duplicate_and_reference_mismatch_destinations_fail_closed() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing = fixture(temp.path(), &footprint("fp-c10", "/other", "C10"));
+        assert!(matches!(
+            resolve_cross_probe(&missing),
+            Err(CrossProbeError::UnresolvedDestination { .. })
+        ));
+
+        let duplicate_body = format!(
+            "{} {}",
+            footprint("fp-a", "/sym-c10", "C10"),
+            footprint("fp-b", "/sym-c10", "C10")
+        );
+        let duplicate = fixture(temp.path(), &duplicate_body);
+        let Err(CrossProbeError::UnresolvedDestination { candidates, .. }) =
+            resolve_cross_probe(&duplicate)
+        else {
+            panic!("duplicate linkage must be unresolved");
+        };
+        assert_eq!(candidates.len(), 2);
+
+        let mismatch = fixture(temp.path(), &footprint("fp-c10", "/sym-c10", "C11"));
+        assert!(matches!(
+            resolve_cross_probe(&mismatch),
+            Err(CrossProbeError::UnresolvedDestination { .. })
+        ));
+    }
+
+    #[test]
+    fn wrong_hierarchy_instance_and_stale_source_are_never_retargeted() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut request = fixture(temp.path(), &footprint("fp-c10", "/sym-c10", "C10"));
+        request.schematic_sheet_instance_path.kiids = vec!["other-root".to_string()];
+        assert!(matches!(
+            resolve_cross_probe(&request),
+            Err(CrossProbeError::Target(_))
+        ));
+
+        request.schematic_sheet_instance_path.kiids = vec!["root".to_string()];
+        request.source_object_kiid = "gone".to_string();
+        assert!(matches!(
+            resolve_cross_probe(&request),
+            Err(CrossProbeError::Target(_))
+        ));
+    }
+}

--- a/crates/konnect-core/src/tools/editor_navigation.rs
+++ b/crates/konnect-core/src/tools/editor_navigation.rs
@@ -15,6 +15,7 @@ use konnect_ipc::{
 use serde_json::json;
 use std::path::PathBuf;
 
+use super::cross_probe::{resolve_cross_probe, CrossProbeError, CrossProbeRequest};
 use super::navigation_target::{
     resolve_navigation_target, NavigationTargetErrorKind, NavigationTargetRequest,
 };
@@ -89,6 +90,25 @@ pub fn tools() -> Vec<ToolDef> {
                 "required": ["operation", "editor", "project_name", "project_path", "document_path", "object_kiids"]
             }),
             |args, ctx| async move { handle_mutate_editor_selection(args, ctx).await }
+        ),
+        tool!(
+            "resolve_cross_probe_target",
+            "Resolve an exact schematic-symbol/PCB-footprint relationship in either direction from stable saved KiCad symbol-path linkage, while proving both explicit live document contexts. This resolve-only operation does not activate or select; pin/pad/net expansion remains unsupported unless a unique stable destination can be modeled.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "source_editor": { "type": "string", "enum": ["schematic", "pcb"] },
+                    "project_name": { "type": "string" },
+                    "project_path": { "type": "string" },
+                    "schematic_document_path": { "type": "string" },
+                    "pcb_document_path": { "type": "string" },
+                    "schematic_sheet_instance_path": { "type": "array", "items": { "type": "string" } },
+                    "sheet_path_human_readable": { "type": "string" },
+                    "source_object_kiid": { "type": "string" }
+                },
+                "required": ["source_editor", "project_name", "project_path", "schematic_document_path", "pcb_document_path", "schematic_sheet_instance_path", "source_object_kiid"]
+            }),
+            |args, ctx| async move { handle_resolve_cross_probe_target(args, ctx).await }
         ),
     ]
 }
@@ -687,6 +707,171 @@ fn selection_mutation_error_result(error: anyhow::Error) -> CallToolResult {
     }
 }
 
+async fn handle_resolve_cross_probe_target(
+    args: &serde_json::Value,
+    ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let request = match parse_cross_probe_request(args) {
+        Ok(request) => request,
+        Err(result) => return Ok(result),
+    };
+    let address = ctx.config.ipc_address.clone();
+    if address.is_empty() {
+        return Ok(editor_unavailable("no KiCad IPC endpoint is configured"));
+    }
+    let result = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+        let resolution = resolve_cross_probe(&request)?;
+        let source_live = live_cross_probe_document(&request, request.source_editor);
+        let destination_editor = match request.source_editor {
+            IpcEditorKind::Schematic => IpcEditorKind::Pcb,
+            IpcEditorKind::Pcb => IpcEditorKind::Schematic,
+        };
+        let destination_live = live_cross_probe_document(&request, destination_editor);
+        let client = konnect_ipc::KiCadIpcClient::new(address);
+        let source_observed = client.observe_exact_open_document(&source_live)?;
+        let destination_observed = client.observe_exact_open_document(&destination_live)?;
+        Ok((resolution, source_observed, destination_observed))
+    })
+    .await?;
+    match result {
+        Ok((resolution, source_observed, destination_observed)) => {
+            Ok(CallToolResult::json(&json!({
+                "resolution": resolution,
+                "live_context_evidence": {
+                    "source": "kicad_ipc_get_open_documents",
+                    "source_document": source_observed,
+                    "destination_document": destination_observed
+                },
+                "destination_navigation": {
+                    "attempted": false,
+                    "status": "not_attempted",
+                    "reason": "exact activation/reveal is unsupported by the bundled stable protocol; resolution does not imply a state change"
+                }
+            })))
+        }
+        Err(error) => Ok(cross_probe_error_result(error)),
+    }
+}
+
+fn parse_cross_probe_request(
+    args: &serde_json::Value,
+) -> Result<CrossProbeRequest, CallToolResult> {
+    let source_editor = match require_str(args, "source_editor")? {
+        "schematic" => IpcEditorKind::Schematic,
+        "pcb" => IpcEditorKind::Pcb,
+        _ => {
+            return Err(invalid_arg(
+                "source_editor",
+                "expected 'schematic' or 'pcb'",
+            ))
+        }
+    };
+    let project_name = require_str(args, "project_name")?;
+    let project_path = require_str(args, "project_path")?;
+    let schematic_document_path = require_str(args, "schematic_document_path")?;
+    let pcb_document_path = require_str(args, "pcb_document_path")?;
+    let source_object_kiid = require_str(args, "source_object_kiid")?;
+    if [
+        project_name,
+        project_path,
+        schematic_document_path,
+        pcb_document_path,
+        source_object_kiid,
+    ]
+    .iter()
+    .any(|value| value.is_empty())
+    {
+        return Err(invalid_arg(
+            "source_object_kiid",
+            "project, document, and source KIID strings must not be empty",
+        ));
+    }
+    let sheet_kiids = require_array(args, "schematic_sheet_instance_path")?
+        .iter()
+        .map(|value| value.as_str().map(str::to_string))
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| {
+            invalid_arg(
+                "schematic_sheet_instance_path",
+                "every entry must be a string",
+            )
+        })?;
+    if sheet_kiids.is_empty() || sheet_kiids.iter().any(String::is_empty) {
+        return Err(invalid_arg(
+            "schematic_sheet_instance_path",
+            "must contain non-empty root-to-leaf KIIIDs",
+        ));
+    }
+    Ok(CrossProbeRequest {
+        project: IpcProjectIdentity {
+            name: project_name.to_string(),
+            path: project_path.to_string(),
+        },
+        schematic_document_path: PathBuf::from(schematic_document_path),
+        pcb_document_path: PathBuf::from(pcb_document_path),
+        schematic_sheet_instance_path: IpcSheetInstancePath {
+            kiids: sheet_kiids,
+            human_readable: opt_str(args, "sheet_path_human_readable")
+                .unwrap_or("")
+                .to_string(),
+        },
+        source_editor,
+        source_object_kiid: source_object_kiid.to_string(),
+    })
+}
+
+fn live_cross_probe_document(
+    request: &CrossProbeRequest,
+    editor: IpcEditorKind,
+) -> IpcEditorDocument {
+    IpcEditorDocument {
+        editor,
+        project: Some(request.project.clone()),
+        document_path: (editor == IpcEditorKind::Pcb)
+            .then(|| request.pcb_document_path.display().to_string()),
+        sheet_instance_path: (editor == IpcEditorKind::Schematic)
+            .then(|| request.schematic_sheet_instance_path.clone()),
+    }
+}
+
+fn cross_probe_error_result(error: anyhow::Error) -> CallToolResult {
+    if let Some(cross_probe) = error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<CrossProbeError>())
+    {
+        return match cross_probe {
+            CrossProbeError::Target(target) => navigation_target_error_result(target.clone()),
+            CrossProbeError::UnresolvedDestination {
+                source_kiid,
+                reason,
+                candidates,
+            } => CallToolResult::error_kind(
+                ToolErrorKind::UnresolvedCrossProbeDestination {
+                    source_kiid: source_kiid.clone(),
+                    candidates: candidates.clone(),
+                    reason: reason.clone(),
+                },
+                cross_probe.to_string(),
+            ),
+        };
+    }
+    if konnect_ipc::IpcSelectionObservationError::from_error(&error).is_some() {
+        return selection_error_result(error);
+    }
+    match konnect_ipc::IpcFailure::from_error(error) {
+        konnect_ipc::IpcFailure::Unreachable(_) => {
+            editor_unavailable("a requested cross-probe editor endpoint is unreachable")
+        }
+        _ => CallToolResult::error_kind(
+            ToolErrorKind::StaleTarget {
+                target: "requested cross-probe context".to_string(),
+                reason: "live or structural evidence was incomplete".to_string(),
+            },
+            "Cross-probe resolution did not return complete live and structural evidence.",
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -698,7 +883,7 @@ mod tests {
     use konnect_ipc::gen::kiapi;
     use nng::options::Options;
     use prost::Message;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     fn context(ipc_address: String) -> ToolContext {
@@ -964,10 +1149,86 @@ mod tests {
         url
     }
 
+    fn spawn_cross_probe_context_mock(
+        project_path: String,
+        commands: Arc<Mutex<Vec<String>>>,
+    ) -> String {
+        static NEXT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let url = format!(
+            "inproc://cross-probe-core-{}",
+            NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        );
+        let socket = nng::Socket::new(nng::Protocol::Rep0).expect("mock socket");
+        socket.listen(&url).expect("listen");
+        std::thread::spawn(move || {
+            for _ in 0..2 {
+                let message = socket.recv().expect("request");
+                let request =
+                    kiapi::common::ApiRequest::decode(message.as_slice()).expect("decode request");
+                let command = request.message.expect("command");
+                commands.lock().unwrap().push(command.type_url.clone());
+                let query =
+                    kiapi::common::commands::GetOpenDocuments::decode(command.value.as_slice())
+                        .expect("open documents");
+                let document = if query.r#type
+                    == kiapi::common::types::DocumentType::DoctypeSchematic as i32
+                {
+                    kiapi::common::types::DocumentSpecifier {
+                        r#type: query.r#type,
+                        identifier: Some(
+                            kiapi::common::types::document_specifier::Identifier::SheetPath(
+                                kiapi::common::types::SheetPath {
+                                    path: vec![kiapi::common::types::Kiid {
+                                        value: "root".to_string(),
+                                    }],
+                                    path_human_readable: "/".to_string(),
+                                },
+                            ),
+                        ),
+                        project: Some(kiapi::common::types::ProjectSpecifier {
+                            name: "nav".to_string(),
+                            path: project_path.clone(),
+                        }),
+                    }
+                } else {
+                    kiapi::common::types::DocumentSpecifier {
+                        r#type: query.r#type,
+                        identifier: Some(
+                            kiapi::common::types::document_specifier::Identifier::BoardFilename(
+                                "nav.kicad_pcb".to_string(),
+                            ),
+                        ),
+                        project: Some(kiapi::common::types::ProjectSpecifier {
+                            name: "nav".to_string(),
+                            path: project_path.clone(),
+                        }),
+                    }
+                };
+                let response = kiapi::common::ApiResponse {
+                    status: Some(kiapi::common::ApiResponseStatus {
+                        status: kiapi::common::ApiStatusCode::AsOk as i32,
+                        error_message: String::new(),
+                    }),
+                    header: None,
+                    message: Some(builders::pack_any(
+                        &kiapi::common::commands::GetOpenDocumentsResponse {
+                            documents: vec![document],
+                        },
+                        "kiapi.common.commands.GetOpenDocumentsResponse",
+                    )),
+                };
+                socket
+                    .send(nng::Message::from(response.encode_to_vec().as_slice()))
+                    .expect("response");
+            }
+        });
+        url
+    }
+
     #[test]
     fn public_tool_is_read_only_and_takes_no_required_arguments() {
         let definitions = tools();
-        assert_eq!(definitions.len(), 4);
+        assert_eq!(definitions.len(), 5);
         let state = definitions
             .iter()
             .find(|tool| tool.name == "get_editor_state")
@@ -1002,6 +1263,22 @@ mod tests {
                 "project_path",
                 "document_path",
                 "object_kiids"
+            ])
+        );
+        let cross_probe = definitions
+            .iter()
+            .find(|tool| tool.name == "resolve_cross_probe_target")
+            .expect("cross-probe resolver tool");
+        assert_eq!(
+            cross_probe.input_schema["required"],
+            json!([
+                "source_editor",
+                "project_name",
+                "project_path",
+                "schematic_document_path",
+                "pcb_document_path",
+                "schematic_sheet_instance_path",
+                "source_object_kiid"
             ])
         );
     }
@@ -1282,6 +1559,83 @@ mod tests {
         assert_eq!(
             extract_error_kind(&result).as_deref(),
             Some("unsupported_capability")
+        );
+    }
+
+    #[tokio::test]
+    async fn public_cross_probe_proves_both_live_contexts_without_state_change() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("nav.kicad_pro"), "{}").unwrap();
+        let schematic = temp.path().join("nav.kicad_sch");
+        std::fs::write(
+            &schematic,
+            "(kicad_sch (uuid \"root\") \
+             (symbol (lib_id \"Device:C\") (at 1 2) (uuid \"sym-c10\") \
+               (property \"Reference\" \"C10\") \
+               (instances (project \"nav\" (path \"/root\" (reference \"C10\") (unit 1))))) \
+             (sheet_instances (path \"/\" (page \"1\"))))",
+        )
+        .unwrap();
+        let board = temp.path().join("nav.kicad_pcb");
+        std::fs::write(
+            &board,
+            "(kicad_pcb (footprint \"Capacitor:C\" (layer \"F.Cu\") (at 1 2) \
+             (uuid \"fp-c10\") (property \"Reference\" \"C10\") (path \"/sym-c10\")))",
+        )
+        .unwrap();
+        let project_path = temp.path().display().to_string();
+        let commands = Arc::new(Mutex::new(Vec::new()));
+        let result = handle_resolve_cross_probe_target(
+            &json!({
+                "source_editor": "schematic",
+                "project_name": "nav",
+                "project_path": project_path.clone(),
+                "schematic_document_path": schematic.display().to_string(),
+                "pcb_document_path": board.display().to_string(),
+                "schematic_sheet_instance_path": ["root"],
+                "sheet_path_human_readable": "/",
+                "source_object_kiid": "sym-c10"
+            }),
+            &context(spawn_cross_probe_context_mock(
+                project_path,
+                commands.clone(),
+            )),
+        )
+        .await
+        .expect("handler result");
+        assert!(!result.is_error);
+        let ToolContent::Text { text } = &result.content[0] else {
+            panic!("expected text result");
+        };
+        let body: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(body["resolution"]["source"]["object"]["kiid"], "sym-c10");
+        assert_eq!(
+            body["resolution"]["destination"]["object"]["kiid"],
+            "fp-c10"
+        );
+        assert_eq!(
+            body["resolution"]["evidence"]["source"],
+            "saved_kicad_footprint_symbol_path"
+        );
+        assert_eq!(body["destination_navigation"]["attempted"], false);
+        let commands = commands.lock().unwrap();
+        assert_eq!(commands.len(), 2);
+        assert!(commands
+            .iter()
+            .all(|command| command.ends_with("GetOpenDocuments")));
+    }
+
+    #[test]
+    fn unresolved_cross_probe_has_a_public_structured_refusal() {
+        let result =
+            cross_probe_error_result(anyhow::Error::new(CrossProbeError::UnresolvedDestination {
+                source_kiid: "sym-c10".to_string(),
+                reason: "duplicate linkage".to_string(),
+                candidates: vec!["fp-a".to_string(), "fp-b".to_string()],
+            }));
+        assert_eq!(
+            extract_error_kind(&result).as_deref(),
+            Some("unresolved_cross_probe_destination")
         );
     }
 }

--- a/crates/konnect-core/src/tools/mod.rs
+++ b/crates/konnect-core/src/tools/mod.rs
@@ -3,6 +3,7 @@
 mod board_session;
 pub mod cli;
 pub mod config;
+pub(crate) mod cross_probe;
 pub mod design_review;
 pub mod editor_navigation;
 mod footprint_graphics;

--- a/crates/konnect-ipc/src/client.rs
+++ b/crates/konnect-ipc/src/client.rs
@@ -3613,10 +3613,14 @@ fn editor_capabilities(
         "konnect_bundled_kicad_protocol",
         "selection is typed, but reveal/center/fit has no stable typed command",
     );
-    let no_cross_probe = unsupported(
-        "konnect_navigation_mvp",
-        "semantic cross-probe resolution is not implemented in this slice",
-    );
+    let cross_probe = if addressable && version.major >= 10 {
+        available("konnect_saved_structure_and_typed_live_context")
+    } else {
+        unsupported(
+            "konnect_saved_structure_and_typed_live_context",
+            "cross-probe resolution requires an addressable KiCad 10-or-newer editor endpoint",
+        )
+    };
 
     IpcEditorCapabilities {
         observe_documents: documents,
@@ -3628,7 +3632,7 @@ fn editor_capabilities(
         reveal_object: no_reveal.clone(),
         center_object: no_reveal.clone(),
         fit_view: no_reveal,
-        cross_probe: no_cross_probe,
+        cross_probe,
     }
 }
 

--- a/crates/konnect-ipc/tests/mock_server_test.rs
+++ b/crates/konnect-ipc/tests/mock_server_test.rs
@@ -228,6 +228,10 @@ fn editor_state_observation_keeps_live_sheet_identity_and_unsupported_context_ho
             .as_deref()
             .is_some_and(|reason| { reason.contains("no stable typed") }));
     }
+    assert_eq!(
+        schematic.capabilities.cross_probe.availability,
+        konnect_ipc::IpcCapabilityAvailability::Available
+    );
 
     let pcb = &state.editors[1];
     assert_eq!(pcb.editor, konnect_ipc::IpcEditorKind::Pcb);

--- a/docs/KICAD_INTEGRATION.md
+++ b/docs/KICAD_INTEGRATION.md
@@ -79,6 +79,17 @@ entire observed set with the expected before/after transition, and returns a
 structured `readback_mismatch` if KiCad did not make precisely that change.
 Duplicate or empty KIID requests are rejected before IPC.
 
+`resolve_cross_probe_target` maps an exact schematic symbol to its PCB
+footprint, or the footprint back to the symbol, from KiCad's saved footprint
+symbol-path linkage. It requires the explicit project, both saved documents,
+the schematic hierarchy instance, and the source KIID; reference agreement is
+checked as an additional consistency guard. Both requested editor documents
+must also be proven open through typed `GetOpenDocuments` readback. Missing,
+duplicate, malformed, or instance-inconsistent links return a structured
+`unresolved_cross_probe_destination` instead of guessing. The operation is
+resolve-only: it does not activate an editor or mutate selection, and pin/pad/
+net expansion remains unsupported until one stable destination can be proven.
+
 ## Schematic-To-Board Sync
 
 `update_pcb_from_schematic` in `tools/pcb_sync.rs` is live-IPC-only. It uses

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -309,7 +309,7 @@ callable tools, the fix is to make the *first* listing complete:
 ```
 
 in `konnect.toml` in the working directory, or a `settings.json` beside the binary. Every toolset is then loaded at
-startup, so `tools/list` carries all 232 tools from the first call.
+startup, so `tools/list` carries all 233 tools from the first call.
 
 It is off by default because it costs what the router exists to save: roughly
 25K tokens per listing instead of ~2K. Turn it on only if your client needs it.

--- a/packaging/metadata.json
+++ b/packaging/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://go.kicad.org/pcm/schemas/v1",
   "name": "Konnect",
-  "description": "AI-assisted PCB design via the Model Context Protocol. Enables Claude and other AI assistants to design schematics and PCBs with 225 tools organized into on-demand toolsets.",
+  "description": "AI-assisted PCB design via the Model Context Protocol. Enables Claude and other AI assistants to design schematics and PCBs with 226 tools organized into on-demand toolsets.",
   "description_full": "Konnect exposes a complete set of KiCAD design tools to AI assistants via the Model Context Protocol (MCP). It supports schematic editing, PCB layout, local Freerouting MCP routing, library management, JLCPCB part search, ERC/DRC, design review audits, and full export pipelines. Tools are organized into 21 toolsets loaded on demand so the AI only sees relevant tools at once.",
   "identifier": "com.github.mixelpixx.konnect",
   "type": "plugin",

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "identifier": "com.github.mixelpixx.konnect",
   "name": "Konnect",
-  "description": "AI-assisted PCB design via the Model Context Protocol. 225 tools for schematic editing, PCB layout, routing, design review, and manufacturing export.",
+  "description": "AI-assisted PCB design via the Model Context Protocol. 226 tools for schematic editing, PCB layout, routing, design review, and manufacturing export.",
   "runtime": {
     "type": "exec"
   },

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -13,7 +13,7 @@ Compatibility notes for removed or narrowed arguments are recorded in
 ## Overview
 
 - **21 toolsets** organized into 10 categories
-- **225 registered tools** + **7 always-visible meta-tools** = **232 total**
+- **226 registered tools** + **7 always-visible meta-tools** = **233 total**
 - **Discovery pattern**: the server pre-loads only the **starter kit** (`project`, `config`) so baseline `tools/list` costs ~2K tokens instead of ~23K. The LLM reads `list_toolboxes` → calls `load_toolset(name)` to expose additional tools on demand; `unload_toolset(name)` prunes them. `tools/list_changed` is notified on every mutation. If the LLM calls a tool whose toolset isn't loaded, the error names the owning toolset so recovery is a single `load_toolset` hop. `load_toolset` also accepts an array of names to load several toolsets with a single `tools/list` refresh.
 - **Observability**: every `tools/call` is recorded — ring buffer of the last 100 calls + per-tool counters + JSONL at `<konnect dir>/logs/calls.jsonl`. The LLM self-diagnoses via `get_recent_calls` and `server_stats`.
 
@@ -61,7 +61,7 @@ Seven tools, grouped into *discovery/routing*, *observability*, and *runtime dia
 | `snapshot_project` | Export the schematic and PCB to PDF as a timestamped snapshot/checkpoint. Useful before major edits. |
 | `open_schematic_viewer` | Launch the live schematic viewer (SVG with auto-refresh on file change). Use after placing components so the user can see changes in real time. |
 
-### `editor_navigation` · 4 tools
+### `editor_navigation` · 5 tools
 **Purpose:** Observe and semantically navigate exact KiCad editor, document, sheet, selection, and cross-probe context.
 **Source:** [`crates/konnect-core/src/tools/editor_navigation.rs`](crates/konnect-core/src/tools/editor_navigation.rs)
 
@@ -71,6 +71,7 @@ Seven tools, grouped into *discovery/routing*, *observability*, and *runtime dia
 | `get_editor_selection` | Read the selection from one exact editor, project, document, and hierarchical sheet instance with stable KIID/UUID identities and document-readback freshness checks. |
 | `resolve_navigation_target` | Resolve an exact open project/document/sheet object by stable KIID, or by a human reference only when saved KiCad structure yields one unambiguous candidate. |
 | `mutate_editor_selection` | Clear, add to, or remove from one exact editor selection after saved-object validation; report success only when a fresh typed selection readback proves the complete requested set transition. |
+| `resolve_cross_probe_target` | Resolve an exact schematic-symbol/PCB-footprint destination in either direction from saved KiCad symbol-path linkage, while proving both explicit live document contexts and performing no activation or selection. |
 
 ---
 


### PR DESCRIPTION
Closes #395.

This is the terminal N6 slice of the approved Navigation MVP. It reconstructs the unique cross-probe work from draft #401 directly on current main after #488, #491, #492, #493, and #494 landed. The rejected #400 activation tool is intentionally absent. Original implementation authorship from @dubesinhower is preserved.

## User-visible capability

- Adds the read-only `resolve_cross_probe_target` tool with the exact maintainer-approved public name.
- Resolves schematic symbol to PCB footprint and PCB footprint to schematic symbol from saved KiCad symbol-path linkage.
- Requires explicit project identity, both saved documents, the exact schematic instance path, source editor, and source KIID.
- Returns exact source and destination identities plus separate saved-structure and live-document evidence.
- Proves both requested documents through typed `GetOpenDocuments` IPC readback.
- Refuses missing, duplicate, malformed, stale, instance-inconsistent, and reference-inconsistent linkage with structured errors.
- Performs no activation, reveal, viewport, selection, raw-action, mouse, or keyboard side effects.

## Navigation MVP acceptance accounting

1. Editor, version, document, sheet-instance, active-state availability, and capability observation: #488 and #494.
2. Deterministic `C10` to exact schematic KIID/instance resolution: #492.
3. Exact activation or typed unsupported: #488/#494 report activation, reveal, center, and fit unavailable; per the maintainer decision no public pretend-to-act tool ships.
4. Exact selection and full readback: #491 observes selection and #493 verifies clear/add/remove mutations by complete readback.
5. Exact cross-probe to one PCB footprint KIID: this PR.
6. PCB destination action or typed unsupported: this PR returns the destination without side effects; #493 provides the supported exact selection operation, while #488/#494 report activation unsupported.
7. Destination document and selection proof: this PR proves the destination document; #491/#493 provide exact selection observation/mutation readback when the client requests it.
8. Structured ambiguity, stale, wrong-context, closed-editor, unresolved-destination, unsupported, and readback-mismatch refusals: covered across #488, #491, #492, #493, and this PR.

This closes the issue under the smaller five-operation composition explicitly approved in the maintainer decision.

## Current-main conflict resolution

The old #401 branch also contained #400's rejected activation API and stale generated counts. The reconstruction keeps current-main board safety and capability-model changes, excludes activation completely, and adds only the cross-probe resolver. Tool counts were regenerated rather than hand-merged.

## Evidence

- `cargo test -p konnect-core cross_probe --lib` - 7 passed.
- `cargo test -p konnect-core editor_navigation --lib` - 14 passed.
- `cargo test -p konnect-ipc --test mock_server_test` - 55 passed, 1 intentionally ignored.
- Guard-neutering proof: disabling reference agreement made `missing_duplicate_and_reference_mismatch_destinations_fail_closed` fail; restoring it made the test pass.
- `cargo xtask fix-doc-counts --check` - 21 toolsets, 226 registered, 233 total; current.
- `cargo fmt --all -- --check` - passed.
- `cargo clippy --workspace --locked --all-targets -- -D warnings` - passed.
- `cargo test --workspace --locked --lib --tests` - passed.
- `cargo test --workspace --locked --doc` - passed.
- `git diff --check` - passed.

Hermetic coverage includes exact forward/reverse mapping, root and nested sheet paths, human `C10` resolution, missing/duplicate/mismatched linkage, stale sources, wrong instances, both live-document proofs, and absence of mutation commands.

## Validation debt and boundaries

No disposable live KiCad GUI endpoint was available for a new manual integration run. The operation is focused and read-only, and its IPC and saved-design behavior is covered deterministically. Saved footprint symbol-path representation remains a KiCad-version compatibility surface. Pin/pad/net expansion remains unsupported until one stable destination can be modeled.