### PR TITLE
fix(schematic): resolve nets by identity, not by name

### DIFF
--- a/crates/konnect-core/src/tools/design_review.rs
+++ b/crates/konnect-core/src/tools/design_review.rs
@@ -8,7 +8,7 @@
 use super::cli;
 use crate::mcp::protocol::CallToolResult;
 use crate::tool;
-use crate::tools::sch_connectivity::{net_graph_for, NetGraph};
+use crate::tools::sch_connectivity::{net_graph_for, NetGraph, NetRoot};
 use crate::tools::{
     get_path, invalid_arg, placed_pins_by_reference, project_name_for, sch_hierarchy, ToolContext,
     ToolDef,
@@ -23,7 +23,7 @@ use konnect_sexp::{
     },
 };
 use serde_json::{json, Value};
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 use tracing::info;
 
@@ -245,7 +245,7 @@ async fn handle_audit_decoupling_file(
     let mut total_power_pins = 0;
 
     // Collect all capacitor references and their net connections
-    let (cap_nets, _) = capacitor_nets(&mut graph, &placed);
+    let (cap_roots, _) = capacitor_nets(&mut graph, &placed);
 
     // For each IC (non-passive, non-connector component), check power pins
     for (inst, pins) in &placed {
@@ -273,17 +273,12 @@ async fn handle_audit_decoupling_file(
             let (px, py) = pin_endpoint(pin, *transform);
 
             // Check if there's a capacitor connected to a net that this pin is on
-            let pin_net = graph.net_at(px, py);
+            let pin_root = graph.root_at(px, py);
 
-            let has_decoupling = if let Some(ref net) = pin_net {
-                cap_nets.contains(net)
-            } else {
-                false
-            };
-
-            if has_decoupling {
+            if cap_roots.contains(&pin_root) {
                 pass_count += 1;
             } else {
+                let pin_net = graph.name_of_root(pin_root);
                 findings.push(AuditFinding {
                     severity: "error",
                     category: "decoupling",
@@ -337,7 +332,7 @@ async fn handle_audit_connections_file(
     let wires = extract_wires(&tree);
     let labels = extract_all_net_labels(&tree);
     let mut graph = net_graph_for(&tree, &wires, &labels);
-    let pull_up_nets = pull_up_nets(&mut graph, &placed);
+    let pull_up_roots = pull_up_nets(&mut graph, &placed);
 
     let mut findings = Vec::new();
 
@@ -352,9 +347,10 @@ async fn handle_audit_connections_file(
             for (pin_name, placed_pin) in [("SDA", named("SDA")), ("SCL", named("SCL"))] {
                 if let Some((pin, transform)) = placed_pin {
                     let (px, py) = pin_endpoint(pin, *transform);
-                    let net = graph.net_at(px, py);
+                    let root = graph.root_at(px, py);
+                    let net = graph.name_of_root(root);
                     if let Some(ref net_name) = net {
-                        if !pull_up_nets.contains(net_name) {
+                        if !pull_up_roots.contains(&root) {
                             findings.push(AuditFinding {
                                 severity: "warning",
                                 category: "connection",
@@ -381,9 +377,10 @@ async fn handle_audit_connections_file(
                 && !name_upper.contains("OUT")
             {
                 let (px, py) = pin_endpoint(pin, *transform);
-                let net = graph.net_at(px, py);
+                let root = graph.root_at(px, py);
+                let net = graph.name_of_root(root);
                 if let Some(ref net_name) = net {
-                    if !pull_up_nets.contains(net_name) {
+                    if !pull_up_roots.contains(&root) {
                         findings.push(AuditFinding {
                             severity: "warning",
                             category: "connection",
@@ -431,17 +428,20 @@ async fn handle_audit_power_rails_file(
     let mut findings = Vec::new();
 
     // Find all power nets (from power symbols and labels)
-    let power_nets = collect_power_nets(&labels);
+    let rails = power_rails(&mut graph, &labels);
 
     // Check each power net for bulk capacitance
-    let (cap_nets, bulk_cap_nets) = capacitor_nets(&mut graph, &placed);
+    let (cap_roots, bulk_cap_roots) = capacitor_nets(&mut graph, &placed);
 
-    for net in &power_nets {
-        if net.to_uppercase().contains("GND") || net.to_uppercase().contains("VSS") {
+    for rail in &rails {
+        let PowerRail {
+            root, name: net, ..
+        } = rail;
+        if rail.any_name_contains("GND") || rail.any_name_contains("VSS") {
             continue; // Ground nets don't need caps
         }
 
-        if !cap_nets.contains(net.as_str()) {
+        if !cap_roots.contains(root) {
             findings.push(AuditFinding {
                 severity: "error",
                 category: "power",
@@ -449,7 +449,7 @@ async fn handle_audit_power_rails_file(
                 issue: format!("Power rail '{}' has no decoupling capacitors", net),
                 recommendation: format!("Add at least one 100nF ceramic cap on the '{}' rail", net),
             });
-        } else if !bulk_cap_nets.contains(net.as_str()) {
+        } else if !bulk_cap_roots.contains(root) {
             findings.push(AuditFinding {
                 severity: "warning",
                 category: "power",
@@ -464,12 +464,15 @@ async fn handle_audit_power_rails_file(
     }
 
     // Check for test points on power rails
-    let test_point_nets = test_point_nets(&mut graph, &placed);
-    for net in &power_nets {
-        if net.to_uppercase().contains("GND") {
+    let test_point_roots = test_point_nets(&mut graph, &placed);
+    for rail in &rails {
+        let PowerRail {
+            root, name: net, ..
+        } = rail;
+        if rail.any_name_contains("GND") {
             continue;
         }
-        if !test_point_nets.contains(net.as_str()) {
+        if !test_point_roots.contains(root) {
             findings.push(AuditFinding {
                 severity: "info",
                 category: "power",
@@ -483,9 +486,9 @@ async fn handle_audit_power_rails_file(
     Ok(CallToolResult::text(
         serde_json::to_string(&json!({
             "audit": "power_rails",
-            "power_nets": power_nets,
+            "power_nets": rails.iter().map(|rail| &rail.name).collect::<Vec<_>>(),
             "findings": findings,
-            "summary": format!("{} power rail issues found across {} rails.", findings.len(), power_nets.len())
+            "summary": format!("{} power rail issues found across {} rails.", findings.len(), rails.len())
         }))
         .unwrap(),
     ))
@@ -1454,25 +1457,30 @@ type PlacedPin = (
 /// A placed unit and the pins it draws — one entry of [`placed_pins_by_reference`].
 type PlacedUnit = (konnect_sexp::schematic::SymbolInstance, Vec<PlacedPin>);
 
-/// Every net a placed unit's pins reach.
+/// Every net a placed unit's pins reach, as graph roots.
 ///
 /// Nets come from the shared net graph, so a pin reaches its net along the
 /// wires and junctions it is drawn with, and a rail named by a power symbol is
 /// a net like any other. The audits used to scan the file for a label within
 /// 0.5 mm of the pin, which followed neither.
 ///
+/// Roots rather than names, because an audit asks whether two pins are on *one
+/// net* and a net can carry more than one name. Comparing names made a rail
+/// named by both a power symbol and a label fail that comparison against
+/// itself, reporting the name the capacitors did not resolve to as an
+/// undecoupled rail of its own. A pin on an unnamed net has a root like any
+/// other and is counted here; it is the reporting sites that need a name.
+///
 /// `pins` comes from [`placed_pins_by_reference`], so it holds this unit's pins
 /// only: a triode of an ECC83 does not report the heater's net at its own
 /// coordinates (#182).
-fn pin_nets(graph: &mut NetGraph, pins: &[PlacedPin]) -> HashSet<String> {
-    let mut nets = HashSet::new();
-    for (pin, transform) in pins {
-        let (px, py) = pin_endpoint(pin, *transform);
-        if let Some(net) = graph.net_at(px, py) {
-            nets.insert(net);
-        }
-    }
-    nets
+fn pin_net_roots(graph: &mut NetGraph, pins: &[PlacedPin]) -> HashSet<NetRoot> {
+    pins.iter()
+        .map(|(pin, transform)| {
+            let (px, py) = pin_endpoint(pin, *transform);
+            graph.root_at(px, py)
+        })
+        .collect()
 }
 
 /// `C1` is a capacitor, `CN1` is a connector.
@@ -1504,11 +1512,11 @@ fn is_bulk_capacitor_value(value: &str) -> bool {
 fn capacitor_nets(
     graph: &mut NetGraph,
     placed: &[PlacedUnit],
-) -> (HashSet<String>, HashSet<String>) {
+) -> (HashSet<NetRoot>, HashSet<NetRoot>) {
     let mut all = HashSet::new();
     let mut bulk = HashSet::new();
     for (inst, pins) in placed.iter().filter(|(inst, _)| is_capacitor(inst)) {
-        let nets = pin_nets(graph, pins);
+        let nets = pin_net_roots(graph, pins);
         if is_bulk_capacitor_value(&inst.value) {
             bulk.extend(nets.iter().cloned());
         }
@@ -1518,13 +1526,13 @@ fn capacitor_nets(
 }
 
 /// Nets with a test point on them.
-fn test_point_nets(graph: &mut NetGraph, placed: &[PlacedUnit]) -> HashSet<String> {
+fn test_point_nets(graph: &mut NetGraph, placed: &[PlacedUnit]) -> HashSet<NetRoot> {
     let is_test_point = |inst: &konnect_sexp::schematic::SymbolInstance| {
         inst.reference.starts_with("TP") || inst.value.to_uppercase().contains("TESTPOINT")
     };
     let mut nets = HashSet::new();
     for (_, pins) in placed.iter().filter(|(inst, _)| is_test_point(inst)) {
-        nets.extend(pin_nets(graph, pins));
+        nets.extend(pin_net_roots(graph, pins));
     }
     nets
 }
@@ -1534,18 +1542,46 @@ fn test_point_nets(graph: &mut NetGraph, placed: &[PlacedUnit]) -> HashSet<Strin
 ///
 /// Built once per sheet. Asking per pin instead re-walked every resistor on
 /// the sheet for each I2C or reset pin found.
-fn pull_up_nets(graph: &mut NetGraph, placed: &[PlacedUnit]) -> HashSet<String> {
+fn pull_up_nets(graph: &mut NetGraph, placed: &[PlacedUnit]) -> HashSet<NetRoot> {
     let mut pulled = HashSet::new();
     for (_, pins) in placed
         .iter()
         .filter(|(inst, _)| inst.reference.starts_with('R'))
     {
-        let nets = pin_nets(graph, pins);
-        if nets.iter().any(|net| is_power_net_name(net)) {
+        let nets = pin_net_roots(graph, pins);
+        // Every name on the net, not the winning one: a rail KiCad calls `SYS`
+        // because a global label outranks its `+3V3` symbol is still the rail
+        // this resistor pulls to.
+        let on_a_rail = nets.iter().any(|root| {
+            graph
+                .aliases_of_root(*root)
+                .iter()
+                .any(|net| is_power_net_name(net))
+        });
+        if on_a_rail {
             pulled.extend(nets);
         }
     }
     pulled
+}
+
+/// One rail of the sheet: the net's graph root, and what that net is called.
+struct PowerRail {
+    root: NetRoot,
+    /// The name KiCad would print for this net.
+    name: String,
+    /// Every name on it. The ground skips read all of them: a rail a power
+    /// symbol calls `GND` and a global label calls `RETURN` is still ground,
+    /// even though the global label wins the name.
+    names: BTreeSet<String>,
+}
+
+impl PowerRail {
+    fn any_name_contains(&self, needle: &str) -> bool {
+        self.names
+            .iter()
+            .any(|name| name.to_uppercase().contains(needle))
+    }
 }
 
 /// The power rails on the sheet: every net a power symbol names, plus every
@@ -1554,14 +1590,40 @@ fn pull_up_nets(graph: &mut NetGraph, placed: &[PlacedUnit]) -> HashSet<String> 
 /// `labels` must be `extract_all_net_labels` — a `+3V3` symbol names a rail
 /// exactly as a label does. `PWR_FLAG` is not a rail and does not appear: its
 /// pin is `power_out`, which the extractor skips.
-fn collect_power_nets(labels: &[Label]) -> Vec<String> {
-    labels
+///
+/// One rail per *net*, not per name. A rail named by both a `+3V3` power symbol
+/// and a `VCC` label is one net that KiCad calls `+3V3`, and listing it twice
+/// made every audit below report the name the capacitors did not resolve to as
+/// a rail with nothing on it. The name is [`NetGraph::name_of_root`]'s, so it is
+/// the one KiCad's netlister would print.
+fn power_rails(graph: &mut NetGraph, labels: &[Label]) -> Vec<PowerRail> {
+    // Which nets are rails, and what each is known as, are separate questions,
+    // asked in that order. Collecting names while deciding made the answer
+    // depend on label order: a rail claimed by the `+3V3` symbol lost the `VCC`
+    // label read before it.
+    let mut rail_roots: BTreeSet<NetRoot> = BTreeSet::new();
+    for label in labels
         .iter()
         .filter(|label| label.kind == LabelKind::PowerSymbol || is_power_net_name(&label.net))
-        .map(|label| label.net.clone())
-        .collect::<std::collections::BTreeSet<_>>()
+    {
+        rail_roots.insert(graph.root_at(label.x, label.y));
+    }
+    let mut rails: Vec<PowerRail> = rail_roots
         .into_iter()
-        .collect()
+        .map(|root| {
+            let names = graph.aliases_of_root(root);
+            PowerRail {
+                name: graph
+                    .name_of_root(root)
+                    .or_else(|| names.iter().next().cloned())
+                    .unwrap_or_default(),
+                root,
+                names,
+            }
+        })
+        .collect();
+    rails.sort_by(|a, b| a.name.cmp(&b.name).then(a.root.cmp(&b.root)));
+    rails
 }
 
 fn is_power_net_name(name: &str) -> bool {
@@ -2453,6 +2515,119 @@ mod net_resolution_tests {
             ],
             "{body}"
         );
+    }
+
+    /// The real KiCad fixture. Provenance, KiCad's own netlist and the ERC
+    /// precedence statements are in `two_name_nets.README.md`; the assertions
+    /// below are that table, not this crate's opinion of it.
+    const TWO_NAME_NETS: &str = include_str!("../../tests/fixtures/two_name_nets.kicad_sch");
+
+    /// `U1.8` and the capacitors share the `+3V3` rail and no wire. KiCad nets
+    /// them together (5 pins on `+3V3`), so the audit has to as well.
+    #[tokio::test]
+    async fn a_capacitor_on_another_stub_of_the_rail_decouples_the_pin() {
+        let file = sheet(TWO_NAME_NETS);
+        let body = audit_json(
+            handle_audit_decoupling(
+                &json!({ "schematic": file.path().to_str().unwrap() }),
+                &test_ctx(),
+            )
+            .await
+            .unwrap(),
+        );
+
+        assert_eq!(body["total_power_pins"], 1, "{body}");
+        assert_eq!(body["pass_count"], 1, "{body}");
+        assert_eq!(body["findings"].as_array().unwrap().len(), 0, "{body}");
+    }
+
+    /// Three rails, one entry each, under the name KiCad prints — and nothing
+    /// to report: `+3V3` and `SYS` carry bulk capacitance and a test point, and
+    /// `RETURN` is ground under a global label's name.
+    ///
+    /// Every failure mode this fixture exists for lands here: a rail counted
+    /// once per stub or once per alias, a rail whose capacitors resolved to a
+    /// different name, and a ground net reported as an undecoupled rail because
+    /// only its winning name was read.
+    #[tokio::test]
+    async fn each_rail_is_audited_once_under_kicads_name() {
+        let file = sheet(TWO_NAME_NETS);
+        let body = audit_json(
+            handle_audit_power_rails(
+                &json!({ "schematic": file.path().to_str().unwrap() }),
+                &test_ctx(),
+            )
+            .await
+            .unwrap(),
+        );
+
+        assert_eq!(
+            body["power_nets"],
+            json!(["+3V3", "RETURN", "SYS"]),
+            "{body}"
+        );
+        assert_eq!(
+            body["findings"].as_array().unwrap(),
+            &vec![] as &Vec<Value>,
+            "{body}"
+        );
+    }
+
+    /// `R1`/`R2` pull `SDA`/`SCL` up to a rail KiCad calls `SYS`, because the
+    /// global label outranks the `+5V` symbol beside it, and they sit on
+    /// segments joined to `U1`'s pins by name. Reading the winning name alone,
+    /// or the wire alone, reports both pull-ups missing.
+    #[tokio::test]
+    async fn a_pull_up_behind_a_global_alias_is_found() {
+        let findings = connection_findings(TWO_NAME_NETS).await;
+        assert!(findings.is_empty(), "{findings:?}");
+    }
+
+    /// The `+3V3` rail of [`WIRED_SHEET`] with a `VCC` label on it as well —
+    /// one net, two names, which is how a rail named by a power symbol and
+    /// labelled for readability is drawn.
+    ///
+    /// Both names were listed as rails while every capacitor resolved to one of
+    /// them, so the other was reported as an `error`-severity undecoupled rail,
+    /// and which of the two it was moved between runs. Twenty runs, because the
+    /// name came out of `HashMap` order.
+    #[tokio::test]
+    async fn a_rail_named_twice_is_audited_as_one_rail() {
+        let sheet_text = WIRED_SHEET.replace(
+            "  (junction (at 110 100)",
+            "  (label \"VCC\" (at 140 125 0) (uuid \"cccccccc-0000-4000-8000-000000000002\"))\n  (junction (at 110 100)",
+        );
+
+        for attempt in 0..20 {
+            let file = sheet(&sheet_text);
+            let body = audit_json(
+                handle_audit_power_rails(
+                    &json!({ "schematic": file.path().to_str().unwrap() }),
+                    &test_ctx(),
+                )
+                .await
+                .unwrap(),
+            );
+
+            // `+3V3` is the power symbol's name and KiCad's own choice over the
+            // label's; `VCC` is the same net and not a rail of its own.
+            assert_eq!(
+                body["power_nets"],
+                json!(["+3V3", "VBUS"]),
+                "attempt {attempt}: {body}"
+            );
+            let errors: Vec<&str> = body["findings"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter(|finding| finding["severity"] == "error")
+                .map(|finding| finding["issue"].as_str().unwrap())
+                .collect();
+            assert!(
+                errors.is_empty(),
+                "attempt {attempt}: C2 decouples that rail under either name: {errors:?}"
+            );
+        }
     }
 
     /// `run_design_review`'s coverage counts the rails power symbols name, and

--- a/crates/konnect-core/src/tools/sch_analysis.rs
+++ b/crates/konnect-core/src/tools/sch_analysis.rs
@@ -146,7 +146,8 @@ pub fn tools() -> Vec<ToolDef> {
         ),
         tool!(
             "find_shorted_nets",
-            "Detect accidentally merged nets — pairs of distinct net names sharing a wire path.",
+            "Detect accidentally merged nets — distinct net names that KiCad nets together, \
+             through a wire path they share or through a name that joins their segments.",
             json!({ "type": "object",
                 "properties": { "schematic": { "type": "string" } },
                 "required": ["schematic"] }),
@@ -696,7 +697,7 @@ async fn handle_find_single_pin_nets(
         for (pin, transform) in pins {
             let (x, y) = konnect_sexp::schematic::pin_endpoint(pin, *transform);
             pins_by_root
-                .entry(graph.find(pt_key(x, y)))
+                .entry(graph.root_at(x, y))
                 .or_default()
                 .push(Connection::ComponentPin {
                     reference: &instance.reference,
@@ -708,7 +709,7 @@ async fn handle_find_single_pin_nets(
     }
     for (x, y) in extract_sheet_pins(&tree) {
         pins_by_root
-            .entry(graph.find(pt_key(x, y)))
+            .entry(graph.root_at(x, y))
             .or_default()
             .push(Connection::SheetPin { x, y });
     }
@@ -806,27 +807,29 @@ async fn handle_get_connected_items(
     let placed_pins = placed_pins_by_reference(&tree);
     let mut g = net_graph_for(&tree, &wires, &labels);
 
-    // Get nets for each pin
-    let mut connected_nets: HashSet<String> = HashSet::new();
+    // The nets this component's pins are on, held by identity: a net can carry
+    // more than one name, and one can carry none at all. Keying this by name
+    // dropped the labels spelling a net its other way, and dropped an unnamed
+    // net's items entirely.
+    let mut connected_roots: HashSet<(i64, i64)> = HashSet::new();
+    let mut connected_nets: BTreeSet<String> = BTreeSet::new();
     for (_, pins) in placed_pins
         .iter()
         .filter(|(instance, _)| instance.reference == reference)
     {
         for (pin, transform) in pins {
             let (px, py) = konnect_sexp::schematic::pin_endpoint(pin, *transform);
-            if let Some(net) = g.net_at(px, py) {
+            let root = g.root_at(px, py);
+            connected_roots.insert(root);
+            if let Some(net) = g.name_of_root(root) {
                 connected_nets.insert(net);
             }
         }
     }
 
     // Find all wires, labels, and components on those nets
-    let mut all_net_pts: HashSet<(i64, i64)> = HashSet::new();
-    for net in &connected_nets {
-        for pt in g.points_on_net(net) {
-            all_net_pts.insert(pt);
-        }
-    }
+    let all_net_pts: HashSet<(i64, i64)> =
+        g.points_on_roots(&connected_roots).into_iter().collect();
 
     let connected_wires: Vec<serde_json::Value> = wires
         .iter()
@@ -836,10 +839,10 @@ async fn handle_get_connected_items(
         .map(|w| json!({ "x1": w.x1, "y1": w.y1, "x2": w.x2, "y2": w.y2, "uuid": w.uuid }))
         .collect();
 
-    let connected_labels: Vec<serde_json::Value> = labels
-        .iter()
-        .filter(|l| connected_nets.contains(&l.net))
-        .map(|l| json!({ "net": l.net, "type": format!("{:?}", l.kind), "x": l.x, "y": l.y }))
+    let connected_labels: Vec<serde_json::Value> = label_roots(&mut g, &labels)
+        .into_iter()
+        .filter(|(root, _)| connected_roots.contains(root))
+        .map(|(_, l)| json!({ "net": l.net, "type": format!("{:?}", l.kind), "x": l.x, "y": l.y }))
         .collect();
 
     // Find other components on the same nets (excluding the queried one)
@@ -868,7 +871,7 @@ async fn handle_get_connected_items(
 
     Ok(CallToolResult::json(&json!({
         "reference": reference,
-        "nets": connected_nets.iter().collect::<Vec<_>>(),
+        "nets": connected_nets,
         "connected_wires": connected_wires.len(),
         "wires": connected_wires,
         "labels": connected_labels,
@@ -1765,5 +1768,111 @@ mod multi_unit_tool_tests {
                 .any(|net| net == "HEATER_TEST"),
             "heater unit net missing: {result}"
         );
+    }
+}
+
+/// The read-only side of net identity, on the real KiCad fixture.
+///
+/// Provenance, KiCad's own netlist and the ERC precedence statements are in
+/// `two_name_nets.README.md`; every expectation below is that table.
+#[cfg(test)]
+mod two_name_net_tests {
+    use super::tool_call_support::call;
+    use super::*;
+
+    const SCH: &str = include_str!("../../tests/fixtures/two_name_nets.kicad_sch");
+
+    /// Every multi-name net on this sheet answers with the name KiCad prints,
+    /// so the five `multiple_net_names` outcomes in the ERC report are all
+    /// asserted here. Twenty runs: the old scan returned the first `point_nets`
+    /// entry on the net's root, so the answer moved between runs of the same
+    /// binary rather than within one.
+    #[tokio::test]
+    async fn a_multi_name_net_answers_with_kicads_name() {
+        // pin, and the name KiCad's netlist gives the net it is on.
+        for (reference, pin, expected) in [
+            // The five nets carrying more than one name, one per precedence rule.
+            ("U1", "8", "+3V3"),   // power symbol over the VCC and ALT labels
+            ("U1", "4", "RETURN"), // global label over the GND symbols
+            ("R1", "1", "SYS"),    // global over both the +5V symbol and PULLUP
+            ("TP2", "1", "AAA"),   // two locals, the lexically first one
+            ("TP4", "1", "MIX"),   // local label over the hierarchical one
+            // And a single-name net whose two segments are joined by that name.
+            ("R1", "2", "SDA"),
+        ] {
+            for attempt in 0..20 {
+                let body = call(
+                    SCH,
+                    "get_pin_connections",
+                    json!({ "reference": reference, "pin_number": pin }),
+                )
+                .await;
+                assert_eq!(
+                    body["net"], expected,
+                    "{reference}.{pin} on attempt {attempt}: {body}"
+                );
+            }
+        }
+    }
+
+    /// `get_connected_items` answers about the component's *nets*: everything
+    /// on them, including the parts reachable only by name and the aliases the
+    /// net is not called by.
+    #[tokio::test]
+    async fn connected_items_span_every_segment_and_alias_of_the_net() {
+        let items = call(SCH, "get_connected_items", json!({ "reference": "U1" })).await;
+
+        let mut nets: Vec<&str> = items["nets"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|net| net.as_str().unwrap())
+            .collect();
+        nets.sort_unstable();
+        assert_eq!(nets, ["+3V3", "RETURN", "SCL", "SDA"], "{items}");
+
+        let components: Vec<&str> = items["connected_components"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|component| component["reference"].as_str().unwrap())
+            .collect();
+        for reachable_by_name_only in ["C1", "C2", "TP1", "TP7", "R1", "R2", "C3"] {
+            assert!(
+                components.contains(&reachable_by_name_only),
+                "{reachable_by_name_only} is on one of U1's nets: {items}"
+            );
+        }
+
+        let labels: Vec<&str> = items["labels"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|label| label["net"].as_str().unwrap())
+            .collect();
+        // The names these nets are *not* called by are still on them: `VCC` and
+        // `ALT` on the rail KiCad calls `+3V3`, `GND` on the one it calls
+        // `RETURN`. (`PULLUP` names the pull-up rail, which U1 is not on — its
+        // SDA/SCL pins reach the resistors, not the rail behind them.)
+        for alias in ["VCC", "ALT", "GND"] {
+            assert!(labels.contains(&alias), "alias {alias} dropped: {items}");
+        }
+    }
+
+    /// A net with no label at all is still a net. Collecting by name left it
+    /// out of the point set entirely, so the wire and the part at its other end
+    /// went unreported.
+    #[tokio::test]
+    async fn an_unnamed_net_reports_its_wire_and_the_part_at_the_far_end() {
+        let items = call(SCH, "get_connected_items", json!({ "reference": "TP8" })).await;
+
+        assert_eq!(items["connected_wires"], 1, "{items}");
+        let components: Vec<&str> = items["connected_components"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|component| component["reference"].as_str().unwrap())
+            .collect();
+        assert_eq!(components, ["TP9"], "{items}");
     }
 }

--- a/crates/konnect-core/src/tools/sch_connectivity.rs
+++ b/crates/konnect-core/src/tools/sch_connectivity.rs
@@ -36,7 +36,7 @@ use konnect_sexp::{
     },
     SexpNode,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 /// The coincidence tolerance the connectivity tools have always used, in mm.
 /// `find_orphan_items` takes its own as an argument; the rest use this.
@@ -181,24 +181,85 @@ pub(crate) fn pt_key(x: f64, y: f64) -> (i64, i64) {
     ((x * 1000.0).round() as i64, (y * 1000.0).round() as i64)
 }
 
+/// A name a label puts on a point, with the kind of label that put it there.
+///
+/// The kind is what makes [`NetGraph::name_of_root`] deterministic: one net can
+/// carry several names, and which one it is *called* follows KiCad's own
+/// precedence rather than whichever the map happened to yield first.
+#[derive(Clone)]
+struct NetName {
+    name: String,
+    kind: LabelKind,
+}
+
+/// KiCad's net-name precedence, highest first: a global label outranks a power
+/// symbol, which outranks a local label, which outranks a hierarchical one.
+///
+/// Verified against KiCad 10.0.5 by netlisting one net carrying each pair:
+/// `+3V3` power symbol with a `LOCAL_VCC` label nets as `+3V3`, either with a
+/// `GLOBAL_SYS` global label nets as `GLOBAL_SYS`, and a local label beats a
+/// hierarchical one. It is `CONNECTION_SUBGRAPH`'s driver priority, minus the
+/// sheet-pin and pin ranks below it — neither names a net here.
+fn driver_priority(kind: LabelKind) -> u8 {
+    match kind {
+        LabelKind::GlobalLabel => 3,
+        LabelKind::PowerSymbol => 2,
+        LabelKind::NetLabel => 1,
+        LabelKind::HierarchicalLabel => 0,
+    }
+}
+
+/// Whether `a` names the net in preference to `b`. Equal priority is broken on
+/// the name, ascending, which is KiCad's own tie-break (two local labels on one
+/// net gave `AAA` over `LOCAL_VCC`, and `LOCAL_VCC` over `ZZZ`).
+fn names_ahead_of(a: &NetName, b: &NetName) -> bool {
+    let (pa, pb) = (driver_priority(a.kind), driver_priority(b.kind));
+    pa > pb || (pa == pb && a.name < b.name)
+}
+
+/// A net's identity: the union-find root every point on that net resolves to.
+///
+/// Distinct from a net *name*, which a net may have several of or none at all.
+pub(crate) type NetRoot = (i64, i64);
+
+/// A graph of points joined into nets, and the name each net carries.
+///
+/// Built only by [`seed_net_graph`], which is why every mutator below is
+/// private: once seeding calls [`NetGraph::name_nets`] the graph is frozen, and
+/// `root_names` cannot go stale behind a later union. Callers get the two
+/// questions they actually ask — [`root_at`](Self::root_at) for a net's
+/// identity, [`name_of_root`](Self::name_of_root) for what it is called.
 pub(crate) struct NetGraph {
-    pub(crate) point_nets: HashMap<(i64, i64), String>,
-    pub(crate) parent: HashMap<(i64, i64), (i64, i64)>,
+    /// Every name at a point, not just the winning one. A rail label written
+    /// over the power symbol that names it puts two names on one coordinate,
+    /// and dropping the loser would keep it out of
+    /// [`merge_named_nets`](Self::merge_named_nets) — so a point carrying
+    /// `AAA` and `ZZZ` would never join a disconnected `ZZZ` segment.
+    point_nets: HashMap<(i64, i64), Vec<NetName>>,
+    parent: HashMap<(i64, i64), NetRoot>,
+    /// The winning name per root, resolved once at the end of seeding.
+    root_names: HashMap<NetRoot, String>,
+    /// Every name on each root, sorted. A caller classifying a net — is this a
+    /// rail? is it ground? — must read all of them: the winning name can be a
+    /// global label that says nothing about the `+3V3` alias beside it.
+    root_aliases: HashMap<NetRoot, BTreeSet<String>>,
 }
 
 impl NetGraph {
-    pub(crate) fn new() -> Self {
+    fn new() -> Self {
         NetGraph {
             point_nets: HashMap::new(),
             parent: HashMap::new(),
+            root_names: HashMap::new(),
+            root_aliases: HashMap::new(),
         }
     }
 
-    pub(crate) fn ensure(&mut self, k: (i64, i64)) {
+    fn ensure(&mut self, k: (i64, i64)) {
         self.parent.entry(k).or_insert(k);
     }
 
-    pub(crate) fn find(&mut self, k: (i64, i64)) -> (i64, i64) {
+    fn find(&mut self, k: (i64, i64)) -> NetRoot {
         self.ensure(k);
         let p = self.parent[&k];
         if p == k {
@@ -209,7 +270,7 @@ impl NetGraph {
         root
     }
 
-    pub(crate) fn union(&mut self, a: (i64, i64), b: (i64, i64)) {
+    fn union(&mut self, a: (i64, i64), b: (i64, i64)) {
         let ra = self.find(a);
         let rb = self.find(b);
         if ra != rb {
@@ -217,7 +278,7 @@ impl NetGraph {
         }
     }
 
-    pub(crate) fn add_wire(&mut self, w: &Wire) {
+    fn add_wire(&mut self, w: &Wire) {
         let a = pt_key(w.x1, w.y1);
         let b = pt_key(w.x2, w.y2);
         self.ensure(a);
@@ -225,23 +286,124 @@ impl NetGraph {
         self.union(a, b);
     }
 
-    pub(crate) fn add_label(&mut self, x: f64, y: f64, net: &str) {
+    fn add_label(&mut self, x: f64, y: f64, net: &str, kind: LabelKind) {
         let k = pt_key(x, y);
         self.ensure(k);
-        self.point_nets.insert(k, net.to_string());
+        let held = self.point_nets.entry(k).or_default();
+        // Kept whole, and ranked only when a name has to be *chosen*: every
+        // name at this point still has to reach `merge_named_nets`, or a net
+        // joined to this one by the losing name would stay a net of its own.
+        if !held.iter().any(|name| name.name == net) {
+            held.push(NetName {
+                name: net.to_string(),
+                kind,
+            });
+        }
     }
 
-    pub(crate) fn net_at(&mut self, x: f64, y: f64) -> Option<String> {
-        let k = pt_key(x, y);
-        self.ensure(k);
-        let root = self.find(k);
-        let labels: Vec<_> = self.point_nets.clone().into_iter().collect();
-        for (lk, net) in labels {
-            if self.find(lk) == root {
-                return Some(net);
+    /// The graph node a point belongs to. Two points share a root exactly when
+    /// they are on one net — through wire and junction geometry, and through
+    /// [`merge_named_nets`](Self::merge_named_nets) for the pieces KiCad joins
+    /// by name alone.
+    ///
+    /// This is the comparison a caller wants wherever it would otherwise
+    /// compare net *names*: a net carrying two names has one root and would
+    /// fail a name comparison against itself.
+    pub(crate) fn root_at(&mut self, x: f64, y: f64) -> NetRoot {
+        self.find(pt_key(x, y))
+    }
+
+    /// What the net at `root` is called, or `None` when no label names it.
+    ///
+    /// A net can carry more than one name — a rail named by a `+3V3` power
+    /// symbol that also has a label on it, a local label on a net that also
+    /// carries a global one. The answer is the one KiCad's netlister would
+    /// choose (see [`driver_priority`]), not whichever the map yielded first:
+    /// that was `HashMap` iteration order, so the name moved between runs of
+    /// the same binary and the audits reported the losing name as a rail of its
+    /// own.
+    pub(crate) fn name_of_root(&self, root: NetRoot) -> Option<String> {
+        self.root_names.get(&root).cloned()
+    }
+
+    /// Every name on the net at `root`, sorted, empty when nothing names it.
+    ///
+    /// [`name_of_root`](Self::name_of_root) answers what the net is *called*;
+    /// this answers what it is *known as*, which is the question a classifier
+    /// asks. A rail whose winning name is the global label `SYS` is still the
+    /// `+3V3` rail, and reading only the winner made it neither a rail to
+    /// decouple nor a pull-up destination.
+    pub(crate) fn aliases_of_root(&self, root: NetRoot) -> BTreeSet<String> {
+        self.root_aliases.get(&root).cloned().unwrap_or_default()
+    }
+
+    /// Join the points that carry the same name.
+    ///
+    /// KiCad nets a sheet by name as well as by wire: two segments each
+    /// carrying a `SIG` label are one net, and every `GND` power symbol on the
+    /// sheet is the same rail. Wires and junctions alone answer for one piece
+    /// of copper, so without this a root is a *segment* rather than a net —
+    /// and a decoupling capacitor drawn the normal way, on its own stub with
+    /// its own `+3V3` symbol, shares no root with the pin it decouples.
+    ///
+    /// Anchoring each name at the first point that carries it and unioning the
+    /// rest into it makes every same-named point one root, whatever order the
+    /// map yields them in.
+    fn merge_named_nets(&mut self) {
+        let mut anchors: HashMap<String, (i64, i64)> = HashMap::new();
+        let named: Vec<((i64, i64), Vec<String>)> = self
+            .point_nets
+            .iter()
+            .map(|(k, names)| (*k, names.iter().map(|name| name.name.clone()).collect()))
+            .collect();
+        for (k, names) in named {
+            for name in names {
+                match anchors.get(&name) {
+                    Some(&anchor) => self.union(anchor, k),
+                    None => {
+                        anchors.insert(name, k);
+                    }
+                }
             }
         }
-        None
+    }
+
+    /// Resolve one winning name per root. Called once, by [`seed_net_graph`],
+    /// after the last union — a name is a property of the finished net, so
+    /// there is nothing to resolve until the graph stops moving.
+    fn name_nets(&mut self) {
+        let mut best: HashMap<NetRoot, NetName> = HashMap::new();
+        let mut aliases: HashMap<NetRoot, BTreeSet<String>> = HashMap::new();
+        for k in self.point_nets.keys().copied().collect::<Vec<_>>() {
+            let root = self.find(k);
+            for candidate in self.point_nets[&k].clone() {
+                aliases
+                    .entry(root)
+                    .or_default()
+                    .insert(candidate.name.clone());
+                let wins = match best.get(&root) {
+                    Some(held) => names_ahead_of(&candidate, held),
+                    None => true,
+                };
+                if wins {
+                    best.insert(root, candidate);
+                }
+            }
+        }
+        self.root_names = best
+            .into_iter()
+            .map(|(root, name)| (root, name.name))
+            .collect();
+        self.root_aliases = aliases;
+    }
+
+    /// The name of the net at a point — [`root_at`](Self::root_at) then
+    /// [`name_of_root`](Self::name_of_root). For reporting a single point only:
+    /// a caller asking whether two points are on one net wants their roots, not
+    /// their names, since a net can carry more than one.
+    pub(crate) fn net_at(&mut self, x: f64, y: f64) -> Option<String> {
+        let root = self.root_at(x, y);
+        self.name_of_root(root)
     }
 
     pub(crate) fn points_on_net(&mut self, net: &str) -> Vec<(i64, i64)> {
@@ -249,14 +411,23 @@ impl NetGraph {
         let net_keys: Vec<(i64, i64)> = self
             .point_nets
             .iter()
-            .filter(|(_, n)| n.as_str() == net)
+            .filter(|(_, names)| names.iter().any(|name| name.name == net))
             .map(|(k, _)| *k)
             .collect();
-        let net_roots: HashSet<(i64, i64)> = net_keys.iter().map(|k| self.find(*k)).collect();
+        let net_roots: HashSet<NetRoot> = net_keys.iter().map(|k| self.find(*k)).collect();
+        self.points_on_roots(&net_roots)
+    }
+
+    /// Every point on any of `roots` — the same walk [`points_on_net`] does,
+    /// for a caller that already holds identities rather than a name. Asking
+    /// once for several nets also walks the graph once instead of per net.
+    ///
+    /// [`points_on_net`]: Self::points_on_net
+    pub(crate) fn points_on_roots(&mut self, roots: &HashSet<NetRoot>) -> Vec<(i64, i64)> {
         let all_keys: Vec<(i64, i64)> = self.parent.keys().cloned().collect();
         all_keys
             .into_iter()
-            .filter(|k| net_roots.contains(&self.find(*k)))
+            .filter(|k| roots.contains(&self.find(*k)))
             .collect()
     }
 }
@@ -293,7 +464,7 @@ fn seed_net_graph(
         }
     };
     for label in labels {
-        graph.add_label(label.x, label.y, &label.net);
+        graph.add_label(label.x, label.y, &label.net, label.kind);
         attach(&mut graph, label.x, label.y);
     }
     for &(x, y) in junctions {
@@ -303,6 +474,8 @@ fn seed_net_graph(
     for &(x, y) in sheet_pins {
         graph.ensure(pt_key(x, y));
     }
+    graph.merge_named_nets();
+    graph.name_nets();
     graph
 }
 
@@ -319,7 +492,7 @@ pub(crate) fn label_roots<'a>(
 ) -> Vec<((i64, i64), &'a Label)> {
     labels
         .iter()
-        .map(|label| (graph.find(pt_key(label.x, label.y)), label))
+        .map(|label| (graph.root_at(label.x, label.y), label))
         .collect()
 }
 
@@ -759,6 +932,39 @@ mod agreement_tests {
         format!(
             "\t(symbol\n\t\t(lib_id \"power:GND\")\n\t\t(at {x} {y} 0)\n\t\t(unit 1)\n\t\t(uuid \"p1\")\n\t\t(property \"Reference\" \"{reference}\"\n\t\t\t(at {x} {y} 0)\n\t\t)\n\t\t(property \"Value\" \"{value}\"\n\t\t\t(at {x} {y} 0)\n\t\t)\n\t)\n"
         )
+    }
+
+    /// The real KiCad fixture, at the graph level: `TP7` reaches the `+3V3`
+    /// rail only through the `ALT` label sitting on the second `+3V3` power
+    /// symbol's own pin. KiCad nets them together (`+3V3` has five pins), so a
+    /// graph that keeps one name per point loses that join — and with it the
+    /// alias every classifier reads.
+    ///
+    /// Provenance and KiCad's own net table: `two_name_nets.README.md`.
+    #[tokio::test]
+    async fn an_alias_on_a_power_symbol_pin_joins_its_segment() {
+        let sch = include_str!("../../tests/fixtures/two_name_nets.kicad_sch");
+        let (tree, wires, labels) = index_for(sch);
+        let mut graph = net_graph_for(&tree, &wires, &labels);
+
+        // TP7's pin, and U1's VCC pin at the other end of the rail.
+        let stub = graph.root_at(30.48, 88.9);
+        let rail = graph.root_at(110.49, 72.39);
+        assert_eq!(stub, rail, "TP7 joins the rail through the ALT alias");
+        assert_eq!(graph.name_of_root(rail), Some("+3V3".to_string()));
+        assert!(
+            graph.aliases_of_root(rail).contains("ALT"),
+            "the alias survives to the classifiers: {:?}",
+            graph.aliases_of_root(rail)
+        );
+
+        // The same join without an alias: two `+3V3` power symbols on separate
+        // stubs are one rail, and C1's pin reaches U1's through it.
+        assert_eq!(graph.root_at(59.69, 96.52), rail);
+
+        // And a plain label doing it: `U1.5` and `R1.2` carry `SDA` on segments
+        // that share no wire. KiCad nets both (`/SDA` has two pins).
+        assert_eq!(graph.root_at(120.65, 77.47), graph.root_at(160.02, 63.5));
     }
 
     /// A power symbol's net name is synthesised as a pseudo-label sitting on

--- a/crates/konnect-core/tests/fixtures/two_name_nets.README.md
+++ b/crates/konnect-core/tests/fixtures/two_name_nets.README.md
@@ -1,0 +1,93 @@
+# Two-name net fixture
+
+`two_name_nets.kicad_sch` carries one net of every shape that separates a net's
+*identity* from its *name*: rails split across stubs and joined only by a name,
+nets carrying two or three names at once, and an alias sitting on a power
+symbol's own pin.
+
+## Provenance
+
+Built through Konnect against KiCad's stock `Device:`, `Memory_EEPROM:`,
+`Connector:` and `power:` libraries — `batch_place_components`,
+`batch_add_wire`, `add_schematic_net_label`, `add_power_symbol`,
+`batch_add_no_connect` — and then parsed and force-resaved by KiCad 10.0.5:
+
+```text
+kicad-cli sch upgrade --force two_name_nets.kicad_sch
+```
+
+What is committed is that Eeschema serialization: `(generator "eeschema")`,
+`(version 20260306)`, KiCad's own library records, field positions and UUIDs.
+
+One shape had to change to match what KiCad actually honours. Two label objects
+placed at the *exact same coordinate* are not both kept: with `AAA` and `ZZZ`
+stacked at `(55.88, 119.38)`, KiCad left `TP2`'s pin unconnected and netted only
+`TP3`. Moving the second label 2.54 mm along the same wire nets both. The
+co-located case that KiCad *does* honour is a label on a power symbol's own pin,
+which is what `ALT` at `(59.69, 88.9)` is — and it is the one that matters here,
+because Konnect synthesises a power symbol's name as a pseudo-label at exactly
+that point.
+
+## KiCad's own answer
+
+Every expectation below is KiCad's, not this crate's:
+
+```text
+kicad-cli sch export netlist --output two_name_nets.net two_name_nets.kicad_sch
+kicad-cli sch erc --severity-all --format json -o erc.json two_name_nets.kicad_sch
+```
+
+| Net | Pins KiCad resolves | Shape under test |
+|---|---|---|
+| `+3V3` | 5 — U1.8, C1.1, C2.1, TP1.1, TP7.1 | one rail over three stubs: the IC's, the capacitors' + test point, and `TP7` joined only by the `ALT` alias on a power symbol's pin |
+| `RETURN` | 4 — U1.4, C1.2, C2.2, C3.2 | ground named by a global label that outranks its `GND` symbols |
+| `SYS` | 4 — R1.1, R2.1, C3.1, TP6.1 | the pull-up rail, named by a global label over both a `+5V` symbol and a `PULLUP` local label |
+| `/SDA` | 2 — U1.5, R1.2 | pin and pull-up on separate segments, joined by the name |
+| `/SCL` | 2 — U1.6, R2.2 | the same |
+| `/AAA` | 2 — TP2.1, TP3.1 | two locals on one segment plus a disconnected `ZZZ` segment, merged transitively |
+| `/MIX` | 1 — TP4.1 | a local label beside a hierarchical one |
+| `Net-(TP8-Pad1)` | 2 — TP8.1, TP9.1 | a net with no label at all, which KiCad names after a pin |
+
+ERC states the precedence outcomes directly, and they are the table Konnect's
+`driver_priority` encodes — global label > power symbol > local label >
+hierarchical label, ties on the name ascending:
+
+```text
+Both +3V3 and ALT are attached to the same items; +3V3 will be used in the netlist
+Both RETURN and GND are attached to the same items; RETURN will be used in the netlist
+Both SYS and PULLUP are attached to the same items; SYS will be used in the netlist
+Both AAA and ZZZ are attached to the same items; AAA will be used in the netlist
+Both MIX and MIX_H are attached to the same items; MIX will be used in the netlist
+```
+
+The `SYS` net carries three names — the `SYS` global label, the `+5V` power
+symbol and the `PULLUP` local label — and KiCad names it `SYS`, so global
+outranks both of the others on one net.
+
+## What each shape is for
+
+- **Decoupling across stubs.** `U1`'s `VCC` pin and the capacitors `C1`
+  (100 nF) and `C2` (10 µF) share no wire; they share the `+3V3` rail. An audit
+  comparing wire-connected roots alone reports this correctly decoupled IC as
+  undecoupled.
+- **One rail, not three.** Two `+3V3` power symbols and the `VCC`/`ALT` labels
+  name one net. A rail keyed by name, or by unmerged root, is reported two or
+  three times, and every capacitor lands under one of them.
+- **Ground under another name.** `RETURN` wins the name, so a ground skip
+  reading only the winning name reports ground as an undecoupled power rail.
+- **A pull-up hidden by a global.** `SYS` wins the name over `+5V`, so a
+  classifier reading only the winning name does not see a rail there and reports
+  `U1`'s `SDA`/`SCL` pins as missing their pull-ups.
+- **An alias on a power symbol's pin.** `ALT` names the same point as the second
+  `+3V3` symbol. A graph that keeps one name per point drops it and `TP7` never
+  joins the rail.
+- **Deterministic naming.** Five nets carry more than one name; each has exactly
+  one answer, and KiCad's ERC above says which.
+- **A net with no name.** `TP8`–`TP9` carry no label, so a reader collecting
+  nets by name has nothing to collect and drops the wire and both pins.
+
+The three `A0`/`A1`/`A2` pins and `WP` carry no-connect flags; the remaining ERC
+violations are the ones this sheet exists to have — `multiple_net_names` on the
+five two-name nets, `power_pin_not_driven` where no `PWR_FLAG` is placed, and
+`isolated_pin_label` on the labels of `/AAA` and the deliberately one-pin
+`/MIX`.

--- a/crates/konnect-core/tests/fixtures/two_name_nets.kicad_sch
+++ b/crates/konnect-core/tests/fixtures/two_name_nets.kicad_sch
@@ -1,0 +1,3141 @@
+(kicad_sch
+	(version 20260306)
+	(generator "eeschema")
+	(generator_version "10.0")
+	(uuid "e40d0c21-6875-44d1-aadc-a601317144dd")
+	(paper "A4")
+	(lib_symbols
+		(symbol "Connector:TestPoint"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.762)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "TP"
+				(at 0 6.858 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "TestPoint"
+				(at 0 5.08 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 5.08 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 5.08 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "test point"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "test point tp"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "Pin* Test*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "TestPoint_0_1"
+				(circle
+					(center 0 3.302)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "TestPoint_1_1"
+				(pin passive line
+					(at 0 0 90)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:C"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C"
+				(at 0.635 -2.54 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Unpolarized capacitor"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "C_*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "C_0_1"
+				(polyline
+					(pts
+						(xy -2.032 0.762) (xy 2.032 0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 -0.762) (xy 2.032 -0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Memory_EEPROM:24LC256"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "U"
+				(at -6.35 6.35 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "24LC256"
+				(at 1.27 6.35 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" "http://ww1.microchip.com/downloads/en/devicedoc/21203m.pdf"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "I2C Serial EEPROM, 256Kb, DIP-8/SOIC-8/TSSOP-8/DFN-8"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "I2C Serial EEPROM"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "DIP*W7.62mm* SOIC*3.9x4.9mm* TSSOP*4.4x3mm*P0.65mm* DFN*3x2mm*P0.5mm*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "24LC256_1_1"
+				(rectangle
+					(start -7.62 5.08)
+					(end 7.62 -5.08)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(pin input line
+					(at -10.16 2.54 0)
+					(length 2.54)
+					(name "A0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -10.16 0 0)
+					(length 2.54)
+					(name "A1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -10.16 -2.54 0)
+					(length 2.54)
+					(name "A2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -7.62 90)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 10.16 2.54 180)
+					(length 2.54)
+					(name "SDA"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 10.16 0 180)
+					(length 2.54)
+					(name "SCL"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 10.16 -2.54 180)
+					(length 2.54)
+					(name "WP"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 7.62 270)
+					(length 2.54)
+					(name "VCC"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:+3V3"
+			(power global)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -3.81 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "+3V3"
+				(at 0 3.556 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"+3V3\""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "+3V3_0_1"
+				(polyline
+					(pts
+						(xy -0.762 1.27) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy 0.762 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "+3V3_1_1"
+				(pin power_in line
+					(at 0 0 90)
+					(length 0)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:+5V"
+			(power global)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -3.81 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "+5V"
+				(at 0 3.556 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"+5V\""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "+5V_0_1"
+				(polyline
+					(pts
+						(xy -0.762 1.27) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy 0.762 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "+5V_1_1"
+				(pin power_in line
+					(at 0 0 90)
+					(length 0)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:GND"
+			(power global)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "GND"
+				(at 0 -3.81 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "GND_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GND_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(junction
+		(at 167.64 52.07)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0d5add5d-7a52-416b-a640-df6504581089")
+	)
+	(junction
+		(at 190.5 52.07)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "17ad685e-0848-48d8-8c6f-00d875193fec")
+	)
+	(junction
+		(at 175.26 52.07)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1aae590a-d020-41e3-b015-389a77b4e27c")
+	)
+	(junction
+		(at 74.93 92.71)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "892bf4e6-3838-47fe-947b-03f7366023e0")
+	)
+	(no_connect
+		(at 120.65 82.55)
+		(uuid "1b509318-c998-45aa-a8ce-df12201d4a86")
+	)
+	(no_connect
+		(at 100.33 77.47)
+		(uuid "3b0a6ae4-0c3d-439c-87ef-e127c95e8fca")
+	)
+	(no_connect
+		(at 100.33 82.55)
+		(uuid "be4d0c1a-a668-4581-886c-64e80f171c3a")
+	)
+	(no_connect
+		(at 100.33 80.01)
+		(uuid "f9c78bfb-0f8f-40f3-889f-f100520d5fce")
+	)
+	(wire
+		(pts
+			(xy 59.69 96.52) (xy 59.69 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "03d48337-dbe2-4388-8df7-3bafb388d98d")
+	)
+	(wire
+		(pts
+			(xy 160.02 52.07) (xy 199.39 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "06875c00-4b01-4580-8d51-21437ef591cf")
+	)
+	(wire
+		(pts
+			(xy 59.69 92.71) (xy 59.69 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0946cc9d-b507-4996-bb4b-56410451fcb9")
+	)
+	(wire
+		(pts
+			(xy 190.5 62.23) (xy 190.5 66.04)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "14dbb418-5bdb-4277-becc-af1e6d0be956")
+	)
+	(wire
+		(pts
+			(xy 80.01 119.38) (xy 91.44 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "16b787b2-7a0f-4df8-9a1e-9081d22e202a")
+	)
+	(wire
+		(pts
+			(xy 74.93 104.14) (xy 74.93 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1c0aa731-595c-4471-88a3-d155a55c41f8")
+	)
+	(wire
+		(pts
+			(xy 74.93 96.52) (xy 74.93 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2c24e837-4310-48ed-a96e-952240101b88")
+	)
+	(wire
+		(pts
+			(xy 110.49 87.63) (xy 110.49 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "46875e96-852c-4d15-aa86-a44ea521cbb5")
+	)
+	(wire
+		(pts
+			(xy 160.02 55.88) (xy 160.02 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4c5b7610-77ba-429b-a646-087f4161f1f5")
+	)
+	(wire
+		(pts
+			(xy 59.69 92.71) (xy 90.17 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "62ae4b9d-b3d4-4615-911b-152a14032dad")
+	)
+	(wire
+		(pts
+			(xy 90.17 95.25) (xy 90.17 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "69539073-a898-4e11-8625-8c63f59ae5e1")
+	)
+	(wire
+		(pts
+			(xy 120.65 80.01) (xy 130.81 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "74871579-cbf9-41ea-aef5-bc67b187391c")
+	)
+	(wire
+		(pts
+			(xy 120.65 77.47) (xy 130.81 77.47)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7547389a-ee2e-4efa-93f2-d8b601c9cd23")
+	)
+	(wire
+		(pts
+			(xy 175.26 55.88) (xy 175.26 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8eac7063-c596-4fc1-be69-19f71c56b5f1")
+	)
+	(wire
+		(pts
+			(xy 110.49 119.38) (xy 121.92 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d2bbe8f-525e-433a-8f76-78aa71f946e8")
+	)
+	(wire
+		(pts
+			(xy 59.69 104.14) (xy 59.69 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a183817c-6c9c-48f3-b833-47e6f17e0471")
+	)
+	(wire
+		(pts
+			(xy 190.5 54.61) (xy 190.5 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a47aa308-459e-47e0-831f-0d0513ca334d")
+	)
+	(wire
+		(pts
+			(xy 160.02 63.5) (xy 160.02 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "acf1a306-c428-4937-8f0a-9603f5bace90")
+	)
+	(wire
+		(pts
+			(xy 175.26 63.5) (xy 175.26 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c4c6b953-0a21-4ec8-991a-a3781f1676bf")
+	)
+	(wire
+		(pts
+			(xy 167.64 52.07) (xy 167.64 46.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cea9d8d9-fa51-4126-824d-71b20b0eaa0b")
+	)
+	(wire
+		(pts
+			(xy 49.53 119.38) (xy 60.96 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dafe558a-b4cd-486b-a5a5-6495707dc0e3")
+	)
+	(wire
+		(pts
+			(xy 110.49 72.39) (xy 110.49 66.04)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "db420fda-ff67-4cd4-82ae-aad5ec051ee7")
+	)
+	(wire
+		(pts
+			(xy 30.48 129.54) (xy 59.69 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e5c1370e-3665-4c2e-a7c1-f04653c256ba")
+	)
+	(wire
+		(pts
+			(xy 30.48 88.9) (xy 41.91 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ede482e6-5ef4-4315-8225-ff9ecac76233")
+	)
+	(label "AAA"
+		(at 55.88 119.38 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "06aae51d-ad92-45a3-ab6b-a2934ec12f2a")
+	)
+	(label "ALT"
+		(at 59.69 88.9 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "15de34f4-cedd-40a3-9159-f3eff2ac13bb")
+	)
+	(label "SDA"
+		(at 128.27 77.47 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "35064194-a7cb-4fcc-b60a-539f8e03bbbc")
+	)
+	(label "SCL"
+		(at 128.27 80.01 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "3893093c-b550-492c-80fd-10739f176fb5")
+	)
+	(label "ZZZ"
+		(at 85.09 119.38 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "5990e890-7fcd-4caf-ac60-269b1b5f7d3e")
+	)
+	(label "ALT"
+		(at 35.56 88.9 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "849c7341-fc4a-4c95-a59f-68f8994893f5")
+	)
+	(label "SDA"
+		(at 160.02 66.04 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "8a222e21-42d9-4588-bafd-c4947977eed0")
+	)
+	(label "PULLUP"
+		(at 182.88 52.07 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "9724b793-eefa-47df-a8b9-9c0dc04b968f")
+	)
+	(label "MIX"
+		(at 115.57 119.38 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "a102cfc5-873d-4e3d-b1ba-a697aa9366ca")
+	)
+	(label "VCC"
+		(at 110.49 69.85 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "ab408dff-d6ba-43fb-abfa-bfff6771323d")
+	)
+	(label "ZZZ"
+		(at 58.42 119.38 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "b6d04cca-e63c-4dab-aa7b-48bc7b576c07")
+	)
+	(label "SCL"
+		(at 175.26 66.04 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "f7a3ae8e-998e-4051-990b-eda340b2e7de")
+	)
+	(global_label "SYS"
+		(shape input)
+		(at 167.64 49.53 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "821185fe-9fdd-4020-a37c-7b17c7a5d1ef")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 167.64 49.53 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+	)
+	(global_label "RETURN"
+		(shape input)
+		(at 110.49 90.17 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "c8e4d402-48cc-4823-9cc2-f7275f5e2973")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 110.49 90.17 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+	)
+	(hierarchical_label "MIX_H"
+		(shape input)
+		(at 118.11 119.38 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f9df2d51-8230-4a59-b15b-468f176904ac")
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 74.93 100.33 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "04d4d439-6c28-4d9f-a89c-2402705aa7fe")
+		(property "Reference" "C2"
+			(at 75.565 97.79 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "10uF"
+			(at 75.565 102.87 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 74.93 100.33 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 74.93 100.33 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 74.93 100.33 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "34f35bd6-2879-4256-abe7-0fb7155b3157")
+		)
+		(pin "1"
+			(uuid "5eedafcc-f7da-430e-af7f-e9529e8ad14d")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "C2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 190.5 66.04 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "09feea4b-574c-47bd-900e-519d4f61024d")
+		(property "Reference" "#PWR006"
+			(at 190.5 72.39 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 190.5 69.85 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 190.5 66.04 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 190.5 66.04 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 190.5 66.04 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "8a429218-f5bd-48b3-91d3-053057c82376")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "#PWR006")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+3V3")
+		(at 59.69 88.9 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "0c8ede1b-ae22-4096-8381-0069e27ad000")
+		(property "Reference" "#PWR002"
+			(at 59.69 92.71 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 59.69 85.344 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 59.69 88.9 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 59.69 88.9 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 59.69 88.9 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "9b52d1de-a8be-42fe-896e-2fbe35abd6c0")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "#PWR002")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 74.93 107.95 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "2ea33046-1a5b-47e1-9a81-b7edf3415d15")
+		(property "Reference" "#PWR004"
+			(at 74.93 114.3 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 74.93 111.76 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 74.93 107.95 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 74.93 107.95 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 74.93 107.95 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "e522a082-8354-4635-8ce0-43dc1845fd13")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "#PWR004")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 59.69 107.95 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "410712c6-9101-48ba-bde9-add556d0b3a6")
+		(property "Reference" "#PWR003"
+			(at 59.69 114.3 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 59.69 111.76 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 59.69 107.95 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 59.69 107.95 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 59.69 107.95 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "3f78a00b-f4b5-4538-83fb-bdbf78a343db")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "#PWR003")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 90.17 95.25 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "501eecff-ecb2-43be-aee8-933a9bfb5ab9")
+		(property "Reference" "TP1"
+			(at 90.17 88.392 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "TestPoint"
+			(at 90.17 90.17 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 90.17 95.25 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 90.17 95.25 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 90.17 95.25 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "13cabb94-48d5-4214-a5ab-9a3ce82a9a68")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "TP1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Memory_EEPROM:24LC256")
+		(at 110.49 80.01 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "58536fb6-3e9d-4e3e-93bb-baffe8540b40")
+		(property "Reference" "U1"
+			(at 104.14 73.66 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "24LC256"
+			(at 111.76 73.66 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 110.49 80.01 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 110.49 80.01 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 110.49 80.01 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "bb70b437-caf7-4192-8452-0fc7a8fc99c8")
+		)
+		(pin "4"
+			(uuid "a3d9ba9a-a1ab-459d-8525-c8bf4b275110")
+		)
+		(pin "2"
+			(uuid "6ccf5fca-393c-41ee-a0b1-6c9a0fcb8a35")
+		)
+		(pin "8"
+			(uuid "6622ef95-afd8-4908-a717-34a96f73f393")
+		)
+		(pin "3"
+			(uuid "aef8aa5c-b867-4b9b-805f-a1f0ca78383c")
+		)
+		(pin "5"
+			(uuid "70cd1964-8932-464d-aca7-cb380c1386e9")
+		)
+		(pin "6"
+			(uuid "f1f57ab4-7713-47f2-b81d-878b15be27ad")
+		)
+		(pin "7"
+			(uuid "aa3db612-c358-4adb-815a-a98848542599")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "U1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 160.02 59.69 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "612e681b-a078-4b71-9aeb-e130a436a7c6")
+		(property "Reference" "R1"
+			(at 162.052 59.69 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4.7k"
+			(at 160.02 59.69 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 59.69 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 160.02 59.69 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 59.69 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "c4a4eb80-caad-429e-af7d-f880ad4220c4")
+		)
+		(pin "1"
+			(uuid "4c4e3049-a842-4037-a7b9-4cb749547c71")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "R1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 167.64 46.99 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "727c29aa-8073-4e5c-ae0f-881d719b33c2")
+		(property "Reference" "#PWR007"
+			(at 167.64 50.8 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+5V"
+			(at 167.64 43.434 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 167.64 46.99 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 167.64 46.99 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 167.64 46.99 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "a83bba9b-cab2-43ab-b1a5-944e3df8c40a")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "#PWR007")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 190.5 58.42 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "8f90c161-571a-4148-83de-720e93d82317")
+		(property "Reference" "C3"
+			(at 191.135 55.88 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "10uF"
+			(at 191.135 60.96 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 190.5 58.42 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 190.5 58.42 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 190.5 58.42 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "e973cfb9-c33f-4444-a44e-90b2cbb4f3e5")
+		)
+		(pin "1"
+			(uuid "a2d8a871-e257-4d90-906d-c702db637fd6")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "C3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 199.39 52.07 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "94b0a9fc-7cb3-4673-9b7e-b280fdf72071")
+		(property "Reference" "TP6"
+			(at 199.39 45.212 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "TestPoint"
+			(at 199.39 46.99 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 199.39 52.07 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 199.39 52.07 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 199.39 52.07 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "9edfbb66-652b-4461-ae98-15c4fe4cab74")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "TP6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 80.01 119.38 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "aae25c7b-d838-4ac6-8d7a-4ae44d2c1e7d")
+		(property "Reference" "TP3"
+			(at 80.01 112.522 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "TestPoint"
+			(at 80.01 114.3 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 80.01 119.38 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 80.01 119.38 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 80.01 119.38 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d6b35401-98eb-44c2-844d-80a9b9d334bf")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "TP3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 49.53 119.38 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "b7e82b2d-42ad-433c-87e8-300de0b3de1f")
+		(property "Reference" "TP2"
+			(at 49.53 112.522 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "TestPoint"
+			(at 49.53 114.3 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 49.53 119.38 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 49.53 119.38 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 49.53 119.38 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "66bb467b-78a5-4357-bd45-87410fab4032")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "TP2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 30.48 129.54 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "bc1f222e-994f-403b-99ea-ae131ab6695b")
+		(property "Reference" "TP8"
+			(at 30.48 122.682 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "TestPoint"
+			(at 30.48 124.46 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 30.48 129.54 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 30.48 129.54 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 30.48 129.54 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "50426fd9-bb4b-49e9-acdf-4fe44dfc4fb3")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "TP8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 175.26 59.69 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "c222e567-3011-43b0-9d41-843f2443bc1e")
+		(property "Reference" "R2"
+			(at 177.292 59.69 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4.7k"
+			(at 175.26 59.69 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 175.26 59.69 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 175.26 59.69 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 59.69 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "0d3240a2-0349-4652-ade6-ae2306eb799b")
+		)
+		(pin "2"
+			(uuid "6a0dff6f-617d-4679-8160-478c9804f34b")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "R2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 59.69 100.33 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "c7a1f90e-ecee-42d5-bdb2-52e0356e1786")
+		(property "Reference" "C1"
+			(at 60.325 97.79 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 60.325 102.87 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 59.69 100.33 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 59.69 100.33 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 59.69 100.33 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "d0b3a9c3-8329-4ca4-90fc-a0cadf2df9c8")
+		)
+		(pin "1"
+			(uuid "98ec8e14-451b-4f61-b479-d5301590ead2")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "C1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 30.48 88.9 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "d5d12f52-dc7b-491e-a827-aab0eb3a7e7f")
+		(property "Reference" "TP7"
+			(at 30.48 82.042 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "TestPoint"
+			(at 30.48 83.82 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 30.48 88.9 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 30.48 88.9 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 30.48 88.9 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d288be88-592b-475b-a6d3-7de718ca8b5d")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "TP7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 59.69 129.54 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "e2e5d84b-da96-40e0-80bc-2adac4c82c0c")
+		(property "Reference" "TP9"
+			(at 59.69 122.682 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "TestPoint"
+			(at 59.69 124.46 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 59.69 129.54 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 59.69 129.54 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 59.69 129.54 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "789df981-513a-4532-a747-b341e63bb51f")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "TP9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 110.49 119.38 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "f01bf14e-27ea-4226-ae99-6423644275f4")
+		(property "Reference" "TP4"
+			(at 110.49 112.522 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "TestPoint"
+			(at 110.49 114.3 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 110.49 119.38 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 110.49 119.38 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 110.49 119.38 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d86c21de-9245-4768-95e2-cad8b022e2fc")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "TP4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+3V3")
+		(at 110.49 66.04 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "f3a99d3d-8f8f-4490-bfb3-b7f566acffc0")
+		(property "Reference" "#PWR001"
+			(at 110.49 69.85 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+3V3"
+			(at 110.49 62.484 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 110.49 66.04 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 110.49 66.04 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 110.49 66.04 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "468b3778-35f4-4b24-bebc-6be028390f61")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "#PWR001")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 110.49 92.71 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "fcc6747e-4d62-4f96-955a-0b67b347edff")
+		(property "Reference" "#PWR005"
+			(at 110.49 99.06 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 110.49 96.52 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 110.49 92.71 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 110.49 92.71 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 110.49 92.71 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "a3d56c8a-0dba-4d15-8b3e-d7f0561063c1")
+		)
+		(instances
+			(project "two_name_nets"
+				(path "/e40d0c21-6875-44d1-aadc-a601317144dd"
+					(reference "#PWR005")
+					(unit 1)
+				)
+			)
+		)
+	)
+)

--- a/crates/konnect-sexp/src/schematic.rs
+++ b/crates/konnect-sexp/src/schematic.rs
@@ -150,7 +150,7 @@ fn at_positions(nodes: Vec<&SexpNode>) -> Vec<(f64, f64)> {
 
 // ─── Net label ────────────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LabelKind {
     NetLabel,
     GlobalLabel,
@@ -212,7 +212,7 @@ pub fn extract_labels(tree: &SexpNode) -> Vec<Label> {
                 .and_then(|u| u.as_str())
                 .map(String::from);
             labels.push(Label {
-                kind: kind.clone(),
+                kind: *kind,
                 net,
                 x,
                 y,

--- a/docs/API_MIGRATIONS.md
+++ b/docs/API_MIGRATIONS.md
@@ -227,6 +227,61 @@ count rather than a substring count clamped to a minimum of two; a board with
 no `(layers …)` table reports `0` and a warning rather than an invented `2`.
 `validate_for_manufacturing`'s `board_info.copper_layers` changes value on any
 board with non-`signal` copper; its shape is unchanged.
+## Unreleased: schematic nets resolve by identity (minor release)
+
+One electrical net can carry several names — a rail named by a `+3V3` power
+symbol that also has a `VCC` label, a local label on a net that also carries a
+global one — and KiCad nets a sheet by name as well as by wire, so two segments
+each carrying a `SIG` label are one net. The shared net graph now joins
+same-named points, and every audit compares net *identity* rather than a net
+name. Where a name is reported it is the one KiCad's netlister would choose:
+global label, then power symbol, then local label, then hierarchical label,
+ties broken on the name ascending.
+
+Two response shapes change meaning:
+
+- `audit_power_rails.power_nets` lists one entry per **net**, named the way
+  KiCad names it. It previously listed one entry per name, so a rail named by
+  both a power symbol and a label appeared twice, as did a rail named by two
+  power symbols on separate stubs. `summary`'s rail count follows. A consumer
+  counting rails gets a smaller, truer number; one matching a specific string
+  should match the KiCad name, since an alias may no longer appear.
+- `get_connected_items.nets` is sorted and deduplicated, where it was in
+  `HashSet` order. Its `labels` array now carries every label on the queried
+  component's nets rather than only those spelling a net its winning way, and
+  its `wires`/`connected_components` now include items on a net that carries no
+  label at all, which were omitted entirely.
+
+Two more tools change what they report, through the shared graph rather than
+through any code of their own:
+
+- `find_shorted_nets` keys off the same label-to-root relation, so a net
+  carrying more than one name is now reported as a short. On a sheet where a
+  rail is named by a power symbol and labelled for readability, that is a new
+  finding per such net — five on this change's own fixture (`+3V3`/`ALT`/`VCC`,
+  `RETURN`/`GND`, `SYS`/`+5V`/`PULLUP`, `AAA`/`ZZZ`, `MIX`/`MIX_H`), reported as
+  one group per net rather than one per pair. It is the same condition KiCad's
+  own ERC reports as `multiple_net_names`, and the tool description now says so.
+- `points_on_net(name)` resolves the whole merged net, so `get_net_components`,
+  `get_net_connections` and `count_net_connections` return the complete net for
+  any name on it. Querying an alias — `VCC` on a rail KiCad calls `+3V3` —
+  returns everything on that rail rather than the segment the alias sits on.
+
+Findings change with them, in the direction of fewer false positives:
+`audit_decoupling`, `audit_power_rails` and `audit_connections` no longer report
+a decoupled rail as undecoupled, a rail twice, or a fitted pull-up as missing
+when the capacitor or resistor sits on another segment of the same net. The
+ground skips read every name on a rail, so a `GND` net that a global label
+renames is skipped rather than reported as an undecoupled power rail.
+
+`net_at`-backed reporting — `get_pin_net`, `get_component_nets`,
+`trace_from_point`, `export_netlist_summary` — returns a stable name across
+processes. For a net with one name the answer is unchanged; for a net with
+several, callers that happened to see an alias now always see the KiCad name.
+
+No tool, argument, or response field was renamed or removed. These changes are
+planned for the next minor release.
+
 ## Unreleased: `find_single_pin_nets` counts pins, not labels (minor release)
 
 `find_single_pin_nets` counted label instances per net name, so an ordinary net

--- a/tool-directory.md
+++ b/tool-directory.md
@@ -168,7 +168,7 @@ and Windows servers do not.
 | `get_net_components` | Get all components (and their pins) connected to a named net. |
 | `trace_from_point` | Trace connectivity from any (X,Y) point — returns what is at that point and the net it belongs to. |
 | `find_orphan_items` | Find dangling wire ends, floating labels, and unconnected pin endpoints. Pins, sheet pins, junctions, and no-connect flags all count as connections. |
-| `find_shorted_nets` | Detect accidentally merged nets — pairs of distinct net names sharing a wire path. |
+| `find_shorted_nets` | Detect accidentally merged nets — distinct net names that KiCad nets together, through a wire path they share or through a name that joins their segments. |
 | `find_single_pin_nets` | Find nets that reach at most one pin — often a missing counterpart, an orphan label, or a stub left by a deleted component. Component pins and hierarchical sheet pins count; a power symbol's own pin names the rail rather than consuming it and does not. Reports the pin and label counts, and every label kind that named the net. Read per sheet: a net a global, hierarchical or power label can carry off this one is flagged cross_sheet_unverified. |
 | `get_connected_items` | Get all wires, labels, and components connected to a given component by tracing each of its pins. |
 | `check_schematic_overlaps` | Find collisions using transformed symbol drawings and pins (excluding free text), with a reported origin fallback when geometry is unavailable. |


### PR DESCRIPTION
Closes #510.

## The bug

One electrical net can carry several names — a rail named by a `+3V3` power symbol that also has a `VCC` label on it, a local label on a net that also carries a global one. `NetGraph::net_at` answered "what net is at this point" by returning the first `point_nets` entry whose root matched, which is `HashMap` iteration order. The name therefore moved between runs of the same binary.

The audits then compared nets by that name where they meant identity. `collect_power_nets` listed **both** names as rails while every capacitor resolved to one of them, so the other was reported as an `error`-severity rail with no decoupling — a false finding on a correctly decoupled rail, landing on a different name run to run:

```
run 1  error: Power rail '+3V3' has no decoupling capacitors
run 2  error: Power rail '+3V3' has no decoupling capacitors
run 3  error: Power rail 'VCC'  has no decoupling capacitors
```

`audit_connections` had it too, via `pull_up_nets`, and `get_connected_items` filtered labels by name.

## The fix

**Identity, from `root_at`.** The audits and `get_connected_items` compare graph roots. One rail per net rather than per name; the capacitor, bulk-capacitor, test-point and pull-up sets are the roots pins reach.

**A root had to mean what KiCad means by a net first.** `seed_net_graph` joined points by geometry alone — wires, junctions, and labels lying on them — so two segments each carrying a `SIG` label were two roots, and every `GND` symbol on a sheet was its own rail. Nothing had depended on that: `points_on_net` pools by name, and `find_single_pin_nets` pools the roots a name reaches. Comparing roots as identity is what makes it matter, and without the merge it breaks the ordinary sheet — a decoupling capacitor is normally drawn on its own stub with its own `+3V3` symbol and shares no wire with the pin it decouples. `merge_named_nets` unions the points that share a name, after the geometry and before the naming.

**`name_of_root` gives KiCad's name,** not the map's first answer. The precedence was measured against KiCad 10.0.5 by netlisting one net carrying each pair, not assumed:

| net carries | KiCad calls it |
|---|---|
| `+3V3` power symbol + `LOCAL_VCC` label | `+3V3` |
| `+3V3` power symbol + `GLOBAL_SYS` global label | `GLOBAL_SYS` |
| `LOCAL_VCC` label + `GLOBAL_SYS` global label | `GLOBAL_SYS` |
| `LOCAL_VCC` label + `HIER_H` hierarchical label | `LOCAL_VCC` |
| `LOCAL_VCC` and `ZZZ` labels; `LOCAL_VCC` and `AAA` | `LOCAL_VCC`; `AAA` |

Global > power symbol > local > hierarchical, ties on the name ascending — `CONNECTION_SUBGRAPH`'s driver priority. A power symbol outranking a local label is why a label cannot rename a rail.

Names now resolve per root once seeding finishes, so `net_at`'s per-query clone of every key and every net-name `String` is gone. Every `NetGraph` mutator is private, so the resolved names cannot go stale behind a later union.

## Also fixed on the way

- **The ground skips in `audit_power_rails` read only the winning name.** A `GND` net that also carries a global label — globals outrank power symbols — escaped the skip and was reported as an undecoupled power rail. A `PowerRail` now carries every name on its net and the skips read all of them.
- **`get_connected_items` keyed everything by name.** On a two-name net it dropped the labels spelling the net its other way, and a net with **no** label contributed no points at all, so the wires and components on it went unreported. It collects roots, filters labels through `label_roots`, and takes points from one `points_on_roots` walk instead of one per name. `nets` still reports names, now sorted rather than in `HashSet` order.

## Behaviour changes visible to callers

- `audit_power_rails`' `power_nets` lists one entry per net instead of one per name, under the name KiCad would print; the `summary` count follows.
- `get_connected_items`' `nets` array is sorted and deduplicated.
- Tools reading `net_at` — `get_pin_net`, `get_component_nets`, `trace_from_point`, `export_netlist_summary` — return a stable name where the answer previously varied between processes.

## Verification

Nine new tests, each confirmed to fail against the code they guard:

- precedence for all five pairs above, twenty graph builds per case so an order-dependent answer cannot pass by luck
- both names of a net share one root
- two segments of one name are one net; two `+3V3` power symbols are one rail
- a capacitor on its own rail stub decouples the pin (1/1 power pins pass, zero findings)
- a rail named twice is audited as one rail, with no duplicate findings
- a pull-up on another segment of the net is found, so a fitted pull-up is not reported missing
- a component on another segment of the same net is reported as connected
- every label on a net is reported, and an unnamed net still reports its wire

Full local gate on this branch against current `main`: `cargo test --workspace --locked --lib --tests`, `--doc`, `cargo clippy --workspace --locked -- -D warnings`, `cargo fmt --all -- --check`, plus `crates/schematic-viewer`'s own tests, since `konnect-sexp` is touched (`LabelKind` gains `Copy`/`Eq`).

## Compatibility

`docs/API_MIGRATIONS.md` carries an entry for this under **Unreleased: schematic nets resolve by identity (minor release)**. Two response shapes change meaning — `audit_power_rails.power_nets` (one entry per net rather than per name) and `get_connected_items.nets` (sorted and deduplicated, with labels and unnamed-net items no longer dropped) — and findings move in the direction of fewer false positives. No tool, argument, or response field is renamed or removed.

`find_shorted_nets`' description is corrected in the tool schema and `tool-directory.md`: with same-named segments joined, two names can be netted together through a name rather than only through a wire path they share.

## Rollback

`git revert` of the single commit. It restores the name-based comparisons and the nondeterministic `net_at`; nothing persisted needs undoing and no caller state migrates either way.

## Known limitation

`find_shorted_nets` still reports two names on one net as a short, which on a rail named by a power symbol and labelled for readability is a false positive. That tool is a deliberate "two names met" report rather than a naming question, so it is left as it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
