### PR TITLE
docs: add interactive architecture diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ The full tool catalog is documented in [tool-directory.md](tool-directory.md).
 | Exports & checks | `kicad-cli` subprocess (Gerber, PDF, ERC, DRC, …) |
 | Transport | MCP JSON-RPC over stdio (default), or Streamable HTTP (`transport = "http"` / `"both"`) |
 
+Explore the request path and safety boundaries in the
+[interactive architecture diagrams](docs/ARCHITECTURE_DIAGRAMS.md). They are
+published from a standalone documentation repository and add no dependencies to
+Konnect.
+
 ## Installation
 
 ### From the KiCAD Plugin Manager (recommended)

--- a/docs/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/ARCHITECTURE_DIAGRAMS.md
@@ -1,0 +1,78 @@
+# Interactive architecture diagrams
+
+These five externally published diagrams provide focused visual explanations of
+Konnect's architecture and safety boundaries:
+
+- [Diagram landing page](https://neusse.github.io/konnect-archify-tool/)
+  provides one index for the complete published set.
+
+- [Runtime architecture](https://neusse.github.io/konnect-archify-tool/konnect-runtime.html)
+  follows an MCP request through dispatch, on-demand tool loading, KiCad
+  mutation backends, and independent command-line checks.
+- [Guarded PCB mutation](https://neusse.github.io/konnect-archify-tool/konnect-guarded-pcb-mutation.html)
+  shows the live IPC path, the bounded closed-board file fallback, and the
+  fail-closed refusal path.
+- [Live PCB tool-call sequence](https://neusse.github.io/konnect-archify-tool/konnect-live-pcb-tool-call.html)
+  traces one request from the MCP client through active-board verification,
+  commit, readback, and return.
+- [Manufacturing evidence flow](https://neusse.github.io/konnect-archify-tool/konnect-manufacturing-evidence.html)
+  separates design sources, ERC/DRC/BOM evidence, the release verdict, package
+  generation, and fabrication-house model review.
+- [Schematic transaction lifecycle](https://neusse.github.io/konnect-archify-tool/konnect-schematic-transaction.html)
+  explains journal-before-write, interruption recovery, divergence, and
+  explicit abandonment.
+
+The links open rendered HTML pages hosted by GitHub Pages. The viewer provides
+light/dark themes, guided views, search, focus, pan/zoom, presentation mode, and
+image export. It may request the JetBrains Mono font from Google Fonts; the
+diagrams remain usable with a fallback font if that request is unavailable.
+
+## Provenance
+
+The five-diagram set was refreshed for the pinned Konnect revision in
+[`neusse/konnect-archify-tool`](https://github.com/neusse/konnect-archify-tool)
+at commit
+[`25c43ad8e9543b99875b3a4bb6708577ecf6cc88`](https://github.com/neusse/konnect-archify-tool/commit/25c43ad8e9543b99875b3a4bb6708577ecf6cc88)
+after reviewing Konnect commit
+[`f0f5ad045c97f02f51d1f54efd3965a1aa4e4215`](https://github.com/mixelpixx/Konnect/commit/f0f5ad045c97f02f51d1f54efd3965a1aa4e4215).
+GitHub Pages publication was introduced at
+[`f931a8243f2dc0276bf364f56c007d9bd81972fc`](https://github.com/neusse/konnect-archify-tool/commit/f931a8243f2dc0276bf364f56c007d9bd81972fc).
+The currently published artifact set, landing page, canonical upstream source
+links, and current Pages workflow are recorded at
+[`8e82e36e45bd28b064dc7aa634640ef53832c63d`](https://github.com/neusse/konnect-archify-tool/commit/8e82e36e45bd28b064dc7aa634640ef53832c63d).
+
+The standalone repository contains the typed sources, pinned Archify v2.16.0
+tooling, validation and delivery receipts, visual evidence, generated HTML, and
+the reusable `konnect-archify-refresh` Codex skill. None of those generated or
+tooling files are copied into Konnect.
+
+The runtime architecture passes Archify's strict browser containment check at
+all tested desktop sizes. The four detailed diagrams retain their raw
+vertical-overflow findings and use a documented readable-scroll baseline; their
+readability, viewer controls, and screenshot captures pass. This is a
+disclosure, not a claim that those raw visual checks passed.
+
+## Maintenance
+
+Regeneration and publication happen in the standalone tool repository. Its
+refresh skill compares the previously pinned Konnect revision with the current
+target, reviews behavior relevant to the five stable reader questions, updates
+the affected typed sources, validates and delivers every artifact, checks
+hashes, and captures light/dark browser evidence. A successful push of delivered
+HTML to its `main` branch publishes the pages through its GitHub Pages workflow.
+
+When updating these links:
+
+1. Run the refresh in `konnect-archify-tool` against the intended Konnect
+   commit.
+2. Review every changed diagram and its visual evidence.
+3. Commit and publish the delivered HTML in that standalone repository.
+4. Verify every public URL returns the refreshed page.
+5. Update the two source revisions above when their content changes.
+
+## Verification boundary
+
+The diagrams document software behavior; they do not replace KiCad rendering,
+ERC, DRC, connectivity inspection, PCB layout-physics review, or manufacturing
+acceptance. A structurally complete package and clean automated checks do not by
+themselves validate fabrication-house component models or physical placement.


### PR DESCRIPTION
## Summary

- add a lightweight Markdown index for five source-backed interactive architecture diagrams
- link the index from the root README
- publish the rendered HTML and a landing page from the standalone `konnect-archify-tool` repository through GitHub Pages
- keep generated HTML, Archify, Node.js, typed sources, screenshots, and receipts out of Konnect

Closes #533

## Issue accounting

- [x] Runtime architecture, guarded PCB mutation, live PCB tool-call sequence, manufacturing evidence flow, and schematic transaction lifecycle are linked.
- [x] The index distinguishes architecture documentation from KiCad/ERC/DRC/manufacturing acceptance evidence.
- [x] The root README links the index.
- [x] No generated HTML, runtime/build dependency, Rust code, tool count, packaging, or runtime behavior is added to Konnect.
- [x] Provenance identifies the five-diagram refresh, current publication, and Konnect source revisions.
- [x] Vertical-scroll limitations and the Google Fonts request are disclosed accurately.
- [x] The PR is one documentation-only commit from current `main`.

## Provenance and publication

- Konnect source revision documented by the diagrams: `f0f5ad045c97f02f51d1f54efd3965a1aa4e4215`
- Five-diagram refresh revision for the pinned Konnect source: `25c43ad8e9543b99875b3a4bb6708577ecf6cc88`
- Pages introduction revision: `f931a8243f2dc0276bf364f56c007d9bd81972fc`
- Current artifact, landing-page, and workflow revision: `8e82e36e45bd28b064dc7aa634640ef53832c63d`
- Standalone repository: https://github.com/neusse/konnect-archify-tool
- Published landing page: https://neusse.github.io/konnect-archify-tool/

The landing page and all five direct diagram URLs return HTTP 200 as `text/html`. Embedded runtime source links identify the canonical `mixelpixx/Konnect` repository at the pinned revision. The Pages workflow uses the current official action majors (`checkout@v7`, `configure-pages@v6`, `upload-pages-artifact@v5`, and `deploy-pages@v5`) and completed successfully.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `cargo test --workspace --locked --lib --tests`
- `cargo test --workspace --locked --doc`
- Archify validation: 9/9 showcase checks, 0 errors, 0 warnings
- runtime visual-check: containment and readability passed at all four tested desktop sizes; four light/dark screenshots inspected
- verified the landing page and all five published URLs return HTTP 200 with an HTML content type
- verified the Konnect diff contains only `README.md` and `docs/ARCHITECTURE_DIAGRAMS.md`
- verified no local absolute paths, generated HTML, credentials, or third-party viewer code enter the Konnect tree

## Known limitations

The diagrams describe Konnect at the pinned source revision, not automatically at the newest `main`. The runtime overview passes the raw one-screen visual gate. The four detailed diagrams intentionally use vertical scrolling to retain readable text; the source repository preserves those raw visual-check failures and the accepted readable-scroll evidence.

The diagrams document architecture and evidence flow. They do not replace KiCad rendering, ERC, DRC, connectivity inspection, PCB layout-physics review, or manufacturing acceptance.

## Risk and rollback

This is documentation-only and adds no executable dependency. Rollback removes the README link and Markdown index. The external diagrams remain versioned independently in their source repository.