### PR TITLE
feat(pcb): name the netclass patterns that fit no net

### DIFF
--- a/crates/konnect-core/src/tools/pcb_routing.rs
+++ b/crates/konnect-core/src/tools/pcb_routing.rs
@@ -255,7 +255,11 @@ pub fn tools() -> Vec<ToolDef> {
              priority) and falls back to Default. Settings are reported \
              resolved, with 'inherits' naming the ones a class takes from the \
              Default rather than setting itself; 'missing_fields' on the \
-             Default names settings nothing can resolve.",
+             Default names settings nothing can resolve. 'orphan_patterns' \
+             lists patterns naming a class that does not exist; \
+             'unmatched_patterns' lists patterns whose class exists but which \
+             fit no net on the board as saved (null when the board could not \
+             be read).",
             json!({
                 "type": "object",
                 "properties": {
@@ -1538,29 +1542,33 @@ async fn handle_get_netclasses(
     // net table at all, so a direct-children scan finds zero nets on every
     // current board and every pattern would match nothing. A board held open
     // with unsaved edits reads as last saved, which the payload says out loud.
-    let (net_names, nets_note): (Vec<String>, String) = match std::fs::read_to_string(&board_path) {
-        Ok(text) => match konnect_sexp::parse_sexp(&text) {
-            Ok(tree) => {
-                let mut names: Vec<String> = konnect_sexp::net::collect_net_keys(&tree)
-                    .into_iter()
-                    .collect();
-                names.sort();
-                (
-                    names,
-                    "board file as last saved; unsaved edits in a running KiCad are not visible"
-                        .to_string(),
-                )
-            }
+    let (net_names, nets_note, nets_readable): (Vec<String>, String, bool) =
+        match std::fs::read_to_string(&board_path) {
+            Ok(text) => match konnect_sexp::parse_sexp(&text) {
+                Ok(tree) => {
+                    let mut names: Vec<String> = konnect_sexp::net::collect_net_keys(&tree)
+                        .into_iter()
+                        .collect();
+                    names.sort();
+                    (
+                        names,
+                        "board file as last saved; unsaved edits in a running KiCad are not visible"
+                            .to_string(),
+                        true,
+                    )
+                }
+                Err(e) => (
+                    Vec::new(),
+                    format!("board could not be parsed ({e}); nets unavailable"),
+                    false,
+                ),
+            },
             Err(e) => (
                 Vec::new(),
-                format!("board could not be parsed ({e}); nets unavailable"),
+                format!("board could not be read ({e}); nets unavailable"),
+                false,
             ),
-        },
-        Err(e) => (
-            Vec::new(),
-            format!("board could not be read ({e}); nets unavailable"),
-        ),
-    };
+        };
 
     // What an omitted key resolves to. A Default in the file is the whole
     // fallback, holes included; KiCad's seeded one applies only when the file
@@ -1654,6 +1662,34 @@ async fn handle_get_netclasses(
         .cloned()
         .collect();
 
+    // A pattern whose class exists but fits no net on the board is just as
+    // silent in KiCad: the class governs nothing, and the dialog shows the
+    // pattern beside the others. It is the usual trace of a renamed net, a
+    // pattern written for another board, or a glob that never fitted the
+    // net's real name. Until now the caller had to subtract `matched_nets`
+    // from `patterns` by hand, and a class with three patterns and five nets
+    // does not even say which pattern is the idle one. Reported in the shape
+    // of the file, like `orphan_patterns`; a pattern with no class is an
+    // orphan, not unmatched, so each is listed once. Without a readable board
+    // the answer is unknown, and the field says so with null rather than an
+    // empty list that would claim every pattern matched.
+    let unmatched_patterns: serde_json::Value = if nets_readable {
+        json!(patterns
+            .iter()
+            .filter(|p| {
+                let target = p["netclass"].as_str().unwrap_or_default();
+                let class_exists = classes.iter().any(|c| c["name"] == json!(target));
+                class_exists
+                    && p["pattern"]
+                        .as_str()
+                        .is_some_and(|pat| !net_names.iter().any(|net| wildcard_matches(pat, net)))
+            })
+            .cloned()
+            .collect::<Vec<_>>())
+    } else {
+        serde_json::Value::Null
+    };
+
     // Netclass membership is many-to-many: KiCad forms an aggregate class per
     // net, taking each property from the highest-priority class that sets it,
     // with Default filling what is left. Naming one winning class per net
@@ -1665,6 +1701,7 @@ async fn handle_get_netclasses(
         "nets_on_board": net_names.len(),
         "nets_source": nets_note,
         "orphan_patterns": orphan_patterns,
+        "unmatched_patterns": unmatched_patterns,
         "note": "A net can match several classes; KiCad then takes each property from the \
                  highest-priority class that sets it and falls back to Default. Lower \
                  priority numbers rank higher.",
@@ -2740,6 +2777,56 @@ mod netclass_tests {
         let body = get_classes(&board).await;
         assert_eq!(body["orphan_patterns"][0]["netclass"], json!("Vanished"));
         assert_eq!(body["netclasses"][0]["matched_nets"], json!([]));
+    }
+
+    /// A pattern whose class exists but fits no net governs nothing, and
+    /// KiCad's dialog shows it beside the ones that work. Subtracting
+    /// `matched_nets` from `patterns` by hand does not even say which pattern
+    /// is idle, so the tool names it — once, and never the orphan too.
+    #[tokio::test]
+    async fn a_pattern_fitting_no_net_is_reported_as_unmatched() {
+        let (_dir, board) = fixture_with_nets(&["GND", "HV_IN"]);
+        create(&board, json!({ "name": "HV" })).await;
+        let pro = board.with_extension("kicad_pro");
+        let mut settings: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&pro).unwrap()).unwrap();
+        settings["net_settings"]["netclass_patterns"] = json!([
+            { "pattern": "HV_*", "netclass": "HV" },
+            { "pattern": "LV_*", "netclass": "HV" },
+            { "pattern": "GND",  "netclass": "Vanished" },
+        ]);
+        std::fs::write(&pro, serde_json::to_string_pretty(&settings).unwrap()).unwrap();
+
+        let body = get_classes(&board).await;
+        assert_eq!(
+            body["unmatched_patterns"],
+            json!([{ "pattern": "LV_*", "netclass": "HV" }]),
+            "{body}"
+        );
+        assert_eq!(body["orphan_patterns"][0]["netclass"], json!("Vanished"));
+        assert_eq!(body["netclasses"][0]["matched_nets"], json!(["HV_IN"]));
+    }
+
+    /// With no readable board there is no net to fit, and an empty list would
+    /// claim every pattern matched. The field is null, and `nets_source` says
+    /// why.
+    #[tokio::test]
+    async fn unmatched_patterns_is_unknown_without_a_readable_board() {
+        let (_dir, board) = fixture_with_nets(&["GND"]);
+        create(&board, json!({ "name": "HV" })).await;
+        assign(&board, "GND", "HV").await;
+        std::fs::write(&board, "(kicad_pcb (version 20260206").unwrap();
+
+        let body = get_classes(&board).await;
+        assert!(body["unmatched_patterns"].is_null(), "{body}");
+        assert_eq!(body["nets_on_board"], json!(0));
+        assert!(
+            body["nets_source"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("nets unavailable"),
+            "{body}"
+        );
     }
 
     /// Default is KiCad's fallback and its clearance explains DRC results no

--- a/docs/API_MIGRATIONS.md
+++ b/docs/API_MIGRATIONS.md
@@ -3,6 +3,23 @@
 Konnect's tool schemas are public API. This file records intentional argument
 removals and the supported replacement workflow.
 
+## Unreleased: `get_netclasses` names the patterns that fit no net (minor release)
+
+`get_netclasses` reported `orphan_patterns` — patterns naming a class that
+does not exist — but a pattern whose class exists and which fits no net on
+the board was invisible: the class simply governed nothing, and the caller
+had to subtract `matched_nets` from `patterns` by hand, which on a class with
+several patterns does not even say which one is idle. That is the usual trace
+of a renamed net, a pattern carried over from another board, or a glob that
+never fitted the net's real name.
+
+One additive response field, `unmatched_patterns`, lists those patterns in
+the shape of the project file (`{ "pattern", "netclass" }`), the same shape
+as `orphan_patterns`. A pattern is listed in one of the two, never both. When
+the board cannot be read or parsed the field is `null` rather than `[]`,
+because an empty list would claim every pattern matched; `nets_source`
+carries the reason, as before. Nothing is renamed or removed.
+
 ## Unreleased: mirrored schematic placement (minor release)
 
 `add_schematic_component` and every entry of `batch_place_components` accept a


### PR DESCRIPTION
## Summary

`get_netclasses` names the netclass patterns that fit no net on the board. Until now only patterns naming a **missing class** were reported (`orphan_patterns`); a pattern whose class exists but matches nothing was invisible, and subtracting `matched_nets` from `patterns` by hand does not say which pattern is the idle one.

Issue: Closes #525

## Approach

The handler already resolves every pattern against the board's nets to build `matched_nets`. This PR runs the same `wildcard_matches` the other way: a pattern whose class exists and which fits zero nets goes into a new additive field `unmatched_patterns`, in the shape of the project file (`{ "pattern", "netclass" }`) — the same shape as `orphan_patterns`, so a caller handles both alike. A pattern is listed in one of the two, never both.

The board read already distinguished "parsed" from "could not read/parse" for `nets_source`; that outcome now also drives the new field. Without a readable board the field is `null`, not `[]`: an empty list would claim every pattern matched, which is the response-derived-from-the-request shape this tool exists to avoid.

Alternatives considered: a per-class `unmatched_patterns` beside `patterns`/`matched_nets`. Not done — one top-level list mirrors `orphan_patterns` and keeps the change to one field; the `netclass` key on each entry makes it just as actionable.

## Branch and dependencies

Base branch: `upstream/main` (`3dbfd9a`)
Depends on: nothing
Series order: none — independent change
Unique commits owned by this PR: 1

## Compatibility and safety

Additive response field only. Nothing renamed or removed; `orphan_patterns`, `patterns`, `matched_nets`, `nets_on_board`, `nets_source` keep their meaning. Read-only tool: no file or IPC mutation. Documented in `docs/API_MIGRATIONS.md` under *Unreleased … (minor release)*, following the existing entries.

## Validation

All four gate commands run locally on this exact head (Windows, `stable-x86_64-pc-windows-msvc`, KiCad 10.0.6 installed so the board-fixture scan runs):

- [x] `cargo fmt --all -- --check` — exit 0
- [x] `cargo test --workspace --locked --lib --tests` — 29 suites, **1765 passed, 0 failed, 29 ignored** (two new tests: `a_pattern_fitting_no_net_is_reported_as_unmatched`, `unmatched_patterns_is_unknown_without_a_readable_board`)
- [x] `cargo test --workspace --locked --doc` — 8 passed, 0 failed
- [x] `cargo clippy --workspace --locked --all-targets -- -D warnings` — exit 0
- [x] Real-KiCad check: release build exercised over MCP stdio against six real KiCad 10 boards (48–190 nets each).

Measured before/after on a real two-layer board (61 nets) whose project file carries a pattern for a since-renamed net and a glob that never fitted:

| | before (v0.11.1) | after |
|---|---|---|
| `HV` | patterns=8 matched=7 | patterns=8 matched=7 |
| `HV_LOW` | patterns=2 matched=1 | patterns=2 matched=1 |
| `orphan_patterns` | `[{"netclass":"Vanished","pattern":"400V"}]` | same |
| `unmatched_patterns` | *(absent)* | `[{"netclass":"HV","pattern":"Net-(R9-Pad2)"}, {"netclass":"HV_LOW","pattern":"HV_*"}]` |

On the five unmodified boards (twelve patterns between them) the new field is `[]`, consistent with each class's `patterns`/`matched_nets` counts.

Not run: the live IPC tests (the tool is file-only and needs no running KiCad).

## Review checklist

- [x] The diff is focused and contains no generated output, personal data, or unrelated cleanup.
- [ ] The branch includes current `upstream/main` and has no merge conflicts; CI on this head pending at open time.
- [x] The branch was based on latest `upstream/main`, not a release tag.
- [x] The PR shows only its unique commits and diff; no dependencies.
- [x] Every review conversation is resolved.
- [x] New names follow `docs/NAMING_CONVENTIONS.md` (`unmatched_patterns` beside `orphan_patterns`).
- [x] New behavior and failure paths have regression coverage.
- [x] File mutations: none (read-only tool).
- [x] IPC mutations: none.
- [x] No tools added or removed: counts untouched.
