### PR TITLE
docs: codify protected-main merge workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,7 @@ Base branch:
 Depends on:
 Series order, if any:
 Unique commits/acceptance criteria owned by this PR:
+Next PR to promote after this one, if any:
 
 Follow docs/BRANCH_AND_PULL_REQUEST_WORKFLOW.md. Do not open a cumulative PR
 against main that repeats unmerged prerequisite commits.
@@ -48,8 +49,19 @@ Write "No public compatibility impact" when applicable.
 - [ ] The branch includes current `upstream/main`, has no merge conflicts, and CI passed on this exact head.
 - [ ] The branch was based on latest `upstream/main`, not a release tag (unless this is an approved backport).
 - [ ] The PR shows only its unique commits and diff; dependencies and series position are explicit.
+- [ ] Every review conversation is resolved; any post-review push or base change has been reviewed again on the new exact head.
 - [ ] New names follow `docs/NAMING_CONVENTIONS.md`; public renames include compatibility handling.
 - [ ] New behavior and failure paths have regression coverage.
 - [ ] File mutations are atomic and preserve unrelated content.
 - [ ] IPC mutations verify the requested board and do not leave partial batches.
 - [ ] If tools were added/removed: counts and docs updated per CONTRIBUTING.md (registry `tool_count`, `tool-directory.md`, DEV.md stats, README count).
+
+## Maintainer merge state
+
+<!-- Maintainers complete this section. Auto-merge is an execution mechanism, not approval. -->
+
+- [ ] The PR has exactly one current `status:*` workflow label.
+- [ ] `status:ready-to-merge` applies to this exact head SHA.
+- [ ] All required checks and review conversations satisfy the `main` ruleset.
+- [ ] Auto-merge uses a merge commit, or an already-green PR will be merged with `gh pr merge N --merge`.
+- [ ] Terminal issue closure and the next PR to promote are identified.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,9 @@ Thanks for your interest! Bug reports, feature requests, and pull requests are w
 - Follow the [branch and pull request workflow](docs/BRANCH_AND_PULL_REQUEST_WORKFLOW.md).
   Independent changes branch from current `upstream/main`; dependent work exposes one
   mergeable step at a time instead of opening cumulative PRs against the same old base.
+- Keep the PR's workflow state honest. A maintainer uses one `status:*` label to name
+  the next actor; `status:ready-to-merge` means the exact current head has completed
+  review, not merely that the author considers it finished.
 - Read [docs/NAMING_CONVENTIONS.md](docs/NAMING_CONVENTIONS.md) before adding public
   tools, schema fields, CLI options, environment variables, or user-facing terms.
 
@@ -72,6 +75,26 @@ The description should state:
 6. tests run, including intentionally skipped environment-dependent checks;
 7. risk and rollback notes for file formats, IPC, packaging, or release changes.
 
+## From review to merge
+
+Konnect currently runs in a personal GitHub repository. Collaborators have Write
+access rather than organization-style Maintain/Admin roles. Maintainers can triage,
+review, merge, and arm auto-merge, but only the owner can change repository settings.
+GitHub's native merge queue is not available in this ownership model, so the documented
+landing order and `status:*` labels are the queue.
+
+The repository requires a pull request, all ten hosted checks, resolved review
+conversations, and the merge-commit method. Once a maintainer has reviewed the exact
+head and marked it `status:ready-to-merge`, they may enable auto-merge while checks are
+finishing. Auto-merge is the last execution step; it is not review and does not make a
+stale, cumulative, or poorly evidenced PR ready.
+
+If you push after that review, assume the readiness decision is invalid. GitHub may
+disable auto-merge automatically for a new commit from a fork. Resolve new feedback,
+bring the branch back to current `upstream/main` when required, rerun the evidence, and
+wait for review of the new head. After merge, GitHub deletes the topic branch
+automatically; retain any later dependent work on its own branch.
+
 You do not need personal access to every supported operating system, KiCad
 version, or hardware configuration. For an environment-dependent check you
 cannot run, name the missing environment, provide the deterministic and hosted
@@ -96,6 +119,8 @@ These are exactly the commands CI runs — if they pass locally, CI should be gr
 - `cargo fmt --all -- --check` is clean
 - The branch includes current `upstream/main`, GitHub reports no conflicts, and the
   required checks passed on the exact head being reviewed
