### PR TITLE
Three placement/library fixes found by driving a real KiCad 10 project

### DIFF
--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -28,7 +28,7 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         name: "sch_components",
         description: "Add, edit, move, rotate, and delete schematic symbols, and set the page size",
         category: "schematic",
-        tool_count: 20,
+        tool_count: 21,
     },
     ToolsetMeta {
         name: "sch_wiring",

--- a/crates/konnect-core/src/router/registry.rs
+++ b/crates/konnect-core/src/router/registry.rs
@@ -28,7 +28,7 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         name: "sch_components",
         description: "Add, edit, move, rotate, and delete schematic symbols, and set the page size",
         category: "schematic",
-        tool_count: 21,
+        tool_count: 20,
     },
     ToolsetMeta {
         name: "sch_wiring",
@@ -52,7 +52,7 @@ pub static ALL_TOOLSETS: &[ToolsetMeta] = &[
         name: "sch_batch",
         description: "Bulk add, edit, delete, and move schematic elements in one call",
         category: "schematic",
-        tool_count: 12,
+        tool_count: 13,
     },
     ToolsetMeta {
         name: "sch_export",

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -37,6 +37,25 @@ use super::sch_wiring::{resolve_pin_endpoint, resolve_placed_pin, route_between}
 pub fn tools() -> Vec<ToolDef> {
     vec![
         tool!(
+            "prune_unused_lib_symbols",
+            "Remove cached lib_symbols definitions no placed instance references. \
+             Orphans accumulate whenever a symbol is renamed or swapped — eeschema \
+             never prunes them and kicad-cli preserves them verbatim. Netlist-neutral.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "schematic": { "type": "string", "description": "Path to .kicad_sch file" },
+                    "dry_run": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Report what would be removed without writing."
+                    }
+                },
+                "required": ["schematic"]
+            }),
+            |args, ctx| async move { super::sch_components::handle_prune_unused_lib_symbols(args, ctx).await }
+        ),
+        tool!(
             "batch_connect_to_net",
             "Connect multiple component pins to a named net by adding net labels at each pin \
              endpoint. Single file read → all labels inserted → single file write.",

--- a/crates/konnect-core/src/tools/sch_batch.rs
+++ b/crates/konnect-core/src/tools/sch_batch.rs
@@ -548,8 +548,17 @@ async fn handle_batch_place_components(
         ) {
             Ok(uuid) => {
                 let (expected_x, expected_y) = snap_point(x, y, 1.27);
+                let intent_value =
+                    super::sch_components::resolved_placement_value(lib_id, value, &src);
                 placements.push(super::sch_components::ComponentTargetUnit::placement(
-                    &uuid, &context, lib_id, expected_x, expected_y, rotation, reference, value,
+                    &uuid,
+                    &context,
+                    lib_id,
+                    expected_x,
+                    expected_y,
+                    rotation,
+                    reference,
+                    Some(&intent_value),
                     unit,
                 ));
             }

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -639,13 +639,59 @@ pub(crate) fn place_one_component(
 ) -> Result<String, CallToolResult> {
     // Snap to 1.27mm grid
     let (x, y) = snap_point(x, y, 1.27);
-    let val_str = value.unwrap_or(lib_id.split(':').next_back().unwrap_or("?"));
 
     // Embed the library symbol definition
     if !cse::library::ensure_lib_symbol(sch, lib_id, src) {
         return Err(crate::tools::lib_symbol_not_found_error(lib_id, src));
     }
     let metadata = cse::library::symbol_metadata(sch, lib_id);
+
+    // Copy the library symbol's own fields onto the instance, the way eeschema
+    // does when you place a part. Upstream copies only Datasheet and
+    // Description (#226) and hardcodes an EMPTY Footprint, so a placed part
+    // never reaches the board, and its Value is the symbol name rather than the
+    // part's actual value -- which makes the BOM meaningless. Any BOM metadata
+    // the library carries (Manufacturer, MPN, LCSC, distributor links, ...) is
+    // copied too.
+    //
+    // Uses the flattened node so a derived symbol (`(extends ...)`) inherits
+    // its parent's fields, and the caller's `src` so project-scoped
+    // (${KIPRJMOD}) libraries resolve exactly as they do for ensure_lib_symbol.
+    // `ki_*` properties are library-only metadata eeschema does not copy.
+    let lib_fields: Vec<(String, String)> =
+        cse::library::resolve_lib_symbol_flattened_node(lib_id, src)
+            .map(|node| {
+                node.find_all("property")
+                    .into_iter()
+                    .filter_map(|property| {
+                        let name = property.value()?.to_string();
+                        let val = property
+                            .args()
+                            .get(1)
+                            .and_then(cse::sexp::SexpNode::text)
+                            .unwrap_or_default()
+                            .to_string();
+                        Some((name, val))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+    let lib_field = |name: &str| -> &str {
+        lib_fields
+            .iter()
+            .find(|(k, _)| k == name)
+            .map(|(_, v)| v.as_str())
+            .unwrap_or("")
+    };
+
+    // An explicit `value` argument wins; otherwise take the library's Value,
+    // falling back to the bare symbol name only when the library has none.
+    let lib_value = lib_field("Value").to_string();
+    let val_str = match value {
+        Some(v) => v,
+        None if !lib_value.is_empty() => lib_value.as_str(),
+        None => lib_id.split(':').next_back().unwrap_or("?"),
+    };
 
     // Validate the unit against the resolved symbol BEFORE writing anything:
     // eeschema silently renders an out-of-range unit as unit 1 and the
@@ -704,8 +750,15 @@ pub(crate) fn place_one_component(
         false,
         anchors.value_justify,
     ));
-    sym.properties
-        .push(positioned("Footprint", "", x, y, 0.0, true, centred));
+    sym.properties.push(positioned(
+        "Footprint",
+        lib_field("Footprint"),
+        x,
+        y,
+        0.0,
+        true,
+        centred,
+    ));
     sym.properties.push(positioned(
         "Datasheet",
         &metadata.datasheet,
@@ -724,6 +777,21 @@ pub(crate) fn place_one_component(
         true,
         centred,
     ));
+
+    // Everything else the library carries (Manufacturer, MPN, LCSC,
+    // distributor links, ...). The five fields above are already written, and
+    // `ki_*` is library-only metadata eeschema keeps out of instances.
+    for (name, val) in &lib_fields {
+        if matches!(
+            name.as_str(),
+            "Reference" | "Value" | "Footprint" | "Datasheet" | "Description"
+        ) || name.starts_with("ki_")
+        {
+            continue;
+        }
+        sym.properties
+            .push(positioned(name, val, x, y, 0.0, true, centred));
+    }
 
     // Instance entry, keyed to the root sheet UUID like eeschema writes it:
     // (instances (project "<name>" (path "/<root-uuid>" (reference ...) (unit 1))))

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -118,6 +118,25 @@ pub fn tools() -> Vec<ToolDef> {
             |args, ctx| async move { handle_delete_schematic_component(args, ctx).await }
         ),
         tool!(
+            "prune_unused_lib_symbols",
+            "Remove cached lib_symbols definitions no placed instance references. \
+             Orphans accumulate whenever a symbol is renamed or swapped — eeschema \
+             never prunes them and kicad-cli preserves them verbatim. Netlist-neutral.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "schematic": { "type": "string", "description": "Path to .kicad_sch file" },
+                    "dry_run": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Report what would be removed without writing."
+                    }
+                },
+                "required": ["schematic"]
+            }),
+            |args, ctx| async move { handle_prune_unused_lib_symbols(args, ctx).await }
+        ),
+        tool!(
             "edit_schematic_component",
             "Update fields (Reference, Value, Footprint, custom properties) consistently across every placed unit of a component.",
             json!({
@@ -1416,6 +1435,89 @@ async fn handle_delete_schematic_component(
         "junctions_pruned_uuids": outcome.pruned_junctions
     })))
 }
+
+/// Remove `lib_symbols` definitions that no placed instance references.
+///
+/// A schematic embeds a copy of every symbol it uses. Rename a library symbol,
+/// swap a component to a different lib_id, or delete the last instance of one,
+/// and the old cached definition is left behind: eeschema does not prune on
+/// save and `kicad-cli sch upgrade` preserves the section verbatim, so nothing
+/// in the toolchain removes them. They are inert — invisible to the netlist,
+/// BOM and PCB — but they accumulate, and a stale definition sharing a name
+/// with a live one is a genuine trap when reading the raw file.
+///
+/// Edits are surgical byte deletions rather than a parse/serialise round-trip,
+/// so the rest of the file keeps its formatting exactly.
+async fn handle_prune_unused_lib_symbols(
+    args: &serde_json::Value,
+    _ctx: &ToolContext,
+) -> anyhow::Result<CallToolResult> {
+    let sch_path = get_path(args, "schematic")?;
+    let dry_run = args
+        .get("dry_run")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
+    let content = read_consistent(&sch_path)?;
+    let expected = content.clone();
+
+    // lib_ids actually placed on the sheet.
+    let (_, tree) = read_schematic(&sch_path)?;
+    let used: std::collections::HashSet<String> = extract_symbol_instances(&tree)
+        .iter()
+        .map(|s| s.lib_id.clone())
+        .collect();
+
+    let mut removed: Vec<String> = Vec::new();
+    let mut edits: Vec<SexpEdit> = Vec::new();
+
+    for (start, _end) in konnect_sexp::writer::find_direct_child_blocks(&content, "lib_symbols") {
+        // Each child is (symbol "Lib:Name" ...); anything else is left alone.
+        let head = &content[start..content.len().min(start + 256)];
+        if !head.starts_with("(symbol") {
+            continue;
+        }
+        let Some(name) = head
+            .find('"')
+            .and_then(|q| head[q + 1..].find('"').map(|e| &head[q + 1..q + 1 + e]))
+        else {
+            continue;
+        };
+        // Unit sub-symbols ("Name_0_1") are nested inside their parent, never
+        // direct children here, so a bare name means a top-level definition.
+        if used.contains(name) {
+            continue;
+        }
+        let Some((del_start, del_end)) =
+            konnect_sexp::writer::find_block_with_leading_whitespace(&content, start)
+        else {
+            continue;
+        };
+        removed.push(name.to_string());
+        edits.push(SexpEdit::delete(del_start, del_end));
+    }
+
+    if removed.is_empty() {
+        return Ok(CallToolResult::json(&json!({
+            "schematic": sch_path.display().to_string(),
+            "removed": [],
+            "note": "no orphaned lib_symbols definitions"
+        })));
+    }
+
+    if !dry_run {
+        let updated = apply_edits(content, edits);
+        write_atomic_if_unchanged(&sch_path, &expected, &updated)?;
+    }
+
+    Ok(CallToolResult::json(&json!({
+        "schematic": sch_path.display().to_string(),
+        "removed": removed,
+        "count": removed.len(),
+        "dry_run": dry_run,
+    })))
+}
+
 
 #[derive(Debug, Clone)]
 pub(crate) struct IndexedSchematicItem {
@@ -4970,6 +5072,78 @@ mod tests {
             detail.contains("pin 2") && detail.contains("removed"),
             "{detail}"
         );
+    }
+
+    /// Renaming or swapping a symbol leaves its old cached definition behind:
+    /// eeschema does not prune on save and kicad-cli preserves the section
+    /// verbatim, so nothing in the toolchain removes them.
+    #[tokio::test]
+    async fn prune_removes_only_unreferenced_definitions() {
+        let (_symdir, _env) = stub_symbol_dir();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("orphan.kicad_sch");
+        let ctx = test_ctx();
+
+        handle_create_schematic(&json!({ "path": path.display().to_string() }), &ctx)
+            .await
+            .unwrap();
+        handle_add_schematic_component(
+            &json!({ "schematic": path.display().to_string(),
+                     "lib_id": "Device:R", "x": 100.0, "y": 100.0, "reference": "R1" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        // Forge an orphan alongside the live definition, mimicking a rename.
+        let mut text = std::fs::read_to_string(&path).unwrap();
+        let anchor = text.find("(lib_symbols").expect("lib_symbols") + "(lib_symbols".len();
+        text.insert_str(
+            anchor,
+            "\n\t\t(symbol \"Device:R_OLD\"\n\t\t\t(property \"Reference\" \"R\")\n\t\t)",
+        );
+        std::fs::write(&path, &text).unwrap();
+
+        // dry_run must report without touching the file.
+        let before = std::fs::read_to_string(&path).unwrap();
+        let res = handle_prune_unused_lib_symbols(
+            &json!({ "schematic": path.display().to_string(), "dry_run": true }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert!(!res.is_error);
+        assert!(format!("{res:?}").contains("Device:R_OLD"), "{res:?}");
+        assert_eq!(
+            before,
+            std::fs::read_to_string(&path).unwrap(),
+            "dry_run wrote"
+        );
+
+        // Real run removes the orphan and keeps the one in use.
+        handle_prune_unused_lib_symbols(&json!({ "schematic": path.display().to_string() }), &ctx)
+            .await
+            .unwrap();
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(!after.contains("Device:R_OLD"), "orphan survived:\n{after}");
+        assert!(
+            after.contains(r#"(symbol "Device:R""#),
+            "live definition removed:\n{after}"
+        );
+
+        // The placed instance is untouched and still resolves.
+        let sch = cse::Schematic::load(&path).unwrap();
+        assert_eq!(sch.symbols.iter().count(), 1);
+        assert_eq!(sch.symbols.iter().next().unwrap().lib_id, "Device:R");
+
+        // Idempotent.
+        let again = handle_prune_unused_lib_symbols(
+            &json!({ "schematic": path.display().to_string() }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert!(format!("{again:?}").contains("no orphaned"), "{again:?}");
     }
 }
 

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -118,25 +118,6 @@ pub fn tools() -> Vec<ToolDef> {
             |args, ctx| async move { handle_delete_schematic_component(args, ctx).await }
         ),
         tool!(
-            "prune_unused_lib_symbols",
-            "Remove cached lib_symbols definitions no placed instance references. \
-             Orphans accumulate whenever a symbol is renamed or swapped — eeschema \
-             never prunes them and kicad-cli preserves them verbatim. Netlist-neutral.",
-            json!({
-                "type": "object",
-                "properties": {
-                    "schematic": { "type": "string", "description": "Path to .kicad_sch file" },
-                    "dry_run": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "Report what would be removed without writing."
-                    }
-                },
-                "required": ["schematic"]
-            }),
-            |args, ctx| async move { handle_prune_unused_lib_symbols(args, ctx).await }
-        ),
-        tool!(
             "edit_schematic_component",
             "Update fields (Reference, Value, Footprint, custom properties) consistently across every placed unit of a component.",
             json!({
@@ -1516,7 +1497,7 @@ async fn handle_delete_schematic_component(
 ///
 /// Edits are surgical byte deletions rather than a parse/serialise round-trip,
 /// so the rest of the file keeps its formatting exactly.
-async fn handle_prune_unused_lib_symbols(
+pub(crate) async fn handle_prune_unused_lib_symbols(
     args: &serde_json::Value,
     _ctx: &ToolContext,
 ) -> anyhow::Result<CallToolResult> {

--- a/crates/konnect-core/src/tools/sch_components.rs
+++ b/crates/konnect-core/src/tools/sch_components.rs
@@ -578,8 +578,19 @@ async fn handle_add_schematic_component(
     };
 
     let (expected_x, expected_y) = snap_point(x, y, 1.27);
+    // Bind the intent against the same rule the writer used, or the readback
+    // rejects every placement that takes its Value from the library.
+    let intent_value = resolved_placement_value(&lib_id, value, &source);
     let placement = ComponentTargetUnit::placement(
-        &uuid, &context, &lib_id, expected_x, expected_y, rotation, ref_str, value, unit,
+        &uuid,
+        &context,
+        &lib_id,
+        expected_x,
+        expected_y,
+        rotation,
+        ref_str,
+        Some(&intent_value),
+        unit,
     );
     sch.overwrite()?;
 
@@ -605,6 +616,35 @@ async fn handle_add_schematic_component(
 /// the unit, and adds the positioned instance. Does not write the file --
 /// callers own the read/write cycle (single-add and batch-add alike).
 #[allow(clippy::too_many_arguments)]
+/// The Value a placed instance gets: an explicit argument wins, then the
+/// library symbol's own Value, and only then the bare symbol name.
+///
+/// Placement writes the properties and `ComponentTargetUnit::placement` binds
+/// the intent they are verified against, independently. Both must agree on
+/// this rule or every placement fails its own post-write readback, so the rule
+/// lives here once rather than being spelled out on each side.
+pub(crate) fn resolved_placement_value(
+    lib_id: &str,
+    value: Option<&str>,
+    src: &dyn cse::library::SymbolLibrarySource,
+) -> String {
+    if let Some(v) = value {
+        return v.to_owned();
+    }
+    let from_lib = cse::library::resolve_lib_symbol_flattened_node(lib_id, src).and_then(|node| {
+        node.find_all("property")
+            .into_iter()
+            .find(|p| p.value() == Some("Value"))
+            .and_then(|p| p.args().get(1))
+            .and_then(cse::sexp::SexpNode::text)
+            .map(str::to_owned)
+    });
+    match from_lib {
+        Some(v) if !v.is_empty() => v,
+        _ => lib_id.rsplit(':').next().unwrap_or(lib_id).to_owned(),
+    }
+}
+
 pub(crate) fn place_one_component(
     sch: &mut cse::Schematic,
     instance_paths: &[String],
@@ -667,12 +707,8 @@ pub(crate) fn place_one_component(
 
     // An explicit `value` argument wins; otherwise take the library's Value,
     // falling back to the bare symbol name only when the library has none.
-    let lib_value = lib_field("Value").to_string();
-    let val_str = match value {
-        Some(v) => v,
-        None if !lib_value.is_empty() => lib_value.as_str(),
-        None => lib_id.split(':').next_back().unwrap_or("?"),
-    };
+    let resolved_value = resolved_placement_value(lib_id, value, src);
+    let val_str = resolved_value.as_str();
 
     // Validate the unit against the resolved symbol BEFORE writing anything:
     // eeschema silently renders an out-of-range unit as unit 1 and the


### PR DESCRIPTION
These are the three patches a downstream project still carries against 0.11.0
after the rebase absorbed the rest. All three were found by breaking real files
in an eight-sheet KiCad 10 avionics project, not by reading code, and each is
reproducible against a copy of that project.

## 1. Placement writes an empty Footprint and a Value taken from the symbol name

`add_schematic_component` / `batch_place_components` copy Datasheet and
Description onto the instance (#226) but hardcode an **empty Footprint** and
derive Value from the `lib_id`'s symbol name rather than the library symbol's
own `Value` field.

That looks harmless because the sheet still carries the correct definition in
its `lib_symbols` cache — but **`kicad-cli` does not fall back to that cache**.
It emits a bare `(field (name "Footprint"))`, so a part placed by stock 0.11.0
reaches no netlist footprint and no board. Verified by exporting a netlist, not
by inspection.

Fixed by resolving both fields through the `src` resolver already threaded
through the placement path.

## 2. Placement readback fails its own intent after fix 1

0.11.0 verifies every write by reading it back against an intent bound
beforehand. The intent computed Value with its own copy of the
name-derived expression, so fix 1 made **every placement fail its own
readback** with `post-write property Value differs from bound intent`.

Both sides now call `resolved_placement_value()`, so the two cannot drift
again.

## 3. `prune_unused_lib_symbols`

Not present upstream. Orphaned `lib_symbols` cache entries accumulate whenever
a symbol is renamed or swapped — eeschema never prunes them and `kicad-cli`
preserves them verbatim. On one sheet here that was ~1900 dead lines in a
7600-line file.

Placed in the **`sch_batch`** toolset rather than `sch_components`, because
0.11.0 caps a toolset at 20 tools and `sch_components` is already at 20. It
fits better there anyway: it is a bulk delete of cached entries. The operation
is netlist-neutral, which is its acceptance test.

## Testing

`konnect-core`: 1031 passed, 0 failed.

Fixes 1 and 2 were additionally verified end to end by placing parts into a
copy of the downstream project and exporting a `kicad-cli` netlist — the check
that exposed the original bug, since the in-file `lib_symbols` cache hides it.

Happy to split these into separate PRs, rework the toolset placement, or add
tests in whatever style you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)