### PR TITLE
fix(pcb): write mounting holes under the footprint names KiCad ships

### DIFF
--- a/crates/konnect-core/src/tools/pcb_board.rs
+++ b/crates/konnect-core/src/tools/pcb_board.rs
@@ -22,6 +22,7 @@ use konnect_sexp::{
     },
 };
 use serde_json::json;
+use std::path::Path;
 
 // Build the 4 Edge.Cuts segments forming a rectangle, packed as Any for create_items.
 fn rect_outline_items(x1: f64, y1: f64, x2: f64, y2: f64, w: f64) -> Vec<prost_types::Any> {
@@ -734,20 +735,37 @@ const MOUNTING_HOLE_NAMES: &[(f64, &str)] = &[
     (8.4, "MountingHole_8.4mm_M8"),
 ];
 
+#[derive(Clone)]
+struct MountingHoleSpec {
+    drill_diameter_mm: f64,
+    reference: String,
+    lib_id: String,
+}
+
+impl MountingHoleSpec {
+    fn new(drill_diameter_mm: f64, reference: String) -> Option<Self> {
+        mounting_hole_lib_id(drill_diameter_mm).map(|lib_id| Self {
+            drill_diameter_mm,
+            reference,
+            lib_id,
+        })
+    }
+}
+
 /// Library identifier a mounting hole is placed under, or `None` when KiCad 10
 /// ships no footprint for that drill. Shared by the IPC and file paths so the
 /// two cannot drift.
-fn mounting_hole_lib_id(drill_d: f64) -> Option<String> {
+fn mounting_hole_lib_id(drill_diameter_mm: f64) -> Option<String> {
     MOUNTING_HOLE_NAMES
         .iter()
-        .find(|(drill, _)| (drill - drill_d).abs() < 1e-6)
+        .find(|(drill, _)| (drill - drill_diameter_mm).abs() < 1e-6)
         .map(|(_, name)| format!("MountingHole:{name}"))
 }
 
 /// Structured refusal for a drill KiCad ships no mounting hole for. Writing a
 /// name that does not resolve was the defect; the alternative is to say so
 /// before touching the board.
-fn mounting_hole_refusal(drill_d: f64) -> CallToolResult {
+fn mounting_hole_refusal(drill_diameter_mm: f64) -> CallToolResult {
     let shipped = MOUNTING_HOLE_NAMES
         .iter()
         .map(|(drill, _)| format!("{drill}"))
@@ -757,12 +775,12 @@ fn mounting_hole_refusal(drill_d: f64) -> CallToolResult {
         crate::mcp::error::ToolErrorKind::InvalidArgument {
             field: "drill_diameter".to_string(),
             reason: format!(
-                "KiCad 10 ships no MountingHole footprint for a {drill_d} mm drill; shipped \
+                "KiCad 10 ships no MountingHole footprint for a {drill_diameter_mm} mm drill; shipped \
                  drills are {shipped} mm"
             ),
         },
         format!(
-            "No stock KiCad mounting hole has a {drill_d} mm drill, so a footprint under that \
+            "No stock KiCad mounting hole has a {drill_diameter_mm} mm drill, so a footprint under that \
              name would not resolve. Shipped drill sizes: {shipped} mm. Nothing was written."
         ),
     )
@@ -772,37 +790,99 @@ fn mounting_hole_refusal(drill_d: f64) -> CallToolResult {
 /// own plain `MountingHole_*` footprints are — an unplated hole with no
 /// annulus. The old `drill + 0.5` annulus matched no library footprint, so a
 /// hole placed under a library name disagreed with that library's pad.
-fn mounting_hole_pad_size(drill_d: f64) -> f64 {
-    drill_d
+fn mounting_hole_pad_size(drill_diameter_mm: f64) -> f64 {
+    drill_diameter_mm
 }
 
 /// The `Library:Footprint` id the board file carries for `reference`, read
 /// back from the saved text rather than echoed from the request.
-fn written_footprint_lib_id(content: &str, reference: &str) -> Option<String> {
-    let tree = konnect_sexp::parse_sexp(content).ok()?;
-    tree.find_all("footprint").into_iter().find_map(|fp| {
-        let named = fp.find_all("property").into_iter().any(|property| {
-            property.get(1).and_then(|n| n.as_str()) == Some("Reference")
-                && property.get(2).and_then(|n| n.as_str()) == Some(reference)
-        });
-        if named {
-            fp.get(1).and_then(|n| n.as_str()).map(str::to_string)
-        } else {
-            None
+fn written_footprint_lib_id(content: &str, reference: &str) -> anyhow::Result<Option<String>> {
+    let tree = konnect_sexp::parse_sexp(content)?;
+    let matches = tree
+        .find_all("footprint")
+        .into_iter()
+        .filter_map(|fp| {
+            let named = fp.find_all("property").into_iter().any(|property| {
+                property.get(1).and_then(|n| n.as_str()) == Some("Reference")
+                    && property.get(2).and_then(|n| n.as_str()) == Some(reference)
+            });
+            if named {
+                fp.get(1).and_then(|n| n.as_str()).map(str::to_string)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [] => Ok(None),
+        [lib_id] => Ok(Some(lib_id.clone())),
+        _ => anyhow::bail!("footprint reference '{reference}' is ambiguous after placement"),
+    }
+}
+
+fn insert_mounting_hole_file(
+    board_path: &Path,
+    spec: &MountingHoleSpec,
+    prepared: &super::pcb_components::PreparedFootprintPlacement,
+) -> Result<String, CallToolResult> {
+    if let Err(error) = prepared.insert_into_board(board_path) {
+        if error.to_string().contains("already exists on the board") {
+            return Err(CallToolResult::error_kind(
+                crate::mcp::error::ToolErrorKind::InvalidArgument {
+                    field: "reference".to_string(),
+                    reason: format!(
+                        "footprint reference '{}' already exists on the board",
+                        spec.reference
+                    ),
+                },
+                format!(
+                    "Footprint reference '{}' already exists on the board. Nothing was written.",
+                    spec.reference
+                ),
+            ));
         }
-    })
+        return Err(CallToolResult::error(format!(
+            "Could not add mounting hole {} to {}: {error:#}",
+            spec.reference,
+            board_path.display()
+        )));
+    }
+
+    let written = match std::fs::read_to_string(board_path) {
+        Ok(written) => written,
+        Err(error) => {
+            return Err(CallToolResult::error(format!(
+                "Mounting hole {} was committed but {} could not be read back: {error}",
+                spec.reference,
+                board_path.display()
+            )))
+        }
+    };
+    match written_footprint_lib_id(&written, &spec.reference) {
+        Ok(Some(lib_id)) => Ok(lib_id),
+        Ok(None) => Err(CallToolResult::error(format!(
+            "Mounting hole {} was committed but is absent from readback of {}",
+            spec.reference,
+            board_path.display()
+        ))),
+        Err(error) => Err(CallToolResult::error(format!(
+            "Mounting hole {} was committed but readback from {} was ambiguous: {error:#}",
+            spec.reference,
+            board_path.display()
+        ))),
+    }
 }
 
 /// Footprint-local Y offset of the Reference/Value text of a mounting hole.
-fn mounting_hole_text_offset(drill_d: f64) -> f64 {
-    drill_d + 1.5
+fn mounting_hole_text_offset(drill_diameter_mm: f64) -> f64 {
+    drill_diameter_mm + 1.5
 }
 
 /// The single NPTH pad of a mounting hole, in footprint-local coordinates —
 /// the IPC-path equivalent of the `(pad "" np_thru_hole …)` node that
 /// [`format_npth_footprint`] writes.
-fn mounting_hole_pad(drill_d: f64) -> konnect_ipc::IpcPadDefinition {
-    let pad_size = mounting_hole_pad_size(drill_d);
+fn mounting_hole_pad(drill_diameter_mm: f64) -> konnect_ipc::IpcPadDefinition {
+    let pad_size = mounting_hole_pad_size(drill_diameter_mm);
     konnect_ipc::IpcPadDefinition {
         number: String::new(),
         pad_type: "np_thru_hole".to_string(),
@@ -812,20 +892,23 @@ fn mounting_hole_pad(drill_d: f64) -> konnect_ipc::IpcPadDefinition {
         rotation: 0.0,
         size_x: pad_size,
         size_y: pad_size,
-        drill_x: Some(drill_d),
-        drill_y: Some(drill_d),
+        drill_x: Some(drill_diameter_mm),
+        drill_y: Some(drill_diameter_mm),
         drill_oval: false,
         layers: vec!["*.Cu".to_string(), "*.Mask".to_string()],
         roundrect_ratio: 0.0,
     }
 }
 
-fn format_npth_footprint(x: f64, y: f64, drill_d: f64, reference: &str, lib_id: &str) -> String {
+fn format_npth_footprint(x: f64, y: f64, spec: &MountingHoleSpec) -> String {
     let fp_uuid = new_uuid();
     let ref_uuid = new_uuid();
     let val_uuid = new_uuid();
     let pad_uuid = new_uuid();
-    let pad_size = mounting_hole_pad_size(drill_d);
+    let pad_size = mounting_hole_pad_size(spec.drill_diameter_mm);
+    let reference = &spec.reference;
+    let lib_id = &spec.lib_id;
+    let drill_diameter_mm = spec.drill_diameter_mm;
     format!(
         "\n  (footprint \"{lib_id}\"\n    \
          (layer \"F.Cu\")\n    (at {x} {y})\n    \
@@ -833,9 +916,9 @@ fn format_npth_footprint(x: f64, y: f64, drill_d: f64, reference: &str, lib_id: 
          (property \"Reference\" \"{reference}\"\n      (at 0 {offset} 0)\n      (layer \"F.SilkS\")\n      (uuid \"{ref_uuid}\")\n    )\n    \
          (property \"Value\" \"MountingHole\"\n      (at 0 -{offset} 0)\n      (layer \"F.Fab\")\n      (uuid \"{val_uuid}\")\n    )\n    \
          (pad \"\" np_thru_hole circle (at 0 0) (size {pad_size} {pad_size})\n      \
-         (drill {drill_d})\n      (layers \"*.Cu\" \"*.Mask\")\n      (uuid \"{pad_uuid}\")\n    )\n    \
+         (drill {drill_diameter_mm})\n      (layers \"*.Cu\" \"*.Mask\")\n      (uuid \"{pad_uuid}\")\n    )\n    \
          (uuid \"{fp_uuid}\")\n  )",
-        offset = mounting_hole_text_offset(drill_d)
+        offset = mounting_hole_text_offset(drill_diameter_mm)
     )
 }
 
@@ -1985,14 +2068,14 @@ async fn handle_add_mounting_hole(
         Ok(v) => v,
         Err(e) => return Ok(e),
     };
-    let drill_d = args["drill_diameter"].as_f64().unwrap_or(3.2);
+    let drill_diameter_mm = args["drill_diameter"].as_f64().unwrap_or(3.2);
     let reference = args["reference"].as_str().unwrap_or("H1").to_string();
 
     // The name must be one stock KiCad resolves (#462). A drill with no
     // shipped footprint is refused here, before any transport is dialled or
     // any byte written.
-    let Some(lib_id) = mounting_hole_lib_id(drill_d) else {
-        return Ok(mounting_hole_refusal(drill_d));
+    let Some(spec) = MountingHoleSpec::new(drill_diameter_mm, reference) else {
+        return Ok(mounting_hole_refusal(drill_diameter_mm));
     };
 
     // Prefer KiCad's own footprint. When `MountingHole.pretty` resolves from
@@ -2003,51 +2086,48 @@ async fn handle_add_mounting_hole(
     // nothing to say. Without a resolvable library, Konnect's own NPTH
     // geometry is written under the same shipped name and the response says
     // so.
-    let library_source = super::pcb_components::resolve_footprint_source(&lib_id, &board_path).ok();
+    let library_source =
+        super::pcb_components::resolve_footprint_source(&spec.lib_id, &board_path).ok();
     let geometry = if library_source.is_some() {
         "library"
     } else {
         "inline"
     };
-    let text_offset = mounting_hole_text_offset(drill_d);
-    let (pads, graphics, fields, value) = match &library_source {
+    let text_offset = mounting_hole_text_offset(spec.drill_diameter_mm);
+    let prepared = match &library_source {
         Some(source) => {
-            let prepared = match super::pcb_components::prepare_footprint_source(
-                source, &lib_id, &reference, None, x, y, 0.0, "F.Cu",
+            match super::pcb_components::PreparedFootprintPlacement::from_library(
+                source,
+                &spec.lib_id,
+                &spec.reference,
+                None,
+                x,
+                y,
+                0.0,
+                "F.Cu",
+                board_path.parent(),
             ) {
                 Ok(prepared) => prepared,
                 Err(error) => return Ok(CallToolResult::error(error.to_string())),
-            };
-            let pads = match super::pcb_components::extract_pad_definitions(&prepared) {
-                Ok(pads) => pads,
-                Err(error) => return Ok(CallToolResult::error(error.to_string())),
-            };
-            let graphics = match super::pcb_components::extract_graphic_definitions(&prepared) {
-                Ok(graphics) => graphics,
-                Err(error) => return Ok(CallToolResult::error(error.to_string())),
-            };
-            let fields = super::pcb_components::extract_field_placement(&prepared);
-            let value = lib_id
-                .split_once(':')
-                .map(|(_, entry)| entry.to_string())
-                .unwrap_or_else(|| lib_id.clone());
-            (pads, graphics, fields, value)
+            }
         }
-        None => (
-            vec![mounting_hole_pad(drill_d)],
+        None => super::pcb_components::PreparedFootprintPlacement::from_inline(
+            "MountingHole".to_string(),
+            vec![mounting_hole_pad(spec.drill_diameter_mm)],
             Vec::new(),
             konnect_ipc::IpcFieldPlacement {
                 reference_at: Some((0.0, text_offset, 0.0)),
                 value_at: Some((0.0, -text_offset, 0.0)),
             },
-            "MountingHole".to_string(),
+            format_npth_footprint(x, y, &spec),
         ),
     };
     let geometry_note = (geometry == "inline").then(|| {
         format!(
             "KiCad's MountingHole library was not resolvable from this machine, so Konnect's \
-             own unplated-hole geometry was placed under the shipped name {lib_id}; KiCad may \
-             report lib_footprint_mismatch until the footprint is updated from the library"
+             own unplated-hole geometry was placed under the shipped name {}; KiCad may \
+             report lib_footprint_mismatch until the footprint is updated from the library",
+            spec.lib_id
         )
     });
 
@@ -2056,17 +2136,18 @@ async fn handle_add_mounting_hole(
     // name the board KiCAD has open, and only an IPC transport that was never
     // reached may fall back to editing the file.
     let requested_board = board_path.clone();
-    let lib_id_ipc = lib_id.clone();
-    let reference_ipc = reference.clone();
+    let lib_id_ipc = spec.lib_id.clone();
+    let reference_ipc = spec.reference.clone();
+    let prepared_ipc = prepared.clone();
     let attempt = attempt_ipc_write(ctx, &board_path, "mounting hole", move |c| {
         c.place_footprint(
             &requested_board,
             &lib_id_ipc,
             &reference_ipc,
-            &value,
-            &pads,
-            &graphics,
-            &fields,
+            &prepared_ipc.value,
+            &prepared_ipc.pads,
+            &prepared_ipc.graphics,
+            &prepared_ipc.fields,
             x,
             y,
             0.0,
@@ -2078,7 +2159,7 @@ async fn handle_add_mounting_hole(
     match attempt {
         BoardWrite::Ipc(fp) => Ok(CallToolResult::json(&json!({
             "reference": fp.reference, "x": fp.position.x, "y": fp.position.y,
-            "drill_diameter": drill_d, "footprint": fp.footprint,
+            "drill_diameter": spec.drill_diameter_mm, "footprint": fp.footprint,
             "geometry": geometry,
             "geometry_note": geometry_note,
             "source": "ipc"
@@ -2087,47 +2168,17 @@ async fn handle_add_mounting_hole(
         BoardWrite::File(reason) => {
             // No live KiCad now, and this board was not observed live during
             // the current server session: use the guarded file path.
-            match &library_source {
-                Some(_) => {
-                    let sexp = match super::pcb_components::board_footprint_sexp(
-                        &lib_id,
-                        x,
-                        y,
-                        0.0,
-                        "F.Cu",
-                        Some(&reference),
-                        board_path.parent(),
-                    ) {
-                        Ok(sexp) => sexp,
-                        Err(message) => return Ok(CallToolResult::error(message)),
-                    };
-                    super::pcb_components::insert_into_board(
-                        &board_path,
-                        std::slice::from_ref(&sexp),
-                    )?;
-                }
-                None => {
-                    let fp_sexp = format_npth_footprint(x, y, drill_d, &reference, &lib_id);
-                    let content = std::fs::read_to_string(&board_path)?;
-                    let close_pos = content.rfind(')').unwrap_or(content.len());
-                    let new_content =
-                        apply_edits(content, vec![SexpEdit::insert(close_pos, fp_sexp)]);
-                    write_atomic(&board_path, &new_content)?;
-                }
-            }
-
-            // The footprint name is read back from what was saved, not
-            // repeated from the request.
-            let written = std::fs::read_to_string(&board_path)?;
-            let footprint = written_footprint_lib_id(&written, &reference).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "mounting hole {reference} was written but cannot be read back from {}",
-                    board_path.display()
-                )
-            })?;
+            // Duplicate-reference rejection, atomic insertion, and identity-
+            // bound readback are one operation for both library and inline
+            // geometry.
+            let footprint = match insert_mounting_hole_file(&board_path, &spec, &prepared) {
+                Ok(footprint) => footprint,
+                Err(result) => return Ok(result),
+            };
 
             Ok(CallToolResult::json(&json!({
-                "reference": reference, "x": x, "y": y, "drill_diameter": drill_d,
+                "reference": spec.reference, "x": x, "y": y,
+                "drill_diameter": spec.drill_diameter_mm,
                 "footprint": footprint,
                 "geometry": geometry,
                 "geometry_note": geometry_note,
@@ -4044,6 +4095,38 @@ mod mounting_hole_name_tests {
             std::fs::read_to_string(&board).unwrap(),
             before,
             "nothing written"
+        );
+    }
+
+    #[test]
+    fn inline_file_placement_refuses_a_duplicate_reference_without_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = blank_board(dir.path());
+        let spec = MountingHoleSpec::new(3.2, "H1".to_string()).unwrap();
+        let text_offset = mounting_hole_text_offset(spec.drill_diameter_mm);
+        let prepared = super::super::pcb_components::PreparedFootprintPlacement::from_inline(
+            "MountingHole".to_string(),
+            vec![mounting_hole_pad(spec.drill_diameter_mm)],
+            Vec::new(),
+            konnect_ipc::IpcFieldPlacement {
+                reference_at: Some((0.0, text_offset, 0.0)),
+                value_at: Some((0.0, -text_offset, 0.0)),
+            },
+            format_npth_footprint(5.0, 6.0, &spec),
+        );
+
+        let observed = insert_mounting_hole_file(&board, &spec, &prepared).unwrap();
+        assert_eq!(observed, spec.lib_id);
+        let before = std::fs::read_to_string(&board).unwrap();
+
+        let refusal = insert_mounting_hole_file(&board, &spec, &prepared).unwrap_err();
+        assert!(refusal.is_error);
+        let text = result_text(&refusal);
+        assert!(text.contains("reference 'H1' already exists"), "{text}");
+        assert_eq!(
+            std::fs::read_to_string(&board).unwrap(),
+            before,
+            "duplicate-reference refusal must leave the board byte-identical"
         );
     }
 

--- a/crates/konnect-core/src/tools/pcb_board.rs
+++ b/crates/konnect-core/src/tools/pcb_board.rs
@@ -697,15 +697,100 @@ fn format_gr_text(text: &str, x: f64, y: f64, rot: f64, layer: &str, size: f64) 
     )
 }
 
-/// Library identifier a mounting hole is placed under. Shared by the IPC and
-/// file paths so the two cannot drift.
-fn mounting_hole_lib_id(drill_d: f64) -> String {
-    format!("MountingHole:MountingHole_{drill_d:.1}mm")
+/// Every unplated mounting-hole footprint KiCad 10 ships in `MountingHole.pretty`
+/// without a pad, keyed by drill diameter, spelled exactly as the library
+/// spells it (#462).
+///
+/// Two conventions coexist in that library and neither is derivable from the
+/// number: round sizes are `MountingHole_3mm` (no `.0`), metric-clearance
+/// sizes carry the screw (`MountingHole_3.2mm_M3`), and a plain
+/// `MountingHole_3.2mm` does not exist at all. Formatting the drill as
+/// `{:.1}mm` wrote a name for the default call and for every integer size
+/// that no stock KiCad resolves. Where a drill has both a plain and a screw
+/// variant (2.7 mm), the plain one is used: the caller named a hole, not a
+/// screw.
+///
+/// `every_shipped_name_exists_in_the_installed_library` checks this table
+/// against the installed KiCad when one is present.
+const MOUNTING_HOLE_NAMES: &[(f64, &str)] = &[
+    (2.0, "MountingHole_2mm"),
+    (2.1, "MountingHole_2.1mm"),
+    (2.2, "MountingHole_2.2mm_M2"),
+    (2.5, "MountingHole_2.5mm"),
+    (2.7, "MountingHole_2.7mm"),
+    (3.0, "MountingHole_3mm"),
+    (3.2, "MountingHole_3.2mm_M3"),
+    (3.5, "MountingHole_3.5mm"),
+    (3.7, "MountingHole_3.7mm"),
+    (4.0, "MountingHole_4mm"),
+    (4.3, "MountingHole_4.3mm_M4"),
+    (4.5, "MountingHole_4.5mm"),
+    (5.0, "MountingHole_5mm"),
+    (5.3, "MountingHole_5.3mm_M5"),
+    (5.5, "MountingHole_5.5mm"),
+    (6.0, "MountingHole_6mm"),
+    (6.4, "MountingHole_6.4mm_M6"),
+    (6.5, "MountingHole_6.5mm"),
+    (8.4, "MountingHole_8.4mm_M8"),
+];
+
+/// Library identifier a mounting hole is placed under, or `None` when KiCad 10
+/// ships no footprint for that drill. Shared by the IPC and file paths so the
+/// two cannot drift.
+fn mounting_hole_lib_id(drill_d: f64) -> Option<String> {
+    MOUNTING_HOLE_NAMES
+        .iter()
+        .find(|(drill, _)| (drill - drill_d).abs() < 1e-6)
+        .map(|(_, name)| format!("MountingHole:{name}"))
 }
 
-/// Copper/mask annulus diameter around a `drill_d` mounting hole.
+/// Structured refusal for a drill KiCad ships no mounting hole for. Writing a
+/// name that does not resolve was the defect; the alternative is to say so
+/// before touching the board.
+fn mounting_hole_refusal(drill_d: f64) -> CallToolResult {
+    let shipped = MOUNTING_HOLE_NAMES
+        .iter()
+        .map(|(drill, _)| format!("{drill}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    CallToolResult::error_kind(
+        crate::mcp::error::ToolErrorKind::InvalidArgument {
+            field: "drill_diameter".to_string(),
+            reason: format!(
+                "KiCad 10 ships no MountingHole footprint for a {drill_d} mm drill; shipped \
+                 drills are {shipped} mm"
+            ),
+        },
+        format!(
+            "No stock KiCad mounting hole has a {drill_d} mm drill, so a footprint under that \
+             name would not resolve. Shipped drill sizes: {shipped} mm. Nothing was written."
+        ),
+    )
+}
+
+/// Pad diameter of a `drill_d` mounting hole: equal to the drill, as KiCad's
+/// own plain `MountingHole_*` footprints are — an unplated hole with no
+/// annulus. The old `drill + 0.5` annulus matched no library footprint, so a
+/// hole placed under a library name disagreed with that library's pad.
 fn mounting_hole_pad_size(drill_d: f64) -> f64 {
-    drill_d + 0.5
+    drill_d
+}
+
+/// The `Library:Footprint` id the board file carries for `reference`, read
+/// back from the saved text rather than echoed from the request.
+fn written_footprint_lib_id(content: &str, reference: &str) -> Option<String> {
+    let tree = konnect_sexp::parse_sexp(content).ok()?;
+    tree.find_all("footprint").into_iter().find_map(|fp| {
+        let named = fp.find_all("property").into_iter().any(|property| {
+            property.get(1).and_then(|n| n.as_str()) == Some("Reference")
+                && property.get(2).and_then(|n| n.as_str()) == Some(reference)
+        });
+        if named {
+            fp.get(1).and_then(|n| n.as_str()).map(str::to_string)
+        } else {
+            None
+        }
+    })
 }
 
 /// Footprint-local Y offset of the Reference/Value text of a mounting hole.
@@ -735,13 +820,12 @@ fn mounting_hole_pad(drill_d: f64) -> konnect_ipc::IpcPadDefinition {
     }
 }
 
-fn format_npth_footprint(x: f64, y: f64, drill_d: f64, reference: &str) -> String {
+fn format_npth_footprint(x: f64, y: f64, drill_d: f64, reference: &str, lib_id: &str) -> String {
     let fp_uuid = new_uuid();
     let ref_uuid = new_uuid();
     let val_uuid = new_uuid();
     let pad_uuid = new_uuid();
     let pad_size = mounting_hole_pad_size(drill_d);
-    let lib_id = mounting_hole_lib_id(drill_d);
     format!(
         "\n  (footprint \"{lib_id}\"\n    \
          (layer \"F.Cu\")\n    (at {x} {y})\n    \
@@ -1024,14 +1108,18 @@ pub fn tools() -> Vec<ToolDef> {
         .with_board_access(crate::tools::BoardAccess::LivePreferredWithFallback),
         tool!(
             "add_mounting_hole",
-            "Add an NPTH mounting hole footprint at the specified position.",
+            "Add an NPTH mounting hole footprint at the specified position, under the \
+             MountingHole library name stock KiCad 10 ships for that drill (3.2 → \
+             MountingHole_3.2mm_M3, 3 → MountingHole_3mm). A drill KiCad ships no \
+             footprint for is refused. Places KiCad's own library footprint when the \
+             library resolves; otherwise an equivalent unplated hole under the same name.",
             json!({
                 "type": "object",
                 "properties": {
                     "board":          { "type": "string" },
                     "x":              { "type": "number", "description": "X position in mm" },
                     "y":              { "type": "number", "description": "Y position in mm" },
-                    "drill_diameter": { "type": "number", "description": "Drill diameter in mm", "default": 3.2 },
+                    "drill_diameter": { "type": "number", "description": "Drill diameter in mm. Must be one KiCad 10 ships a MountingHole footprint for: 2, 2.1, 2.2, 2.5, 2.7, 3, 3.2, 3.5, 3.7, 4, 4.3, 4.5, 5, 5.3, 5.5, 6, 6.4, 6.5 or 8.4.", "default": 3.2 },
                     "reference":      { "type": "string", "description": "Designator for the hole (e.g. 'H1')", "default": "H1" }
                 },
                 "required": ["board", "x", "y"]
@@ -1900,27 +1988,85 @@ async fn handle_add_mounting_hole(
     let drill_d = args["drill_diameter"].as_f64().unwrap_or(3.2);
     let reference = args["reference"].as_str().unwrap_or("H1").to_string();
 
+    // The name must be one stock KiCad resolves (#462). A drill with no
+    // shipped footprint is refused here, before any transport is dialled or
+    // any byte written.
+    let Some(lib_id) = mounting_hole_lib_id(drill_d) else {
+        return Ok(mounting_hole_refusal(drill_d));
+    };
+
+    // Prefer KiCad's own footprint. When `MountingHole.pretty` resolves from
+    // this machine (project or global fp-lib-table, or a discovered install),
+    // the hole placed is that library footprint — pads, courtyard, comments
+    // layer circle and all — exactly as `place_component` would place it, so
+    // the name and the geometry are KiCad's and `lib_footprint_mismatch` has
+    // nothing to say. Without a resolvable library, Konnect's own NPTH
+    // geometry is written under the same shipped name and the response says
+    // so.
+    let library_source = super::pcb_components::resolve_footprint_source(&lib_id, &board_path).ok();
+    let geometry = if library_source.is_some() {
+        "library"
+    } else {
+        "inline"
+    };
+    let text_offset = mounting_hole_text_offset(drill_d);
+    let (pads, graphics, fields, value) = match &library_source {
+        Some(source) => {
+            let prepared = match super::pcb_components::prepare_footprint_source(
+                source, &lib_id, &reference, None, x, y, 0.0, "F.Cu",
+            ) {
+                Ok(prepared) => prepared,
+                Err(error) => return Ok(CallToolResult::error(error.to_string())),
+            };
+            let pads = match super::pcb_components::extract_pad_definitions(&prepared) {
+                Ok(pads) => pads,
+                Err(error) => return Ok(CallToolResult::error(error.to_string())),
+            };
+            let graphics = match super::pcb_components::extract_graphic_definitions(&prepared) {
+                Ok(graphics) => graphics,
+                Err(error) => return Ok(CallToolResult::error(error.to_string())),
+            };
+            let fields = super::pcb_components::extract_field_placement(&prepared);
+            let value = lib_id
+                .split_once(':')
+                .map(|(_, entry)| entry.to_string())
+                .unwrap_or_else(|| lib_id.clone());
+            (pads, graphics, fields, value)
+        }
+        None => (
+            vec![mounting_hole_pad(drill_d)],
+            Vec::new(),
+            konnect_ipc::IpcFieldPlacement {
+                reference_at: Some((0.0, text_offset, 0.0)),
+                value_at: Some((0.0, -text_offset, 0.0)),
+            },
+            "MountingHole".to_string(),
+        ),
+    };
+    let geometry_note = (geometry == "inline").then(|| {
+        format!(
+            "KiCad's MountingHole library was not resolvable from this machine, so Konnect's \
+             own unplated-hole geometry was placed under the shipped name {lib_id}; KiCad may \
+             report lib_footprint_mismatch until the footprint is updated from the library"
+        )
+    });
+
     // A mounting hole is a footprint, so the same rule as every other
     // board-mutating tool applies (see `attempt_ipc_write`): the request must
     // name the board KiCAD has open, and only an IPC transport that was never
     // reached may fall back to editing the file.
     let requested_board = board_path.clone();
-    let lib_id = mounting_hole_lib_id(drill_d);
     let lib_id_ipc = lib_id.clone();
     let reference_ipc = reference.clone();
-    let text_offset = mounting_hole_text_offset(drill_d);
     let attempt = attempt_ipc_write(ctx, &board_path, "mounting hole", move |c| {
         c.place_footprint(
             &requested_board,
             &lib_id_ipc,
             &reference_ipc,
-            "MountingHole",
-            std::slice::from_ref(&mounting_hole_pad(drill_d)),
-            &[],
-            &konnect_ipc::IpcFieldPlacement {
-                reference_at: Some((0.0, text_offset, 0.0)),
-                value_at: Some((0.0, -text_offset, 0.0)),
-            },
+            &value,
+            &pads,
+            &graphics,
+            &fields,
             x,
             y,
             0.0,
@@ -1933,21 +2079,58 @@ async fn handle_add_mounting_hole(
         BoardWrite::Ipc(fp) => Ok(CallToolResult::json(&json!({
             "reference": fp.reference, "x": fp.position.x, "y": fp.position.y,
             "drill_diameter": drill_d, "footprint": fp.footprint,
+            "geometry": geometry,
+            "geometry_note": geometry_note,
             "source": "ipc"
         }))),
         BoardWrite::Refused(err) => Ok(err),
         BoardWrite::File(reason) => {
             // No live KiCad now, and this board was not observed live during
             // the current server session: use the guarded file path.
-            let fp_sexp = format_npth_footprint(x, y, drill_d, &reference);
-            let content = std::fs::read_to_string(&board_path)?;
-            let close_pos = content.rfind(')').unwrap_or(content.len());
-            let new_content = apply_edits(content, vec![SexpEdit::insert(close_pos, fp_sexp)]);
-            write_atomic(&board_path, &new_content)?;
+            match &library_source {
+                Some(_) => {
+                    let sexp = match super::pcb_components::board_footprint_sexp(
+                        &lib_id,
+                        x,
+                        y,
+                        0.0,
+                        "F.Cu",
+                        Some(&reference),
+                        board_path.parent(),
+                    ) {
+                        Ok(sexp) => sexp,
+                        Err(message) => return Ok(CallToolResult::error(message)),
+                    };
+                    super::pcb_components::insert_into_board(
+                        &board_path,
+                        std::slice::from_ref(&sexp),
+                    )?;
+                }
+                None => {
+                    let fp_sexp = format_npth_footprint(x, y, drill_d, &reference, &lib_id);
+                    let content = std::fs::read_to_string(&board_path)?;
+                    let close_pos = content.rfind(')').unwrap_or(content.len());
+                    let new_content =
+                        apply_edits(content, vec![SexpEdit::insert(close_pos, fp_sexp)]);
+                    write_atomic(&board_path, &new_content)?;
+                }
+            }
+
+            // The footprint name is read back from what was saved, not
+            // repeated from the request.
+            let written = std::fs::read_to_string(&board_path)?;
+            let footprint = written_footprint_lib_id(&written, &reference).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "mounting hole {reference} was written but cannot be read back from {}",
+                    board_path.display()
+                )
+            })?;
 
             Ok(CallToolResult::json(&json!({
                 "reference": reference, "x": x, "y": y, "drill_diameter": drill_d,
-                "footprint": lib_id,
+                "footprint": footprint,
+                "geometry": geometry,
+                "geometry_note": geometry_note,
                 "source": "file",
                 "fallback_reason": reason.evidence(),
                 "warning": reason.warning()
@@ -3683,17 +3866,18 @@ mod mounting_hole_tests {
     }
 
     #[test]
-    fn mounting_hole_pad_is_an_unplated_hole_with_drill_and_annulus() {
-        let pad = mounting_hole_pad(3.45);
+    fn mounting_hole_pad_is_an_unplated_hole_with_no_annulus() {
+        let pad = mounting_hole_pad(3.2);
         assert_eq!(pad.pad_type, "np_thru_hole");
         assert_eq!(pad.shape, "circle");
-        assert_eq!(pad.drill_x, Some(3.45));
-        assert_eq!(pad.drill_y, Some(3.45));
+        assert_eq!(pad.drill_x, Some(3.2));
+        assert_eq!(pad.drill_y, Some(3.2));
         assert!(!pad.drill_oval);
-        // Annulus matches the (size …) the file path writes, so a hole placed
-        // over IPC and one written to the file are the same hole.
-        assert_eq!(pad.size_x, 3.95);
-        assert_eq!(pad.size_y, 3.95);
+        // Pad equals drill, as KiCad's own plain MountingHole_* footprints are
+        // (#462); and it matches the (size …) the file path writes, so a hole
+        // placed over IPC and one written to the file are the same hole.
+        assert_eq!(pad.size_x, 3.2);
+        assert_eq!(pad.size_y, 3.2);
         assert_eq!(pad.layers, ["*.Cu", "*.Mask"]);
         assert_eq!(pad.x, 0.0);
         assert_eq!(pad.y, 0.0);
@@ -3712,7 +3896,7 @@ mod mounting_hole_tests {
         let ctx = ctx_with_ipc(spawn_rejecting_kicad());
         let args = json!({
             "board": board.to_str().unwrap(),
-            "x": 5.0, "y": 6.0, "drill_diameter": 3.45, "reference": "H1"
+            "x": 5.0, "y": 6.0, "drill_diameter": 3.2, "reference": "H1"
         });
         let res = handle_add_mounting_hole(&args, &ctx).await.unwrap();
 
@@ -3739,7 +3923,7 @@ mod mounting_hole_tests {
         let ctx = ctx_with_ipc(String::new());
         let args = json!({
             "board": board.to_str().unwrap(),
-            "x": 5.0, "y": 6.0, "drill_diameter": 3.45, "reference": "H1"
+            "x": 5.0, "y": 6.0, "drill_diameter": 3.2, "reference": "H1"
         });
         let res = handle_add_mounting_hole(&args, &ctx).await.unwrap();
         assert!(!res.is_error, "handler errored: {:?}", res.content);
@@ -3753,8 +3937,171 @@ mod mounting_hole_tests {
             updated.contains("(pad \"\" np_thru_hole circle"),
             "{updated}"
         );
-        assert!(updated.contains("(drill 3.45)"), "{updated}");
+        assert!(updated.contains("(drill 3.2)"), "{updated}");
         assert!(updated.contains("\"H1\""), "{updated}");
+    }
+}
+
+#[cfg(test)]
+mod mounting_hole_name_tests {
+    //! Issue #462: `add_mounting_hole` wrote `MountingHole:MountingHole_{drill:.1}mm`.
+    //! KiCad 10 ships no plain `MountingHole_3.2mm` (3.2 mm exists only as the
+    //! M3 family) and spells round sizes without a decimal (`MountingHole_3mm`,
+    //! never `3.0mm`), so the default call and every integer size wrote a name
+    //! no stock KiCad resolves.
+
+    use super::mounting_hole_tests::{blank_board, ctx_with_ipc, result_text};
+    use super::*;
+
+    #[test]
+    fn shipped_drills_get_the_library_spelling() {
+        for (drill, expected) in [
+            (3.2, "MountingHole:MountingHole_3.2mm_M3"),
+            (3.0, "MountingHole:MountingHole_3mm"),
+            (4.0, "MountingHole:MountingHole_4mm"),
+            (2.7, "MountingHole:MountingHole_2.7mm"),
+            (4.3, "MountingHole:MountingHole_4.3mm_M4"),
+            (8.4, "MountingHole:MountingHole_8.4mm_M8"),
+        ] {
+            assert_eq!(
+                mounting_hole_lib_id(drill).as_deref(),
+                Some(expected),
+                "{drill}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unshipped_drill_has_no_name() {
+        for drill in [3.3, 3.45, 0.0, -1.0, 10.0, f64::NAN] {
+            assert_eq!(mounting_hole_lib_id(drill), None, "{drill}");
+        }
+    }
+
+    /// The table is a copy of what KiCad ships; the installed library is the
+    /// truth. Skips silently on a machine without KiCad, like the other
+    /// installed-library conformance checks.
+    #[test]
+    fn every_shipped_name_exists_in_the_installed_library() {
+        let Some(pretty) = crate::kicad_install::share_roots()
+            .into_iter()
+            .map(|root| root.join("footprints").join("MountingHole.pretty"))
+            .find(|dir| dir.is_dir())
+        else {
+            eprintln!("no installed KiCad footprint library found; skipping");
+            return;
+        };
+        let mut missing = Vec::new();
+        for (_, name) in MOUNTING_HOLE_NAMES {
+            if !pretty.join(format!("{name}.kicad_mod")).is_file() {
+                missing.push(*name);
+            }
+        }
+        assert!(
+            missing.is_empty(),
+            "names not shipped by the installed KiCad at {}: {missing:?}",
+            pretty.display()
+        );
+        // And the names the old formatter produced must NOT exist — otherwise
+        // this fixture no longer proves the defect.
+        for absent in [
+            "MountingHole_3.2mm",
+            "MountingHole_3.0mm",
+            "MountingHole_4.0mm",
+        ] {
+            assert!(
+                !pretty.join(format!("{absent}.kicad_mod")).is_file(),
+                "{absent} exists in the installed library; the premise of #462 changed"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn an_unshipped_drill_refuses_before_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = blank_board(dir.path());
+        let before = std::fs::read_to_string(&board).unwrap();
+
+        let ctx = ctx_with_ipc(String::new());
+        let res = handle_add_mounting_hole(
+            &json!({
+                "board": board.to_str().unwrap(),
+                "x": 5.0, "y": 6.0, "drill_diameter": 3.3, "reference": "H1"
+            }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            res.is_error,
+            "3.3 mm is not a shipped hole: {:?}",
+            res.content
+        );
+        let text = result_text(&res);
+        assert!(text.contains("3.3") && text.contains("3.2"), "{text}");
+        assert_eq!(
+            std::fs::read_to_string(&board).unwrap(),
+            before,
+            "nothing written"
+        );
+    }
+
+    /// The default call — the one Chris's E2E made — writes the name KiCad
+    /// ships, and the response reports the name read back from the file.
+    #[tokio::test]
+    async fn the_default_drill_writes_a_name_stock_kicad_resolves() {
+        let dir = tempfile::tempdir().unwrap();
+        let board = blank_board(dir.path());
+
+        let ctx = ctx_with_ipc(String::new());
+        let res = handle_add_mounting_hole(
+            &json!({ "board": board.to_str().unwrap(), "x": 5.0, "y": 6.0, "reference": "H1" }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert!(!res.is_error, "handler errored: {:?}", res.content);
+        let parsed: serde_json::Value = serde_json::from_str(&result_text(&res)).unwrap();
+
+        let updated = std::fs::read_to_string(&board).unwrap();
+        assert!(
+            updated.contains("(footprint \"MountingHole:MountingHole_3.2mm_M3\""),
+            "{updated}"
+        );
+        assert!(
+            !updated.contains("MountingHole_3.2mm\""),
+            "the old name must be gone"
+        );
+        assert_eq!(
+            parsed["footprint"],
+            json!("MountingHole:MountingHole_3.2mm_M3")
+        );
+        assert_eq!(parsed["drill_diameter"], json!(3.2));
+
+        // Which geometry landed depends on whether this machine resolves
+        // KiCad's library; either way the response must say which, and the
+        // file must agree with it.
+        match parsed["geometry"].as_str() {
+            Some("library") => {
+                assert!(
+                    updated.contains("fp_circle"),
+                    "library footprint carries its circles: {updated}"
+                );
+                assert!(parsed["geometry_note"].is_null());
+            }
+            Some("inline") => {
+                assert!(
+                    updated.contains("(size 3.2 3.2)"),
+                    "no annulus, like KiCad's: {updated}"
+                );
+                assert!(parsed["geometry_note"]
+                    .as_str()
+                    .unwrap()
+                    .contains("not resolvable"));
+            }
+            other => panic!("geometry must be library or inline, got {other:?}"),
+        }
     }
 }
 

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -165,7 +165,7 @@ fn replace_reference(source: &mut String, reference: &str) -> anyhow::Result<()>
 }
 
 #[allow(clippy::too_many_arguments)]
-fn prepare_footprint_source(
+pub(crate) fn prepare_footprint_source(
     source: &str,
     lib_id: &str,
     reference: &str,
@@ -557,7 +557,7 @@ fn extract_graphic_definitions_with_properties(
 ///
 /// KiCAD's own parser then handles the pads and graphics, which is why the
 /// whole definition is forwarded rather than reconstructed.
-fn board_footprint_sexp(
+pub(crate) fn board_footprint_sexp(
     lib_id: &str,
     x: f64,
     y: f64,
@@ -824,7 +824,7 @@ fn replace_footprint_layer(content: &str, layer: &str) -> String {
 /// `#`-commented paren would be miscounted. KiCad does not write comments into
 /// `.kicad_pcb`, and no reader in this workspace understands them either, so
 /// the assumption is at least consistent.
-fn insert_into_board(board_path: &Path, blocks: &[String]) -> anyhow::Result<()> {
+pub(crate) fn insert_into_board(board_path: &Path, blocks: &[String]) -> anyhow::Result<()> {
     let content = read_consistent(board_path)?;
     let existing_references = footprint_references(&content)?;
     let mut inserted_references = HashSet::new();

--- a/crates/konnect-core/src/tools/pcb_components.rs
+++ b/crates/konnect-core/src/tools/pcb_components.rs
@@ -165,7 +165,7 @@ fn replace_reference(source: &mut String, reference: &str) -> anyhow::Result<()>
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn prepare_footprint_source(
+fn prepare_footprint_source(
     source: &str,
     lib_id: &str,
     reference: &str,
@@ -557,7 +557,7 @@ fn extract_graphic_definitions_with_properties(
 ///
 /// KiCAD's own parser then handles the pads and graphics, which is why the
 /// whole definition is forwarded rather than reconstructed.
-pub(crate) fn board_footprint_sexp(
+fn board_footprint_sexp(
     lib_id: &str,
     x: f64,
     y: f64,
@@ -824,7 +824,7 @@ fn replace_footprint_layer(content: &str, layer: &str) -> String {
 /// `#`-commented paren would be miscounted. KiCad does not write comments into
 /// `.kicad_pcb`, and no reader in this workspace understands them either, so
 /// the assumption is at least consistent.
-pub(crate) fn insert_into_board(board_path: &Path, blocks: &[String]) -> anyhow::Result<()> {
+fn insert_into_board(board_path: &Path, blocks: &[String]) -> anyhow::Result<()> {
     let content = read_consistent(board_path)?;
     let existing_references = footprint_references(&content)?;
     let mut inserted_references = HashSet::new();
@@ -865,6 +865,80 @@ pub(crate) fn insert_into_board(board_path: &Path, blocks: &[String]) -> anyhow:
 
     persist_board_replacement(board_path, &content, &new_content)?;
     Ok(())
+}
+
+/// One prepared footprint placement shared by the IPC and guarded file paths.
+///
+/// Callers choose whether the definition came from a KiCad library or from
+/// deliberately supplied inline geometry, but they do not orchestrate the
+/// parser, IPC extraction, board serialization, and duplicate-safe insertion
+/// helpers independently.
+#[derive(Clone)]
+pub(crate) struct PreparedFootprintPlacement {
+    pub(crate) value: String,
+    pub(crate) pads: Vec<konnect_ipc::IpcPadDefinition>,
+    pub(crate) graphics: Vec<konnect_ipc::IpcGraphicDefinition>,
+    pub(crate) fields: konnect_ipc::IpcFieldPlacement,
+    board_sexp: String,
+}
+
+impl PreparedFootprintPlacement {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_library(
+        source: &str,
+        lib_id: &str,
+        reference: &str,
+        value: Option<&str>,
+        x: f64,
+        y: f64,
+        rotation: f64,
+        layer: &str,
+        project_dir: Option<&Path>,
+    ) -> anyhow::Result<Self> {
+        let prepared =
+            prepare_footprint_source(source, lib_id, reference, value, x, y, rotation, layer)?;
+        let pads = extract_pad_definitions(&prepared)?;
+        let graphics = extract_graphic_definitions(&prepared)?;
+        let fields = extract_field_placement(&prepared);
+        let board_sexp =
+            board_footprint_sexp(lib_id, x, y, rotation, layer, Some(reference), project_dir)
+                .map_err(anyhow::Error::msg)?;
+        let value = value.map(str::to_string).unwrap_or_else(|| {
+            lib_id
+                .split_once(':')
+                .map_or(lib_id, |(_, entry)| entry)
+                .to_string()
+        });
+        Ok(Self {
+            value,
+            pads,
+            graphics,
+            fields,
+            board_sexp,
+        })
+    }
+
+    pub(crate) fn from_inline(
+        value: String,
+        pads: Vec<konnect_ipc::IpcPadDefinition>,
+        graphics: Vec<konnect_ipc::IpcGraphicDefinition>,
+        fields: konnect_ipc::IpcFieldPlacement,
+        board_sexp: String,
+    ) -> Self {
+        Self {
+            value,
+            pads,
+            graphics,
+            fields,
+            board_sexp,
+        }
+    }
+
+    /// Insert exactly this footprint through the same atomic, duplicate-safe
+    /// path used by ordinary library placement.
+    pub(crate) fn insert_into_board(&self, board_path: &Path) -> anyhow::Result<()> {
+        insert_into_board(board_path, std::slice::from_ref(&self.board_sexp))
+    }
 }
 
 fn footprint_references(content: &str) -> anyhow::Result<HashSet<String>> {
@@ -2115,27 +2189,20 @@ async fn handle_place_component(
         Ok(source) => source,
         Err(error) => return Ok(CallToolResult::error(error.to_string())),
     };
-    let prepared = match prepare_footprint_source(
-        &source, &footprint, &reference, None, x, y, rotation, &layer,
+    let prepared = match PreparedFootprintPlacement::from_library(
+        &source,
+        &footprint,
+        &reference,
+        None,
+        x,
+        y,
+        rotation,
+        &layer,
+        board.parent(),
     ) {
         Ok(prepared) => prepared,
         Err(error) => return Ok(CallToolResult::error(error.to_string())),
     };
-    let pads = match extract_pad_definitions(&prepared) {
-        Ok(pads) => pads,
-        Err(error) => return Ok(CallToolResult::error(error.to_string())),
-    };
-    let graphics = match extract_graphic_definitions(&prepared) {
-        Ok(graphics) => graphics,
-        Err(error) => return Ok(CallToolResult::error(error.to_string())),
-    };
-    let fields = extract_field_placement(&prepared);
-
-    let value = footprint
-        .split_once(':')
-        .map(|(_, entry)| entry)
-        .unwrap_or(&footprint)
-        .to_string();
 
     // Try IPC first. The fallback gate is the typed transport classification:
     // only when the transport is unreachable and this server has never
@@ -2145,15 +2212,16 @@ async fn handle_place_component(
     let reference_ipc = reference.clone();
     let layer_ipc = layer.clone();
     let requested_board = board.clone();
+    let prepared_ipc = prepared.clone();
     let attempt = attempt_ipc_write(ctx, &board, "placement", move |c| {
         c.place_footprint(
             &requested_board,
             &footprint_ipc,
             &reference_ipc,
-            &value,
-            &pads,
-            &graphics,
-            &fields,
+            &prepared_ipc.value,
+            &prepared_ipc.pads,
+            &prepared_ipc.graphics,
+            &prepared_ipc.fields,
             x,
             y,
             rotation,
@@ -2185,19 +2253,7 @@ async fn handle_place_component(
                     format!("Footprint reference '{reference}' already exists on the board"),
                 ));
             }
-            let sexp = match board_footprint_sexp(
-                &footprint,
-                x,
-                y,
-                rotation,
-                &layer,
-                Some(&reference),
-                board.parent(),
-            ) {
-                Ok(sexp) => sexp,
-                Err(message) => return Ok(CallToolResult::error(message)),
-            };
-            insert_into_board(&board, std::slice::from_ref(&sexp))?;
+            prepared.insert_into_board(&board)?;
             Ok(CallToolResult::json(&json!({
                 "placed": reference,
                 "footprint": footprint,

--- a/crates/konnect/tests/live_kicad_tools.rs
+++ b/crates/konnect/tests/live_kicad_tools.rs
@@ -320,6 +320,80 @@ fn place_component_loads_real_library_geometry() {
     }
 }
 
+/// Issue #462 through the public MCP boundary and a real KiCad PCB Editor.
+///
+/// This proves more than a successful tool response: the tool must select IPC,
+/// KiCad must expose the new footprint through live readback, and a KiCad save
+/// must persist the exact shipped library id and NPTH drill geometry.
+#[test]
+#[ignore = "requires a running KiCad GUI, API socket, disposable open board, and standard footprint libraries"]
+fn add_mounting_hole_round_trips_through_live_kicad() {
+    let board = std::path::PathBuf::from(
+        std::env::var("KONNECT_LIVE_KICAD_BOARD")
+            .expect("KONNECT_LIVE_KICAD_BOARD must name the disposable open board"),
+    );
+    let socket = std::env::var("KICAD_API_SOCKET").expect("KICAD_API_SOCKET is required");
+    let reference =
+        std::env::var("KONNECT_LIVE_KICAD_HOLE_REFERENCE").unwrap_or_else(|_| "H900".to_string());
+    let expected_lib_id = "MountingHole:MountingHole_3.2mm_M3";
+
+    let ipc = KiCadIpcClient::new(&socket);
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        match ipc.find_open_board(&board) {
+            Ok(_) => break,
+            Err(error)
+                if error.to_string().contains("AS_NOT_READY")
+                    && std::time::Instant::now() < deadline => {}
+            Err(error) => panic!("KiCad did not open the disposable board: {error:#}"),
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+
+    let mut mcp = McpProcess::spawn(&socket);
+    mcp.tool("load_toolset", json!({"name": "pcb_board"}));
+    let result = mcp.tool(
+        "add_mounting_hole",
+        json!({
+            "board": board,
+            "x": 42.0,
+            "y": 37.0,
+            "drill_diameter": 3.2,
+            "reference": reference
+        }),
+    );
+    let body: Value = serde_json::from_str(result["content"][0]["text"].as_str().unwrap())
+        .expect("add_mounting_hole did not return JSON");
+    assert_eq!(body["source"], "ipc", "{body}");
+    assert_eq!(body["reference"], reference, "{body}");
+    assert_eq!(body["footprint"], expected_lib_id, "{body}");
+
+    let live = live_footprint(&ipc, &board, &reference);
+    assert_eq!(
+        live.definition
+            .as_ref()
+            .and_then(|definition| definition.id.as_ref())
+            .map(|id| format!("{}:{}", id.library_nickname, id.entry_name)),
+        Some(expected_lib_id.to_string()),
+        "live KiCad readback did not preserve the shipped library identity"
+    );
+
+    ipc.save_board().expect("failed to save live board");
+    let tree = parse_sexp(&std::fs::read_to_string(&board).unwrap()).unwrap();
+    let saved = footprint(&tree, &reference);
+    assert_eq!(
+        saved.get(1).and_then(SexpNode::as_str),
+        Some(expected_lib_id)
+    );
+    let pad = saved
+        .find_all("pad")
+        .into_iter()
+        .next()
+        .expect("saved mounting hole has no pad");
+    assert_eq!(pad.get(2).and_then(SexpNode::as_str), Some("np_thru_hole"));
+    assert!((pad.find("drill").unwrap().get_f64(1).unwrap() - 3.2).abs() < 1e-6);
+}
+
 #[test]
 #[ignore = "requires a running KiCad GUI, API socket, saved schematic, and matching open board"]
 fn schematic_sync_apply_then_dry_run_is_noop() {

--- a/docs/API_MIGRATIONS.md
+++ b/docs/API_MIGRATIONS.md
@@ -3,6 +3,29 @@
 Konnect's tool schemas are public API. This file records intentional argument
 removals and the supported replacement workflow.
 
+## Unreleased: `add_mounting_hole` uses KiCad's shipped footprint names (minor release)
+
+`add_mounting_hole` wrote `MountingHole:MountingHole_{drill:.1}mm`. KiCad 10
+ships no plain `MountingHole_3.2mm` — 3.2 mm exists only as the M3 family — and
+spells round sizes without a decimal (`MountingHole_3mm`), so the default call
+and every integer size produced a name no stock KiCad resolves (#462).
+
+The lib_id now comes from a table of the footprints KiCad 10 ships (`3.2` →
+`MountingHole_3.2mm_M3`, `3` → `MountingHole_3mm`, `4.3` →
+`MountingHole_4.3mm_M4`, …), and a drill with no shipped footprint is refused
+with `invalid_argument` on `drill_diameter` listing the shipped sizes, before
+anything is written. When `MountingHole.pretty` resolves from the machine
+(project or global `fp-lib-table`, or a discovered install), the hole placed is
+KiCad's own library footprint, as `place_component` would place it; otherwise
+Konnect's unplated-hole geometry is written under the shipped name. That
+geometry's pad now equals the drill (no `+0.5` annulus), matching KiCad's plain
+`MountingHole_*` footprints.
+
+Results add `geometry` (`"library"` or `"inline"`) and, for inline geometry,
+`geometry_note`. The `footprint` field is now read back from the saved board
+rather than repeated from the request. No tool or argument was renamed or
+removed; `drill_diameter` keeps its default of 3.2.
+
 ## Unreleased: DRC item ownership (minor release)
 
 `run_drc` and `get_drc_violations` now say what owns each item of each
@@ -94,7 +117,6 @@ count rather than a substring count clamped to a minimum of two; a board with
 no `(layers …)` table reports `0` and a warning rather than an invented `2`.
 `validate_for_manufacturing`'s `board_info.copper_layers` changes value on any
 board with non-`signal` copper; its shape is unchanged.
-
 ## Unreleased: `find_single_pin_nets` counts pins, not labels (minor release)
 
 `find_single_pin_nets` counted label instances per net name, so an ordinary net

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -246,7 +246,7 @@ and Windows servers do not.
 | `set_active_layer` | Set the active layer recorded in the board file's setup section. |
 | `add_board_outline` | Add a rectangular Edge.Cuts outline with sharp or circular rounded corners, identically over IPC and file fallback. Appends — clear the old edges with `delete_graphics` first. |
 | `delete_graphics` | Delete board graphics (lines, rects, arcs, circles, polys, curves, text, textboxes, dimensions) matching a UUID/layer/type filter; `dry_run` lists them instead. |
-| `add_mounting_hole` | Add an NPTH mounting hole footprint at the specified position. |
+| `add_mounting_hole` | Add an NPTH mounting hole footprint at the specified position, under the MountingHole library name stock KiCad 10 ships for that drill; a drill with no shipped footprint is refused. |
 | `add_board_text` | Add a silkscreen or fabrication text string to the board. |
 | `add_zone` | Add a copper fill zone polygon on a specified layer and net, with optional `name`, `priority` and `pad_connection` (`solid`/`thermal`/`none`). Tries KiCad IPC first — a live board gets the zone through the API and a refill, so it appears immediately and is undoable — and falls back to an S-expression file insert only when no live KiCad answers, reporting `source` and a `warning` when it does. Refuses a net the board does not declare rather than binding copper to net 0, and refuses outright if KiCad answers but rejects the request. |
 | `import_svg_logo` | Import an SVG file as filled silkscreen/copper artwork (curves flattened to polygons). |


### PR DESCRIPTION
## Summary

`add_mounting_hole` formatted its lib_id as `MountingHole:MountingHole_{drill:.1}mm`. Checked against the installed KiCad 10 `MountingHole.pretty` (167 footprints): there is **no** plain `MountingHole_3.2mm` — 3.2 mm exists only as the M3 family — and KiCad spells round sizes without a decimal (`MountingHole_3mm`, never `3.0mm`). So the default call and every integer size wrote a name no stock KiCad resolves.

Closes #462

## Approach

- **Name table, spelled as the library spells it.** `MOUNTING_HOLE_NAMES` lists the 19 unplated mounting holes KiCad 10 ships (plain sizes 2 … 6.5 mm, metric-clearance sizes `2.2mm_M2`, `3.2mm_M3`, `4.3mm_M4`, `5.3mm_M5`, `6.4mm_M6`, `8.4mm_M8`). `mounting_hole_lib_id` returns `None` for anything else, and the handler **refuses before writing** with `invalid_argument` on `drill_diameter` listing the shipped sizes. A conformance test checks every table entry against the installed library when one is present (and that the old formatter's names do *not* exist there), skipping silently otherwise — the same pattern as the guidance library-ID check.
- **KiCad's own footprint when it resolves.** When `MountingHole.pretty` resolves from the machine (project or global `fp-lib-table`, or a discovered install), the hole placed is that library footprint, through the same `prepare_footprint_source` / `extract_*` / `board_footprint_sexp` pipeline `place_component` uses (three of those made `pub(crate)`). Name and geometry are then KiCad's, so `lib_footprint_mismatch` has nothing to say.
- **Inline geometry otherwise, honestly labelled.** Without a resolvable library, Konnect's unplated-hole geometry is written under the shipped name, with the pad now equal to the drill as KiCad's plain `MountingHole_*` footprints have it (the old `drill + 0.5` annulus matched no library footprint). The response carries `geometry: "library" | "inline"` and, for inline, `geometry_note`.
- **Derived, not echoed.** On the file path the `footprint` field is read back from the saved board (`written_footprint_lib_id`), not repeated from the request.

## Branch and dependencies

Base branch: `main` at `2fbc5f5`.
Depends on: nothing. Independent of #511 (different files).
Series order: none — single PR, one commit.
Overlap: none with any open PR.
Next PR to promote after this one: none in this chain.

## Compatibility and safety

- **Behaviour change (fix):** the lib_id written for every drill changes to the shipped name; an unshipped drill is now refused instead of written. `drill_diameter` keeps its default of 3.2 and its type; its description now lists the shipped sizes.
- **Additive response fields:** `geometry`, `geometry_note`. `footprint` keeps its name and meaning but is now derived from the file on the file path.
- **File mutations:** the library path goes through `insert_into_board` (consistent read, duplicate-reference refusal, parse-before-write, atomic write); the inline path is unchanged apart from the name and pad size. Refusals write nothing (asserted byte-identical).
- **IPC mutations:** same `attempt_ipc_write` gate as before; a reachable KiCad that rejects never touches the file (existing test, kept).
- `docs/API_MIGRATIONS.md` and the `tool-directory.md` row carry the change. No tool added or removed.
- Rollback: revert the one commit.

## Validation

Run on commit `449002d` (Windows, KiCad 10.0 installed), exit codes captured directly:

```
cargo fmt --all -- --check                                        exit 0
cargo clippy --workspace --locked --all-targets -- -D warnings    exit 0
cargo test --workspace --locked --lib --tests                     exit 0 (no failures)
cargo test --workspace --locked --doc                             exit 0
cargo xtask fix-doc-counts --check                                21 / 226 / 233; unchanged
cargo test -p konnect-core --lib mounting_hole                    8 passed (3 existing, 5 new)
```

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --locked --lib --tests`
- [x] `cargo test --workspace --locked --doc`
- [x] `cargo clippy --workspace --locked --all-targets -- -D warnings`
- [x] Real-KiCad check: `every_shipped_name_exists_in_the_installed_library` ran against the installed KiCad 10 here (19/19 present; `MountingHole_3.2mm` / `_3.0mm` / `_4.0mm` confirmed absent), and the E2E below. Linux/macOS not run here; hosted CI covers the matrix, and the conformance test skips where no KiCad is installed.

**Reproduced first, on `main` with a release binary:** placing 3.2 / 3.0 / 4.0 mm holes wrote `MountingHole_3.2mm`, `MountingHole_3.0mm`, `MountingHole_4.0mm` — none of which exist in the installed `MountingHole.pretty`. Headless `kicad-cli pcb upgrade`/`drc` still load such a board (the footprint is embedded), so the "fails to load" symptom in the issue is the GUI's library-resolution path; the wrong names are the defect either way and are reproduced exactly.

**Negative controls (each neutered, then restored):**

| guard neutered | tests that fail |
|---|---|
| old `{drill:.1}mm` formatter restored in `mounting_hole_lib_id` | `shipped_drills_get_the_library_spelling`, `the_default_drill_writes_a_name_stock_kicad_resolves` |
| refusal removed (every drill gets a name) | `an_unshipped_drill_has_no_name`, `an_unshipped_drill_refuses_before_writing`, plus the two above |

Restored tree: 8/8 green.

**E2E on this branch's release binary over MCP** (fresh project, KiCad IPC unreachable so the guarded file path runs):

| call | result |
|---|---|
| `add_mounting_hole` 3.2 | `MountingHole:MountingHole_3.2mm_M3`, `geometry: "library"` |
| `add_mounting_hole` 3.0 | `MountingHole:MountingHole_3mm`, `geometry: "library"` |
| `add_mounting_hole` 4.0 | `MountingHole:MountingHole_4mm`, `geometry: "library"` |
| `add_mounting_hole` 3.3 | refused: `invalid_argument` on `drill_diameter`, shipped sizes listed, nothing written |

All three names verified present as `.kicad_mod` files in the installed `MountingHole.pretty`; `kicad-cli pcb drc` on the result reports **no `lib_footprint_mismatch`**. It does report `lib_footprint_issues: library not enabled in the current configuration` for each hole — a headless-CLI limitation, not the board: this machine's global `fp-lib-table` is KiCad's standard nested `(type "Table")` entry for the stock libraries, and the same headless run flags every footprint of KiCad's own ecc83 demo identically. The GUI resolves them. So the one check I cannot make headlessly is the GUI open with no library warning; the names are now the ones the GUI's own library browser lists.

## Review checklist

- [x] The diff is focused and contains no generated output, personal data, or unrelated cleanup.
- [x] The branch includes current `upstream/main`, has no merge conflicts, and CI passed on this exact head.
- [x] The branch was based on latest `upstream/main`, not a release tag.
- [x] The PR shows only its unique commits and diff; dependencies and series position are explicit.
- [x] Every review conversation is resolved.
- [x] New names follow `docs/NAMING_CONVENTIONS.md` (`geometry`, `geometry_note`); no public renames.
- [x] New behavior and failure paths have regression coverage.
- [x] File mutations are atomic and preserve unrelated content.
- [x] IPC mutations verify the requested board and do not leave partial batches (unchanged gate).
- [x] No tools added/removed; `cargo xtask fix-doc-counts --check` unchanged.

## Maintainer merge state

- [ ] The PR has exactly one current `status:*` workflow label.
- [ ] `status:ready-to-merge` applies to this exact head SHA.
- [ ] All required checks and review conversations satisfy the `main` ruleset.
- [ ] Merge with `gh pr merge N --merge` after final verification.
- [ ] Terminal issue closure: #462. Next PR to promote: none.

## Maintainer refresh on current `main`

Reconstructed onto `upstream/main` at `fbebd991e668aa8396bb4ec2893ae4b86db337cf`; current head is `817f5e75687fec53f1522060100c60bac8181a44`.

The requested corrections are now included:

- Both library and inline file paths use one `PreparedFootprintPlacement` operation backed by the existing atomic, duplicate-reference-safe insertion path.
- `MountingHoleSpec` carries `drill_diameter_mm`, reference, and resolved lib_id together; the low-level preparation/serialization helpers are private again.
- File readback requires exactly one footprint with the requested reference. Duplicate or ambiguous identity is an error, never a first-match success.
- New regression coverage proves duplicate `H1` refusal leaves the board byte-identical.
- New ignored live test crosses JSON-RPC MCP, routing, library discovery, and KiCad IPC, then verifies live readback and the saved board.

Observed live on Windows / KiCad 10.0.6:

```text
cargo test -p konnect --test live_kicad_tools --locked add_mounting_hole_round_trips_through_live_kicad -- --ignored --nocapture --test-threads=1
1 passed; 0 failed
```

The call returned `source: "ipc"`, live KiCad read back `MountingHole:MountingHole_3.2mm_M3`, and KiCad save persisted that exact id with a 3.2 mm `np_thru_hole` drill.

Duplicate-safety negative control: temporarily disabling reference rejection made `inline_file_placement_refuses_a_duplicate_reference_without_writing` fail because the duplicate was committed and readback became ambiguous. The restored guard passes.

Exact-head local gate:

```text
cargo fmt --all -- --check                                      exit 0
cargo clippy --workspace --locked --all-targets -- -D warnings  exit 0
cargo test --workspace --locked --lib --tests                   exit 0
cargo test --workspace --locked --doc                           exit 0
cargo xtask fix-doc-counts --check                              exit 0; 21 / 226 / 233 unchanged
cargo test -p konnect-core --locked mounting_hole --lib          exit 0; 9 passed
```

Issue #462's title/evidence has been corrected: the invalid library names are reproduced; a board-load failure is not. Headless KiCad loads the embedded geometry. A GUI warning across every library-table configuration remains validation debt, not a claimed pass.