+- Every review conversation is resolved; a post-review commit or base change requires
+  review of the new exact head before auto-merge is armed again
 - The commit list and diff contain only this PR's unique work; dependencies and stack
   position are explicit
 - New names follow [the naming conventions](docs/NAMING_CONVENTIONS.md); public name

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -9,6 +9,21 @@ One page, so nobody has to reconstruct this from issue threads.
 - **[@neusse](https://github.com/neusse)** — maintainer. Owns the areas listed
   in [`.github/CODEOWNERS`](.github/CODEOWNERS).
 
+### Current repository access model
+
+Konnect currently lives in a personal GitHub account. [GitHub gives a personal
+repository one owner and write collaborators](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/repository-access-and-collaboration/permission-levels-for-a-personal-account-repository);
+it does not offer the granular Triage, Maintain, and Admin roles available to
+organization repositories.
+Accordingly, `@neusse` can triage, label, assign, review, push, merge, and arm
+auto-merge, but cannot change repository settings or bypass the `main` ruleset.
+Only `@mixelpixx`, as owner, can administer those controls.
+
+Moving Konnect to an organization is accepted in principle but is not part of
+the current workflow. Until that happens, [GitHub's native merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
+is not available here. The ordered queue below, the `status:*` labels, and
+auto-merge provide the deliberately smaller substitute.
+
 Konnect is deliberately built and reviewed through **two different AI
 toolchains** — Claude Code on one side, OpenAI Codex on the other. That is not
 duplication to be tidied away. Every defect found so far in the agent-facing
@@ -18,10 +33,18 @@ independent.
 
 ## Merging
 
-- **A green PR may be merged by its author.** No approval is required. CI is
-  the gate: `main` requires all ten checks to pass, and that requirement is not
-  waived for anyone with write access.
+- **A reviewed green PR may be merged by its author or a maintainer.** No
+  approving-review count is required, but review is still a real decision:
+  every conversation must be resolved and the exact current head must satisfy
+  the issue, evidence, and queue requirements below.
 - **Merge commits only** (`gh pr merge N --merge`), so authorship survives.
+- **The active `main: CI must pass` ruleset is the protection source of truth.**
+  It requires pull requests, all ten CI checks, and resolved review threads;
+  blocks force-pushes and deletion; and permits only merge commits. Repository
+  auto-merge and automatic deletion of merged topic branches are enabled.
+- A write collaborator cannot bypass the ruleset. Any owner-only direct-push
+  exception is reserved for the documented release recipe's bump/stamp commits;
+  it is not an ordinary merge shortcut.
 - **Run the full local gate after each merge** before landing the next one:
 
   ```
@@ -35,6 +58,26 @@ independent.
   that has put a red commit on `main` twice.
 - **CODEOWNERS is a routing hint, not a veto.** It auto-requests the right
   reviewer; it does not block a merge.
+
+### Review-to-merge execution
+
+1. Review the PR's exact head, issue accounting, focused diff, compatibility
+   impact, and available evidence. Resolve every review conversation.
+2. If work remains, apply the one `status:*` label naming the next actor. Do not
+   arm auto-merge.
+3. When the PR is genuinely merge-ready, replace its workflow-state label with
+   `status:ready-to-merge`. If checks are still running, arm GitHub auto-merge
+   with the **merge commit** method. If every requirement is already green,
+   merge with `gh pr merge N --merge` after the same final verification.
+4. Any new commit, force-push, base change, required-check regression, or newly
+   unresolved conversation invalidates the readiness decision. Return the PR to
+   the appropriate state, review the new exact head, and arm it again only after
+   the gate is restored. GitHub may automatically disable auto-merge after a
+   fork contributor pushes; that is expected safety behavior.
+5. After merge, synchronize local `main`, run the complete local gate below,
+   verify terminal issue closure and post the acceptance evidence, then promote
+   only the next PR in the documented dependency order. GitHub deletes the
+   merged topic branch automatically.
 
 ## Claiming work
 

--- a/docs/BRANCH_AND_PULL_REQUEST_WORKFLOW.md
+++ b/docs/BRANCH_AND_PULL_REQUEST_WORKFLOW.md
@@ -14,6 +14,20 @@ do not contain work merged after the release. A PR based on a release can be
 green in isolation while omitting fixes and contracts already present on
 `main`.
 
+## Current repository mechanics
+
+Konnect is currently a personal-account repository. Write collaborators can
+triage, review, merge, and enable auto-merge, but only the owner can administer
+repository settings. Organization-only Maintain/Admin role separation and the
+native GitHub merge queue are not available here yet.
+
+The repository therefore uses one explicit ordered queue rather than pretending
+that GitHub is sequencing PRs for us. One active `main: CI must pass` ruleset
+requires pull requests, all ten hosted checks, resolved review conversations,
+no force-push or deletion, and merge commits only. Auto-merge is enabled for a
+maintainer to arm after exact-head review, and merged topic branches are deleted
+automatically.
+
 ## Default: one independent change
 
 Use an independent branch when a change can be reviewed and merged without
@@ -134,6 +148,38 @@ A PR is merge-ready only when all of the following are true:
 - partial and terminal issue-closing keywords are correct.
 
 A PR is not merge-ready merely because an earlier cumulative head was green.
+
+## Merge execution loop
+
+The next actor is represented by exactly one workflow label:
+
+- `status:waiting-on-author`: the contributor must change or clarify the PR;
+- `status:waiting-on-dependency`: another named change must land first;
+- `status:waiting-on-review`: the focused current head is ready for review; and
+- `status:ready-to-merge`: review of this exact head is complete and only the
+  repository gate or merge execution remains.
+
+For the one next-to-land PR in an overlap set:
+
+1. A maintainer verifies the head SHA, focused diff, dependency position,
+   issue-closing references, evidence, and every resolved review conversation.
+2. If something remains, the maintainer applies the label for the actual next
+   actor and leaves auto-merge off.
+3. If the PR is ready but required checks are still running, the maintainer
+   applies `status:ready-to-merge` and enables auto-merge with the merge-commit
+   method. If all requirements are already satisfied, the maintainer may merge
+   immediately with `gh pr merge N --merge` after the same verification.
+4. A new commit, rewritten head, base change, failed or missing required check,
+   or unresolved conversation returns the PR to review. Recheck the new exact
+   head before arming auto-merge again.
+5. After GitHub merges it, update local `main`, run the complete gate from
+   `GOVERNANCE.md`, verify terminal issue closure, post the acceptance mapping,
+   and only then promote or reconstruct the immediate successor.
+
+Auto-merge removes waiting time; it does not relax admission control, review,
+CI, or the one-next-PR rule. Until Konnect moves to an organization with a
+native merge queue, maintainers must not arm several overlapping PRs and hope
+GitHub chooses a safe order.
 
 ## Responsibilities when `main` moves
 


### PR DESCRIPTION
Closes #496.

## Summary

Codifies Konnect's newly enabled protected-main and auto-merge operating model across governance, contributor instructions, the detailed branch workflow, and the pull-request template.

## What changes

- Documents the current personal-repository boundary: one owner plus Write collaborators, with repository settings remaining owner-only.
- Records the active `main: CI must pass` ruleset as the single protection source of truth.
- States the enforced controls: PR-only changes, all ten checks, resolved review conversations, merge commits only, and blocked force-push/deletion.
- Documents repository auto-merge and automatic deletion of merged topic branches.
- Adds an executable review-to-merge loop using one `status:*` next-actor label.
- Makes exact-head review invalidation explicit for new commits, rewritten heads, base changes, failed checks, or new unresolved conversations.
- Defines the post-merge sequence: synchronize `main`, run the full gate, verify issue closure, then promote only the immediate successor.
- Keeps organization migration and native merge queue clearly future-facing.
- Extends the PR template with dependency successor and maintainer merge-state accounting.

## Live configuration evidence

Verified before editing:

- collaborator role for `@neusse`: `write`, not Maintain/Admin;
- auto-merge: enabled;
- delete merged branches: enabled;
- merge commits: enabled;
- squash/rebase merge: disabled;
- one active `main: CI must pass` ruleset;
- exactly ten required check contexts;
- pull requests and resolved review threads required;
- deletion and non-fast-forward changes blocked;
- current write collaborator cannot bypass the ruleset;
- no separate classic branch-protection response.

## Scope and compatibility

Documentation and PR-template only. No Rust, tool, schema, packaging, workflow, or repository-setting changes are made by this PR.

The private per-operator approval policy is not changed; this PR documents the upstream project's shared operating model.

## Validation

- `cargo fmt --all -- --check` - passed
- `cargo test -p konnect --test asset_references` - 12 passed
- `cargo test -p konnect --test doc_tool_counts` - 6 passed
- `cargo xtask fix-doc-counts --check` - 21 toolsets, 226 registered, 233 total; unchanged
- `git diff --check` - passed